### PR TITLE
Create Families based on custom properties

### DIFF
--- a/churchinfo/CSVImport.php
+++ b/churchinfo/CSVImport.php
@@ -35,10 +35,10 @@ class Family
     var $WeddingDate;   // one per family
     var $Phone;         // one per family
     var $Envelope;      // one per family
-    var $_nAdultMale;   // if one adult male 
+    var $_nAdultMale;   // if one adult male
     var $_nAdultFemale; // and 1 adult female we assume spouses
     var $_type;         // 0=patriarch, 1=martriarch
-    
+
     // constructor, initialize variables
     function Family($famtype)
     {
@@ -51,15 +51,15 @@ class Family
         $this->WeddingDate = "0000-00-00";
         $this->Phone = "";
     }
-    
+
     /** Add what we need to know about members for role assignment later **/
     function AddMember($PersonID, $Gender, $Age, $Wedding, $Phone, $Envelope)
     {
         // add member with un-assigned role
         $this->Members[] = array('personid'=>$PersonID,
-                                 'age'=>$Age, 
-                                 'gender'=>$Gender, 
-                                 'role'=> 0, 
+                                 'age'=>$Age,
+                                 'gender'=>$Gender,
+                                 'role'=> 0,
                                  'phone'=> $Phone,
                                  'envelope'=>$Envelope);
         if($Wedding != "0000-00-00")
@@ -72,7 +72,7 @@ class Family
             $Gender==1 ? $this->_nAdultMale++ : $this->_nAdultFemale++ ;
         }
     }
