### PR TITLE
Customize session name to allow multiple CRM instances

### DIFF
--- a/churchinfo/Include/LoadConfigs.php
+++ b/churchinfo/Include/LoadConfigs.php
@@ -63,6 +63,7 @@ if (!$tablecheck) {
 }
 
 // Initialize the session
+session_name('CRM@' . $sRootPath);
 session_start();
 
 // Avoid consecutive slashes when $sRootPath = '/'


### PR DESCRIPTION
Use `session_name` and also validate the session in the pretty URL proxy.

Closes #490