### PR TITLE
Make custom field delete work in Chrome 

### DIFF
--- a/churchinfo/FamilyCustomFieldsEditor.php
+++ b/churchinfo/FamilyCustomFieldsEditor.php
@@ -307,12 +307,16 @@ function GetSecurityList($aSecGrp, $fld_name, $currOpt='bAll') {
 ?>
 
 <script language="javascript">
-
-function confirmDeleteField( Field, Row ) {
-var answer = confirm (<?php echo "'" . gettext("Warning:  By deleting this field, you will irrevokably lose all family data assigned for this field!") . "'"; ?>)
-if ( answer )
-    window.location="FamilyCustomFieldsRowOps.php?Field=" + Field + "&OrderID=" + Row + "&Action=delete";
-    confirm ("Field Deleted");
+function confirmDeleteField( event ) {
+	var answer = confirm (<?php echo "'" . gettext("Warning:  By deleting this field, you will irrevokably lose all family data assigned for this field!") . "'"; ?>)
+	if ( answer )
+	{
+		window.location="FamilyCustomFieldsRowOps.php?Field=" + Field + "&OrderID=" + Row + "&Action=delete";
+		confirm ("Field Deleted");
+		return true;
+	}
+	event.preventDefault ? event.preventDefault() : event.returnValue = false;
+	return false;
 }
 </script>
 
@@ -374,7 +378,7 @@ else
                     echo "<a href=\"FamilyCustomFieldsRowOps.php?OrderID=$row&Field=" . $aFieldFields[$row] . "&Action=up\"><img src=\"Images/uparrow.gif\" border=\"0\"></a>";
                 if ($row < $numRows)
                     echo "<a href=\"FamilyCustomFieldsRowOps.php?OrderID=$row&Field=" . $aFieldFields[$row] . "&Action=down\"><img src=\"Images/downarrow.gif\" border=\"0\"></a>";
-		echo "<a href=\"FamilyCustomFieldsRowOps.php?Field= $aFieldFields[$row] &OrderID=$row&Action=delete\"><img src=\"Images/x.gif\" border=\"0\"></a>";
+		echo "<a href=\"FamilyCustomFieldsRowOps.php?Field=" . $aFieldFields[$row] . "&OrderID=". $row . "&Action=delete\" onclick=\"return confirmDeleteField(event)\"><img src=\"Images/x.gif\" border=\"0\"></a>";
                 ?>
             </td>
 

--- a/churchinfo/PersonCustomFieldsEditor.php
+++ b/churchinfo/PersonCustomFieldsEditor.php
@@ -288,11 +288,15 @@ function GetSecurityList($aSecGrp, $fld_name, $currOpt='bAll') {
 ?>
 <script language="javascript">
 
-function confirmDeleteField( Field, Row ) {
-var answer = confirm (<?php echo "'" . gettext("Warning:  By deleting this field, you will irrevokably lose all person data assigned for this field!") . "'"; ?>)
-if ( answer )
-	window.location="PersonCustomFieldsRowOps.php?Field=" + Field + "&OrderID=" + Row + "&Action=delete";
-	confirm ("Field Deleted");
+function confirmDeleteField(event) {
+	var answer = confirm (<?php echo "'" . gettext("Warning:  By deleting this field, you will irrevokably lose all person data assigned for this field!") . "'"; ?>)
+	if ( answer )
+	{
+		confirm ("Field Deleted");
+		return true;
+	}
+	event.preventDefault ? event.preventDefault() : event.returnValue = false;
+	return false;
 }
 </script>
 
@@ -355,7 +359,7 @@ else
 				if ($row < $numRows)
 					echo "<a href=\"PersonCustomFieldsRowOps.php?OrderID=$row&Field=" . $aFieldFields[$row] . "&Action=down\"><img src=\"Images/downarrow.gif\" border=\"0\"></a>";
 				?>
-				<input type="image" value="delete" Name="delete" onclick="confirmDeleteField(<?php echo "'" . $aFieldFields[$row] . "', '" . $row . "'"; ?>);" src="Images/x.gif">
+				<a href="PersonCustomFieldsRowOps.php?Field=<?= $aFieldFields[$row] ?>&OrderID=<?= $row ?>&Action=delete" onclick="return confirmDeleteField(event)"><img src="Images/x.gif"></a>
 			</td>
 
 			<td class="TextColumn" style="font-size:80%;">


### PR DESCRIPTION
The `window.location` trick does not work in current browsers. I suggest using an `A` tag (which has the benefit of gracefully degrading w/o JavaScript). This fixes it for me.
As a side note, I noticed that JQuery is loaded but not used on that page. I'd suggest separating some JS code out into external `.js` files and using JQuery to attach event handlers (that way portability issues like this one can be avoided).

Closes #81 