-    
+
     /** Assigning of roles to be called after all members added **/
     function AssignRoles()
     {
@@ -135,10 +135,10 @@ if (isset($_POST["UploadCSV"]))
     // Valid file, so save it and display the import mapping form.
     else
     {
-    	$csvTempFile = "import.csv";
+        $csvTempFile = "import.csv";
         $system_temp = ini_get("session.save_path");
         if (strlen ($system_temp)>0)
-	        $csvTempFile = $system_temp . "/" . $csvTempFile;
+            $csvTempFile = $system_temp . "/" . $csvTempFile;
         move_uploaded_file($_FILES['CSVfile']['tmp_name'], $csvTempFile);
 
         // create the file pointer
@@ -166,7 +166,7 @@ if (isset($_POST["UploadCSV"]))
 
             echo "<tr>";
             for ($col = 0; $col < $numCol; $col++) {
-                echo "<td>" . $aData[$col] . "&nbsp;</td>"; 
+                echo "<td>" . $aData[$col] . "&nbsp;</td>";
             }
             echo "</tr>";
         }
@@ -176,47 +176,47 @@ if (isset($_POST["UploadCSV"]))
         $sSQL = "SELECT * FROM person_custom_master ORDER BY custom_Order";
         $rsCustomFields = RunQuery($sSQL);
 
-		  $sPerCustomFieldList = "";
+        $sPerCustomFieldList = "";
         while ($aRow = mysql_fetch_array($rsCustomFields))
         {
             extract($aRow);
             // No easy way to import person-from-group or custom-list types
             if ($type_ID != 9 && $type_ID != 12)
-				{
-               $sPerCustomFieldList .= "<option value=\"" . $custom_Field . "\">" . $custom_Name . "</option>\n";
-				}
+            {
+                 $sPerCustomFieldList .= "<option value=\"" . $custom_Field . "\">" . $custom_Name . "</option>\n";
+            }
         }
-		
+
         $sSQL = "SELECT * FROM family_custom_master ORDER BY fam_custom_Order";
         $rsfamCustomFields = RunQuery($sSQL);
 
-		  $sFamCustomFieldList = "";
-		  while ($aRow = mysql_fetch_array($rsfamCustomFields))
+        $sFamCustomFieldList = "";
+        while ($aRow = mysql_fetch_array($rsfamCustomFields))
         {
             extract($aRow);
-				if ($type_ID != 9 && $type_ID != 12)
-				{
-               $sFamCustomFieldList .= "<option value=\"f" . $fam_custom_Field . "\">" . $fam_custom_Name . "</option>\n";
-				}
+            if ($type_ID != 9 && $type_ID != 12)
+            {
+                $sFamCustomFieldList .= "<option value=\"f" . $fam_custom_Field . "\">" . $fam_custom_Name . "</option>\n";
+            }
         }
 
-		  // Get Field Security List Matrix
-		  $sSQL = "SELECT * FROM list_lst WHERE lst_ID = 5 ORDER BY lst_OptionSequence";
-		  $rsSecurityGrp = RunQuery($sSQL);
+        // Get Field Security List Matrix
+        $sSQL = "SELECT * FROM list_lst WHERE lst_ID = 5 ORDER BY lst_OptionSequence";
+        $rsSecurityGrp = RunQuery($sSQL);
 
-		  while ($aRow = mysql_fetch_array($rsSecurityGrp))
-		  {
-			  extract ($aRow);
-		     $aSecurityType[$lst_OptionID] = $lst_OptionName;
-		  }
+        while ($aRow = mysql_fetch_array($rsSecurityGrp))
+        {
+            extract ($aRow);
+            $aSecurityType[$lst_OptionID] = $lst_OptionName;
+        }
 
 
         // add select boxes for import destination mapping
         for ($col = 0; $col < $numCol; $col++)
-        {				
+        {
         ?>
             <td>
-            <select name="<?php echo "col" . $col;?>">
+            <select name="<?= "col" . $col ?>">
                 <option value="0"><?php echo gettext("Ignore this Field"); ?></option>
                 <option value="1"><?php echo gettext("Title"); ?></option>
                 <option value="2"><?php echo gettext("First Name"); ?></option>
@@ -239,8 +239,7 @@ if (isset($_POST["UploadCSV"]))
                 <option value="19"><?php echo gettext("Birth Date"); ?></option>
                 <option value="20"><?php echo gettext("Membership Date"); ?></option>
                 <option value="21"><?php echo gettext("Wedding Date"); ?></option>
-					 <?php echo $sPerCustomFieldList.$sFamCustomFieldList; ?>
-
+                <?= $sPerCustomFieldList.$sFamCustomFieldList; ?>
             </select>
             </td>
         <?php
@@ -252,20 +251,25 @@ if (isset($_POST["UploadCSV"]))
         <input type="checkbox" value="1" name="IgnoreFirstRow"><?php echo gettext("Ignore first CSV row (to exclude a header)"); ?>
         <BR><BR>
         <BR>
-        <input type="checkbox" value="1" name="MakeFamilyRecords" checked="true"><?php echo gettext("Make Family records based on last name and address"); ?>
+        <input type="checkbox" value="1" name="MakeFamilyRecords" checked="true">
+        <select name="bundleFamCustom">
+            <option value="0"><?= gettext("Make Family records based on last name and address") ?></option>
+            <?= $sPerCustomFieldList.$sFamCustomFieldList; ?>
+        </select>
+
         <BR><BR>
         <select name="FamilyMode">
             <option value="0"><?php echo gettext("Patriarch");?></option>
             <option value="1"><?php echo gettext("Matriarch");?></option>
         </select>
-        <?php echo gettext("Family Type: used with Make Family records... option above"); ?>
+        <?= gettext("Family Type: used with Make Family records... option above"); ?>
         <BR><BR>
         <select name="DateMode">
             <option value="1">YYYY-MM-DD</option>
             <option value="2">MM-DD-YYYY</option>
             <option value="3">DD-MM-YYYY</option>
         </select>
-        <?php echo gettext("NOTE: Separators (dashes, etc.) or lack thereof do not matter"); ?>
+        <?= gettext("NOTE: Separators (dashes, etc.) or lack thereof do not matter"); ?>
         <BR><BR>
         <?php
             $sCountry = $sDefaultCountry;
@@ -277,7 +281,7 @@ if (isset($_POST["UploadCSV"]))
         ?>
         <BR><BR>
         <select name="Classification">
-            <option value="0"><?php echo gettext("Unassigned"); ?></option>
+            <option value="0"><?= gettext("Unassigned"); ?></option>
             <option value="0">-----------------------</option>
 
             <?php
@@ -289,9 +293,9 @@ if (isset($_POST["UploadCSV"]))
                 }
             ?>
         </select>
-        <?php echo gettext("Classification"); ?>
+        <?= gettext("Classification"); ?>
         <BR><BR>
-        <input type="submit" class="icButton" value="<?php echo gettext("Perform Import"); ?>" name="DoImport">
+        <input type="submit" class="icButton" value="<?= gettext("Perform Import"); ?>" name="DoImport">
         </form>
 
         <?php
@@ -303,16 +307,16 @@ if (isset($_POST["UploadCSV"]))
 // Has the import form been submitted yet?
 if (isset($_POST["DoImport"]))
 {
-	$aColumnCustom = array();
-	$aFamColumnCustom = array();
-	$bHasCustom = false;
-	$bHasFamCustom = false;
-	
+    $aColumnCustom = array();
+    $aFamColumnCustom = array();
+    $bHasCustom = false;
+    $bHasFamCustom = false;
+
     $csvTempFile = "import.csv";
     $system_temp = ini_get("session.save_path");
     if (strlen ($system_temp)>0)
         $csvTempFile = $system_temp . "/" . $csvTempFile;
-    
+
     $Families = array();
 
     // make sure the file still exists
@@ -334,24 +338,24 @@ if (isset($_POST["DoImport"]))
         // Put the column types from the mapping form into an array
         for ($col = 0; $col < $numCol; $col++)
         {
-            if (substr($_POST["col" . $col],0,1) == "c") 
+            if (substr($_POST["col" . $col],0,1) == "c")
             {
                 $aColumnCustom[$col] = 1;
-				$aFamColumnCustom[$col] = 0;
+                $aFamColumnCustom[$col] = 0;
                 $bHasCustom = true;
             }
-            else 
-				{
-		            $aColumnCustom[$col] = 0;
-					if (substr($_POST["col" . $col],0,2) == "fc")
-					{
-						$aFamColumnCustom[$col] = 1;
-						$bHasFamCustom = true;
-					}
-					else
-					{
-						$aFamColumnCustom[$col] = 0;
-					}
+            else
+            {
+                $aColumnCustom[$col] = 0;
+                if (substr($_POST["col" . $col],0,2) == "fc")
+                {
+                    $aFamColumnCustom[$col] = 1;
+                    $bHasFamCustom = true;
+                }
+                else
+                {
+                    $aFamColumnCustom[$col] = 0;
+                }
             }
             $aColumnID[$col] = $_POST["col" . $col];
         }
@@ -375,7 +379,7 @@ if (isset($_POST["DoImport"]))
                 extract($aRow);
                 $afamCustomTypes[$fam_custom_Field] = $type_ID;
             }
-			}
+        }
 
         //
         // Need to lock the person_custom and person_per tables!!
@@ -386,9 +390,9 @@ if (isset($_POST["DoImport"]))
                 5=>"per_Suffix", 6=>"per_Gender", 7=>"per_Envelope", 8=>"per_Address1", 9=>"per_Address2",
                 10=>"per_City", 11=>"per_State", 12=>"per_Zip", 13=>"per_Country", 14=>"per_HomePhone",
                 15=>"per_WorkPhone", 16=>"per_CellPhone", 17=>"per_Email", 18=>"per_WorkEmail",
-                19=>"per_BirthYear, per_BirthMonth, per_BirthDay", 20=>"per_MembershipDate", 
+                19=>"per_BirthYear, per_BirthMonth, per_BirthDay", 20=>"per_MembershipDate",
                 21=>"fam_WeddingDate"
-                 );
+        );
 
         $importCount = 0;
 
