### PR TITLE
Use JSON functionality to build bday list

### DIFF
--- a/churchinfo/calendar.php
+++ b/churchinfo/calendar.php
@@ -7,13 +7,14 @@ $birthDays = $personService->getBirthDays();
 $year = date("Y");
 
 foreach ($birthDays as $birthDay) {
-  $event = "{ title: '". $birthDay["firstName"] . " " . $birthDay["lastName"]  ."',
-              start: '". $year. "-". $birthDay["birthMonth"]. "-". $birthDay["birthDay"]. "',
-              url: '".$birthDay["uri"]."',
-              backgroundColor: '#f56954', //red
-              borderColor: '#f56954', //red
-              allDay: true
-            }";
+  $event = array(
+             "title" => $birthDay["firstName"] . " " . $birthDay["lastName"],
+             "start" => $year . "-" . $birthDay["birthMonth"] . "-" . $birthDay["birthDay"],
+             "url"   => $birthDay["uri"],
+             "backgroundColor" => '#f56954', //red
+             "borderColor"     => '#f56954', //red
+             "allDay" => true
+           );
 
   array_push($events, $event);
 }
@@ -70,9 +71,7 @@ require "Include/Header.php"; ?>
         day: 'day'
       },
       //Random default events
-      events: [
-        <?= implode(",", $events) ?>
-      ]
+      events: <?= json_encode($events) ?>
     });
  });
 </script>


### PR DESCRIPTION
Using `json_encode` is more robust than piecing the JSON together by string operations. This fixes the single quote breaking strings issue.

Closes #502