### PR TITLE
add Renderer class for easy rendering of HTML blocks

### DIFF
--- a/churchinfo/Include/RenderFunctions.php
+++ b/churchinfo/Include/RenderFunctions.php
@@ -30,8 +30,8 @@ class Renderer
   }
 
   // Renders a typical box header element around the given HTML content.
-  public function BoxHeader($content) {
-    ?><div class="box-header with-border">
+  public function BoxHeader($content, $border=false) {
+    ?><div class="box-header <?= $border ? 'with-border' : '' ?>">
       <h3 class="box-title"><?= $content ?></h3>
     </div>
 <?php

--- a/churchinfo/Include/RenderFunctions.php
+++ b/churchinfo/Include/RenderFunctions.php
@@ -1,0 +1,42 @@
+<?php
+/* Renderer provides a clean way to output very common HTML blocks with less code.
+   It also allows us to modify these HTML blocks without needing to Find/Replace everywhere.
+   It writes directly to the output buffer so you can just call it with <? not with <?=
+
+   Example:
+     <? $render->Checkbox("Click me!", 'bClicked'); ?>
+*/
+
+class Renderer
+{
+  // Renders a checkbox with the given text, name and value.
+  // Note: You do not need to wrap your text in `gettext`. This function will do it for you.
+  public function Checkbox($text, $name, $value=1, $checked=false) {
+    ?><label class='c-checkbox'>
+      <input type="checkbox" Name="<?= $name ?>" value="<?= $value ?>" <?= $checked ? 'checked' : '' ?> />
+      <div class='c-indicator'></div>
+      <? if (!empty($text)) { echo gettext($text); } ?>
+    </label><?php
+  }
+
+  // Renders a radio  button with the given text, name and value.
+  // Note: You do not need to wrap your text in `gettext`. This function will do it for you.
+  public function Radio($text, $name, $value=1, $checked=false) {
+    ?><label class='c-radio'>
+      <input type="radio" Name="<?= $name ?>" value="<?= $value ?>" <?= $checked ? 'checked' : '' ?> />
+      <div class='c-indicator'></div>
+      <? if (!empty($text)) { echo gettext($text); } ?>
+    </label><?php
+  }
+
+  // Renders a typical box header element around the given HTML content.
+  public function BoxHeader($content) {
+    ?><div class="box-header with-border">
+      <h3 class="box-title"><?= $content ?></h3>
+    </div>
+<?php
+  }
+}
+
+$render = new Renderer();
+?>


### PR DESCRIPTION
From the file itself:

> Renderer provides a clean way to output very common HTML blocks with less code.
> It also allows us to modify these HTML blocks without needing to Find/Replace everywhere.
> It writes directly to the output buffer so you can just call it with <? not with <?=

We can add more functions to this file as it goes on. Its aim is to make our HTML code shorter, and move repeated UI patterns into one place so that we don't copy & paste code, which often leads to inconsistent UI and neglected parts of the site looking out of date.

### Examples:

Checkboxes:
```php
<? $render->Checkbox("Click me!", 'bClicked'); ?>
```
```html
<label class='c-checkbox'>
  <input type="checkbox" Name="bClicked" value="1" />
  <div class='c-indicator'></div>
  Click me!
</label>
```

Box headers:
```php
<? $render->BoxHeader(gettext("User functions")); ?>
```
```html
<div class="box-header">
  <h3 class="box-title">User functions</h3>
</div>
```