@@ -417,7 +421,7 @@ if (isset($_POST["DoImport"]))
                     switch($currentType)
                     {
                         // Address goes with family record if creating families
-                        case 8: case 9: case 10: case 11: case 12: 
+                        case 8: case 9: case 10: case 11: case 12:
                             // if not making family records, add to person
                             if (!isset($_POST["MakeFamilyRecords"]))
                             {
@@ -444,9 +448,9 @@ if (isset($_POST["DoImport"]))
                                 }
                             }
                             break;
-                        
+
                         // Simple strings.. no special processing
-                        case 1: case 2: case 3: case 4: case 5: 
+                        case 1: case 2: case 3: case 4: case 5:
                         case 17: case 18:
                             $sSQLpersonData .= "'" . addslashes($aData[$col]) . "',";
                             break;
@@ -507,11 +511,11 @@ if (isset($_POST["DoImport"]))
                         case 20:
                             $sDate = $aData[$col];
                             $aDate = ParseDate($sDate,$iDateMode);
-							if ($aDate[0] == 'NULL' || $aDate[1] == 'NULL' || $aDate[2] == 'NULL'){
-								$sSQLpersonData .= "NULL,";
-							}else{
-								$sSQLpersonData .= "\"" . $aDate[0] . "-" . $aDate[1] . "-" . $aDate[2] . "\",";
-							}
+                            if ($aDate[0] == 'NULL' || $aDate[1] == 'NULL' || $aDate[2] == 'NULL'){
+                                $sSQLpersonData .= "NULL,";
+                            } else {
+                                $sSQLpersonData .= "\"" . $aDate[0] . "-" . $aDate[1] . "-" . $aDate[2] . "\",";
+                            }
                             break;
 
                         // Wedding date.. parse multiple date standards
@@ -519,10 +523,10 @@ if (isset($_POST["DoImport"]))
                             $sDate = $aData[$col];
                             $aDate = ParseDate($sDate,$iDateMode);
                             if ($aDate[0] == 'NULL' || $aDate[1] == 'NULL' || $aDate[2] == 'NULL'){
-								$dWedding = "NULL";
-							}else{
-								$dWedding = $aDate[0] . "-" . $aDate[1] . "-" . $aDate[2];
-							}
+                                $dWedding = "NULL";
+                            } else {
+                                $dWedding = $aDate[0] . "-" . $aDate[1] . "-" . $aDate[2];
+                            }
                             break;
 
                         // Ignore field option
