### PR TITLE
Move Config.php out of version control

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,5 +14,5 @@ Vagrant.configure("2") do |config|
   config.vm.hostname = "scotchbox"
   config.vm.synced_folder "churchinfo", "/var/www/public", :mount_options => ["dmode=777", "fmode=666"]
 
-   config.vm.provision :shell, :path => "vagrant/bootstrap.sh"
+  config.vm.provision :shell, :path => "vagrant/bootstrap.sh"
 end

--- a/churchinfo/AccessReport.php
+++ b/churchinfo/AccessReport.php
@@ -12,7 +12,7 @@
  ******************************************************************************/
 
 // Include the function library
-require 'Include/Config.php';
+require 'Include/LoadConfigs.php';
 require 'Include/Functions.php';
 
 // If user is not admin, redirect to the menu.

--- a/churchinfo/AddDonors.php
+++ b/churchinfo/AddDonors.php
@@ -16,7 +16,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 $linkBack = "";

--- a/churchinfo/AutoPaymentClearAccounts.php
+++ b/churchinfo/AutoPaymentClearAccounts.php
@@ -1,5 +1,5 @@
 <?php 
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 require "Include/VancoConfig.php";
 

--- a/churchinfo/AutoPaymentDelete.php
+++ b/churchinfo/AutoPaymentDelete.php
@@ -14,7 +14,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 //Set the page title

--- a/churchinfo/AutoPaymentEditor.php
+++ b/churchinfo/AutoPaymentEditor.php
@@ -12,7 +12,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 $linkBack = FilterInput($_GET["linkBack"]);

--- a/churchinfo/BackupDatabase.php
+++ b/churchinfo/BackupDatabase.php
@@ -16,7 +16,7 @@
  ******************************************************************************/
 
 // Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 // Security: User must be an Admin to access this page.

--- a/churchinfo/BatchWinnerEntry.php
+++ b/churchinfo/BatchWinnerEntry.php
@@ -14,7 +14,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 $linkBack = FilterInput($_GET["linkBack"]);

--- a/churchinfo/CSVCreateFile.php
+++ b/churchinfo/CSVCreateFile.php
@@ -14,7 +14,7 @@
  ******************************************************************************/
 
 // Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 require "Include/ReportFunctions.php";
 

--- a/churchinfo/CSVExport.php
+++ b/churchinfo/CSVExport.php
@@ -25,7 +25,7 @@
  ******************************************************************************/
 
 // Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 // If user does not have CSV Export permission, redirect to the menu.

--- a/churchinfo/CSVImport.php
+++ b/churchinfo/CSVImport.php
@@ -16,7 +16,7 @@
  ******************************************************************************/
 
 // Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 if (!$_SESSION['bAdmin']) {

--- a/churchinfo/Canvas05Editor.php
+++ b/churchinfo/Canvas05Editor.php
@@ -14,7 +14,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 $iCanvas05ID = FilterInput($_GET["Canvas05ID"],'int');

--- a/churchinfo/CanvassAutomation.php
+++ b/churchinfo/CanvassAutomation.php
@@ -14,7 +14,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 require "Include/CanvassUtilities.php";

--- a/churchinfo/CanvassEditor.php
+++ b/churchinfo/CanvassEditor.php
@@ -14,7 +14,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 // Security: User must have canvasser permission to use this form

--- a/churchinfo/CartToEvent.php
+++ b/churchinfo/CartToEvent.php
@@ -18,7 +18,7 @@
  ******************************************************************************/
 
 // Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 // Security: User must have Manage Groups & Roles permission

--- a/churchinfo/CartToFamily.php
+++ b/churchinfo/CartToFamily.php
@@ -16,7 +16,7 @@
  ******************************************************************************/
 
 // Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 require "Include/PersonFunctions.php";
 

--- a/churchinfo/CartToGroup.php
+++ b/churchinfo/CartToGroup.php
@@ -16,7 +16,7 @@
  ******************************************************************************/
 
 // Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 require_once "Service/GroupService.php";
 

--- a/churchinfo/CartView.php
+++ b/churchinfo/CartView.php
@@ -26,7 +26,7 @@
 ******************************************************************************/
 // Include the function library
 
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 require "Include/LabelFunctions.php";
 require "Include/PersonFunctions.php";

--- a/churchinfo/CatchCreatePayment.php
+++ b/churchinfo/CatchCreatePayment.php
@@ -1,5 +1,5 @@
 <?php 
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 require "Include/VancoConfig.php";
 

--- a/churchinfo/CheckVersion.php
+++ b/churchinfo/CheckVersion.php
@@ -25,7 +25,7 @@
 ******************************************************************************/
 
 // Include the function library
-require 'Include/Config.php';
+require 'Include/LoadConfigs.php';
 require 'Include/Functions.php';
 require 'Service/SystemService.php';
 $systemService = new SystemService();

--- a/churchinfo/Checkin.php
+++ b/churchinfo/Checkin.php
@@ -18,7 +18,7 @@
  ******************************************************************************/
 
 // Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 require "Include/Header.php";
 

--- a/churchinfo/ConvertIndividualToFamily.php
+++ b/churchinfo/ConvertIndividualToFamily.php
@@ -30,7 +30,7 @@
 ******************************************************************************/
 
 //Include the function library
-require 'Include/Config.php';
+require 'Include/LoadConfigs.php';
 require 'Include/Functions.php';
 
 // Security

--- a/churchinfo/ConvertOnePaymentXML.php
+++ b/churchinfo/ConvertOnePaymentXML.php
@@ -1,5 +1,5 @@
 <?php
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 include "Include/vancowebservices.php";
 include "Include/VancoConfig.php";

--- a/churchinfo/DepositSlipEditor.php
+++ b/churchinfo/DepositSlipEditor.php
@@ -14,7 +14,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 require "Include/MICRFunctions.php";

--- a/churchinfo/DirectoryReports.php
+++ b/churchinfo/DirectoryReports.php
@@ -17,7 +17,7 @@
  ******************************************************************************/
 
 // Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 // Check for Create Directory user permission.

--- a/churchinfo/DonatedItemDelete.php
+++ b/churchinfo/DonatedItemDelete.php
@@ -13,7 +13,7 @@
 *
 ******************************************************************************/
 
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 $iDonatedItemID = FilterInput($_GET["DonatedItemID"],'int');

--- a/churchinfo/DonatedItemEditor.php
+++ b/churchinfo/DonatedItemEditor.php
@@ -14,7 +14,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 $iDonatedItemID = FilterInputArr($_GET,"DonatedItemID",'int');

--- a/churchinfo/DonatedItemReplicate.php
+++ b/churchinfo/DonatedItemReplicate.php
@@ -14,7 +14,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 $iFundRaiserID = $_SESSION['iCurrentFundraiser'];

--- a/churchinfo/DonationFundEditor.php
+++ b/churchinfo/DonationFundEditor.php
@@ -15,7 +15,7 @@
  *
  ******************************************************************************/
 
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 // Security: user must be administrator to use this page

--- a/churchinfo/EditEventAttendees.php
+++ b/churchinfo/EditEventAttendees.php
@@ -2,7 +2,7 @@
 //*******************************************************************************
 
 
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 require "Include/Header.php";
 

