### PR TITLE
Bug fix

### DIFF
--- a/churchinfo/Include/ReportConfig.php
+++ b/churchinfo/Include/ReportConfig.php
@@ -74,7 +74,7 @@ class ChurchInfoReport extends FPDF {
 	function WriteAtCell ($x, $y, $wid, $str) {
 		$strconv=iconv("UTF-8","ISO-8859-1",$str);
 		$this->SetXY ($x, $y);
-		$this->Cell ($wid, 4, $strconv, 1);
+		$this->MultiCell ($wid, 4, $strconv, 1);
 	}
 
    function StartLetterPage ($fam_ID, $fam_Name, $fam_Address1, $fam_Address2, $fam_City, $fam_State, $fam_Zip, $fam_Country, $letterhead="") {

--- a/churchinfo/Reports/ConfirmReport.php
+++ b/churchinfo/Reports/ConfirmReport.php
@@ -140,10 +140,10 @@ while ($aFam = mysql_fetch_array($rsFamilies)) {
    $pdf->WriteAtCell ($pdf->leftX, $curY, $dataCol - $pdf->leftX, gettext ("Home phone"));
 	$pdf->SetFont("Times",'',10);
    $pdf->WriteAtCell ($dataCol, $curY, $dataWid, $fam_HomePhone); $curY += $pdf->incrementY;
-	//$pdf->SetFont("Times",'B',10);
-   //$pdf->WriteAtCell ($pdf->leftX, $curY, $dataCol - $pdf->leftX, gettext ("Send Newsletter"));
-	//$pdf->SetFont("Times",'',10);
-  // $pdf->WriteAtCell ($dataCol, $curY, $dataWid, $fam_SendNewsLetter); $curY += $pdf->incrementY;
+	$pdf->SetFont("Times",'B',10);
+   $pdf->WriteAtCell ($pdf->leftX, $curY, $dataCol - $pdf->leftX, gettext ("Send Newsletter"));
+	$pdf->SetFont("Times",'',10);
+  $pdf->WriteAtCell ($dataCol, $curY, $dataWid, $fam_SendNewsLetter); $curY += $pdf->incrementY;
 
 // Missing the following information from the Family record:
 // Wedding date (if present) - need to figure how to do this with sensitivity

--- a/churchinfo/Reports/ConfirmReport.php
+++ b/churchinfo/Reports/ConfirmReport.php
@@ -57,10 +57,9 @@ class PDF_ConfirmReport extends ChurchInfoReport {
 			$curY += 2 * $this->incrementY;
 			$this->WriteAt ($this->leftX, $curY, $this->sConfirm6);
 		}
-
-		if ($this->sConfirmSigner) {
+        //If the Reports Settings Menu's sConfirmSigner is set, then display the closing statement.  Hide it otherwise.
+        if ($this->sConfirmSigner) {
             $curY += 4 * $this->incrementY;
-
             $this->WriteAt ($this->leftX, $curY, "Sincerely,");
             $curY += 4 * $this->incrementY;
             $this->WriteAt ($this->leftX, $curY, $this->sConfirmSigner);
@@ -111,7 +110,8 @@ $dataWid = 65;
 // Loop through families
 while ($aFam = mysql_fetch_array($rsFamilies)) {
 	extract ($aFam);
-    
+
+    //If this is a report for a single family, name the file accordingly.
     if ($_GET["familyId"]) {
         $filename = "ConfirmReport-".$fam_Name.".pdf";
     } 
@@ -143,7 +143,7 @@ while ($aFam = mysql_fetch_array($rsFamilies)) {
 	$pdf->SetFont("Times",'B',10);
    $pdf->WriteAtCell ($pdf->leftX, $curY, $dataCol - $pdf->leftX, gettext ("Send Newsletter"));
 	$pdf->SetFont("Times",'',10);
-  $pdf->WriteAtCell ($dataCol, $curY, $dataWid, $fam_SendNewsLetter); $curY += $pdf->incrementY;
+   $pdf->WriteAtCell ($dataCol, $curY, $dataWid, $fam_SendNewsLetter); $curY += $pdf->incrementY;
 
 // Missing the following information from the Family record:
 // Wedding date (if present) - need to figure how to do this with sensitivity
@@ -220,14 +220,15 @@ while ($aFam = mysql_fetch_array($rsFamilies)) {
 		$pdf->WriteAtCell ($XGender, $curY, $XRole - $XGender, $genderStr);
 		$pdf->WriteAtCell ($XRole, $curY, $XEmail - $XRole, $sFamRole);
 		$pdf->WriteAtCell ($XEmail, $curY, $XBirthday - $XEmail, $per_Email);
-		if ($per_BirthYear)
+        if ($per_BirthYear)
         {
             $birthdayStr = $per_BirthYear . "-" . $per_BirthMonth . "-" . $per_BirthDay;
         }
         elseif ($per_BirthMonth)
             $birthdayStr = $per_BirthMonth . "-" . $per_BirthDay;
-		else
-			$birthdayStr = "";
+        else
+            $birthdayStr = "";
+        //If the "HideAge" check box is true, then create a Yes/No representation of the check box.
         if ($per_Flags)
         {
             $hideAgeStr="Yes";
@@ -238,7 +239,7 @@ while ($aFam = mysql_fetch_array($rsFamilies)) {
         }
         
 		$pdf->WriteAtCell ($XBirthday, $curY, $XHideAge - $XBirthday, $birthdayStr);
-        $pdf->WriteAtCell ($XHideAge, $curY, $XCellPhone - $XHideAge,$hideAgeStr);
+		$pdf->WriteAtCell ($XHideAge, $curY, $XCellPhone - $XHideAge,$hideAgeStr);
 		$pdf->WriteAtCell ($XCellPhone, $curY, $XClassification - $XCellPhone, $per_CellPhone);
 		$pdf->WriteAtCell ($XClassification, $curY, $XRight - $XClassification, $sClassName);
 		$curY += $pdf->incrementY;

--- a/churchinfo/Reports/ConfirmReport.php
+++ b/churchinfo/Reports/ConfirmReport.php
@@ -68,6 +68,7 @@ class PDF_ConfirmReport extends ChurchInfoReport {
 
 // Instantiate the directory class and build the report.
 $pdf = new PDF_ConfirmReport();
+$filename = "ConfirmReport" . date("Ymd") . ".pdf";
 
 // Read in report settings from database
 $rsConfig = mysql_query("SELECT cfg_name, IFNULL(cfg_value, cfg_default) AS value FROM config_cfg WHERE cfg_section='ChurchInfoReport'");
@@ -108,6 +109,10 @@ $dataWid = 65;
 // Loop through families
 while ($aFam = mysql_fetch_array($rsFamilies)) {
 	extract ($aFam);
+    
+    if ($_GET["familyId"]) {
+        $filename = "ConfirmReport-".$fam_Name.".pdf";
+    } 
 
 	$curY = $pdf->StartNewPage ($fam_ID, $fam_Name, $fam_Address1, $fam_Address2, $fam_City, 
                                $fam_State, $fam_Zip, $fam_Country);
@@ -323,7 +328,7 @@ while ($aFam = mysql_fetch_array($rsFamilies)) {
 
 header('Pragma: public');  // Needed for IE when using a shared SSL certificate
 if ($iPDFOutputType == 1)
-	$pdf->Output("ConfirmReport" . date("Ymd") . ".pdf", "D");
+	$pdf->Output($filename, "D");
 else
 	$pdf->Output();	
 ?>

--- a/churchinfo/Reports/ConfirmReport.php
+++ b/churchinfo/Reports/ConfirmReport.php
@@ -169,10 +169,11 @@ while ($aFam = mysql_fetch_array($rsFamilies)) {
 	$rsFamilyMembers = RunQuery ($sSQL);
 
 	$XName = 10;
-	$XGender = 50;
-	$XRole = 60;
-	$XEmail = 90;
-	$XBirthday = 135;
+	$XGender = 40;
+	$XRole = 50;
+	$XEmail = 80;
+	$XBirthday = 125;
+    $XHideAge=145;
 	$XCellPhone = 155;
 	$XClassification = 180;
 	$XWorkPhone = 155;
@@ -183,11 +184,12 @@ while ($aFam = mysql_fetch_array($rsFamilies)) {
    $pdf->WriteAtCell ($XGender, $curY, $XRole - $XGender, gettext ("M/F"));
    $pdf->WriteAtCell ($XRole, $curY, $XEmail - $XRole, gettext ("Adult/Child"));
    $pdf->WriteAtCell ($XEmail, $curY, $XBirthday - $XEmail, gettext ("Email"));
-   $pdf->WriteAtCell ($XBirthday, $curY, $XCellPhone - $XBirthday, gettext ("Birthday"));
+   $pdf->WriteAtCell ($XBirthday, $curY, $XHideAge - $XBirthday, gettext ("Birthday"));
+   $pdf->WriteAtCell ($XHideAge, $curY, $XCellPhone - $XHideAge, gettext ("Hide Age"));
    $pdf->WriteAtCell ($XCellPhone, $curY, $XClassification - $XCellPhone, gettext ("Cell phone"));
    $pdf->WriteAtCell ($XClassification, $curY, $XRight - $XClassification, gettext ("Member/Friend"));
 	$pdf->SetFont("Times",'',10);
-	$curY += $pdf->incrementY;
+	$curY += 3*$pdf->incrementY;
 
 	$numFamilyMembers = 0;
 	while ($aMember = mysql_fetch_array($rsFamilyMembers)) {
@@ -202,7 +204,8 @@ while ($aFam = mysql_fetch_array($rsFamilies)) {
 		   $pdf->WriteAtCell ($XGender, $curY, $XRole - $XGender, gettext ("M/F"));
 		   $pdf->WriteAtCell ($XRole, $curY, $XEmail - $XRole, gettext ("Adult/Child"));
 		   $pdf->WriteAtCell ($XEmail, $curY, $XBirthday - $XEmail, gettext ("Email"));
-		   $pdf->WriteAtCell ($XBirthday, $curY, $XCellPhone - $XBirthday, gettext ("Birthday"));
+		   $pdf->WriteAtCell ($XBirthday, $curY, $XHideAge - $XBirthday, gettext ("Birthday"));
+           $pdf->WriteAtCell ($XHideAge, $curY, $XCellPhone - $XHideAge, gettext ("Hide Age"));
 		   $pdf->WriteAtCell ($XCellPhone, $curY, $XClassification - $XCellPhone, gettext ("Cell phone"));
 		   $pdf->WriteAtCell ($XClassification, $curY, $XRight - $XClassification, gettext ("Member/Friend"));
 			$pdf->SetFont("Times",'',10);
@@ -218,12 +221,24 @@ while ($aFam = mysql_fetch_array($rsFamilies)) {
 		$pdf->WriteAtCell ($XRole, $curY, $XEmail - $XRole, $sFamRole);
 		$pdf->WriteAtCell ($XEmail, $curY, $XBirthday - $XEmail, $per_Email);
 		if ($per_BirthYear)
-			$birthdayStr = $per_BirthYear . "-" . $per_BirthMonth . "-" . $per_BirthDay;
+        {
+            $birthdayStr = $per_BirthYear . "-" . $per_BirthMonth . "-" . $per_BirthDay;
+        }
         elseif ($per_BirthMonth)
             $birthdayStr = $per_BirthMonth . "-" . $per_BirthDay;
 		else
 			$birthdayStr = "";
-		$pdf->WriteAtCell ($XBirthday, $curY, $XCellPhone - $XBirthday, $birthdayStr);
+        if ($per_Flags)
+        {
+            $hideAgeStr="Yes";
+        }
+        else
+        {
+            $hideAgeStr="No";
+        }
+        
+		$pdf->WriteAtCell ($XBirthday, $curY, $XHideAge - $XBirthday, $birthdayStr);
+        $pdf->WriteAtCell ($XHideAge, $curY, $XCellPhone - $XHideAge,$hideAgeStr);
 		$pdf->WriteAtCell ($XCellPhone, $curY, $XClassification - $XCellPhone, $per_CellPhone);
 		$pdf->WriteAtCell ($XClassification, $curY, $XRight - $XClassification, $sClassName);
 		$curY += $pdf->incrementY;

--- a/churchinfo/Reports/ConfirmReport.php
+++ b/churchinfo/Reports/ConfirmReport.php
@@ -58,11 +58,13 @@ class PDF_ConfirmReport extends ChurchInfoReport {
 			$this->WriteAt ($this->leftX, $curY, $this->sConfirm6);
 		}
 
-		$curY += 4 * $this->incrementY;
+		if ($this->sConfirmSigner) {
+            $curY += 4 * $this->incrementY;
 
-		$this->WriteAt ($this->leftX, $curY, "Sincerely,");
-		$curY += 4 * $this->incrementY;
-		$this->WriteAt ($this->leftX, $curY, $this->sConfirmSigner);
+            $this->WriteAt ($this->leftX, $curY, "Sincerely,");
+            $curY += 4 * $this->incrementY;
+            $this->WriteAt ($this->leftX, $curY, $this->sConfirmSigner);
+        }
 	}
 }
 
@@ -138,10 +140,10 @@ while ($aFam = mysql_fetch_array($rsFamilies)) {
    $pdf->WriteAtCell ($pdf->leftX, $curY, $dataCol - $pdf->leftX, gettext ("Home phone"));
 	$pdf->SetFont("Times",'',10);
    $pdf->WriteAtCell ($dataCol, $curY, $dataWid, $fam_HomePhone); $curY += $pdf->incrementY;
-	$pdf->SetFont("Times",'B',10);
-   $pdf->WriteAtCell ($pdf->leftX, $curY, $dataCol - $pdf->leftX, gettext ("Send Newsletter"));
-	$pdf->SetFont("Times",'',10);
-   $pdf->WriteAtCell ($dataCol, $curY, $dataWid, $fam_SendNewsLetter); $curY += $pdf->incrementY;
+	//$pdf->SetFont("Times",'B',10);
+   //$pdf->WriteAtCell ($pdf->leftX, $curY, $dataCol - $pdf->leftX, gettext ("Send Newsletter"));
+	//$pdf->SetFont("Times",'',10);
+  // $pdf->WriteAtCell ($dataCol, $curY, $dataWid, $fam_SendNewsLetter); $curY += $pdf->incrementY;
 
 // Missing the following information from the Family record:
 // Wedding date (if present) - need to figure how to do this with sensitivity
@@ -217,6 +219,8 @@ while ($aFam = mysql_fetch_array($rsFamilies)) {
 		$pdf->WriteAtCell ($XEmail, $curY, $XBirthday - $XEmail, $per_Email);
 		if ($per_BirthYear)
 			$birthdayStr = $per_BirthYear . "-" . $per_BirthMonth . "-" . $per_BirthDay;
+        elseif ($per_BirthMonth)
+            $birthdayStr = $per_BirthMonth . "-" . $per_BirthDay;
 		else
 			$birthdayStr = "";
 		$pdf->WriteAtCell ($XBirthday, $curY, $XCellPhone - $XBirthday, $birthdayStr);

--- a/churchinfo/Reports/DirectoryReport.php
+++ b/churchinfo/Reports/DirectoryReport.php
@@ -382,7 +382,13 @@ class PDF_Directory extends ChurchInfoReport {
         $iTempLen = strlen($sHeadStr);
 
         if ($bDirBirthday && $per_BirthMonth && $per_BirthDay)
-            $sHeadStr .= sprintf(" (%d/%d)\n", $per_BirthMonth, $per_BirthDay);
+        {
+            $sHeadStr .= sprintf(" (%d/%d", $per_BirthMonth, $per_BirthDay);
+            if ($per_BirthYear  && ! $per_Flags)
+                $sHeadStr .= sprintf("/%d)\n", $per_BirthYear);
+            else
+                $sHeadStr .= ")\n";
+        }
         else
         {
             $sHeadStr .= "\n";
@@ -442,7 +448,7 @@ class PDF_Directory extends ChurchInfoReport {
         if ($bDirBirthday && $per_BirthMonth && $per_BirthDay)
         {
             $sMemberStr .= sprintf(" (%d/%d", $per_BirthMonth, $per_BirthDay);
-            if ($per_BirthYear && in_array($per_fmr_ID, $aChildren))
+            if ($per_BirthYear  && ! $per_Flags)
                 $sMemberStr .= sprintf("/%d)\n", $per_BirthYear);
             else
                 $sMemberStr .= ")\n";


### PR DESCRIPTION
Fixes bugs:
#41 #42 #43 #44 

Alters the "WriteAtCell" function to use MultiCell instead of Cell (http://www.fpdf.org/en/doc/cell.htm vs http://www.fpdf.org/en/doc/multicell.htm)

Adds logic to prevent displaying the trailing "Sincerely, " on the Confirm Report if there is no sConfirmSigner defined

Names the reports according to the family, if the report is only for one family.

Displays the status of the "Hide Age" checkbox on the Confirm Report

Hides the birth year on the directory if "Hide Age" is checked.