### PR TITLE
Avoid string concatenation in <?= ?>, normalize logic operators

### DIFF
--- a/churchinfo/CSVCreateFile.php
+++ b/churchinfo/CSVCreateFile.php
@@ -503,7 +503,7 @@ else
 							$type_ID = "";
 
 							extract($aCustomField);
-							if (($aSecurityType[$custom_FieldSec] == 'bAll') or ($_SESSION[$aSecurityType[$custom_FieldSec]]))
+							if ($aSecurityType[$custom_FieldSec] == 'bAll' || $_SESSION[$aSecurityType[$custom_FieldSec]])
 							{
 								if (isset($_POST["$custom_Field"]))
 								{

--- a/churchinfo/CSVCreateFile.php
+++ b/churchinfo/CSVCreateFile.php
@@ -295,7 +295,7 @@ else
 		while($aFamRow = mysql_fetch_array($rsFamCustomFields))
 		{
 			extract($aFamRow);
-			if (($aSecurityType[$fam_custom_FieldSec] == 'bAll') or ($_SESSION[$aSecurityType[$fam_custom_FieldSec]]))
+			if (($aSecurityType[$fam_custom_FieldSec] == 'bAll') || ($_SESSION[$aSecurityType[$fam_custom_FieldSec]]))
 			{			
 				if (isset($_POST["$fam_custom_Field"]))
 				{
@@ -311,7 +311,7 @@ else
 		while($aFamRow = mysql_fetch_array($rsFamCustomFields))
 		{
 			extract($aFamRow);
-			if (($aSecurityType[$fam_custom_FieldSec] == 'bAll') or ($_SESSION[$aSecurityType[$fam_custom_FieldSec]]))
+			if (($aSecurityType[$fam_custom_FieldSec] == 'bAll') || ($_SESSION[$aSecurityType[$fam_custom_FieldSec]]))
 			{			
 				if (isset($_POST["$fam_custom_Field"]))
 				{

--- a/churchinfo/CSVExport.php
+++ b/churchinfo/CSVExport.php
@@ -192,7 +192,7 @@ require "Include/Header.php";
   </table>
     </td>
 
-    <?php if (($numCustomFields > 0) or ($numFamCustomFields > 0)) { ?>
+    <?php if ($numCustomFields > 0 || $numFamCustomFields > 0) { ?>
     <td width="20%" valign="top"><table border="0">
     <?php if ($numCustomFields > 0) { ?>
     <tr><td width="100%" valign="top" align="left">
@@ -202,7 +202,7 @@ require "Include/Header.php";
             // Display the custom fields
             while ($Row = mysql_fetch_array($rsCustomFields)) {
                 extract($Row);
-                if (($aSecurityType[$custom_FieldSec] == 'bAll') or ($_SESSION[$aSecurityType[$custom_FieldSec]]))
+                if ($aSecurityType[$custom_FieldSec] == 'bAll' || $_SESSION[$aSecurityType[$custom_FieldSec]])
                 {
                     echo "<tr><td class=\"LabelColumn\">" . $custom_Name . "</td>";
                     echo "<td class=\"TextColumn\"><input type=\"checkbox\" name=" . $custom_Field . " value=\"1\"></td></tr>";
@@ -221,7 +221,7 @@ require "Include/Header.php";
             // Display the family custom fields
             while ($Row = mysql_fetch_array($rsFamCustomFields)) {
                 extract($Row);
-                if (($aSecurityType[$fam_custom_FieldSec] == 'bAll') or ($_SESSION[$aSecurityType[$fam_custom_FieldSec]]))
+                if ($aSecurityType[$fam_custom_FieldSec] == 'bAll' || $_SESSION[$aSecurityType[$fam_custom_FieldSec]])
                 {
                     echo "<tr><td class=\"LabelColumn\">" . $fam_custom_Name . "</td>";
                     echo "<td class=\"TextColumn\"><input type=\"checkbox\" name=" . $fam_custom_Field . " value=\"1\"></td></tr>";
@@ -244,7 +244,7 @@ require "Include/Header.php";
         <td class="TextColumnWithBottomBorder">
             <select name="Source">
                 <option value="filters"><?= gettext("Based on filters below..") ?></option>
-                <option value="cart" <?php if (array_key_exists ("Source", $_GET) and $_GET["Source"] == 'cart') echo "selected";?>><?= gettext("People in Cart (filters ignored)") ?></option>
+                <option value="cart" <?php if (array_key_exists("Source", $_GET) && $_GET["Source"] == 'cart') echo "selected";?>><?= gettext("People in Cart (filters ignored)") ?></option>
             </select>
         </td>
     </tr>

--- a/churchinfo/CSVImport.php
+++ b/churchinfo/CSVImport.php
@@ -421,7 +421,7 @@ if (isset($_POST["DoImport"]))
             for ($col = 0; $col < $numCol; $col++)
             {
                 // Is it not a custom field?
-                if (!$aColumnCustom[$col] and !$aFamColumnCustom[$col])
+                if (!$aColumnCustom[$col] && !$aFamColumnCustom[$col])
                 {
                     $currentType = $aColumnID[$col];
 
@@ -567,7 +567,7 @@ if (isset($_POST["DoImport"]))
             for ($col = 0; $col < $numCol; $col++)
             {
                 // Is it not a custom field?
-                if (!$aColumnCustom[$col] and !$aFamColumnCustom[$col])
+                if (!$aColumnCustom[$col] && !$aFamColumnCustom[$col])
                 {
                     $currentType = $aColumnID[$col];
                     switch($currentType)

--- a/churchinfo/CartView.php
+++ b/churchinfo/CartView.php
@@ -42,7 +42,7 @@ require "Include/Header.php"; ?>
 <div class="box box-body">
 <?php
 // Confirmation message that people where added to Event from Cart
-if (array_key_exists('aPeopleCart', $_SESSION) and count($_SESSION['aPeopleCart']) == 0) {
+if (array_key_exists('aPeopleCart', $_SESSION) && count($_SESSION['aPeopleCart']) == 0) {
         if (!array_key_exists("Message", $_GET)) { ?>
              <p class="text-center callout callout-warning"><?= gettext("You have no items in your cart.") ?> </p>
         <?php } else {
@@ -294,19 +294,19 @@ if (array_key_exists('aPeopleCart', $_SESSION) and count($_SESSION['aPeopleCart'
                 echo '  <td>';
                 echo '  <input name="bulkmailpresort" type="checkbox" onclick="codename()"';
                 echo '  id="BulkMailPresort" value="1" ';
-                if (array_key_exists ("buildmailpresort", $_COOKIE) and $_COOKIE["bulkmailpresort"])
+                if (array_key_exists("buildmailpresort", $_COOKIE) && $_COOKIE["bulkmailpresort"])
                     echo "checked";
                 echo '  ><br></td></tr>';
 
                 echo '  <tr><td>' . gettext("Quiet Presort") . '</td>';
                 echo '  <td>';
                 echo '  <input ';
-                if (array_key_exists ("buildmailpresort", $_COOKIE) and !$_COOKIE["bulkmailpresort"])
+                if (array_key_exists("buildmailpresort", $_COOKIE) && !$_COOKIE["bulkmailpresort"])
                     echo 'disabled ';   // This would be better with $_SESSION variable
                                         // instead of cookie ... (save $_SESSION in MySQL)
                 echo 'name="bulkmailquiet" type="checkbox" onclick="codename()"';
                 echo '  id="QuietBulkMail" value="1" ';
-                if (array_key_exists ("bulkmailquiet", $_COOKIE) and $_COOKIE["bulkmailquiet"] && array_key_exists ("buildmailpresort", $_COOKIE) and $_COOKIE["bulkmailpresort"])
+                if (array_key_exists("bulkmailquiet", $_COOKIE) && $_COOKIE["bulkmailquiet"] && array_key_exists("buildmailpresort", $_COOKIE) && $_COOKIE["bulkmailpresort"])
                     echo "checked";
                 echo '  ><br></td></tr>';
 
@@ -382,7 +382,7 @@ if (array_key_exists('aPeopleCart', $_SESSION) and count($_SESSION['aPeopleCart'
             $aRow = mysql_fetch_array($rsPendingEmail);
             extract($aRow);
 
-            if ($emp_to_send==0 && $countrecipients==0) {
+            if ($emp_to_send == 0 && $countrecipients == 0) {
                 // if both are zero the email job has not started.  In this
                 // case the user may edit the email and/or change the distribution
 

--- a/churchinfo/DepositSlipEditor.php
+++ b/churchinfo/DepositSlipEditor.php
@@ -578,7 +578,7 @@ require "Include/Header.php";
 			<input type="button" class="btn" value="Download OFX" name="DownloadOFX" onclick="javascript:document.location='Reports/ExportOFX.php?deposit=<?= $iDepositSlipID ?>';">
 			<input type="button" class="btn" value="<?= gettext("More Reports") ?>" name="DepositSlipGeneratePDF" onclick="javascript:document.location='FinancialReports.php';">
 			<?php
-			if ($iDepositSlipID and $sDepositType and !$dep_Closed) {
+			if ($iDepositSlipID && $sDepositType && !$dep_Closed) {
 				if ($sDepositType == "eGive") {
 					echo "<input type=button class=btn value=\"".gettext("Import eGive")."\" name=ImporteGive onclick=\"javascript:document.location='eGive.php?DepositSlipID=$iDepositSlipID&linkBack=DepositSlipEditor.php?DepositSlipID=$iDepositSlipID&PledgeOrPayment=Payment&CurrentDeposit=$iDepositSlipID';\">";
 				} else {
@@ -603,7 +603,7 @@ require "Include/Header.php";
 
 
 			<?php
-			if (!$iDepositSlipID or !$sDepositType)
+			if (!$iDepositSlipID || !$sDepositType)
 			{
 				$selectOther = "";
 				$selectCreditCard = "";

--- a/churchinfo/DirectoryReports.php
+++ b/churchinfo/DirectoryReports.php
@@ -189,7 +189,7 @@ while ($aRow = mysql_fetch_array($rsSecurityGrp))
          <?php
          if ($numCustomFields > 0) {
             while ( $rowCustomField = mysql_fetch_array($rsCustomFields, MYSQL_ASSOC) ){
-					if (($aSecurityType[$rowCustomField['custom_FieldSec']] == 'bAll') or ($_SESSION[$aSecurityType[$rowCustomField['custom_FieldSec']]]))
+					if (($aSecurityType[$rowCustomField['custom_FieldSec']] == 'bAll') || ($_SESSION[$aSecurityType[$rowCustomField['custom_FieldSec']]]))
 					{ ?>
 		            <input type="checkbox" Name="bCustom<?= $rowCustomField['custom_Order'] ?>" value="1" checked><?= $rowCustomField['custom_Name'] ?><br>
          <?php

--- a/churchinfo/EmailEditor.php
+++ b/churchinfo/EmailEditor.php
@@ -41,7 +41,7 @@ $sEmailSubject = "";
 $sEmailMessage = "";
 $sEmailAttachName = "";
 
-if (array_key_exists ('mysql', $_POST) and $_POST['mysql'] == 'true') {
+if (array_key_exists ('mysql', $_POST) && $_POST['mysql'] == 'true') {
 
     // There is a subject and message already stored in mysql
     $sSQL = "SELECT * FROM email_message_pending_emp ".

--- a/churchinfo/EventAttendance.php
+++ b/churchinfo/EventAttendance.php
@@ -18,7 +18,7 @@
 require "Include/Config.php";
 require "Include/Functions.php";
 
-if (array_key_exists ('Action', $_POST) and $_POST['Action'] == "Retrieve" && !empty($_POST['Event']))
+if (array_key_exists('Action', $_POST) && $_POST['Action'] == "Retrieve" && !empty($_POST['Event']))
 {
     if ($_POST['Choice'] == "Attendees")
     {
@@ -63,7 +63,7 @@ if (array_key_exists ('Action', $_POST) and $_POST['Action'] == "Retrieve" && !e
         $sPageTitle = gettext("Event Guests");
     }
 }
-elseif (array_key_exists ('Action', $_GET) and $_GET['Action']== "List" && !empty($_GET['Event']))
+elseif (array_key_exists('Action', $_GET) && $_GET['Action']== "List" && !empty($_GET['Event']))
 {
     $sSQL = "SELECT * FROM events_event WHERE event_type = ".$_GET['Event']." ORDER BY event_start";
 
@@ -87,7 +87,7 @@ for ($row = 1; $row <= $numRows; $row++)
     $aRow = mysql_fetch_assoc($rsOpps);
     extract($aRow);
 
-    if (array_key_exists ('Action', $_GET) and $_GET['Action'] == "List")
+    if (array_key_exists ('Action', $_GET) & $_GET['Action'] == "List")
     {
         $aEventID[$row] = $event_id;
         $aEventTitle[$row] = htmlentities(stripslashes($event_title),ENT_NOQUOTES, "UTF-8");
@@ -111,7 +111,7 @@ for ($row = 1; $row <= $numRows; $row++)
 <table cellpadding="4" align="center" cellspacing="0" width="60%">
 
 <?php
-if (array_key_exists ('Action', $_GET) and $_GET['Action'] == "List" && $numRows > 0)
+if (array_key_exists ('Action', $_GET) && $_GET['Action'] == "List" && $numRows > 0)
 {
 ?>
        <caption>
@@ -218,8 +218,8 @@ elseif ($_POST['Action']== "Retrieve" && $numRows > 0)
          ?>
          <tr class="<?= $sRowClass ?>">
            <td class="TextColumn"><?= FormatFullName($aTitle[$row],$aFistName[$row],$aMiddleName[$row],$aLastName[$row],$aSuffix[$row],3) ?></td>
-           <td class="TextColumn"><?= $aEmail[$row] ? '<a href="mailto:'.$aEmail[$row].'" title="Send Email">'.$aEmail[$row].'</a>':'Not Available' ?></td>
-           <td class="TextColumn"><?= ($aHomePhone[$row] ? $aHomePhone[$row]:'Not Available') ?></td>
+           <td class="TextColumn"><?= $aEmail[$row] ? '<a href="mailto:' . $aEmail[$row] . '" title="Send Email">' . $aEmail[$row] . '</a>' : 'Not Available' ?></td>
+           <td class="TextColumn"><?= $aHomePhone[$row] ? $aHomePhone[$row] : 'Not Available' ?></td>
 <?php
 // AddToCart call to go here
 ?>
@@ -232,7 +232,7 @@ else
 {
 ?>
        <caption>
-         <h3><?= ($_GET ? gettext("There are no events in this category"):gettext("There are no Records")) ?><br><br></h3>
+         <h3><?= $_GET ? gettext("There are no events in this category") : gettext("There are no Records") ?><br><br></h3>
        </caption>
        <tr><td>&nbsp;</td></tr>
 <?php

--- a/churchinfo/FamilyEditor.php
+++ b/churchinfo/FamilyEditor.php
@@ -480,7 +480,7 @@ if (isset($_POST["FamilySubmit"]) || isset($_POST["FamilySubmitAndAdd"]))
 			while ( $rowCustomField = mysql_fetch_array($rsCustomFields, MYSQL_BOTH) )
 			{
 				extract($rowCustomField);
-				if (($aSecurityType[$fam_custom_FieldSec] == 'bAll') or ($_SESSION[$aSecurityType[$fam_custom_FieldSec]]))
+				if (($aSecurityType[$fam_custom_FieldSec] == 'bAll') || ($_SESSION[$aSecurityType[$fam_custom_FieldSec]]))
 				{
 					$currentFieldData = trim($aCustomData[$fam_custom_Field]);
 
@@ -883,7 +883,7 @@ require "Include/Header.php";
 		<?php mysql_data_seek($rsCustomFields,0);
 		while ( $rowCustomField = mysql_fetch_array($rsCustomFields, MYSQL_BOTH) ) {
 			extract($rowCustomField);
-			if (($aSecurityType[$fam_custom_FieldSec] == 'bAll') or ($_SESSION[$aSecurityType[$fam_custom_FieldSec]])) { ?>
+			if (($aSecurityType[$fam_custom_FieldSec] == 'bAll') || ($_SESSION[$aSecurityType[$fam_custom_FieldSec]])) { ?>
 			<div class="row">
 				<div class="form-group col-xs-5">
 				<label><?= $fam_custom_Name  ?> </label>
@@ -912,7 +912,9 @@ require "Include/Header.php";
 
 	<tr>
 		<td colspan="2">
-		<div class="MediumText"><center><?php if ($iFamilyID<0) { echo gettext("You may create family members now or add them later.  All entries will become <i>new</i> person records."); } ?></center></div><br><br>
+		<div class="MediumText">
+			<center><?= $iFamilyID < 0 ? gettext("You may create family members now or add them later.  All entries will become <i>new</i> person records.") : '' ?></center>
+		</div><br><br>
 		<table cellpadding="3" cellspacing="0" width="100%">
 		<thead>
 		<tr class="TableHeader" align="center">
@@ -1011,7 +1013,7 @@ require "Include/Header.php";
 				</select>
 			</td>
 			<td class="TextColumn">
-			<?php	if ((!array_key_exists ($iCount, $aperFlags) || (!$aperFlags[$iCount])) or ($_SESSION['bSeePrivacyData']))
+			<?php	if (!array_key_exists ($iCount, $aperFlags) || !$aperFlags[$iCount] || $_SESSION['bSeePrivacyData'])
 			{
 				$UpdateBirthYear = 1;
 			?>

--- a/churchinfo/FinancialReports.php
+++ b/churchinfo/FinancialReports.php
@@ -284,7 +284,7 @@ if ($sReportType == "") {
             ." &nbsp; <input name=only_owe type=radio value='no'>".gettext("All Families")."</td></tr>";
     }
     
-    if ($sReportType == "Giving Report" or $sReportType == "Zero Givers"){
+    if ($sReportType == "Giving Report" || $sReportType == "Zero Givers"){
         echo "<tr><td class=LabelColumn>".gettext("Report Heading:")."</td>"
             ."<td class=TextColumnWithBottomBorder><input name=letterhead type=radio value='graphic'>".gettext("Graphic")
             ." <input name=letterhead type=radio value='address' checked>".gettext("Church Address")

--- a/churchinfo/GroupView.php
+++ b/churchinfo/GroupView.php
@@ -35,7 +35,7 @@ $groupService = new GroupService();
 
 
 //Do they want to add this group to their cart?
-if (array_key_exists ('Action', $_GET) and $_GET['Action'] == 'AddGroupToCart')
+if (array_key_exists('Action', $_GET) && $_GET['Action'] == 'AddGroupToCart')
 {
     //Get all the members of this group
     $sSQL = 'SELECT per_ID FROM person_per, person2group2role_p2g2r WHERE per_ID = p2g2r_per_ID AND p2g2r_grp_ID = ' . $iGroupID;

--- a/churchinfo/Include/LabelFunctions.php
+++ b/churchinfo/Include/LabelFunctions.php
@@ -102,13 +102,13 @@ function LabelGroupSelect($fieldname)
 	echo "<td class=\"TextColumn\">";
 	echo "<input name=\"$fieldname\" type=\"radio\" value=\"indiv\" ";
 
-	if (array_key_exists ($fieldname, $_COOKIE) and $_COOKIE[$fieldname] != "fam")
+	if (array_key_exists($fieldname, $_COOKIE) && $_COOKIE[$fieldname] != "fam")
 		echo "checked";
 	
 	echo ">" . gettext("All Individuals") . "<br>";
 	echo "<input name=\"$fieldname\" type=\"radio\" value=\"fam\" ";
 
-	if (array_key_exists ($fieldname, $_COOKIE) and $_COOKIE[$fieldname] == "fam")
+	if (array_key_exists($fieldname, $_COOKIE) && $_COOKIE[$fieldname] == "fam")
 		echo "checked";
 
 	echo ">" . gettext("Grouped by Family") . "<br></td></tr>";
@@ -122,7 +122,7 @@ function ToParentsOfCheckBox($fieldname)
 	echo "<input name=\"$fieldname\" type=\"checkbox\" ";
 	echo "id=\"ToParent\" value=\"1\" ";
 
-	if (array_key_exists ($fieldname, $_COOKIE) and $_COOKIE[$fieldname])
+	if (array_key_exists($fieldname, $_COOKIE) && $_COOKIE[$fieldname])
 		echo "checked";
 	
 	echo "><br></td></tr>";

--- a/churchinfo/Include/class_fpdf_labels.php
+++ b/churchinfo/Include/class_fpdf_labels.php
@@ -146,7 +146,7 @@ class PDF_Label extends ChurchInfoReport
 	// Print a label
 	function Add_PDF_Label($texte) {
 		// We are in a new page, then we must add a page
-		if (($this->_COUNTX==0) and ($this->_COUNTY==0)) {
+		if ($this->_COUNTX == 0 && $this->_COUNTY == 0) {
 			$this->AddPage();
 		}
 

--- a/churchinfo/Include/phpmailer/class.phpmailer.php
+++ b/churchinfo/Include/phpmailer/class.phpmailer.php
@@ -741,7 +741,7 @@ class PHPMailer {
     } else {
       $params = sprintf("-oi -f %s", $this->Sender);
     }
-    if ($this->Sender != '' and !ini_get('safe_mode')) {
+    if ($this->Sender != '' && !ini_get('safe_mode')) {
       $old_from = ini_get('sendmail_from');
       ini_set('sendmail_from', $this->Sender);
       if ($this->SingleTo === true && count($toArr) > 1) {
@@ -1041,7 +1041,7 @@ class PHPMailer {
       $buf = '';
       for ($e = 0; $e<count($line_part); $e++) {
         $word = $line_part[$e];
-        if ($qp_mode and (strlen($word) > $length)) {
+        if ($qp_mode && (strlen($word) > $length)) {
           $space_left = $length - strlen($buf) - 1;
           if ($e != 0) {
             if ($space_left > 20) {
@@ -1084,7 +1084,7 @@ class PHPMailer {
           $buf_o = $buf;
           $buf .= ($e == 0) ? $word : (' ' . $word);
 
-          if (strlen($buf) > $length and $buf_o != '') {
+          if (strlen($buf) > $length && $buf_o != '') {
             $message .= $buf_o . $soft_break;
             $buf = $word;
           }
@@ -2115,9 +2115,9 @@ class PHPMailer {
    */
   protected function SetError($msg) {
     $this->error_count++;
-    if ($this->Mailer == 'smtp' and !is_null($this->smtp)) {
+    if ($this->Mailer == 'smtp' && !is_null($this->smtp)) {
       $lasterror = $this->smtp->getError();
-      if (!empty($lasterror) and array_key_exists('smtp_msg', $lasterror)) {
+      if (!empty($lasterror) && array_key_exists('smtp_msg', $lasterror)) {
         $msg .= '<p>' . $this->Lang('smtp_error') . $lasterror['smtp_msg'] . "</p>\n";
       }
     }

--- a/churchinfo/PersonEditor.php
+++ b/churchinfo/PersonEditor.php
@@ -255,7 +255,7 @@ if (isset($_POST["PersonSubmit"]) || isset($_POST["PersonSubmitAndAdd"]))
 	{
 		extract($rowCustomField);
 		
-		if (($aSecurityType[$custom_FieldSec] == 'bAll') or ($_SESSION[$aSecurityType[$custom_FieldSec]]))
+		if ($aSecurityType[$custom_FieldSec] == 'bAll' || $_SESSION[$aSecurityType[$custom_FieldSec]])
 		{
 			$currentFieldData = FilterInput($_POST[$custom_Field]);
 
@@ -374,7 +374,7 @@ if (isset($_POST["PersonSubmit"]) || isset($_POST["PersonSubmitAndAdd"]))
 			while ( $rowCustomField = mysql_fetch_array($rsCustomFields, MYSQL_BOTH) )
 			{
 				extract($rowCustomField);
-				if (($aSecurityType[$custom_FieldSec] == 'bAll') or ($_SESSION[$aSecurityType[$custom_FieldSec]]))
+				if ($aSecurityType[$custom_FieldSec] == 'bAll' || $_SESSION[$aSecurityType[$custom_FieldSec]])
 				{
 					$currentFieldData = trim($aCustomData[$custom_Field]);
 					sqlCustomField($sSQL, $type_ID, $currentFieldData, $custom_Field, $sPhoneCountry);

--- a/churchinfo/PersonEditor.php
+++ b/churchinfo/PersonEditor.php
@@ -950,7 +950,7 @@ require "Include/Header.php";
 				{
 					extract($rowCustomField);
 
-					if (($aSecurityType[$custom_FieldSec] == 'bAll') or ($_SESSION[$aSecurityType[$custom_FieldSec]]))
+					if ($aSecurityType[$custom_FieldSec] == 'bAll' || $_SESSION[$aSecurityType[$custom_FieldSec]])
 					{
 						echo "<div class='row'><div class=\"form-group col-xs-3\"><label>" . $custom_Name . "</label>";
 

--- a/churchinfo/PledgeEditor.php
+++ b/churchinfo/PledgeEditor.php
@@ -229,7 +229,7 @@ if (isset($_POST["PledgeSubmit"]) or
 		else
 			$iMethod = 'Check';
 	}
-	if (!$iEnvelope and $iFamily) {
+	if (!$iEnvelope && $iFamily) {
 		$sSQL = "SELECT fam_Envelope FROM family_fam WHERE fam_ID=\"" . $iFamily . "\";";
 		$rsEnv = RunQuery($sSQL);
 		extract(mysql_fetch_array($rsEnv));
@@ -256,7 +256,7 @@ if ($PledgeOrPayment == 'Pledge') { // Don't assign the deposit slip if this is 
 	}
 }
 
-if ($iMethod == "CASH" or $iMethod == "CHECK")
+if ($iMethod == "CASH" || $iMethod == "CHECK")
 	$dep_Type = "Bank";
 elseif ($iMethod == "CREDITCARD")
 	$dep_Type = "CreditCard";
@@ -267,7 +267,7 @@ if ($PledgeOrPayment == 'Payment') {
 	$bEnableNonDeductible = 1; // this could/should be a config parm?  regardless, having a non-deductible amount for a pledge doesn't seem possible
 }
 
-if (isset($_POST["PledgeSubmit"]) or isset($_POST["PledgeSubmitAndAdd"])) {
+if (isset($_POST["PledgeSubmit"]) || isset($_POST["PledgeSubmitAndAdd"])) {
 	//Initialize the error flag
 	$bErrorFlag = false;
 
@@ -307,17 +307,17 @@ if (isset($_POST["PledgeSubmit"]) or isset($_POST["PledgeSubmitAndAdd"])) {
 		$iAutID = FilterInput($_POST["AutoPay"]);
 	//$iEnvelope = FilterInput($_POST["Envelope"], 'int');
 
-	if ($PledgeOrPayment=='Payment' and !$iCheckNo and $iMethod == "CHECK") {
+	if ($PledgeOrPayment=='Payment' && !$iCheckNo && $iMethod == "CHECK") {
 		$sCheckNoError = "<span style=\"color: red; \">" . gettext("Must specify non-zero check number") . "</span>";
 		$bErrorFlag = true;
 	}
 
 	// detect check inconsistencies
-	if ($PledgeOrPayment=='Payment' and $iCheckNo) {
+	if ($PledgeOrPayment=='Payment' && $iCheckNo) {
 		if ($iMethod == "CASH") {
 			$sCheckNoError = "<span style=\"color: red; \">" . gettext("Check number not valid for 'CASH' payment") . "</span>";
 			$bErrorFlag = true;
-		} elseif ($iMethod=='CHECK' and !$sGroupKey) {
+		} elseif ($iMethod=='CHECK' && !$sGroupKey) {
 			$chkKey = $iFamily . "|" . $iCheckNo;
 			if (array_key_exists($chkKey, $checkHash)) {
 				$text = "Check number '" . $iCheckNo . "' for selected family already exists.";
@@ -337,13 +337,13 @@ if (isset($_POST["PledgeSubmit"]) or isset($_POST["PledgeSubmitAndAdd"])) {
 	}
 
 	//If no errors, then let's update...
-	if (!$bErrorFlag and !$dep_Closed) {
+	if (!$bErrorFlag && !$dep_Closed) {
 		// Only set PledgeOrPayment when the record is first created
 		// loop through all funds and create non-zero amount pledge records
 		foreach ($fundId2Name as $fun_id => $fun_name) {
 			if (!$iCheckNo) { $iCheckNo = 0; }
 			unset($sSQL);
-			if ($fund2PlgIds and array_key_exists($fun_id, $fund2PlgIds)) {
+			if ($fund2PlgIds && array_key_exists($fun_id, $fund2PlgIds)) {
 				if ($nAmount[$fun_id] > 0) {
 					$sSQL = "UPDATE pledge_plg SET plg_famID = '" . $iFamily . "',plg_FYID = '" . $iFYID . "',plg_date = '" . $dDate . "', plg_amount = '" . $nAmount[$fun_id] . "', plg_schedule = '" . $iSchedule . "', plg_method = '" . $iMethod . "', plg_comment = '" . $sComment[$fun_id] . "'";
 					$sSQL .= ", plg_DateLastEdited = '" . date("YmdHis") . "', plg_EditedBy = " . $_SESSION['iUserID'] . ", plg_CheckNo = '" . $iCheckNo . "', plg_scanString = '" . $tScanString . "', plg_aut_ID='" . $iAutID . "', plg_NonDeductible='" . $nNonDeductible[$fun_id] . "' WHERE plg_plgID='" . $fund2PlgIds[$fun_id] . "'";
@@ -351,7 +351,7 @@ if (isset($_POST["PledgeSubmit"]) or isset($_POST["PledgeSubmitAndAdd"])) {
 					$sSQL = "DELETE FROM pledge_plg WHERE plg_plgID =" . $fund2PlgIds[$fun_id];
 				}
 			} elseif ($nAmount[$fun_id] > 0) {
-				if ($iMethod <> "CHECK") {
+				if ($iMethod != "CHECK") {
 					$iCheckNo = "NULL";
 				}
 				if (!$sGroupKey) {
@@ -393,11 +393,11 @@ if (isset($_POST["PledgeSubmit"]) or isset($_POST["PledgeSubmitAndAdd"])) {
 			Redirect("PledgeEditor.php?CurrentDeposit=$iCurrentDeposit&PledgeOrPayment=" . $PledgeOrPayment . "&linkBack=", $linkBack);
 		}
 	} // end if !$bErrorFlag
-} elseif (isset($_POST["MatchFamily"]) or isset($_POST["MatchEnvelope"]) or isset($_POST["SetDefaultCheck"]) or isset($_POST["TotalAmount"])) {
+} elseif (isset($_POST["MatchFamily"]) || isset($_POST["MatchEnvelope"]) || isset($_POST["SetDefaultCheck"]) || isset($_POST["TotalAmount"])) {
 
 	//$iCheckNo = 0;
 	// Take care of match-family first- select the family based on the scanned check
-	if ($bUseScannedChecks and isset($_POST["MatchFamily"])) {
+	if ($bUseScannedChecks && isset($_POST["MatchFamily"])) {
 		$tScanString = FilterInput($_POST["ScanInput"]);
 
 		$routeAndAccount = $micrObj->FindRouteAndAccount ($tScanString); // use routing and account number for matching
@@ -417,7 +417,7 @@ if (isset($_POST["PledgeSubmit"]) or isset($_POST["PledgeSubmitAndAdd"])) {
 		// Match envelope is similar to match check- use the envelope number to choose a family
 		
 		$iEnvelope = FilterInput($_POST["Envelope"], 'int');
-		if ($iEnvelope and strlen($iEnvelope) > 0) {
+		if ($iEnvelope && strlen($iEnvelope) > 0) {
 			$sSQL = "SELECT fam_ID FROM family_fam WHERE fam_Envelope=" . $iEnvelope;
 			$rsFam = RunQuery($sSQL);
 			$numRows = mysql_num_rows($rsFam);
@@ -445,13 +445,13 @@ if (isset($_POST["PledgeSubmit"]) or isset($_POST["PledgeSubmitAndAdd"])) {
 				$calcAmount = round($iTotalAmount * ($plgAmount / $totalPledgeAmount), 2);
 
 				$nAmount[$fundID] = number_format($calcAmount, 2, ".", "");
-				if ($fundID <> $defaultFundID) {
+				if ($fundID != $defaultFundID) {
 					$calcOtherFunds = $calcOtherFunds + $calcAmount;
 				}
 
 				$calcTotal += $calcAmount;
 			}
-			if ($calcTotal <> $iTotalAmount) {
+			if ($calcTotal != $iTotalAmount) {
 				$nAmount[$defaultFundID] = number_format($iTotalAmount - $calcOtherFunds, 2, ".", "");
 			}
 		} else {
@@ -498,7 +498,7 @@ if ($PledgeOrPayment == 'Pledge') {
 	while ($aRow = mysql_fetch_array($rsChecksThisDep)) {
 		extract($aRow);
 		$chkKey = $plg_FamID . "|" . $plg_checkNo;
-		if ($plg_method=='CHECK' and (!array_key_exists($chkKey, $checkHash))) {
+		if ($plg_method == 'CHECK' && (!array_key_exists($chkKey, $checkHash))) {
 			$checkHash[$chkKey] = $plg_plgID;
 			++$depositCount;
 		}
@@ -564,7 +564,7 @@ require "Include/Header.php";
 		<table border="0" cellspacing="0" cellpadding="2">
 		<td valign="top" align="left">
 		<table cellpadding="2">
-			<?php if ($dep_Type == 'Bank' and $bUseDonationEnvelopes) { ?>
+			<?php if ($dep_Type == 'Bank' && $bUseDonationEnvelopes) { ?>
 			<tr>
 				<td class="PaymentLabelColumn"><?= gettext("Envelope #") ?></td>
 				<td class="TextColumn"><input type="text" name="Envelope" size=8 id="Envelope" value="<?= $iEnvelope ?>">
@@ -604,7 +604,7 @@ require "Include/Header.php";
 						<?php if ($PledgeOrPayment=='Pledge' || $dep_Type == "BankDraft" || !$iCurrentDeposit) { ?>
 						<option value="BANKDRAFT" <?php if ($iMethod == "BANKDRAFT") { echo "selected"; } ?>><?= 						gettext("Bank Draft") ?></option>
 						<?php } ?>
-                                                <?php if ($PledgeOrPayment=='Pledge') { ?>
+                                                <?php if ($PledgeOrPayment == 'Pledge') { ?>
                                                 <option value="EGIVE" <?= $iMethod == "EGIVE" ? 'selected' : '' ?>><?=
                           gettext("eGive") ?></option>
                                                 <?php } ?>
@@ -622,10 +622,10 @@ require "Include/Header.php";
 				<td class="<?= $PledgeOrPayment == 'Pledge' ? 'LabelColumn' : 'PaymentLabelColumn' ?>"><?= gettext("Fund") ?></td>
 				<td class="TextColumnWithBottomBorder">
 					<select name="FundSplit">
-						<option value=0 <?php if (!$iSelectedFund) { echo ' selected'; } ?>><?= gettext("Split") ?></option>
-						<?php foreach ($fundId2Name as $fun_id => $fun_name) {
-							echo "<option value=\"" . $fun_id . "\""; if ($iSelectedFund==$fun_id) echo " selected"; echo ">"; echo gettext($fun_name) . "</option>";
-						} ?>
+						<option value=0 <?= !$iSelectedFund ? 'selected' : '' ?>><?= gettext("Split") ?></option>
+						<?php foreach ($fundId2Name as $fun_id => $fun_name) { ?>
+							<option value="<?= $fun_id ?>" <?= $iSelectedFund == $fun_id ? 'selected' : '' ?>><?= gettext($fun_name) ?></option>
+						<?php } ?> 
 					</select>
 					<?php if (!$dep_Closed) { ?>
 					<input type="submit" class="btn" name="SetFundTypeSelection" value="<-Set">

--- a/churchinfo/PledgeEditor.php
+++ b/churchinfo/PledgeEditor.php
@@ -538,7 +538,7 @@ if ($iFamily) {
 require "Include/Header.php";
 
 ?>
-<form method="post" action="PledgeEditor.php?<?= "CurrentDeposit=" . $iCurrentDeposit . "&GroupKey=" . $sGroupKey . "&PledgeOrPayment=" . $PledgeOrPayment. "&linkBack=" . $linkBack ?>" name="PledgeEditor">
+<form method="post" action="PledgeEditor.php?CurrentDeposit=<?= $iCurrentDeposit ?>&GroupKey=<?= $sGroupKey ?>&PledgeOrPayment=<?= $PledgeOrPayment ?>&linkBack=<?= $linkBack ?>" name="PledgeEditor">
 
 <input type="hidden" name="FamilyID" id="FamilyID" value="<?= $iFamily ?>">
 <input type="hidden" name="PledgeOrPayment" id="PledgeOrPayment" value="<?= $PledgeOrPayment ?>">
@@ -555,7 +555,7 @@ require "Include/Header.php";
 			} else {
 				$cancelText = "Return";
 			} ?>	
-			<input type="button" class="btn" value="<?= gettext($cancelText) ?>" name="PledgeCancel" onclick="javascript:document.location='<?php if (strlen($linkBack) > 0) { echo $linkBack; } else {echo "Menu.php"; } ?>';">
+			<input type="button" class="btn" value="<?= gettext($cancelText) ?>" name="PledgeCancel" onclick="javascript:document.location='<?= $linkBack ? $linkBack : 'Menu.php' ?>';">
 		</td>
 	</tr>
 
@@ -569,14 +569,14 @@ require "Include/Header.php";
 				<td class="PaymentLabelColumn"><?= gettext("Envelope #") ?></td>
 				<td class="TextColumn"><input type="text" name="Envelope" size=8 id="Envelope" value="<?= $iEnvelope ?>">
 				<?php if (!$dep_Closed) { ?>
-				<input type="submit" class="btn" value="<?= gettext("Find family->"); ?>" name="MatchEnvelope">
+				<input type="submit" class="btn" value="<?= gettext("Find family->") ?>" name="MatchEnvelope">
 				<?php } ?>
 			</td>
 			</tr>
 			<?php } ?>
 			<tr>
 				<?php if ($PledgeOrPayment=='Pledge') { ?>
-					<td <?php if ($PledgeOrPayment=='Pledge') echo "class=\"LabelColumn\">"; else echo "class=\"PaymentLabelColumn\">"; ?><?= gettext("Payment Schedule") ?></td>
+					<td class="<?= $PledgeOrPayment == 'Pledge' ? 'LabelColumn' : 'PaymentLabelColumn' ?>"><?= gettext("Payment Schedule") ?></td>
 					<td class="TextColumnWithBottomBorder">
 						<select name="Schedule">
 							<option value="0"><?= gettext("Select Schedule") ?></option>
@@ -591,21 +591,21 @@ require "Include/Header.php";
 
 			</tr>
 			<tr>
-				<td <?php if ($PledgeOrPayment=='Pledge') echo "class=\"LabelColumn\">"; else echo "class=\"PaymentLabelColumn\">"; ?><?= gettext("Payment by") ?></td>
+				<td class="<?= $PledgeOrPayment == 'Pledge' ? 'LabelColumn' : 'PaymentLabelColumn' ?>"><?= gettext("Payment by") ?></td>
 				<td class="TextColumnWithBottomBorder">
 					<select name="Method">
-						<?php if ($PledgeOrPayment=='Pledge' or $dep_Type == "Bank" or !$iCurrentDeposit) { ?>
+						<?php if ($PledgeOrPayment=='Pledge' || $dep_Type == "Bank" || !$iCurrentDeposit) { ?>
 						<option value="CHECK" <?php if ($iMethod == "CHECK") { echo "selected"; } ?>><?= gettext("CHECK"); 						?></option>
 						<option value="CASH" <?php if ($iMethod == "CASH") { echo "selected"; } ?>><?= gettext("CASH"); 						?></option>
 						<?php } ?>
-						<?php if ($PledgeOrPayment=='Pledge' or $dep_Type == "CreditCard" or !$iCurrentDeposit) { ?>
+						<?php if ($PledgeOrPayment=='Pledge' || $dep_Type == "CreditCard" || !$iCurrentDeposit) { ?>
 						<option value="CREDITCARD" <?php if ($iMethod == "CREDITCARD") { echo "selected"; } ?>><?= 						gettext("Credit Card") ?></option>
 						<?php } ?>
-						<?php if ($PledgeOrPayment=='Pledge' or $dep_Type == "BankDraft" or !$iCurrentDeposit) { ?>
+						<?php if ($PledgeOrPayment=='Pledge' || $dep_Type == "BankDraft" || !$iCurrentDeposit) { ?>
 						<option value="BANKDRAFT" <?php if ($iMethod == "BANKDRAFT") { echo "selected"; } ?>><?= 						gettext("Bank Draft") ?></option>
 						<?php } ?>
                                                 <?php if ($PledgeOrPayment=='Pledge') { ?>
-                                                <option value="EGIVE" <?php if ($iMethod == "EGIVE") { echo "selected"; } ?>><?=
+                                                <option value="EGIVE" <?= $iMethod == "EGIVE" ? 'selected' : '' ?>><?=
                           gettext("eGive") ?></option>
                                                 <?php } ?>
 					</select>
@@ -613,13 +613,13 @@ require "Include/Header.php";
 			</tr>
 
 			<tr>
-				<td <?php if ($PledgeOrPayment=='Pledge') echo "class=\"LabelColumn\">"; else echo "class=\"PaymentLabelColumn\">"; ?><?= gettext("Fiscal Year") ?></td>
+				<td class="<?= $PledgeOrPayment == 'Pledge' ? 'LabelColumn' : 'PaymentLabelColumn' ?>"><?= gettext("Fiscal Year") ?></td>
 				<td class="TextColumnWithBottomBorder">
 					<?php PrintFYIDSelect ($iFYID, "FYID") ?>
 				</td>
 			</tr>
 			<tr>
-				<td <?php if ($PledgeOrPayment=='Pledge') echo "class=\"LabelColumn\">"; else echo "class=\"PaymentLabelColumn\">"; echo gettext("Fund"); ?></td>
+				<td class="<?= $PledgeOrPayment == 'Pledge' ? 'LabelColumn' : 'PaymentLabelColumn' ?>"><?= gettext("Fund") ?></td>
 				<td class="TextColumnWithBottomBorder">
 					<select name="FundSplit">
 						<option value=0 <?php if (!$iSelectedFund) { echo ' selected'; } ?>><?= gettext("Split") ?></option>
@@ -634,8 +634,8 @@ require "Include/Header.php";
 			</tr>
 			<tr>
 			<?php if ($iSelectedFund) { ?>
-				<td valign="top" align="left" <?php  if ($PledgeOrPayment=='Pledge') echo "class=\"LabelColumn\">"; else echo "class=\"PaymentLabelColumn\">"; echo gettext("Comment"); ?></td>
-				<td <?= "class=\"TextColumnWithBottomBorder\">"; echo "<input type=\"text\" name=\"OneComment\" id=\"OneComment\" value=\" ". $sComment[$iSelectedFund] . "\""; ?>">
+				<td valign="top" align="left" class="<?= $PledgeOrPayment == 'Pledge' ? 'LabelColumn' : 'PaymentLabelColumn' ?>"><?= gettext("Comment") ?></td>
+				<td class="TextColumnWithBottomBorder"><input type="text" name="OneComment" id="OneComment" value="<?= $sComment[$iSelectedFund] ?>">
 			<?php } ?>
 			</tr>
 		</table>
@@ -643,7 +643,7 @@ require "Include/Header.php";
 		<td valign="top" align="center">
 		<table cellpadding="2">
 			<tr>
-				<td <?php if ($PledgeOrPayment=='Pledge') echo "class=\"LabelColumn\""; else echo "class=\"PaymentLabelColumn\""; ?>><?= gettext("Family") ?></td>
+				<td class="<?= $PledgeOrPayment == 'Pledge' ? 'LabelColumn' : 'PaymentLabelColumn' ?>"><?= gettext("Family") ?></td>
 				<td class="TextColumn">
 
 <script language="javascript" type="text/javascript">
@@ -677,10 +677,10 @@ $(document).ready(function() {
 				</td>
 			</tr>
 
-			<?php if ($PledgeOrPayment=='Payment' and $dep_Type == 'Bank') { ?>
+			<?php if ($PledgeOrPayment == 'Payment' && $dep_Type == 'Bank') { ?>
 				<tr>
 					<td class="PaymentLabelColumn"><?= gettext("Check #") ?></td>
-					<td class="TextColumn"><input type="text" name="CheckNo" id="CheckNo" value="<?= $iCheckNo ?>"><font color="red"><?php echo $sCheckNoError ?></font></td>
+					<td class="TextColumn"><input type="text" name="CheckNo" id="CheckNo" value="<?= $iCheckNo ?>"><font color="red"><?= $sCheckNoError ?></font></td>
 				</tr>
 			<?php } ?>
 
@@ -690,17 +690,17 @@ $(document).ready(function() {
 				<td <?php if ($PledgeOrPayment=='Pledge') echo "class=\"LabelColumn\""; else echo "class=\"PaymentLabelColumn\""; ?>><?= gettext("Date") ?></td>
 <?php	if (!$dDate)	$dDate = $dep_Date ?>
 	
-				<td class="TextColumn"><input type="text" name="Date" value="<?= $dDate ?>" maxlength="10" id="Date" size="11"><font color="red"><?php echo $sDateError ?></font></td>
+				<td class="TextColumn"><input type="text" name="Date" value="<?= $dDate ?>" maxlength="10" id="Date" size="11"><font color="red"><?= $sDateError ?></font></td>
 			</tr>
 
 
 
 		<tr> 
-			<td valign="top" align="left" <?php  if ($PledgeOrPayment=='Pledge') echo "class=\"LabelColumn\">"; else echo "class=\"PaymentLabelColumn\">"; echo gettext("Total $"); ?></td>
-			<td <?= "class=\"TextColumnWithBottomBorder\">"; echo "<input type=\"text\" name=\"TotalAmount\" id=\"TotalAmount\" value=\" ". $iTotalAmount . "\""; ?>">
-		    <?php if ($PledgeOrPayment=='Payment') { ?>
+			<td valign="top" align="left" class="<?= $PledgeOrPayment == 'Pledge' ? 'LabelColumn' : 'PaymentLabelColumn' ?>"><?= gettext("Total $") ?></td>
+			<td class="TextColumnWithBottomBorder"><input type="text" name="TotalAmount" id="TotalAmount" value="<?= $iTotalAmount ?>"></td>
+		    <?php if ($PledgeOrPayment == 'Payment') { ?>
 
-				<?php if (!$iSelectedFund and !$dep_Closed) { ?>
+				<?php if (!$iSelectedFund && !$dep_Closed) { ?>
 
 				<input type="submit" class="btn" value="<?= gettext("Split to Funds by pledge") ?>" name="SplitTotal"></td>
 
@@ -711,10 +711,10 @@ $(document).ready(function() {
 			<td valign="top" align="left">
 
 <?php
-			if (($dep_Type == 'CreditCard') or ($dep_Type == 'BankDraft')) {
+			if ($dep_Type == 'CreditCard' || $dep_Type == 'BankDraft') {
 ?>
 			<tr>
-				<td <?php  if ($PledgeOrPayment=='Pledge') echo "class=\"LabelColumn\">"; else echo "class=\"PaymentLabelColumn\">";echo gettext("Choose online payment method"); ?></td>
+				<td class="<?= $PledgeOrPayment == 'Pledge' ? 'LabelColumn' : 'PaymentLabelColumn' ?>"><?= gettext("Choose online payment method") ?></td>
 				<td class="TextColumnWithBottomBorder">
 					<select name="AutoPay">
 <?php
@@ -727,7 +727,7 @@ $(document).ready(function() {
 					while ($aRow = mysql_fetch_array($rsFindAut))
 					{
 						extract($aRow);
-						if ($aut_CreditCard <> "") {
+						if ($aut_CreditCard != "") {
 							$showStr = gettext ("Credit card ...") . substr ($aut_CreditCard, strlen ($aut_CreditCard) - 4, 4);
 						} else {
 							$showStr = gettext ("Bank account ") . $aut_BankName . " " . $aut_Route . " " . $aut_Account;
@@ -748,13 +748,13 @@ $(document).ready(function() {
 		</td>
 
 		<tr>
-		<?php if ($bUseScannedChecks and ($dep_Type == 'Bank' or $PledgeOrPayment=='Pledge')) { ?>
-			<td <?php  if ($PledgeOrPayment=='Pledge') echo "class=\"LabelColumn\" align=\"center\">"; else echo "class=\"PaymentLabelColumn\" align=\"center\">";echo gettext("Scan check"); ?>
+		<?php if ($bUseScannedChecks && ($dep_Type == 'Bank' || $PledgeOrPayment == 'Pledge')) { ?>
+			<td align="center" class="<?= $PledgeOrPayment == 'Pledge' ? 'LabelColumn' : 'PaymentLabelColumn' ?>"><?= gettext("Scan check") ?>
 			<textarea name="ScanInput" rows="2" cols="70"><?= $tScanString ?></textarea></td>
 		<?php } ?>
 
 			<td align="center">
-			<?php if ($dep_Type == 'Bank' and $bUseScannedChecks) { ?>
+			<?php if ($bUseScannedChecks && $dep_Type == 'Bank') { ?>
 				<input type="submit" class="btn" value="<?= gettext("find family from check account #") ?>" name="MatchFamily">
 				<input type="submit" class="btn" value="<?= gettext("Set default check account number for family") ?>" name="SetDefaultCheck">
 	        <?php } ?>
@@ -773,20 +773,24 @@ $(document).ready(function() {
 
 			<tr>
 
-				<td <?php if ($PledgeOrPayment=='Pledge') echo "class=\"LabelColumn\">"; else echo "class=\"PaymentLabelColumn\">"; ?><?= gettext("Fund Name") ?></td>
-				<td <?php if ($PledgeOrPayment=='Pledge') echo "class=\"LabelColumn\">"; else echo "class=\"PaymentLabelColumn\">"; ?><?= gettext("Amount") ?></td>
+				<td class="<?= $PledgeOrPayment == 'Pledge' ? 'LabelColumn' : 'PaymentLabelColumn' ?>"><?= gettext("Fund Name") ?></td>
+				<td class="<?= $PledgeOrPayment == 'Pledge' ? 'LabelColumn' : 'PaymentLabelColumn' ?>"><?= gettext("Amount") ?></td>
 
 				<?php if ($bEnableNonDeductible) {?>
-					<td <?php if ($PledgeOrPayment=='Pledge') echo "class=\"LabelColumn\">"; else echo "class=\"PaymentLabelColumn\">"; ?><?= gettext("Non-deductible amount") ?></td>
+					<td class="<?= $PledgeOrPayment == 'Pledge' ? 'LabelColumn' : 'PaymentLabelColumn' ?>"><?= gettext("Non-deductible amount") ?></td>
 				<?php }?>
 
-				<td <?php if ($PledgeOrPayment=='Pledge') echo "class=\"LabelColumn\">"; else echo "class=\"PaymentLabelColumn\">"; ?><?= gettext("Comment") ?></td>
+				<td class="<?= $PledgeOrPayment == 'Pledge' ? 'LabelColumn' : 'PaymentLabelColumn' ?>"><?= gettext("Comment") ?></td>
              </tr>
 
-			<?php foreach ($fundId2Name as $fun_id => $fun_name) {
-				echo "<tr>";
-				echo "<td class=\"TextColumn\"><b>" . $fun_name . "</b></td>";
-				echo "<td class=\"TextColumn\"><input type=\"text\" name=\"" . $fun_id . "_Amount\" id=\"" . $fun_id . "_Amount\" value=\"" . $nAmount[$fun_id] . "\"><br><font color=\"red\">" . $sAmountError[$fun_id] . "</font></td>";
+			<?php 
+      foreach ($fundId2Name as $fun_id => $fun_name) { ?>
+				<tr>
+				<td class="TextColumn"><b><?= $fun_name ?></b></td>
+				<td class="TextColumn">
+          <input type="text" name="<?= $fun_id ?>_Amount" id="<?= $fun_id ?>_Amount" value="<?= $nAmount[$fun_id] ?>"><br>
+          <font color="red"><?= $sAmountError[$fun_id] ?></font>
+        </td> <?php
 				if ($bEnableNonDeductible) {
 					echo "<td class=\"TextColumn\"><input type=\"text\" name=\"" . $fun_id . "_NonDeductible\" id=\"" . $fun_id . "_Amount\" value=\"" . $nNonDeductible[$fun_id] . "\"><br><font color=\"red\">" . $sAmountError[$fun_id] . "</font></td>";
 				}

--- a/churchinfo/PrintView.php
+++ b/churchinfo/PrintView.php
@@ -187,7 +187,7 @@ if ($fam_ID)
 			{
 				$Row = mysql_fetch_array($rsCustomFields);
 				extract($Row);
-				if (($aSecurityType[$custom_FieldSec] == 'bAll') or ($_SESSION[$aSecurityType[$custom_FieldSec]]))
+				if ($aSecurityType[$custom_FieldSec] == 'bAll' || $_SESSION[$aSecurityType[$custom_FieldSec]])
 				{
 					$currentData = trim($aCustomData[$custom_Field]);
 					if ($type_ID == 11) $custom_Special = $sCountry;

--- a/churchinfo/VolunteerOpportunityEditor.php
+++ b/churchinfo/VolunteerOpportunityEditor.php
@@ -298,17 +298,14 @@ if ($numRows == 0) {
     <div class="callout callout-warning"><?= gettext("No volunteer opportunities have been added yet") ?></div>
 <?php
 } else { // if an 'action' (up/down arrow clicked, or order was input)
-   if ($iRowNum and $sAction != "") {
+   if ($iRowNum && $sAction != "") {
       // cast as int and couple with switch for sql injection prevention for $row_num
-      if ($sAction == 'up' or $sAction == 'down') {
-         $swapRow = $iRowNum;
-         if ($sAction == 'up') {
-            $newRow = --$iRowNum;
-         } else if ($sAction == 'down') {
-            $newRow = ++$iRowNum;
-         }
+      $swapRow = $iRowNum;
+      if ($sAction == 'up') {
+         $newRow = --$iRowNum;
+      } else if ($sAction == 'down') {
+         $newRow = ++$iRowNum;
       } else {
-         $swapRow = $iRowNum;
       	 $newRow = $iRowNum;
       }
 
@@ -353,7 +350,7 @@ if ($numRows == 0) {
 <tr>
     <td colspan="5">
         <?php
-        if ( $bErrorFlag ) {
+        if ($bErrorFlag) {
             echo '<div class="callout callout-danger">';
             echo gettext("Invalid fields or selections. Changes not saved! Please correct and try again!");
             echo '</div>';
@@ -405,7 +402,7 @@ for ($row=1; $row <= $numRows; $row++) {
 	   </td>
 	
 	   <td class="TextColumn">
-	   <input type="text" Name="<?php echo $row . "desc" ?>" value="<?= htmlentities(stripslashes($aDescFields[$row]),ENT_NOQUOTES, "UTF-8") ?>" size="40" maxlength="100">
+	   <input type="text" name="<?= $row ?>desc" value="<?= htmlentities(stripslashes($aDescFields[$row]), ENT_NOQUOTES, "UTF-8") ?>" size="40" maxlength="100">
 	   </td>
 	
 	   </tr>

--- a/churchinfo/eGive.php
+++ b/churchinfo/eGive.php
@@ -43,7 +43,7 @@ if (!function_exists(stream_get_contents)) {
 	}
 }
 
-if (!$_SESSION['bFinance'] and !$_SESSION['bAdmin']) {
+if (!$_SESSION['bFinance'] && !$_SESSION['bAdmin']) {
     Redirect("Menu.php");
     exit;
 }
@@ -126,7 +126,7 @@ if (isset($_POST["ApiGet"])) {
 	//$status = $logon["status"];
 	//$message = $login["message"];
 
-	if ($logon and $logon['status'] == 'success') {
+	if ($logon && $logon['status'] == 'success') {
 		$api_error = 0;
  		$token = $logon["token"];
 
@@ -142,7 +142,7 @@ if (isset($_POST["ApiGet"])) {
 		$json = stream_get_contents($fp);
 		fclose($fp);
 		$data = get_api_data($json, true);
-		if ($data and $data['status'] == 'success') {
+		if ($data && $data['status'] == 'success') {
 			$api_error = 0;
 
 		// each transaction has these fields: 'transactionID' 'envelopeID' 'giftID' 'frequency' 'amount'
@@ -163,7 +163,7 @@ if (isset($_POST["ApiGet"])) {
 				$date = yearFirstDate($dateTime[0]);
 				$famID = 0;
 
-				if ($egiveID2FamID and array_key_exists($egiveID, $egiveID2FamID)) {
+				if ($egiveID2FamID && array_key_exists($egiveID, $egiveID2FamID)) {
 					$famID = $egiveID2FamID[$egiveID];
 				} else {
 					$patterns[0] = '/\s+/'; // any whitespace
@@ -313,7 +313,7 @@ function updateDB($famID, $transId, $date, $name, $amount, $fundId, $comment, $f
 	global $importNoChange;
 
 	$keyExisting = eGiveExistingKey($transId, $famID, $date, $fundId, $comment);
-	if ($eGiveExisting and array_key_exists($keyExisting, $eGiveExisting)) {
+	if ($eGiveExisting && array_key_exists($keyExisting, $eGiveExisting)) {
 		++$importNoChange;
 	} elseif ($famID) { //  insert a new record
 		$sSQL = "INSERT INTO pledge_plg (plg_famID, plg_FYID, plg_date, plg_amount, plg_schedule, plg_method, plg_comment, plg_DateLastEdited, plg_EditedBy, plg_PledgeOrPayment, plg_fundID, plg_depID, plg_CheckNo, plg_NonDeductible, plg_GroupKey) VALUES ('" . $famID . "','" . $iFYID . "','" . $date . "','" . $amount . "','" . $frequency . "','EGIVE','" . $comment . "','" . date("YmdHis") . "'," . $_SESSION['iUserID'] . ",'Payment'," . $fundId . ",'" . $iDepositSlipID . "','" . $transId . "','0','" . $groupKey . "')";


### PR DESCRIPTION
This moves string constants outside of `<?= ?>` tags (to have a more template like structure and to avoid unreadable `"\""` quote escape sequences).

I switched some `<?php if(..` to ternary `? :` operators, which is more concise and in my opinion improves readability.

I also think we should deprecate the `and` and `or` logic operators and the `<>` inequality. Those are just confusing (especially for people working in C++ and JavaScript projects).