### PR TITLE
Add test for DOS line endings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,6 @@ before_script:
 # use the $DB env variable to determine the phpunit.xml to use
 script: 
   - if [[ "$DB" == "mysql" ]]; then mysql churchcrm_test < ./churchinfo/mysql/install/Install.sql -uroot; fi
+  - tests/LineEndings.sh
   - phpunit --configuration phpunit_$DB.xml --coverage-text
 

--- a/tests/LineEndings.sh
+++ b/tests/LineEndings.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# grep for ^M (DOS line endings) in all files recursively (except for the .git dir)
+OUT=$(egrep '^M$' `ls` -R -l)
+
+# if the return code is 0 egrep found a match - this is bad
+if [ $? == 0 ]
+then
+  echo "The following files have DOS line endings:"
+  echo $OUT
+  echo -e "\e[1m\e[7m\e[91m Failed \e[0m"
+  exit 1
+fi
+
+# otherwise we output a bright green inverted "Passed"
+echo -e "\e[1m\e[7m\e[92m Passed \e[0m"


### PR DESCRIPTION
This is a preliminary test. Let's see how it goes on Travis CI. It checks every file in the repo (including binary files). I'll probably go ahead and make this check only `.sql`, `.php`, `.md` files etc.

Closes #345 