--- a/churchinfo/EditEventTypes.php
+++ b/churchinfo/EditEventTypes.php
@@ -19,7 +19,7 @@
  *  fields
  *
  ******************************************************************************/
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 if (!$_SESSION['bAdmin'])
 {

--- a/churchinfo/EditSettings.php
+++ b/churchinfo/EditSettings.php
@@ -13,7 +13,7 @@
  ******************************************************************************/
 
 // Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 require "Include/TranslateMenuOptions.php";
 

--- a/churchinfo/ElectronicPaymentList.php
+++ b/churchinfo/ElectronicPaymentList.php
@@ -16,7 +16,7 @@
  ******************************************************************************/
 
 // Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 // Security: User must be an Admin to access this page.

--- a/churchinfo/EmailEditor.php
+++ b/churchinfo/EmailEditor.php
@@ -26,7 +26,7 @@
 ******************************************************************************/
 
 // Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 if (array_key_exists ('emaillist', $_POST))

--- a/churchinfo/EmailSend.php
+++ b/churchinfo/EmailSend.php
@@ -33,7 +33,7 @@
 $bEmailLog = FALSE;
 
 // Include the function library
-require 'Include/Config.php';
+require 'Include/LoadConfigs.php';
 require 'Include/Functions.php';
 
 $iUserID = $_SESSION['iUserID']; // Read into local variable for faster access

--- a/churchinfo/EventAttendance.php
+++ b/churchinfo/EventAttendance.php
@@ -15,7 +15,7 @@
  *
  ******************************************************************************/
 
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 if (array_key_exists('Action', $_POST) && $_POST['Action'] == "Retrieve" && !empty($_POST['Event']))

--- a/churchinfo/EventEditor.php
+++ b/churchinfo/EventEditor.php
@@ -25,7 +25,7 @@
 //  event_end      datetime
 //  inactive       int(1) default 0
 
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 require "Include/RenderFunctions.php";
 

--- a/churchinfo/EventNames.php
+++ b/churchinfo/EventNames.php
@@ -20,7 +20,7 @@
  *
  ******************************************************************************/
 
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 require "Include/RenderFunctions.php";
 

--- a/churchinfo/FamilyCustomFieldsEditor.php
+++ b/churchinfo/FamilyCustomFieldsEditor.php
@@ -26,7 +26,7 @@
 *
 ******************************************************************************/
 
-require 'Include/Config.php';
+require 'Include/LoadConfigs.php';
 require 'Include/Functions.php';
 
 // Security: user must be administrator to use this page

--- a/churchinfo/FamilyCustomFieldsRowOps.php
+++ b/churchinfo/FamilyCustomFieldsRowOps.php
@@ -16,7 +16,7 @@
 
  ******************************************************************************/
 
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 // Security: user must be administrator to use this page.

--- a/churchinfo/FamilyEditor.php
+++ b/churchinfo/FamilyEditor.php
@@ -14,7 +14,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 require "Include/CanvassUtilities.php";
 require "Include/GeoCoder.php";

--- a/churchinfo/FamilyList.php
+++ b/churchinfo/FamilyList.php
@@ -1,5 +1,5 @@
 <?php
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 $sSQL = "select * from family_fam fam order by fam_Name";

--- a/churchinfo/FamilyView.php
+++ b/churchinfo/FamilyView.php
@@ -24,7 +24,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 require "Include/GeoCoder.php";
 require 'Include/PersonFunctions.php';

--- a/churchinfo/FinancialReports.php
+++ b/churchinfo/FinancialReports.php
@@ -13,7 +13,7 @@
  ******************************************************************************/
 
 // Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 // Security

--- a/churchinfo/FindDepositSlip.php
+++ b/churchinfo/FindDepositSlip.php
@@ -14,7 +14,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 require 'Service/FinancialService.php';
 

--- a/churchinfo/FindFundRaiser.php
+++ b/churchinfo/FindFundRaiser.php
@@ -14,7 +14,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 //Set the page title

--- a/churchinfo/FundRaiserEditor.php
+++ b/churchinfo/FundRaiserEditor.php
@@ -14,7 +14,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 $linkBack = FilterInputArr($_GET,"linkBack");

--- a/churchinfo/GenerateSeedData.php
+++ b/churchinfo/GenerateSeedData.php
@@ -12,7 +12,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 // Security: User must have Manage Groups permission
@@ -60,7 +60,7 @@ require 'Include/Header.php';
             data        : JSON.stringify(formData), // our data object
             dataType    : 'json', // what type of data do we expect back from the server
             encode      : true,
-            beforeSend  : function () { 
+            beforeSend  : function () {
                 $('#results').empty();
                 $('#results').append('<div class="text-center"><i class="fa fa-spinner"></i><h3>Loading Seed Data</h3></div>');
             }
@@ -68,12 +68,12 @@ require 'Include/Header.php';
 		 .done(function(data) {
 			console.log(data);
              $('#results').empty();
-			$('#results').append('<pre>'+JSON.stringify(data,null,4) +'</pre>');          
+			$('#results').append('<pre>'+JSON.stringify(data,null,4) +'</pre>');
 		  });
-		 
-		
 
-        
+
+
+
     });
 
 

--- a/churchinfo/GeoPage.php
+++ b/churchinfo/GeoPage.php
@@ -21,7 +21,7 @@
 ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 require "Include/GeoCoder.php";

--- a/churchinfo/GetText.php
+++ b/churchinfo/GetText.php
@@ -14,7 +14,7 @@
  *  (at your option) any later version.
  *
  ******************************************************************************/
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 $sSQL = "SELECT * FROM events_event WHERE event_id = ".$_GET['EID'];

--- a/churchinfo/GroupEditor.php
+++ b/churchinfo/GroupEditor.php
@@ -15,7 +15,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 require "Service/GroupService.php";
 

--- a/churchinfo/GroupList.php
+++ b/churchinfo/GroupList.php
@@ -22,7 +22,7 @@
 *
 ******************************************************************************/
 //Include the function library
-require 'Include/Config.php';
+require 'Include/LoadConfigs.php';
 require 'Include/Functions.php';
 require 'Service/GroupService.php';
 

--- a/churchinfo/GroupMeeting.php
+++ b/churchinfo/GroupMeeting.php
@@ -14,7 +14,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 //Get the GroupID out of the querystring

--- a/churchinfo/GroupPropsEditor.php
+++ b/churchinfo/GroupPropsEditor.php
@@ -16,7 +16,7 @@
  *
  ******************************************************************************/
 
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 // Security: user must be allowed to edit records to use this page.

--- a/churchinfo/GroupPropsFormEditor.php
+++ b/churchinfo/GroupPropsFormEditor.php
@@ -15,7 +15,7 @@
  *  (at your option) any later version.
 ******************************************************************************/
 
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 // Security: user must be allowed to edit records to use this page.

--- a/churchinfo/GroupPropsFormRowOps.php
+++ b/churchinfo/GroupPropsFormRowOps.php
@@ -15,7 +15,7 @@
 
  ******************************************************************************/
 
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 // Security: user must be allowed to edit records to use this page.

--- a/churchinfo/GroupReports.php
+++ b/churchinfo/GroupReports.php
@@ -17,7 +17,7 @@
  ******************************************************************************/
 
 // Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 // Get all the groups

--- a/churchinfo/GroupView.php
+++ b/churchinfo/GroupView.php
@@ -21,7 +21,7 @@
 ******************************************************************************/
 
 //Include the function library
-require 'Include/Config.php';
+require 'Include/LoadConfigs.php';
 require 'Include/Functions.php';
 require 'Service/GroupService.php';
 

