### PR TITLE
Database setup script

### DIFF
--- a/mysql/database_setup_and_install.sh
+++ b/mysql/database_setup_and_install.sh
@@ -14,25 +14,39 @@ CRM_DB_USER="churchcrm"
 CRM_DB_PASS="churchcrm"
 CRM_DB_NAME="churchcrm"
 
+# autodetect if mysql is installed through Mac homebrew
+MYSQLPATH=`readlink $(which mysql) | cut -c-10`
+if [[ "x$MYSQLPATH" != "x../Cellar/" ]]; then
+  # it is not!
+  SUDO="sudo"
+  PASS="-p\"$DB_PASS\""
+fi
+
 RET=1
-while [[ RET -ne 0 ]]; do
+while [[ 1 ]]; do
     echo "Database: Waiting for confirmation of MySQL service startup"
-    sleep 5
-    sudo mysql -u"$DB_USER" -p"$DB_PASS" -e "status" > /dev/null 2>&1
+    $SUDO mysql -u"$DB_USER" $PASS -e "status" > /dev/null 2>&1
     RET=$?
+    if [[ RET -ne 0 ]]; then
+      # wait and try again
+      sleep 5
+    else
+      # mysql server is running
+      break
+    fi
 done
 
 echo "Database: mysql started"
 
-sudo mysql -u"$DB_USER" -p"$DB_PASS" -e "CREATE DATABASE $CRM_DB_NAME CHARACTER SET utf8;"
+$SUDO mysql -u"$DB_USER" $PASS -e "CREATE DATABASE $CRM_DB_NAME CHARACTER SET utf8;"
 
 echo "Database: created"
 
-sudo mysql -u"$DB_USER" -p"$DB_PASS" -e "CREATE USER '$CRM_DB_USER'@'$DB_HOST' IDENTIFIED BY '$CRM_DB_PASS';"
-sudo mysql -u"$DB_USER" -p"$DB_PASS" -e "GRANT ALL PRIVILEGES ON $CRM_DB_NAME.* TO '$CRM_DB_NAME'@'$DB_HOST' WITH GRANT OPTION;"
+$SUDO mysql -u"$DB_USER" $PASS -e "CREATE USER '$CRM_DB_USER'@'$DB_HOST' IDENTIFIED BY '$CRM_DB_PASS';"
+$SUDO mysql -u"$DB_USER" $PASS -e "GRANT ALL PRIVILEGES ON $CRM_DB_NAME.* TO '$CRM_DB_NAME'@'$DB_HOST' WITH GRANT OPTION;"
 
 echo "Database: user created with needed PRIVILEGES"
 
-sudo mysql -u"$CRM_DB_USER" -p"$CRM_DB_PASS" "$CRM_DB_NAME" < $CRM_DB_INSTALL_SCRIPT
+$SUDO mysql -u"$CRM_DB_USER" -p"$CRM_DB_PASS" "$CRM_DB_NAME" < $CRM_DB_INSTALL_SCRIPT
 
 echo "Database: tables and metadata deployed"


### PR DESCRIPTION
This is a suggestion for the mysql DB setup script. It autodetects if mysql is installed on a mac via homebrew and changes the mysql cals accordingly (use the current user without sudo, and connect without a password). This may need some further testing...

I've also removed the 5sec delay in the loop if the mysql server is up already (the likely code path).