### PR TITLE
support API ajax calls when churchcrm is in subfolder

### DIFF
--- a/churchinfo/GroupList.php
+++ b/churchinfo/GroupList.php
@@ -76,7 +76,7 @@ $(document).ready(function() {
         console.log(newGroup);
         $.ajax({
             method: "POST",
-            url:   "/api/groups",
+            url:   window.CRM.root + "/api/groups",
             data:  JSON.stringify(newGroup)
         }).done(function(data){
             console.log(data);

--- a/churchinfo/GroupView.php
+++ b/churchinfo/GroupView.php
@@ -629,7 +629,7 @@ $(document).ready(function() {
     $(".personSearch").on("select2:select",function (e) { 
         $.ajax({
             method: "POST",
-            url: "/api/groups/<?= $iGroupID ?>/adduser/"+e.params.data.objid,
+            url: window.CRM.root + "/api/groups/<?= $iGroupID ?>/adduser/"+e.params.data.objid,
             dataType: "json"
         }).done(function (data){
            var person = data[0]; 
@@ -659,7 +659,7 @@ function initHandlers()
         console.log(userid);
         $.ajax({
             method: "POST",
-            url: "/api/groups/<?= $iGroupID ?>/removeuser/"+userid,
+            url: window.CRM.root + "/api/groups/<?= $iGroupID ?>/removeuser/"+userid,
             dataType: "json"
         }).done(function(data){
             dataT.row(function(idx,data,node) { if  (data.per_ID == userid){return true;} } ).remove();
@@ -681,7 +681,7 @@ function initHandlers()
         var changeingMemberID = $("#changeingMemberID").val();
         $.ajax({
             method: "POST",
-            url: "/api/groups/<?= $iGroupID ?>/userRole/" + changeingMemberID,
+            url: window.CRM.root + "/api/groups/<?= $iGroupID ?>/userRole/" + changeingMemberID,
             data: JSON.stringify({'roleID': $("#newRoleSelection option:selected").val()}),
             dataType: "json"
         }).done(function(data){
@@ -697,7 +697,7 @@ function initHandlers()
       console.log(e);        
       $.ajax({
             method: "DELETE",
-            url: "/api/groups/<?= $iGroupID ?>",
+            url: window.CRM.root + "/api/groups/<?= $iGroupID ?>",
             dataType: "json"
         }).done(function(data){
             console.log(data);

--- a/churchinfo/Include/Header-function.php
+++ b/churchinfo/Include/Header-function.php
@@ -53,6 +53,7 @@ function Header_body_scripts()
     <script type="text/javascript" src="<?= $sRootPath . "/" ?>Include/jscalendar/lang/calendar-<?= substr($sLanguage,0,2) ?>.js"></script>
 
     <script language="javascript" type="text/javascript">
+        window.CRM = { root: "<?= $sRootPath ?>" };
 
         // Popup Calendar stuff
         function selected(cal, date)

--- a/churchinfo/PersonView.php
+++ b/churchinfo/PersonView.php
@@ -842,7 +842,7 @@ $bOkToEdit = ($_SESSION['bEditRecords'] ||
 		if ( answer )
 			$.ajax({
                 method: "POST",
-                url:    "/api/groups/"+Group+"/removeuser/"+Person
+                url:    window.CRM.root + "/api/groups/"+Group+"/removeuser/"+Person
             }).done(function (data){
                location.reload(); 
             });

--- a/churchinfo/js/GroupEditor.js
+++ b/churchinfo/js/GroupEditor.js
@@ -46,7 +46,7 @@ $("document").ready(function(){
         console.log(formData);
         $.ajax({
             method: "POST",
-            url:   "/api/groups/"+groupID,
+            url:   window.CRM.root + "/api/groups/"+groupID,
             data:  JSON.stringify(formData)
         }).done(function(data){
            console.log(data);
@@ -60,7 +60,7 @@ $("document").ready(function(){
        
         $.ajax({
             method: "POST",
-            url:    "/api/groups/"+groupID+"/roles",
+            url:    window.CRM.root + "/api/groups/"+groupID+"/roles",
             data:  '{"roleName":"'+newRoleName+'"}'
         }).done(function(data){
             var newRole = data.newRole;
@@ -80,7 +80,7 @@ $("document").ready(function(){
         console.log("deleting group role: "+roleID);
         $.ajax({
             method: "DELETE",
-            url:    "/api/groups/"+groupID+"/roles/"+roleID
+            url:    window.CRM.root + "/api/groups/"+groupID+"/roles/"+roleID
         }).done(function(data){
             console.log(data);
             dataT.clear();
@@ -138,7 +138,7 @@ $("document").ready(function(){
         var roleID=e.target.id.split("-")[1];
         $.ajax({
             method: "POST",
-            url:    "/api/groups/"+groupID+"/roles/"+roleID,
+            url:    window.CRM.root + "/api/groups/"+groupID+"/roles/"+roleID,
             data: '{"groupRoleName":"'+groupRoleName+'"}'
         }).done(function(data){
         });
@@ -150,7 +150,7 @@ $("document").ready(function(){
         var roleID=e.target.id.split("-")[1];
         $.ajax({
             method: "POST",
-            url:    "/api/groups/"+groupID+"/defaultRole",
+            url:    window.CRM.root + "/api/groups/"+groupID+"/defaultRole",
             data: '{"roleID":"'+roleID+'"}'
         }).done(function(data){
             defaultRoleID=roleID; //update the local variable representing the default role id
@@ -233,7 +233,7 @@ function setGroupRoleOrder(groupID,roleID,groupRoleOrder)
 {
     $.ajax({
         method: "POST",
-        url:    "/api/groups/"+groupID+"/roles/"+roleID,
+        url:    window.CRM.root + "/api/groups/"+groupID+"/roles/"+roleID,
         data:   '{"groupRoleOrder":"'+groupRoleOrder+'"}'
     }).done(function(data){
     });

--- a/churchinfo/js/GroupEditor.js
+++ b/churchinfo/js/GroupEditor.js
@@ -1,7 +1,7 @@
 
 
 $("document").ready(function(){
-       
+
     $(".groupSpecificProperties").click(function (e){
             var groupPropertyAction = e.currentTarget.id;
             if (groupPropertyAction == "enableGroupProps")
@@ -19,11 +19,11 @@ $("document").ready(function(){
                 $("#setgroupSpecificProperties").text("Disable Group Specific Properties");
             }
     });
-    
-    
+
+
 
     $("#selectGroupIDDiv").hide();
-    
+
     $("#cloneGroupRole").click(function(e){
     if (e.target.checked)
         $("#selectGroupIDDiv").show();
@@ -36,28 +36,26 @@ $("document").ready(function(){
 
     $("#groupEditForm").submit(function(e) {
         e.preventDefault();
-       
+
         var formData ={
             "groupName": $("input[name='Name']").val(),
             "description": $("textarea[name='Description']").val(),
             "groupType" : $("select[name='GroupType'] option:selected").val()
-            
+
         };
-        console.log(formData);
         $.ajax({
             method: "POST",
             url:   window.CRM.root + "/api/groups/"+groupID,
             data:  JSON.stringify(formData)
         }).done(function(data){
-           console.log(data);
-           window.location.href="/GroupList.php";
+           window.location.href = CRM.root + "/GroupList.php";
         });
 
     });
-    
+
     $("#addNewRole").click(function(e) {
         var newRoleName = $("#newRole").val();
-       
+
         $.ajax({
             method: "POST",
             url:    window.CRM.root + "/api/groups/"+groupID+"/roles",
@@ -71,12 +69,12 @@ $("document").ready(function(){
             $("#newRole").val('');
             //location.reload(); // this shouldn't be necessary
         });
-        
+
     });
-    
+
     $(document).on('click','.deleteRole', function(e) {
         var roleID = e.currentTarget.id.split("-")[1];
-       
+
         console.log("deleting group role: "+roleID);
         $.ajax({
             method: "DELETE",
@@ -88,14 +86,14 @@ $("document").ready(function(){
             if (roleID == defaultRoleID)        // if we delete the default group role, set the default group role to 1 before we tell the table to re-render so that the buttons work correctly
                 defaultRoleID =1;
             dataT.rows().invalidate().draw(true);
-            
-            
-            
+
+
+
         });
     });
-    
+
     $(document).on('click','.rollOrder', function (e) {
-      
+
        var roleID = e.currentTarget.id.split("-")[1]; // get the ID of the role that we're manipulating
        var roleSequenceAction =  e.currentTarget.id.split("-")[0];  //determine whether we're increasing or decreasing this role's sequence number
        var newRoleSequence =0;      //create a variable at the function scope to store the new role's sequence
@@ -126,14 +124,14 @@ $("document").ready(function(){
         //   console.log("no cells to replace - something was funky.");
        //}
       dataT.cell(function(idx,data,node) { if  (data.lst_OptionID == roleID){return true;}}, 2).data(newRoleSequence); // set our role to the new sequence number
-      setGroupRoleOrder(groupID,roleID,newRoleSequence);       
+      setGroupRoleOrder(groupID,roleID,newRoleSequence);
       dataT.rows().invalidate().draw(true);
       dataT.order([[ 2, "asc" ]]).draw();
-      
+
     });
-    
+
     $(document).on('change','.roleName',function(e){
-       
+
         var groupRoleName = e.target.value;
         var roleID=e.target.id.split("-")[1];
         $.ajax({
@@ -142,9 +140,9 @@ $("document").ready(function(){
             data: '{"groupRoleName":"'+groupRoleName+'"}'
         }).done(function(data){
         });
-        
+
     });
-    
+
     $(document).on('click','.defaultRole', function(e){
        console.log(e);
         var roleID=e.target.id.split("-")[1];
@@ -157,7 +155,7 @@ $("document").ready(function(){
             dataT.rows().invalidate().draw(true);
              // re-register the JQuery handlers since we changed the DOM, and new buttons will not have an action bound.
         });
-    }); 
+    });
 
     dataT =  $("#groupRoleTable").DataTable({
     data:groupRoleData,
@@ -168,7 +166,7 @@ $("document").ready(function(){
             data:'lst_OptionName',
             render: function  (data, type, full, meta ) {
                 if ( type === 'display')
-                    return '<input type="text" value="'+data+'">'; 
+                    return '<input type="text" value="'+data+'">';
                 else
                     return data;
             }
@@ -217,14 +215,14 @@ $("document").ready(function(){
             title:'Delete',
             render: function  (data, type, full, meta ) {
                 return '<button type="button" id="roleDelete-'+full.lst_OptionID+'" class="btn btn-danger deleteRole">Delete</button>';
-                   
+
             }
         },
-        
+
     ],
     "order": [[ 3, "asc" ]]
     });
-    
+
      // initialize the event handlers when the document is ready.  Don't do it here, since we need to be able to initialize these handlers on the fly in response to user action.
 });
 


### PR DESCRIPTION
Hello, I have just started looking at ChurchCRM for my church. I'm going to start making some pull requests to fix little bugs here and there and suggest usability improvements.

--

### This PR
Currently the API features do not work if the site is in a subfolder. This is because the JavaScript ajax calls all begin with a backslash, and they have no knowledge of `$sRootPath`.

This pull request sets up a JavaScript object `window.CRM.root = "<?= $sRootPath; ?>"` providing the site's absolute path `/path/to/churchinfo`

I've grouped the root value under this global object `CRM` as it seems useful to have a single object that can contain any future JavaScript configuration for the site.