--- a/churchinfo/ImageDelete.php
+++ b/churchinfo/ImageDelete.php
@@ -1,6 +1,6 @@
 <?php
 
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 $redirectURL="Menu.php";

--- a/churchinfo/ImageUpload.php
+++ b/churchinfo/ImageUpload.php
@@ -1,6 +1,6 @@
 <?php
 
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 require "Include/PersonFunctions.php";
 require "Include/class.upload.php";

--- a/churchinfo/Include/Config.php.example
+++ b/churchinfo/Include/Config.php.example
@@ -1,11 +1,11 @@
 <?php
 /*******************************************************************************
- *
- *  filename    : Include/Config.php
- *  website     : http://www.churchdb.org
- *  description : global configuration
- *
- ******************************************************************************/
+*
+*  filename    : Include/Config.php
+*  website     : http://www.churchdb.org
+*  description : global configuration
+*
+******************************************************************************/
 
 // Database connection constants
 $sSERVERNAME = 'localhost';
@@ -58,10 +58,5 @@ error_reporting(E_ERROR);
 // ini_set('log_errors', 1);
 // ini_set('error_log','/tmp/churchCRM.log');
 
-//
-// SETTINGS END HERE.  DO NOT MODIFY BELOW THIS LINE
-//
-// Absolute path must be specified since this file is called
-// from scripts located in other directories
-require_once(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'LoadConfigs.php');
+require 'Include/LoadConfigs.php';
 ?>

--- a/churchinfo/Include/Config.php.example
+++ b/churchinfo/Include/Config.php.example
@@ -57,6 +57,4 @@ error_reporting(E_ERROR);
 // Warning: The error_log file can grow very large over time.
 // ini_set('log_errors', 1);
 // ini_set('error_log','/tmp/churchCRM.log');
-
-require 'Include/LoadConfigs.php';
 ?>

--- a/churchinfo/Include/Config.php.example
+++ b/churchinfo/Include/Config.php.example
@@ -1,60 +1,86 @@
 <?php
 /*******************************************************************************
-*
-*  filename    : Include/Config.php
-*  website     : http://www.churchdb.org
-*  description : global configuration
-*
-******************************************************************************/
+ *
+ *  filename    : Include/Config.php
+ *  website     : http://www.churchcrm.io
+ *  description : global configuration
+ *
+ ******************************************************************************/
 
-// Database connection constants
+/**
+ * Database connection constants
+ */
+
 $sSERVERNAME = 'localhost';
 $sUSER = 'churchcrm';
 $sPASSWORD = 'churchcrm';
 $sDATABASE = 'churchcrm';
 
-// Root path of your ChurchCRM installation ( THIS MUST BE SET CORRECTLY! )
-// For example, if you will be accessing from http://www.yourdomain.com/web/churchcrm
-// then you would enter '/web/churchcrm' here.
-// Another example, if you will be accessing from http://www.yourdomain.com
-// then you would enter '' ... an empty string for a top level installation.
-// This path SHOULD NOT end with slash.  This is case sensitive.
+
+/**
+ * Root path of your ChurchCRM installation (THIS MUST BE SET CORRECTLY!)
+ * For example, if you will be accessing from http://www.yourdomain.com/web/churchcrm
+ * then you would enter '/web/churchcrm' here.
+ * Another example, if you will be accessing from http://www.yourdomain.com
+ * then you would enter '' ... an empty string for a top level installation.
+ * This path SHOULD NOT end with slash.  This is case sensitive.
+ */
+
 $sRootPath = '';
 
-// Set $bLockURL=TRUE to enforce https access by specifying exactly
-// which URL's your users may use to log into ChurchCRM.
+
+/**
+ * Set $bLockURL=TRUE to enforce https access by specifying exactly
+ * which URL's your users may use to log into ChurchCRM.
+ */
+
 $bLockURL = TRUE;
 
-// URL[0] is the URL that you prefer most users use when they
-// log in.  These are case sensitive.  Only used when $bLockURL = TRUE
+
+/**
+ * URL[0] is the URL that you prefer most users use when they
+ * log in.  These are case sensitive.  Only used when $bLockURL = TRUE
+ */
+
 $URL[0] = 'http://192.168.33.10/';
-// List as many other URL's as may be needed. Number them sequentially.
-//$URL[1] = 'https://www.mychurch.org/churchcrm/';
-//$URL[2] = 'https://www.mychurch.org:8080/churchcrm/';
-//$URL[3] = 'https://www.mychurch.org/churchcrm/';
-//$URL[4] = 'https://ssl.sharedsslserver.com/mychurch.org/churchcrm/';
-//$URL[5] = 'https://crm.mychurch.org/';
 
-// If you are using a non-standard port number be sure to include the
-// port number in the URL. See example $URL[2]
+/**
+ * List as many other URL's as may be needed. Number them sequentially.
+ */
 
-// To enforce https access make sure that "https" is specified in all of the
-// the allowable URLs.  Safe exceptions are when you are at the local machine
-// and using "localhost" or "127.0.0.1"
+// $URL[1] = 'https://www.mychurch.org/churchcrm/';
+// $URL[2] = 'https://www.mychurch.org:8080/churchcrm/';
+// $URL[3] = 'https://www.mychurch.org/churchcrm/';
+// $URL[4] = 'https://ssl.sharedsslserver.com/mychurch.org/churchcrm/';
+// $URL[5] = 'https://crm.mychurch.org/';
 
-// When using a shared SSL certificate provided by your webhost for https access
-// you may need to add the shared SSL server name as well as your host name to
-// the URL.  See example $URL[4]
+/**
+ * If you are using a non-standard port number be sure to include the
+ * port number in the URL. See example $URL[2]
+ *
+ * To enforce https access make sure that "https" is specified in all of the
+ * the allowable URLs.  Safe exceptions are when you are at the local machine
+ * and using "localhost" or "127.0.0.1"
+ *
+ * When using a shared SSL certificate provided by your webhost for https access
+ * you may need to add the shared SSL server name as well as your host name to
+ * the URL.  See example $URL[4]
+ */
 
-// Set error reporting
 
-// Sets which PHP errors are reported see http://php.net/manual/en/errorfunc.constants.php
+/**
+ * Set which PHP errors are reported see http://php.net/manual/en/errorfunc.constants.php
+ */
+
 error_reporting(E_ERROR);
 
-// Rather than display errors on the screen it is more secure to
-// send error messages to a file.  Make sure that your web
-// server has permission to write to this file.
-// Warning: The error_log file can grow very large over time.
+/**
+ * Rather than display errors on the screen it is more secure to
+ * send error messages to a file.  Make sure that your web
+ * server has permission to write to this file.
+ * Warning: The error_log file can grow very large over time.
+ */
+
 // ini_set('log_errors', 1);
 // ini_set('error_log','/tmp/churchCRM.log');
 ?>

--- a/churchinfo/Include/LoadConfigs.php
+++ b/churchinfo/Include/LoadConfigs.php
@@ -25,8 +25,7 @@
 *
 *  http://www.gnu.org/licenses
 *
-*  This file best viewed in a text editor with tabs stops set to 4 characters.
-*  Please configure your editor to use soft tabs (4 spaces for a tab) instead
+*  Please configure your editor to use soft tabs (2 spaces for a tab) instead
 *  of hard tab characters.
 *
 ******************************************************************************/
