### PR TITLE
Fix Remote SQL Backup

### DIFF
--- a/churchinfo/BackupDatabase.php
+++ b/churchinfo/BackupDatabase.php
@@ -60,7 +60,7 @@ if (isset($_POST["doBackup"]))
 	if ($bNoErrors)
 	{
 		$saveTo = "SQL/InfoCentral-Backup-" . date("Ymd-Gis") . ".sql";
-		$backupCommand = "mysqldump -u $sUSER --password=$sPASSWORD $sDATABASE > $saveTo";
+		$backupCommand = "mysqldump -u $sUSER --password=$sPASSWORD --host=$sSERVERNAME $sDATABASE > $saveTo";
 		exec($backupCommand, $returnString, $returnStatus);
 
 		switch ($iArchiveType)


### PR DESCRIPTION
The backup command does not account for when the SQL Server is not local
host.  Add a reference to the $sSERVERNAME configuration variable for
database backups.