### PR TITLE
Support for pretty URLs

### DIFF
--- a/churchinfo/.htaccess
+++ b/churchinfo/.htaccess
@@ -1,0 +1,10 @@
+RewriteEngine On
+
+# Some hosts may require you to use the `RewriteBase` directive.
+# If you need to use the `RewriteBase` directive, it should be the
+# absolute physical path to the directory that contains this htaccess file.
+#
+# RewriteBase /
+
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteRule ^(.*)$ index.php [QSA,L]

--- a/churchinfo/Include/Config.php
+++ b/churchinfo/Include/Config.php
@@ -63,5 +63,5 @@ error_reporting(E_ERROR);
 //
 // Absolute path must be specified since this file is called
 // from scripts located in other directories
-require (dirname(__FILE__) . DIRECTORY_SEPARATOR . 'LoadConfigs.php');
+require_once (dirname(__FILE__) . DIRECTORY_SEPARATOR . 'LoadConfigs.php');
 ?>

--- a/churchinfo/index.php
+++ b/churchinfo/index.php
@@ -1,11 +1,57 @@
 <?php
-require 'Include/Config.php';
-require 'Include/Functions.php';
+require_once 'Include/Config.php';
 
-if (!isset($_SESSION['iUserID']))
+function dashesToCamelCase($string, $capitalizeFirstCharacter = false)
 {
-    Redirect("Login.php");
-} else {
-    Redirect("Menu.php");
+  $str = str_replace(' ', '', ucwords(str_replace('-', ' ', $string)));
+
+  if (!$capitalizeFirstCharacter) {
+    $str[0] = strtolower($str[0]);
+  }
+
+  return $str;
 }
-exit;
+
+function endsWith($haystack, $needle) {
+  // search forward starting from end minus needle length characters
+  return $needle === "" || (($temp = strlen($haystack) - strlen($needle)) >= 0 && strpos($haystack, $needle, $temp) !== false);
+}
+
+$hasSession = isset($_SESSION['iUserID']);
+$redirectTo = ($hasSession) ? '/menu' : '/login';
+
+// Get the current request path and convert it into a magic filename
+// e.g. /list-events => /ListEvents.php
+$shortName = str_replace($sRootPath . '/', '', $_SERVER['REQUEST_URI']);
+$fileName = dashesToCamelCase($shortName, true) . '.php';
+
+if (strtolower($shortName) == 'index.php' || strtolower($fileName) == 'index.php')
+{
+  // Index.php -> Menu.php or Login.php
+  Header("Location: " . $sRootPath . $redirectTo);
+  exit;
+}
+else if (!$hasSession)
+{
+  // Must show login form if no session
+  require 'Login.php';
+}
+else if (file_exists($shortName))
+{
+  // Try actual path
+  require $shortName;
+}
+else if (file_exists($fileName))
+{
+  // Try magic filename
+  require $fileName;
+}
+else
+{
+  // Unknown page, must be 404
+  header('HTTP/1.0 404 Not Found');
+  echo "<head><title>404 Not Found</title></head>";
+  echo "<h1>Not Found</h1>";
+  echo "<p>The requested URL ". $_SERVER['REQUEST_URI'] ." was not found on this server.</p>";
+}
+?>


### PR DESCRIPTION
This is an idea that I had to prettify the URLs. It doesn't convert all the URLs on the site, but it does allow us to use them if we want to.

The `index.php` page acts as a router if you enter a URL without `.php` on the end (and which is not a resource). It CamelCases the page and searches for a PHP file with that name. If it finds a file, it includes that file and continues the page. If no file is found, it renders a 404.

This helps to hide PHP a little from prying users, and also makes the page URLs easier to remember, and to copy and paste.

Ergo: `/family-list` <=> `/FamilyList.php`

![image](https://cloud.githubusercontent.com/assets/1628558/13413043/6e12a196-df3f-11e5-86fd-028e3f6ddf21.png)