@@ -38,7 +37,8 @@ if (!file_exists('Include/Config.php'))
 else
   require_once 'Include/Config.php';
 
-if (!function_exists("mysql_failure")) {
+if (!function_exists("mysql_failure"))
+{
   function mysql_failure($message)
   {
     require("Include/HeaderNotLoggedIn.php");
@@ -66,7 +66,8 @@ or mysql_failure("Could not connect to the MySQL database <strong>" . $sDATABASE
 $sql = "SHOW TABLES FROM `$sDATABASE`";
 $tablecheck = mysql_num_rows(mysql_query($sql));
 
-if (!$tablecheck) {
+if (!$tablecheck)
+{
   mysql_failure("There are no tables installed in your database. Please run the migration script in <strong>mysql/install/install.sql</strong>.");
 }
 
@@ -81,7 +82,8 @@ $sDocumentRoot = dirname(dirname(__FILE__));
 
 $version = mysql_fetch_row(mysql_query("SELECT version()"));
 
-if (substr($version[0], 0, 3) >= "4.1") {
+if (substr($version[0], 0, 3) >= "4.1")
+{
   mysql_query("SET NAMES 'utf8'");
 }
 
@@ -90,13 +92,17 @@ if (substr($version[0], 0, 3) >= "4.1") {
 $sSQL = "SELECT cfg_name, IFNULL(cfg_value, cfg_default) AS value "
   . "FROM config_cfg WHERE cfg_section='General'";
 $rsConfig = mysql_query($sSQL);         // Can't use RunQuery -- not defined yet
-if ($rsConfig) {
-  while (list($cfg_name, $value) = mysql_fetch_row($rsConfig)) {
+if ($rsConfig)
+{
+  while (list($cfg_name, $value) = mysql_fetch_row($rsConfig))
+  {
     $$cfg_name = $value;
   }
 }
 
-if (isset($_SESSION['iUserID'])) {      // Not set on Login.php
+// Not set on Login.php
+if (isset($_SESSION['iUserID']))
+{
   // Load user variables from user config table.
   // **************************************************
   $sSQL = "SELECT ucfg_name, ucfg_value AS value "
@@ -114,25 +120,24 @@ $sMetaRefresh = '';  // Initialize to empty
 
 require_once("winlocalelist.php");
 
-if (!function_exists("stripos")) {
+if (!function_exists("stripos"))
+{
   function stripos($str, $needle)
   {
     return strpos(strtolower($str), strtolower($needle));
   }
 }
 
-if (!(stripos(php_uname('s'), "windows") === false)) {
-//  $sLanguage = $lang_map_windows[strtolower($sLanguage)];
+if (!(stripos(php_uname('s'), "windows") === false))
   $sLang_Code = $lang_map_windows[strtolower($sLanguage)];
-} else {
+else
   $sLang_Code = $sLanguage;
-}
+
 putenv("LANG=$sLang_Code");
 setlocale(LC_ALL, $sLang_Code, $sLang_Code . ".utf8", $sLang_Code . ".UTF8", $sLang_Code . ".utf-8", $sLang_Code . ".UTF-8");
 
-if (isset($sTimeZone)) {
+if (isset($sTimeZone))
   date_default_timezone_set($sTimeZone);
-}
 
 // Get numeric and monetary locale settings.
 $aLocaleInfo = localeconv();
@@ -141,12 +146,14 @@ $aLocaleInfo = localeconv();
 setlocale(LC_NUMERIC, 'C');
 
 // patch some missing data for Italian.  This shouldn't be necessary!
-if ($sLanguage == 'it_IT') {
+if ($sLanguage == 'it_IT')
+{
   $aLocaleInfo['thousands_sep'] = '.';
   $aLocaleInfo['frac_digits'] = '2';
 }
 
-if (function_exists('bindtextdomain')) {
+if (function_exists('bindtextdomain'))
+{
   $domain = 'messages';
 
   $sLocaleDir = 'locale';
@@ -156,8 +163,11 @@ if (function_exists('bindtextdomain')) {
   bind_textdomain_codeset($domain, 'UTF-8');
   bindtextdomain($domain, $sLocaleDir);
   textdomain($domain);
-} else {
-  if ($sLanguage != 'en_US') {
+}
+else
+{
+  if ($sLanguage != 'en_US')
+  {
     // PHP array version of the l18n strings
     $sLocaleMessages = "locale/$sLanguage/LC_MESSAGES/messages.php";
 
@@ -176,7 +186,9 @@ if (function_exists('bindtextdomain')) {
       else
         return $text;
     }
-  } else {
+  }
+  else
+  {
     // dummy gettext function
     function gettext($text)
     {

--- a/churchinfo/Include/LoadConfigs.php
+++ b/churchinfo/Include/LoadConfigs.php
@@ -1,35 +1,43 @@
 <?php
 /*******************************************************************************
- *
- *  filename    : Include/LoadConfigs.php
- *  website     : http://www.churchcrm.io
- *  description : global configuration
- *                   The code in this file used to be part of part of Config.php
- *
- *  Copyright 2001-2005 Phillip Hullquist, Deane Barker, Chris Gebhardt,
- *                      Michael Wilt, Timothy Dearborn
- *
- *
- *  LICENSE:
- *  (C) Free Software Foundation, Inc.
- *
- *  ChurchCRM is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- *  General Public License for more details.
- *
- *  http://www.gnu.org/licenses
- *
- *  This file best viewed in a text editor with tabs stops set to 4 characters.
- *  Please configure your editor to use soft tabs (4 spaces for a tab) instead
- *  of hard tab characters.
- *
- ******************************************************************************/
+*
+*  filename    : Include/LoadConfigs.php
+*  website     : http://www.churchcrm.io
+*  description : global configuration
+*                   The code in this file used to be part of part of Config.php
+*
+*  Copyright 2001-2005 Phillip Hullquist, Deane Barker, Chris Gebhardt,
+*                      Michael Wilt, Timothy Dearborn
+*
+*
+*  LICENSE:
+*  (C) Free Software Foundation, Inc.
+*
+*  ChurchCRM is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 3 of the License, or
+*  (at your option) any later version.
+*
+*  This program is distributed in the hope that it will be useful, but
+*  WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+*  General Public License for more details.
+*
+*  http://www.gnu.org/licenses
+*
+*  This file best viewed in a text editor with tabs stops set to 4 characters.
+*  Please configure your editor to use soft tabs (4 spaces for a tab) instead
+*  of hard tab characters.
+*
+******************************************************************************/
+if (!file_exists('Include/Config.php'))
+{
+  echo "To setup ChurchCRM copy <tt>Include/Config.php.example</tt> to <tt>Include/Config.php</tt> and customize.";
+  exit;
+}
+else
+  require_once 'Include/Config.php';
+
 if (!function_exists("mysql_failure")) {
   function mysql_failure($message)
   {

--- a/churchinfo/Include/index.html
+++ b/churchinfo/Include/index.html
@@ -1,0 +1,7 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<meta http-equiv="Refresh" CONTENT="0;URL=../index.php">
+</head>
+</html>

--- a/churchinfo/LettersAndLabels.php
+++ b/churchinfo/LettersAndLabels.php
@@ -21,7 +21,7 @@
 
 
 // Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 require "Include/LabelFunctions.php";
 

--- a/churchinfo/ListEvents.php
+++ b/churchinfo/ListEvents.php
@@ -26,7 +26,7 @@
 *
 ******************************************************************************/
 
-require 'Include/Config.php';
+require 'Include/LoadConfigs.php';
 require 'Include/Functions.php';
 $eType="All";
 $ThisYear=date("Y");

--- a/churchinfo/Login.php
+++ b/churchinfo/Login.php
@@ -39,7 +39,7 @@ if (ini_get('register_globals'))
 }
 
 // Include the function library
-require 'Include/Config.php';
+require 'Include/LoadConfigs.php';
 $bSuppressSessionTests = TRUE;
 require 'Include/Functions.php';
 // Initialize the variables

--- a/churchinfo/ManageEnvelopes.php
+++ b/churchinfo/ManageEnvelopes.php
@@ -14,7 +14,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 require "Include/EnvelopeFunctions.php";

--- a/churchinfo/MemberRoleChange.php
+++ b/churchinfo/MemberRoleChange.php
@@ -14,7 +14,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 // Security: User must have Manage Groups & Roles permission

--- a/churchinfo/MembersDashboard.php
+++ b/churchinfo/MembersDashboard.php
@@ -4,7 +4,7 @@
  * Date: 1/17/2016
  * Time: 8:01 AM
  */
-require 'Include/Config.php';
+require 'Include/LoadConfigs.php';
 require 'Include/Functions.php';
 require 'Include/PersonFunctions.php';
 

--- a/churchinfo/Menu.php
+++ b/churchinfo/Menu.php
@@ -24,7 +24,7 @@
 ******************************************************************************/
 
 // Include the function library
-require 'Include/Config.php';
+require 'Include/LoadConfigs.php';
 require 'Include/Functions.php';
 require 'Include/PersonFunctions.php';
 require 'Service/FinancialService.php';

--- a/churchinfo/NoteDelete.php
+++ b/churchinfo/NoteDelete.php
@@ -14,7 +14,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 // Security: User must have Notes permission

--- a/churchinfo/NoteEditor.php
+++ b/churchinfo/NoteEditor.php
@@ -14,7 +14,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 require "Service/NoteService.php";
 

--- a/churchinfo/OptionManager.php
+++ b/churchinfo/OptionManager.php
@@ -17,7 +17,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 $mode = trim($_GET["mode"]);

--- a/churchinfo/OptionManagerRowOps.php
+++ b/churchinfo/OptionManagerRowOps.php
@@ -15,7 +15,7 @@
 
  ******************************************************************************/
 
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 // Get the Order, ID, Mode, and Action from the querystring

--- a/churchinfo/PaddleNumDelete.php
+++ b/churchinfo/PaddleNumDelete.php
@@ -13,7 +13,7 @@
 *
 ******************************************************************************/
 
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 $iPaddleNumID = FilterInput($_GET["PaddleNumID"],'int');

--- a/churchinfo/PaddleNumEditor.php
+++ b/churchinfo/PaddleNumEditor.php
@@ -14,7 +14,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 $iPaddleNumID = FilterInputArr($_GET,"PaddleNumID",'int');

--- a/churchinfo/PaddleNumList.php
+++ b/churchinfo/PaddleNumList.php
@@ -14,7 +14,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 $linkBack = FilterInputArr($_GET,"linkBack");

--- a/churchinfo/PersonCustomFieldsEditor.php
+++ b/churchinfo/PersonCustomFieldsEditor.php
@@ -14,7 +14,7 @@
  *  (at your option) any later version.
  ******************************************************************************/
 
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 // Security: user must be administrator to use this page

--- a/churchinfo/PersonCustomFieldsRowOps.php
+++ b/churchinfo/PersonCustomFieldsRowOps.php
@@ -15,7 +15,7 @@
 
  ******************************************************************************/
 
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 // Security: user must be administrator to use this page.

--- a/churchinfo/PersonEditor.php
+++ b/churchinfo/PersonEditor.php
@@ -14,7 +14,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 //Set the page title

--- a/churchinfo/PersonToGroup.php
+++ b/churchinfo/PersonToGroup.php
@@ -17,7 +17,7 @@
  ******************************************************************************/
 
 // Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 require_once "Service/GroupService.php";
 

--- a/churchinfo/PersonView.php
+++ b/churchinfo/PersonView.php
@@ -16,7 +16,7 @@
  ******************************************************************************/
 
 // Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 require 'Include/PersonFunctions.php';
 require 'Service/MailchimpService.php';

--- a/churchinfo/PledgeDelete.php
+++ b/churchinfo/PledgeDelete.php
@@ -14,7 +14,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 //Set the page title

--- a/churchinfo/PledgeDetails.php
+++ b/churchinfo/PledgeDetails.php
@@ -12,7 +12,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 //Set the page title

--- a/churchinfo/PledgeEditor.php
+++ b/churchinfo/PledgeEditor.php
@@ -17,7 +17,7 @@
 global $iChecksPerDepositForm;
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 require "Include/MICRFunctions.php";
 

--- a/churchinfo/PrintView.php
+++ b/churchinfo/PrintView.php
@@ -15,7 +15,7 @@
  ******************************************************************************/
 
 // Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 // Get the person ID from the querystring

--- a/churchinfo/PropertyAssign.php
+++ b/churchinfo/PropertyAssign.php
@@ -16,7 +16,7 @@
  ******************************************************************************/
 
 // Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 // Security: User must have Manage Groups or Edit Records permissions

--- a/churchinfo/PropertyDelete.php
+++ b/churchinfo/PropertyDelete.php
@@ -14,7 +14,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 if (!$_SESSION['bMenuOptions'])

--- a/churchinfo/PropertyEditor.php
+++ b/churchinfo/PropertyEditor.php
@@ -14,7 +14,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 // Security: User must have property and classification editing permission

--- a/churchinfo/PropertyList.php
+++ b/churchinfo/PropertyList.php
@@ -14,7 +14,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 //Get the type to display

--- a/churchinfo/PropertyTypeDelete.php
+++ b/churchinfo/PropertyTypeDelete.php
@@ -14,7 +14,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 // Security: User must have property and classification editing permission

--- a/churchinfo/PropertyTypeEditor.php
+++ b/churchinfo/PropertyTypeEditor.php
@@ -14,7 +14,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 // Security: User must have property and classification editing permission

--- a/churchinfo/PropertyTypeList.php
+++ b/churchinfo/PropertyTypeList.php
@@ -14,7 +14,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 // Set the page title

--- a/churchinfo/PropertyUnassign.php
+++ b/churchinfo/PropertyUnassign.php
@@ -14,7 +14,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 // Security: User must have Manage Groups or Edit Records permissions

--- a/churchinfo/QueryList.php
+++ b/churchinfo/QueryList.php
@@ -14,7 +14,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 //Set the page title

--- a/churchinfo/QuerySQL.php
+++ b/churchinfo/QuerySQL.php
@@ -14,7 +14,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 //Set the page title

--- a/churchinfo/QueryView.php
+++ b/churchinfo/QueryView.php
@@ -15,7 +15,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 //Set the page title

--- a/churchinfo/RPCdummy.php
+++ b/churchinfo/RPCdummy.php
@@ -1,5 +1,5 @@
 <?php
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 $mode = $_GET['mode'];

--- a/churchinfo/Register.php
+++ b/churchinfo/Register.php
@@ -13,7 +13,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 
 require "Include/Functions.php";
 

--- a/churchinfo/ReminderReport.php
+++ b/churchinfo/ReminderReport.php
@@ -13,7 +13,7 @@
  ******************************************************************************/
 
 // Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 // If CSVAdminOnly option is enabled and user is not admin, redirect to the menu.

--- a/churchinfo/ReportList.php
+++ b/churchinfo/ReportList.php
@@ -13,7 +13,7 @@
  *
  ******************************************************************************/
 
-require 'Include/Config.php';
+require 'Include/LoadConfigs.php';
 require 'Include/Functions.php';
 
 //Set the page title

--- a/churchinfo/Reports/AdvancedDeposit.php
+++ b/churchinfo/Reports/AdvancedDeposit.php
@@ -12,7 +12,7 @@
 *
 ******************************************************************************/
 
-require "../Include/Config.php";
+require "../Include/LoadConfigs.php";
 require "../Include/Functions.php";
 require "../Include/ReportFunctions.php";
 require "../Include/ReportConfig.php";

--- a/churchinfo/Reports/CanvassReports.php
+++ b/churchinfo/Reports/CanvassReports.php
@@ -14,7 +14,7 @@
  ******************************************************************************/
 
 
-require "../Include/Config.php";
+require "../Include/LoadConfigs.php";
 require "../Include/Functions.php";
 require "../Include/ReportFunctions.php";
 require "../Include/ReportConfig.php";

--- a/churchinfo/Reports/ClassAttendance.php
+++ b/churchinfo/Reports/ClassAttendance.php
@@ -12,7 +12,7 @@
 *
 ******************************************************************************/
 
-require "../Include/Config.php";
+require "../Include/LoadConfigs.php";
 require "../Include/Functions.php";
 require "../Include/ReportFunctions.php";
 require "../Include/ReportConfig.php";

--- a/churchinfo/Reports/ClassList.php
+++ b/churchinfo/Reports/ClassList.php
@@ -12,7 +12,7 @@
 *
 ******************************************************************************/
 
-require "../Include/Config.php";
+require "../Include/LoadConfigs.php";
 require "../Include/Functions.php";
 require "../Include/ReportFunctions.php";
 require "../Include/ReportConfig.php";

--- a/churchinfo/Reports/ConfirmLabels.php
+++ b/churchinfo/Reports/ConfirmLabels.php
@@ -12,7 +12,7 @@
 *
 ******************************************************************************/
 
-require "../Include/Config.php";
+require "../Include/LoadConfigs.php";
 require "../Include/Functions.php";
 require "../Include/ReportFunctions.php";
 require "../Include/ReportConfig.php";

--- a/churchinfo/Reports/ConfirmReport.php
+++ b/churchinfo/Reports/ConfirmReport.php
@@ -13,7 +13,7 @@
 *
 ******************************************************************************/
 
-require "../Include/Config.php";
+require "../Include/LoadConfigs.php";
 require "../Include/Functions.php";
 require "../Include/ReportFunctions.php";
 require "../Include/ReportConfig.php";

--- a/churchinfo/Reports/ConfirmReportEmail.php
+++ b/churchinfo/Reports/ConfirmReportEmail.php
@@ -13,7 +13,7 @@
 *
 ******************************************************************************/
 
-require "../Include/Config.php";
+require "../Include/LoadConfigs.php";
 require "../Include/Functions.php";
 require "../Include/ReportFunctions.php";
 require "../Include/ReportConfig.php";

--- a/churchinfo/Reports/EnvelopeReport.php
+++ b/churchinfo/Reports/EnvelopeReport.php
@@ -11,7 +11,7 @@
 *
 ******************************************************************************/
 
-require "../Include/Config.php";
+require "../Include/LoadConfigs.php";
 require "../Include/Functions.php";
 require "../Include/ReportFunctions.php";
 require "../Include/ReportConfig.php";

--- a/churchinfo/Reports/FRBidSheets.php
+++ b/churchinfo/Reports/FRBidSheets.php
@@ -12,7 +12,7 @@
 *
 ******************************************************************************/
 
-require "../Include/Config.php";
+require "../Include/LoadConfigs.php";
 require "../Include/Functions.php";
 require "../Include/ReportFunctions.php";
 require "../Include/ReportConfig.php";

--- a/churchinfo/Reports/FRCatalog.php
+++ b/churchinfo/Reports/FRCatalog.php
@@ -13,7 +13,7 @@
 *
 ******************************************************************************/
 
-require "../Include/Config.php";
+require "../Include/LoadConfigs.php";
 require "../Include/Functions.php";
 require "../Include/ReportFunctions.php";
 require "../Include/ReportConfig.php";

--- a/churchinfo/Reports/FRCertificates.php
+++ b/churchinfo/Reports/FRCertificates.php
@@ -12,7 +12,7 @@
 *
 ******************************************************************************/
 
-require "../Include/Config.php";
+require "../Include/LoadConfigs.php";
 require "../Include/Functions.php";
 require "../Include/ReportFunctions.php";
 require "../Include/ReportConfig.php";

--- a/churchinfo/Reports/FamilyPledgeSummary.php
+++ b/churchinfo/Reports/FamilyPledgeSummary.php
@@ -13,7 +13,7 @@
 *
 ******************************************************************************/
 
-require "../Include/Config.php";
+require "../Include/LoadConfigs.php";
 require "../Include/Functions.php";
 require "../Include/ReportFunctions.php";
 require "../Include/ReportConfig.php";

--- a/churchinfo/Reports/FundRaiserStatement.php
+++ b/churchinfo/Reports/FundRaiserStatement.php
@@ -13,7 +13,7 @@
 *
 ******************************************************************************/
 
-require "../Include/Config.php";
+require "../Include/LoadConfigs.php";
 require "../Include/Functions.php";
 require "../Include/ReportFunctions.php";
 require "../Include/ReportConfig.php";

--- a/churchinfo/Reports/GroupReport.php
+++ b/churchinfo/Reports/GroupReport.php
@@ -15,7 +15,7 @@
 *
 ******************************************************************************/
 
-require "../Include/Config.php";
+require "../Include/LoadConfigs.php";
 require "../Include/Functions.php";
 require "../Include/ReportFunctions.php";
 require "../Include/ReportConfig.php";

--- a/churchinfo/Reports/NameTags.php
+++ b/churchinfo/Reports/NameTags.php
@@ -12,7 +12,7 @@
 *
 ******************************************************************************/
 
-require "../Include/Config.php";
+require "../Include/LoadConfigs.php";
 require "../Include/Functions.php";
 require "../Include/ReportFunctions.php";
 require "../Include/ReportConfig.php";
@@ -38,11 +38,11 @@ $sFontSize = $_GET["labelfontsize"];
 setcookie("labelfontsize", $sFontSize, time()+60*60*24*90, "/");
 $pdf->SetFont($sFontInfo[0],$sFontInfo[1]);
 
-if($sFontSize != "default") 
+if($sFontSize != "default")
 	$pdf->Set_Char_Size($sFontSize);
-//if($sFontSize != "default") 
+//if($sFontSize != "default")
 //	$pdf->SetFontSize($sFontSize);
-	
+
 $sSQL = "SELECT * FROM person_per WHERE per_ID IN (" . ConvertCartToString($_SESSION['aPeopleCart']) . ") ORDER BY per_LastName";
 $rsPersons = RunQuery($sSQL);
 
@@ -51,7 +51,7 @@ while ($aPer = mysql_fetch_array($rsPersons)) {
 
 	$PosX = $pdf->_Margin_Left+($pdf->_COUNTX*($pdf->_Width+$pdf->_X_Space));
 	$PosY = $pdf->_Margin_Top+($pdf->_COUNTY*($pdf->_Height+$pdf->_Y_Space));
-		
+
 	$perimg = "../Images/Person/".$per_ID.".jpg";
     if (file_exists($perimg)) {
         $s = getimagesize($perimg);
@@ -60,24 +60,24 @@ while ($aPer = mysql_fetch_array($rsPersons)) {
         	$useWidth = $pdf->_Width * $pdf->_Height / $h;
         else
         	$useWidth = $pdf->_Width;
-        
+
         $pdf->Image($perimg, $PosX, $PosY, $useWidth);
-	    
+
 		$labelStr = sprintf ("%s\n%s\n\n%d", $per_FirstName, $per_LastName, $per_ID);
-		
+
 		$firstWid = $pdf->GetStringWidth($per_FirstName);
 		$lastWid = $pdf->GetStringWidth($per_LastName);
 		$maxWid = max($firstWid, $lastWid);
 		$useWid = $pdf->_Width/2 - 2;
-		
+
 		if ($maxWid > $useWid) {
 			$useFontSize = (int)($sFontSize * $useWid / $maxWid);
 			$pdf->Set_Char_Size ($useFontSize);
 		}
-		
+
 		$pdf->SetXY($PosX+$pdf->_Width/2, $PosY+3);
 		$pdf->MultiCell($pdf->_Width/2, $pdf->_Line_Height, iconv("UTF-8","ISO-8859-1",$labelStr));
-		$pdf->Set_Char_Size($sFontSize);		
+		$pdf->Set_Char_Size($sFontSize);
 	    $pdf->Add_PDF_Label("");
     } else {
 		$labelStr = sprintf ("%s %s\n\n%d", $per_FirstName, $per_LastName, $per_ID);
@@ -96,5 +96,5 @@ header('Pragma: public');  // Needed for IE when using a shared SSL certificate
 if ($iPDFOutputType == 1)
 	$pdf->Output("NameTags" . date("Ymd") . ".pdf", "D");
 else
-	$pdf->Output();	
+	$pdf->Output();
 ?>

--- a/churchinfo/Reports/NewsLetterLabels.php
+++ b/churchinfo/Reports/NewsLetterLabels.php
@@ -12,7 +12,7 @@
 *
 ******************************************************************************/
 
-require "../Include/Config.php";
+require "../Include/LoadConfigs.php";
 require "../Include/Functions.php";
 require "../Include/ReportFunctions.php";
 require "../Include/ReportConfig.php";

--- a/churchinfo/Reports/PDFLabel.php
+++ b/churchinfo/Reports/PDFLabel.php
@@ -32,7 +32,7 @@
 *
 ******************************************************************************/
 
-require "../Include/Config.php";
+require "../Include/LoadConfigs.php";
 require "../Include/Functions.php";
 require "../Include/ReportFunctions.php";
 require "../Include/ReportConfig.php";

--- a/churchinfo/Reports/PledgeSummary.php
+++ b/churchinfo/Reports/PledgeSummary.php
@@ -12,7 +12,7 @@
 *
 ******************************************************************************/
 
-require "../Include/Config.php";
+require "../Include/LoadConfigs.php";
 require "../Include/Functions.php";
 require "../Include/ReportFunctions.php";
 require "../Include/ReportConfig.php";

--- a/churchinfo/Reports/PrintDeposit.php
+++ b/churchinfo/Reports/PrintDeposit.php
@@ -14,7 +14,7 @@
 
 global $iChecksPerDepositForm;
 
-require "../Include/Config.php";
+require "../Include/LoadConfigs.php";
 require "../Include/Functions.php";
 require "../Include/ReportFunctions.php";
 require "../Include/ReportConfig.php";

--- a/churchinfo/Reports/ReminderReport.php
+++ b/churchinfo/Reports/ReminderReport.php
@@ -23,7 +23,7 @@
 *
 ******************************************************************************/
 
-require "../Include/Config.php";
+require "../Include/LoadConfigs.php";
 require "../Include/Functions.php";
 require "../Include/ReportFunctions.php";
 require "../Include/ReportConfig.php";

--- a/churchinfo/Reports/TaxReport.php
+++ b/churchinfo/Reports/TaxReport.php
@@ -12,7 +12,7 @@
 *
 ******************************************************************************/
 
-require "../Include/Config.php";
+require "../Include/LoadConfigs.php";
 require "../Include/Functions.php";
 require "../Include/ReportFunctions.php";
 require "../Include/ReportConfig.php";

--- a/churchinfo/Reports/VotingMembers.php
+++ b/churchinfo/Reports/VotingMembers.php
@@ -12,7 +12,7 @@
 *
 ******************************************************************************/
 
-require "../Include/Config.php";
+require "../Include/LoadConfigs.php";
 require "../Include/Functions.php";
 require "../Include/ReportFunctions.php";
 require "../Include/ReportConfig.php";

--- a/churchinfo/Reports/ZeroGivers.php
+++ b/churchinfo/Reports/ZeroGivers.php
@@ -13,7 +13,7 @@
 *
 ******************************************************************************/
 
-require "../Include/Config.php";
+require "../Include/LoadConfigs.php";
 require "../Include/Functions.php";
 require "../Include/ReportFunctions.php";
 require "../Include/ReportConfig.php";

--- a/churchinfo/RestoreDatabase.php
+++ b/churchinfo/RestoreDatabase.php
@@ -12,7 +12,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 // Security: User must have Manage Groups permission

--- a/churchinfo/SelectDelete.php
+++ b/churchinfo/SelectDelete.php
@@ -14,7 +14,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 require "Service/GroupService.php";
 

--- a/churchinfo/SelectList.php
+++ b/churchinfo/SelectList.php
@@ -29,7 +29,7 @@
 ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 require "Include/PersonFunctions.php";
 

--- a/churchinfo/SettingsIndividual.php
+++ b/churchinfo/SettingsIndividual.php
@@ -25,7 +25,7 @@
 
 
 // Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 $iPersonID=$_SESSION['iUserID'];

--- a/churchinfo/SettingsUser.php
+++ b/churchinfo/SettingsUser.php
@@ -26,7 +26,7 @@
 
 
 // Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 // Security

--- a/churchinfo/SundaySchool.php
+++ b/churchinfo/SundaySchool.php
@@ -14,7 +14,7 @@
  ******************************************************************************/
 
 // Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 // Get all the groups

--- a/churchinfo/SystemSettings.php
+++ b/churchinfo/SystemSettings.php
@@ -25,7 +25,7 @@
  ******************************************************************************/
 
 // Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 

--- a/churchinfo/TaxReport.php
+++ b/churchinfo/TaxReport.php
@@ -13,7 +13,7 @@
  ******************************************************************************/
 
 // Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 // If CSVAdminOnly option is enabled and user is not admin, redirect to the menu.

--- a/churchinfo/USISTAddressVerification.php
+++ b/churchinfo/USISTAddressVerification.php
@@ -27,7 +27,7 @@
 // See https://www.intelligentsearch.com/Hosted/User/
 
 // Include the function library
-require 'Include/Config.php';
+require 'Include/LoadConfigs.php';
 require 'Include/Functions.php';
 
 function XMLparseIST($xmlstr,$xmlfield) {

--- a/churchinfo/UpdateAllLatLon.php
+++ b/churchinfo/UpdateAllLatLon.php
@@ -23,7 +23,7 @@
  ******************************************************************************/
 
 
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 require "Include/GeoCoder.php";

--- a/churchinfo/UserDelete.php
+++ b/churchinfo/UserDelete.php
@@ -16,7 +16,7 @@
  ******************************************************************************/
 
 // Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 // Security: User must be an Admin to access this page.

--- a/churchinfo/UserEditor.php
+++ b/churchinfo/UserEditor.php
@@ -35,7 +35,7 @@
 *
 ******************************************************************************/
 // Include the function library
-require 'Include/Config.php';
+require 'Include/LoadConfigs.php';
 require 'Include/Functions.php';
 
 // Security: User must be an Admin to access this page.

--- a/churchinfo/UserList.php
+++ b/churchinfo/UserList.php
@@ -16,7 +16,7 @@
  ******************************************************************************/
 
 // Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 // Security: User must be an Admin to access this page.

--- a/churchinfo/UserPasswordChange.php
+++ b/churchinfo/UserPasswordChange.php
@@ -24,7 +24,7 @@
  ******************************************************************************/
 
 // Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 $bNoPasswordRedirect = true; // Subdue UserPasswordChange redirect to prevent looping
 require "Include/Functions.php";
 

--- a/churchinfo/UserReset.php
+++ b/churchinfo/UserReset.php
@@ -16,7 +16,7 @@
  ******************************************************************************/
 
 // Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 // Get the PersonID out of the querystring

--- a/churchinfo/VolunteerOpportunityEditor.php
+++ b/churchinfo/VolunteerOpportunityEditor.php
@@ -22,7 +22,7 @@
  *
  ******************************************************************************/
 
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 // Security: User must have proper permission

--- a/churchinfo/WhyCameEditor.php
+++ b/churchinfo/WhyCameEditor.php
@@ -14,7 +14,7 @@
  ******************************************************************************/
 
 //Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 $linkBack = FilterInput($_GET["linkBack"]);

--- a/churchinfo/calendar.php
+++ b/churchinfo/calendar.php
@@ -1,5 +1,5 @@
 <?php
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 $events = array();

--- a/churchinfo/eGive.php
+++ b/churchinfo/eGive.php
@@ -8,7 +8,7 @@
  ******************************************************************************/
 
 // Include the function library
-require "Include/Config.php";
+require 'Include/LoadConfigs.php';
 require "Include/Functions.php";
 
 if( !function_exists(json_decode) ) {

--- a/churchinfo/mailchimp/MailChimpCsvExport.php
+++ b/churchinfo/mailchimp/MailChimpCsvExport.php
@@ -1,5 +1,5 @@
 <?php
-require "../Include/Config.php";
+require "../Include/LoadConfigs.php";
 require "../Include/Functions.php";
 
 header("Content-type: text/csv");

--- a/churchinfo/mrbs.php
+++ b/churchinfo/mrbs.php
@@ -19,7 +19,7 @@
 ******************************************************************************/
 
 // Include the function library
-require 'Include/Config.php';
+require 'Include/LoadConfigs.php';
 require 'Include/Functions.php';
 
 // Set the page title

--- a/churchinfo/sundayschool/SundaySchoolClassListExport.php
+++ b/churchinfo/sundayschool/SundaySchoolClassListExport.php
@@ -1,5 +1,5 @@
 <?php
-require "../Include/Config.php";
+require "../Include/LoadConfigs.php";
 require "../Include/Functions.php";
 
 header("Content-type: text/csv");

--- a/churchinfo/sundayschool/SundaySchoolClassView.php
+++ b/churchinfo/sundayschool/SundaySchoolClassView.php
@@ -1,6 +1,6 @@
 <?php
 
-require "../Include/Config.php";
+require "../Include/LoadConfigs.php";
 require "../Include/Functions.php";
 require "../Include/PersonFunctions.php";
 require "../Service/SundaySchoolService.php";

--- a/churchinfo/sundayschool/SundaySchoolDashboard.php
+++ b/churchinfo/sundayschool/SundaySchoolDashboard.php
@@ -1,5 +1,5 @@
 <?php
-require "../Include/Config.php";
+require "../Include/LoadConfigs.php";
 require "../Include/Functions.php";
 
 // Get all the groups

--- a/churchinfo/webcalendar.php
+++ b/churchinfo/webcalendar.php
@@ -19,7 +19,7 @@
 ******************************************************************************/
 
 // Include the function library
-require 'Include/Config.php';
+require 'Include/LoadConfigs.php';
 require 'Include/Functions.php';
 
 // Set the page title

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -39,21 +39,25 @@ sudo mysql -u"$CRM_DB_USER" -p"$CRM_DB_PASS" "$CRM_DB_NAME" < $CRM_DB_INSTALL_SC
 
 echo "Database: tables and metadata deployed"
 
+cp /var/www/public/Include/Config.php.example /var/www/public/Include/Config.php
+
+echo "ChurchCRM configured"
+
 echo "=========================================================="
 echo "=========================================================="
-echo "===   .o88b. db   db db    db d8888b.  .o88b. db   db  ==="     
-echo "===  d8P  Y8 88   88 88    88 88  '8D d8P  Y8 88   88  ==="  
-echo "===  8P      88ooo88 88    88 88oobY' 8P      88ooo88  ==="  
-echo "===  8b      88~~~88 88    88 88'8b   8b      88~~~88  ===" 
-echo "===  Y8b  d8 88   88 88b  d88 88 '88. Y8b  d8 88   88  ===" 
-echo "===   'Y88P' YP   YP ~Y8888P' 88   YD  'Y88P' YP   YP  ===" 
+echo "===   .o88b. db   db db    db d8888b.  .o88b. db   db  ==="
+echo "===  d8P  Y8 88   88 88    88 88  '8D d8P  Y8 88   88  ==="
+echo "===  8P      88ooo88 88    88 88oobY' 8P      88ooo88  ==="
+echo "===  8b      88~~~88 88    88 88'8b   8b      88~~~88  ==="
+echo "===  Y8b  d8 88   88 88b  d88 88 '88. Y8b  d8 88   88  ==="
+echo "===   'Y88P' YP   YP ~Y8888P' 88   YD  'Y88P' YP   YP  ==="
 echo "===                                                    ==="
 echo "===                         .o88b. d8888b. .88b  d88.  ==="
 echo "===                        d8P  Y8 88  '8D 88'YbdP'88  ==="
 echo "===                        8P      88oobY' 88  88  88  ==="
 echo "===                        8b      88'8b   88  88  88  ==="
 echo "===                        Y8b  d8 88 '88. 88  88  88  ==="
-echo "===                         'Y88P' 88   YD YP  YP  YP  ==="                           
+echo "===                         'Y88P' 88   YD YP  YP  YP  ==="
 echo "=========================================================="
 echo "=========================================================="
 echo "====== Visit  http://192.168.33.10/               ========"


### PR DESCRIPTION
Move logic code out of `Config.php` (use `LoadConfigs.php` as a wrapper to load the Config rather than the other way around). Alert user if `Config.php` does not exist. Fix up Vagrant to copy `Config.php` into place automatically.

@crossan007 and @DawoudIO I'll add a commit to update the installation instructions. Is another change required to get the demo site working correctly?

Closes #503