@@ -539,9 +543,9 @@ if (isset($_POST["DoImport"]))
                     {
                         case 0: case 7: case 13: case 14: case 15: case 16: case 21:
                             break;
-                        case 8: case 9: case 10: case 11: case 12: 
+                        case 8: case 9: case 10: case 11: case 12:
                             // if not making family records, add to person
-                            if (!isset($_POST["MakeFamilyRecords"])) 
+                            if (!isset($_POST["MakeFamilyRecords"]))
                                 $sSQLpersonFields .= $aPersonTableFields[$currentType] . ", ";
                             break;
                         default:
@@ -555,7 +559,7 @@ if (isset($_POST["DoImport"]))
             for ($col = 0; $col < $numCol; $col++)
             {
                 // Is it not a custom field?
-				if (!$aColumnCustom[$col] and !$aFamColumnCustom[$col]) 
+                if (!$aColumnCustom[$col] and !$aFamColumnCustom[$col])
                 {
                     $currentType = $aColumnID[$col];
                     switch($currentType)
@@ -573,195 +577,195 @@ if (isset($_POST["DoImport"]))
 
             // Finish up the person_per SQL..
             $sSQLpersonData .= $iClassID . ",'" . addslashes($sCountry) . "',";
-            $sSQLpersonData .= "'" . date("YmdHis") . "'," . $_SESSION['iUserID'];            
+            $sSQLpersonData .= "'" . date("YmdHis") . "'," . $_SESSION['iUserID'];
             $sSQLpersonData .= ")";
-            
+
             $sSQLpersonFields .= "per_cls_ID, per_Country, per_DateEntered, per_EnteredBy";
             $sSQLpersonFields .= ")";
             $sSQLperson = $sSQLpersonFields . $sSQLpersonData;
 
             RunQuery($sSQLperson);
 
-           // Make a one-person family if requested
-           if (isset($_POST["MakeFamilyRecords"])) {
-               $sSQL = "SELECT MAX(per_ID) AS iPersonID FROM person_per";
-               $rsPersonID = RunQuery($sSQL);
-               extract(mysql_fetch_array($rsPersonID));
-               $sSQL = "SELECT * FROM person_per WHERE per_ID = " . $iPersonID;
-               $rsNewPerson = RunQuery($sSQL);
-               extract(mysql_fetch_array($rsNewPerson));
-               
-               // see if there is a family with same last name and address
-               $sSQL = "SELECT fam_ID, fam_name, fam_Address1 
-                        FROM family_fam where fam_Name = '".addslashes($per_LastName)."' 
-                        AND fam_Address1 = '".$sAddress1."'"; // slashes added already
-               $rsExistingFamily = RunQuery($sSQL);
-               $famid = 0;
-               if(mysql_num_rows($rsExistingFamily) > 0)
-               {
-                   extract(mysql_fetch_array($rsExistingFamily));
-                   $famid = $fam_ID;
-                   if(array_key_exists($famid, $Families))
-                       $Families[$famid]->AddMember($per_ID,
-                                                    $iGender,
-                                                    GetAge($iBirthMonth, $iBirthDay, $iBirthYear), 
-                                                    $dWedding, 
-                                                    $per_HomePhone,
-                                                    $iEnvelope);
-               }
-               else
-               {
-                   $sSQL = "INSERT INTO family_fam (fam_ID,
-                                                 fam_Name, 
-                                                 fam_Address1, 
-                                                 fam_Address2, 
-                                                 fam_City, 
-                                                 fam_State, 
-                                                 fam_Zip, 
-                                                 fam_Country, 
-                                                 fam_HomePhone, 
-                                                 fam_WorkPhone, 
-                                                 fam_CellPhone, 
-                                                 fam_Email, 
-                                                 fam_DateEntered, 
-                                                 fam_EnteredBy)
-                            VALUES (NULL, " .
-                                   "\"" . $per_LastName . "\", " .
-                                   "\"" . $sAddress1 . "\", " .
-                                   "\"" . $sAddress2 . "\", " .
-                                   "\"" . $sCity . "\", " .
-                                   "\"" . $sState . "\", " .
-                                   "\"" . $sZip . "\", " .
-                                   "\"" . $per_Country . "\", " .
-                                   "\"" . $per_HomePhone . "\", " .
-                                   "\"" . $per_WorkPhone . "\", " .
-                                   "\"" . $per_CellPhone . "\", " .
-                                   "\"" . $per_Email . "\"," .
-                                   "\"" . date("YmdHis") . "\"," .
-                                   "\"" . $_SESSION['iUserID'] . "\");";
-                   RunQuery($sSQL);
-                   $sSQL = "SELECT LAST_INSERT_ID()";
-                   $rsFid = RunQuery($sSQL); 
-                   $aFid = mysql_fetch_array($rsFid);
-                   $famid =  $aFid[0];
-						 
-					 $sSQL = "INSERT INTO `family_custom` (`fam_ID`) VALUES ('" . $famid . "')";
-					 RunQuery($sSQL);
-						 
-                   $fFamily = new Family(FilterInput($_POST["FamilyMode"],'int'));
-                   $fFamily->AddMember($per_ID,
-                                       $iGender,
-                                       GetAge($iBirthMonth, $iBirthDay, $iBirthYear), 
-                                       $dWedding, 
-                                       $per_HomePhone,
-                                       $iEnvelope);
-                   $Families[$famid] = $fFamily;
-               }   
-               $sSQL = "UPDATE person_per SET per_fam_ID = " . $famid . " WHERE per_ID = " . $per_ID;
-               RunQuery($sSQL);
+            // Make a one-person family if requested
+            if (isset($_POST["MakeFamilyRecords"])) {
+                $sSQL = "SELECT MAX(per_ID) AS iPersonID FROM person_per";
+                $rsPersonID = RunQuery($sSQL);
+                extract(mysql_fetch_array($rsPersonID));
+                $sSQL = "SELECT * FROM person_per WHERE per_ID = " . $iPersonID;
+                $rsNewPerson = RunQuery($sSQL);
+                extract(mysql_fetch_array($rsNewPerson));
 
-				if ($bHasFamCustom)
-				{
-					// Check if family_custom record exists
-					$sSQL = "SELECT fam_id FROM family_custom WHERE fam_id = $famid";
-					$rsFamCustomID = RunQuery($sSQL);
-					if (mysql_num_rows($rsFamCustomID) == 0)
-					{
-						$sSQL = "INSERT INTO `family_custom` (`fam_ID`) VALUES ('" . $famid . "')";
-						RunQuery($sSQL);
-					}
+                // see if there is a family with same last name and address
+                $sSQL = "SELECT fam_ID, fam_name, fam_Address1
+                         FROM family_fam where fam_Name = '".addslashes($per_LastName)."'
+                         AND fam_Address1 = '".$sAddress1."'"; // slashes added already
+                $rsExistingFamily = RunQuery($sSQL);
+                $famid = 0;
+                if(mysql_num_rows($rsExistingFamily) > 0)
+                {
+                    extract(mysql_fetch_array($rsExistingFamily));
+                    $famid = $fam_ID;
+                    if(array_key_exists($famid, $Families))
+                        $Families[$famid]->AddMember($per_ID,
+                                                     $iGender,
+                                                     GetAge($iBirthMonth, $iBirthDay, $iBirthYear),
+                                                     $dWedding,
+                                                     $per_HomePhone,
+                                                     $iEnvelope);
+                }
+                else
+                {
+                    $sSQL = "INSERT INTO family_fam (fam_ID,
+                                                     fam_Name,
+                                                     fam_Address1,
+                                                     fam_Address2,
+                                                     fam_City,
+                                                     fam_State,
+                                                     fam_Zip,
+                                                     fam_Country,
+                                                     fam_HomePhone,
+                                                     fam_WorkPhone,
+                                                     fam_CellPhone,
+                                                     fam_Email,
+                                                     fam_DateEntered,
+                                                     fam_EnteredBy)
+                             VALUES (NULL, " .
+                                     "\"" . $per_LastName . "\", " .
+                                     "\"" . $sAddress1 . "\", " .
+                                     "\"" . $sAddress2 . "\", " .
+                                     "\"" . $sCity . "\", " .
+                                     "\"" . $sState . "\", " .
+                                     "\"" . $sZip . "\", " .
+                                     "\"" . $per_Country . "\", " .
+                                     "\"" . $per_HomePhone . "\", " .
+                                     "\"" . $per_WorkPhone . "\", " .
+                                     "\"" . $per_CellPhone . "\", " .
+                                     "\"" . $per_Email . "\"," .
+                                     "\"" . date("YmdHis") . "\"," .
+                                     "\"" . $_SESSION['iUserID'] . "\");";
+                    RunQuery($sSQL);
+                    $sSQL = "SELECT LAST_INSERT_ID()";
+                    $rsFid = RunQuery($sSQL);
+                    $aFid = mysql_fetch_array($rsFid);
+                    $famid =  $aFid[0];
 
-					// Build the family_custom SQL
-					$sSQLFamCustom = "UPDATE family_custom SET ";
-						for ($col = 0; $col < $numCol; $col++)
-						{
-							// Is it a custom field?
-							if ($aFamColumnCustom[$col])
-							{
-								$colID = substr($aColumnID[$col],1);
-						$currentType = $afamCustomTypes[$colID];
-						$currentFieldData = trim($aData[$col]);
+                    $sSQL = "INSERT INTO `family_custom` (`fam_ID`) VALUES ('" . $famid . "')";
+                    RunQuery($sSQL);
 
-						// If date, first parse it to the standard format..
-						if ($currentType == 2)
-						{
-							$aDate = ParseDate($currentFieldData,$iDateMode);
-							if ($aDate[0] == 'NULL' || $aDate[1] == 'NULL' || $aDate[2] == 'NULL'){
-								$currentFieldData = "";
-							}else{
-								$currentFieldData = implode("-",$aDate);
-							}
-						}
-						// If boolean, convert to the expected values for custom field
-						elseif ($currentType == 1)
-						{
-							if (strlen($currentFieldData))
-								$currentFieldData = ConvertToBoolean($currentFieldData);
-						}
-						else
-							$currentFieldData = addslashes($currentFieldData);
+                    $fFamily = new Family(FilterInput($_POST["FamilyMode"],'int'));
+                    $fFamily->AddMember($per_ID,
+                                        $iGender,
+                                        GetAge($iBirthMonth, $iBirthDay, $iBirthYear),
+                                        $dWedding,
+                                        $per_HomePhone,
+                                        $iEnvelope);
+                    $Families[$famid] = $fFamily;
+                }
+                $sSQL = "UPDATE person_per SET per_fam_ID = " . $famid . " WHERE per_ID = " . $per_ID;
+                RunQuery($sSQL);
 
-						// aColumnID is the custom table column name
-						sqlCustomField($sSQLFamCustom, $currentType, $currentFieldData, $colID, $sCountry);
-						}
-					}
+                if ($bHasFamCustom)
+                {
+                    // Check if family_custom record exists
+                    $sSQL = "SELECT fam_id FROM family_custom WHERE fam_id = $famid";
+                    $rsFamCustomID = RunQuery($sSQL);
+                    if (mysql_num_rows($rsFamCustomID) == 0)
+                    {
+                        $sSQL = "INSERT INTO `family_custom` (`fam_ID`) VALUES ('" . $famid . "')";
+                        RunQuery($sSQL);
+                    }
 
-					// Finalize and run the update for the person_custom table.
-					$sSQLFamCustom = substr($sSQLFamCustom,0,-2);
-					$sSQLFamCustom .= " WHERE fam_ID = " . $famid;
-					RunQuery($sSQLFamCustom);
-				}
+                    // Build the family_custom SQL
+                    $sSQLFamCustom = "UPDATE family_custom SET ";
+                    for ($col = 0; $col < $numCol; $col++)
+                    {
+                        // Is it a custom field?
+                        if ($aFamColumnCustom[$col])
+                        {
+                            $colID = substr($aColumnID[$col],1);
+                            $currentType = $afamCustomTypes[$colID];
+                            $currentFieldData = trim($aData[$col]);
+
+                            // If date, first parse it to the standard format..
+                            if ($currentType == 2)
+                            {
+                                $aDate = ParseDate($currentFieldData,$iDateMode);
+                                if ($aDate[0] == 'NULL' || $aDate[1] == 'NULL' || $aDate[2] == 'NULL'){
+                                    $currentFieldData = "";
+                                } else {
+                                    $currentFieldData = implode("-",$aDate);
+                                }
+                            }
+                            // If boolean, convert to the expected values for custom field
+                            elseif ($currentType == 1)
+                            {
+                                if (strlen($currentFieldData))
+                                    $currentFieldData = ConvertToBoolean($currentFieldData);
+                            }
+                            else
+                                $currentFieldData = addslashes($currentFieldData);
+
+                            // aColumnID is the custom table column name
+                            sqlCustomField($sSQLFamCustom, $currentType, $currentFieldData, $colID, $sCountry);
+                        }
+                    }
+
+                    // Finalize and run the update for the person_custom table.
+                    $sSQLFamCustom = substr($sSQLFamCustom,0,-2);
+                    $sSQLFamCustom .= " WHERE fam_ID = " . $famid;
+                    RunQuery($sSQLFamCustom);
+                }
             }
 
             if ($bHasCustom)
             {
-               // Get the last inserted person ID and insert a dummy row in the person_custom table
-               $sSQL = "SELECT MAX(per_ID) AS iPersonID FROM person_per";
-               $rsPersonID = RunQuery($sSQL);
-               extract(mysql_fetch_array($rsPersonID));
-               $sSQL = "INSERT INTO `person_custom` (`per_ID`) VALUES ('" . $iPersonID . "')";
-               RunQuery($sSQL);
+                // Get the last inserted person ID and insert a dummy row in the person_custom table
+                $sSQL = "SELECT MAX(per_ID) AS iPersonID FROM person_per";
+                $rsPersonID = RunQuery($sSQL);
+                extract(mysql_fetch_array($rsPersonID));
+                $sSQL = "INSERT INTO `person_custom` (`per_ID`) VALUES ('" . $iPersonID . "')";
+                RunQuery($sSQL);
 
-               // Build the person_custom SQL
-               for ($col = 0; $col < $numCol; $col++)
-               {
-				// Is it a custom field?
-				if ($aColumnCustom[$col])
-                  {
-                     $currentType = $aCustomTypes[$aColumnID[$col]];
-                     $currentFieldData = trim($aData[$col]);
+                // Build the person_custom SQL
+                for ($col = 0; $col < $numCol; $col++)
+                {
+                    // Is it a custom field?
+                    if ($aColumnCustom[$col])
+                    {
+                        $currentType = $aCustomTypes[$aColumnID[$col]];
+                        $currentFieldData = trim($aData[$col]);
 
-                     // If date, first parse it to the standard format..
-                     if ($currentType == 2)
-                     {
-                        $aDate = ParseDate($currentFieldData,$iDateMode);
-						if ($aDate[0] == 'NULL' || $aDate[1] == 'NULL' || $aDate[2] == 'NULL'){
-	                        $currentFieldData = "";
-						}else{
-							$currentFieldData = implode("-",$aDate);
-						}
-                     }
-                     // If boolean, convert to the expected values for custom field
-                     elseif ($currentType == 1)
-                     {
-						if (strlen($currentFieldData))
-						{
-							$currentFieldData = ConvertToBoolean($currentFieldData);
-						}
-					 }
-                     else
-								$currentFieldData = addslashes($currentFieldData);
+                        // If date, first parse it to the standard format..
+                        if ($currentType == 2)
+                        {
+                            $aDate = ParseDate($currentFieldData,$iDateMode);
+                            if ($aDate[0] == 'NULL' || $aDate[1] == 'NULL' || $aDate[2] == 'NULL'){
+                                $currentFieldData = "";
+                            } else {
+                                $currentFieldData = implode("-",$aDate);
+                            }
+                        }
+                        // If boolean, convert to the expected values for custom field
+                        elseif ($currentType == 1)
+                        {
+                            if (strlen($currentFieldData))
+                            {
+                            $currentFieldData = ConvertToBoolean($currentFieldData);
+                            }
+                        }
+                        else
+                            $currentFieldData = addslashes($currentFieldData);
 
-                     // aColumnID is the custom table column name
-                     sqlCustomField($sSQLcustom, $currentType, $currentFieldData, $aColumnID[$col], $sCountry);
-						}
-					}
+                        // aColumnID is the custom table column name
+                        sqlCustomField($sSQLcustom, $currentType, $currentFieldData, $aColumnID[$col], $sCountry);
+                    }
+                }
 
-					// Finalize and run the update for the person_custom table.
-					$sSQLcustom = substr($sSQLcustom,0,-2);
-					$sSQLcustom .= " WHERE per_ID = " . $iPersonID;
-					RunQuery($sSQLcustom);
-				}
+                // Finalize and run the update for the person_custom table.
+                $sSQLcustom = substr($sSQLcustom,0,-2);
+                $sSQLcustom .= " WHERE per_ID = " . $iPersonID;
+                RunQuery($sSQLcustom);
+            }
 
             $importCount++;
         }
@@ -770,7 +774,7 @@ if (isset($_POST["DoImport"]))
 
         // delete the temp file
         unlink($csvTempFile);
-        
+
         // role assignments from config
         $aDirRoleHead = explode(",",$sDirRoleHead);
         $aDirRoleSpouse = explode(",",$sDirRoleSpouse);
@@ -780,7 +784,7 @@ if (isset($_POST["DoImport"]))
         foreach($Families as $fid=>$family)
         {
             $family->AssignRoles();
-            foreach($family->Members as $member) 
+            foreach($family->Members as $member)
             {
                 switch($member['role'])
                 {
@@ -799,13 +803,18 @@ if (isset($_POST["DoImport"]))
                 $sSQL = "UPDATE person_per SET per_fmr_ID = " . $iRole . " WHERE per_ID = " . $member['personid'];
                 RunQuery($sSQL);
             }
-            $sSQL = "UPDATE family_fam SET fam_WeddingDate = " . "'" . $family->WeddingDate. "'";
-			if($family->Phone != "")    $sSQL.= ", fam_HomePhone =" . "'" . $family->Phone . "'";
 
-            if($family->Envelope != 0)    $sSQL.= ", fam_Envelope  = " . $family->Envelope;
+            $sSQL = "UPDATE family_fam SET fam_WeddingDate = " . "'" . $family->WeddingDate. "'";
+
+            if($family->Phone != "")
+                $sSQL.= ", fam_HomePhone =" . "'" . $family->Phone . "'";
+
+            if($family->Envelope != 0)
+                $sSQL.= ", fam_Envelope  = " . $family->Envelope;
+
             $sSQL.=  " WHERE fam_ID = " . $fid;
             RunQuery($sSQL);
-    }
+        }
 
         $iStage = 3;
     }
@@ -819,14 +828,14 @@ if(isset($_POST["Clear"]))
 {
     if(isset($_POST["chkClear"]))
     {
-        $sSQL = "TRUNCATE `family_fam`;";    
+        $sSQL = "TRUNCATE `family_fam`;";
         RunQuery($sSQL);
         $sSQL = "TRUNCATE `person_per`;";
         RunQuery($sSQL);
-    		$sSQL = "TRUNCATE `person_custom`;";
-		    RunQuery($sSQL);
-    		$sSQL = "TRUNCATE `family_custom`;";
-		    RunQuery($sSQL);
+        $sSQL = "TRUNCATE `person_custom`;";
+        RunQuery($sSQL);
+        $sSQL = "TRUNCATE `family_custom`;";
+        RunQuery($sSQL);
         $sSQL = "INSERT INTO person_per VALUES (1,NULL,'ChurchInfo',NULL,'Admin',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,0,0,0000,NULL,0,0,0,0,NULL,NULL,'2004-08-25 18:00:00',0,0,NULL,0);";
         RunQuery($sSQL);
         $sClear = gettext("Data Cleared Successfully!");
@@ -840,21 +849,21 @@ if(isset($_POST["Clear"]))
 if ($iStage == 1)
 {
     // Display the select file form
-    echo ' 
+    echo '
         <p style="color: red">' . $csvError . '</p>
         <form method="post" action="CSVImport.php" enctype="multipart/form-data">
-        <input class="icTinyButton" type="file" name="CSVfile"> 
+        <input class="icTinyButton" type="file" name="CSVfile">
         <input type="submit" class="icButton" value="' . gettext("Upload CSV File") . '"
         name="UploadCSV">
         </form><br/><br/><br/><br/>
         <form method="post" action="CSVImport.php" enctype="multipart/form-data">'
-        .gettext("Are you sure?"). ' 
+        .gettext("Are you sure?"). '
         <input type="checkbox" name="chkClear" value=' . "'0'>" . '
         <input type="submit" class="icButton" value="'. gettext("Clear Persons and Families").'"
         name="Clear">
         <p style="color: red">' .
         gettext("Warning!  Do not select this option if you plan to add to an existing database.<br/>") .
-        gettext("Use only if unsatisfied with initial import.  All person and member data will be destroyed!");            
+        gettext("Use only if unsatisfied with initial import.  All person and member data will be destroyed!");
     echo '</p></form>';
     echo $sClear;
 }
@@ -878,7 +887,7 @@ function ParseDate($sDate,$iDateMode)
     $aDate[0] = "0000";
     $aDate[1] = "00";
     $aDate[2] = "00";
-    
+
     switch($iDateMode)
     {
         // International standard: YYYY-MM-DD
@@ -888,9 +897,9 @@ function ParseDate($sDate,$iDateMode)
                 $sDate = str_replace($cSeparator,"",$sDate);
              if(strlen($sDate) == 8)
              {
-                $aDate[0] = substr($sDate,0,4);	
-                $aDate[1] = substr($sDate,4,2);	
-                $aDate[2] = substr($sDate,6,2);	
+                $aDate[0] = substr($sDate,0,4);
+                $aDate[1] = substr($sDate,4,2);
+                $aDate[2] = substr($sDate,6,2);
              }
             break;
 
@@ -937,14 +946,14 @@ function ParseDate($sDate,$iDateMode)
             break;
     }
     if( (0 + $aDate[0]) < 1901 || (0 + $aDate[0]) > 2155 ) {
-		$aDate[0] = "NULL";
-	}
-	if( (0 + $aDate[1]) < 0  || (0 + $aDate[1]) > 12 ) {
-		$aDate[1] = "NULL";
-	}
-	if( (0 + $aDate[2]) < 0  || (0 + $aDate[2]) > 31 ) {
-		$aDate[2] = "NULL";
-	}
+        $aDate[0] = "NULL";
+    }
+    if( (0 + $aDate[1]) < 0  || (0 + $aDate[1]) > 12 ) {
+        $aDate[1] = "NULL";
+    }
+    if( (0 + $aDate[2]) < 0  || (0 + $aDate[2]) > 31 ) {
+        $aDate[2] = "NULL";
+    }
     return $aDate;
 }
 

--- a/churchinfo/CSVImport.php
+++ b/churchinfo/CSVImport.php
@@ -217,28 +217,28 @@ if (isset($_POST["UploadCSV"]))
         ?>
             <td>
             <select name="<?= "col" . $col ?>">
-                <option value="0"><?php echo gettext("Ignore this Field"); ?></option>
-                <option value="1"><?php echo gettext("Title"); ?></option>
-                <option value="2"><?php echo gettext("First Name"); ?></option>
-                <option value="3"><?php echo gettext("Middle Name"); ?></option>
-                <option value="4"><?php echo gettext("Last Name"); ?></option>
-                <option value="5"><?php echo gettext("Suffix"); ?></option>
-                <option value="6"><?php echo gettext("Gender"); ?></option>
-                <option value="7"><?php echo gettext("Donation Envelope"); ?></option>
-                <option value="8"><?php echo gettext("Address1"); ?></option>
-                <option value="9"><?php echo gettext("Address2"); ?></option>
-                <option value="10"><?php echo gettext("City"); ?></option>
-                <option value="11"><?php echo gettext("State"); ?></option>
-                <option value="12"><?php echo gettext("Zip"); ?></option>
-                <option value="13"><?php echo gettext("Country"); ?></option>
-                <option value="14"><?php echo gettext("Home Phone"); ?></option>
-                <option value="15"><?php echo gettext("Work Phone"); ?></option>
-                <option value="16"><?php echo gettext("Mobile Phone"); ?></option>
-                <option value="17"><?php echo gettext("Email"); ?></option>
-                <option value="18"><?php echo gettext("Work / Other Email"); ?></option>
-                <option value="19"><?php echo gettext("Birth Date"); ?></option>
-                <option value="20"><?php echo gettext("Membership Date"); ?></option>
-                <option value="21"><?php echo gettext("Wedding Date"); ?></option>
+                <option value="0"><?= gettext("Ignore this Field"); ?></option>
+                <option value="1"><?= gettext("Title"); ?></option>
+                <option value="2"><?= gettext("First Name"); ?></option>
+                <option value="3"><?= gettext("Middle Name"); ?></option>
+                <option value="4"><?= gettext("Last Name"); ?></option>
+                <option value="5"><?= gettext("Suffix"); ?></option>
+                <option value="6"><?= gettext("Gender"); ?></option>
+                <option value="7"><?= gettext("Donation Envelope"); ?></option>
+                <option value="8"><?= gettext("Address1"); ?></option>
+                <option value="9"><?= gettext("Address2"); ?></option>
+                <option value="10"><?= gettext("City"); ?></option>
+                <option value="11"><?= gettext("State"); ?></option>
+                <option value="12"><?= gettext("Zip"); ?></option>
+                <option value="13"><?= gettext("Country"); ?></option>
+                <option value="14"><?= gettext("Home Phone"); ?></option>
+                <option value="15"><?= gettext("Work Phone"); ?></option>
+                <option value="16"><?= gettext("Mobile Phone"); ?></option>
+                <option value="17"><?= gettext("Email"); ?></option>
+                <option value="18"><?= gettext("Work / Other Email"); ?></option>
+                <option value="19"><?= gettext("Birth Date"); ?></option>
+                <option value="20"><?= gettext("Membership Date"); ?></option>
+                <option value="21"><?= gettext("Wedding Date"); ?></option>
                 <?= $sPerCustomFieldList.$sFamCustomFieldList; ?>
             </select>
             </td>
@@ -248,19 +248,19 @@ if (isset($_POST["UploadCSV"]))
         echo "</table>";
         ?>
         <BR>
-        <input type="checkbox" value="1" name="IgnoreFirstRow"><?php echo gettext("Ignore first CSV row (to exclude a header)"); ?>
+        <input type="checkbox" value="1" name="IgnoreFirstRow"><?= gettext("Ignore first CSV row (to exclude a header)"); ?>
         <BR><BR>
         <BR>
         <input type="checkbox" value="1" name="MakeFamilyRecords" checked="true">
-        <select name="bundleFamCustom">
+        <select name="MakeFamilyRecordsMode">
             <option value="0"><?= gettext("Make Family records based on last name and address") ?></option>
             <?= $sPerCustomFieldList.$sFamCustomFieldList; ?>
         </select>
 
         <BR><BR>
         <select name="FamilyMode">
-            <option value="0"><?php echo gettext("Patriarch");?></option>
-            <option value="1"><?php echo gettext("Matriarch");?></option>
+            <option value="0"><?= gettext("Patriarch");?></option>
+            <option value="1"><?= gettext("Matriarch");?></option>
         </select>
         <?= gettext("Family Type: used with Make Family records... option above"); ?>
         <BR><BR>
@@ -595,10 +595,28 @@ if (isset($_POST["DoImport"]))
                 $rsNewPerson = RunQuery($sSQL);
                 extract(mysql_fetch_array($rsNewPerson));
 
-                // see if there is a family with same last name and address
-                $sSQL = "SELECT fam_ID, fam_name, fam_Address1
-                         FROM family_fam where fam_Name = '".addslashes($per_LastName)."'
-                         AND fam_Address1 = '".$sAddress1."'"; // slashes added already
+                // see if there is a family...
+                if (!isset($_POST["MakeFamilyRecordsMode"]) || $_POST["MakeFamilyRecordsMode"] == "0")
+                {
+                    // ...with same last name and address
+                    $sSQL = "SELECT fam_ID
+                             FROM family_fam where fam_Name = '".addslashes($per_LastName)."'
+                             AND fam_Address1 = '".$sAddress1."'"; // slashes added already
+                } else {
+                    // ...with the same custom field values
+                    $field = $_POST["MakeFamilyRecordsMode"];
+                    $field_value = '';
+                    for ($col = 0; $col < $numCol; $col++)
+                    {
+                        if ($aFamColumnCustom[$col] && $field == $aColumnID[$col])
+                        {
+                            $field_value = trim($aData[$col]);
+                            break;
+                        }
+                    }
+                    $sSQL = "SELECT f.fam_ID FROM family_fam f, family_custom c
+                             WHERE f.fam_ID = c.fam_ID AND c.".addslashes(substr($field,1))." = '".addslashes($field_value)."'";
+                }
                 $rsExistingFamily = RunQuery($sSQL);
                 $famid = 0;
                 if(mysql_num_rows($rsExistingFamily) > 0)


### PR DESCRIPTION
This adds an import feature that allows families to be created for persons that share a common custom family property value (like a numerical _family ID_). This makes importing member directories easier if they are dumped from a software that supports family IDs and if lots of families are in the data set that do not share last names.

The meat is in f9ca97b. The other commit adds the select box and fixes a ton of whitespace issues (sorry, I'm a little OCD about this, but I think this improves the readability of the code).

Btw. do you guys have a design document about what you plan to include in the API?