### PR TITLE
Fixes 548

### DIFF
--- a/src/mysql/upgrade/1.2.14-2.0.0.sql
+++ b/src/mysql/upgrade/1.2.14-2.0.0.sql
@@ -14,7 +14,7 @@ INSERT INTO `config_cfg` (`cfg_id`, `cfg_name`, `cfg_value`, `cfg_type`, `cfg_de
   (2001, 'mailChimpApiKey', '', 'text', '', 'see http://kb.mailchimp.com/accounts/management/about-api-keys', 'General', NULL),
   (1034, 'sChurchChkAcctNum', '111111111', 'text', '', 'Church Checking Account Number', 'ChurchInfoReport', NULL);
 UPDATE user_usr
-SET usr_Style = "skin-blue";
+ SET usr_Style = "skin-blue";
 
 ALTER TABLE `config_cfg`
-ADD COLUMN `cfg_order` INT NULL COMMENT '' AFTER `cfg_category`;
+ ADD COLUMN `cfg_order` INT NULL COMMENT '' AFTER `cfg_category`;

--- a/src/mysql/upgrade/1.2.14-2.0.0.sql
+++ b/src/mysql/upgrade/1.2.14-2.0.0.sql
@@ -14,4 +14,7 @@ INSERT INTO `config_cfg` (`cfg_id`, `cfg_name`, `cfg_value`, `cfg_type`, `cfg_de
   (2001, 'mailChimpApiKey', '', 'text', '', 'see http://kb.mailchimp.com/accounts/management/about-api-keys', 'General', NULL),
   (1034, 'sChurchChkAcctNum', '111111111', 'text', '', 'Church Checking Account Number', 'ChurchInfoReport', NULL);
 UPDATE user_usr
- SET usr_Style = "skin-blue";
+SET usr_Style = "skin-blue";
+
+ALTER TABLE `config_cfg`
+ADD COLUMN `cfg_order` INT NULL COMMENT '' AFTER `cfg_category`;

--- a/src/mysql/upgrade/1.3.0-2.0.0.sql
+++ b/src/mysql/upgrade/1.3.0-2.0.0.sql
@@ -13,4 +13,7 @@ INSERT INTO `config_cfg` (`cfg_id`, `cfg_name`, `cfg_value`, `cfg_type`, `cfg_de
    'ChurchCRM has been registered.  The ChurchCRM team uses registration information to track usage.  This information is kept confidential and never released or sold.  If this field is true the registration option in the admin menu changes to update registration.', 'General', NULL),
   (1034, 'sChurchChkAcctNum', '111111111', 'text', '', 'Church Checking Account Number', 'ChurchInfoReport', NULL);
 UPDATE user_usr
- SET usr_Style = "skin-blue";
+SET usr_Style = "skin-blue";
+
+ALTER TABLE `config_cfg`
+ADD COLUMN `cfg_order` INT NULL COMMENT '' AFTER `cfg_category`;

--- a/src/mysql/upgrade/1.3.0-2.0.0.sql
+++ b/src/mysql/upgrade/1.3.0-2.0.0.sql
@@ -13,7 +13,7 @@ INSERT INTO `config_cfg` (`cfg_id`, `cfg_name`, `cfg_value`, `cfg_type`, `cfg_de
    'ChurchCRM has been registered.  The ChurchCRM team uses registration information to track usage.  This information is kept confidential and never released or sold.  If this field is true the registration option in the admin menu changes to update registration.', 'General', NULL),
   (1034, 'sChurchChkAcctNum', '111111111', 'text', '', 'Church Checking Account Number', 'ChurchInfoReport', NULL);
 UPDATE user_usr
-SET usr_Style = "skin-blue";
+ SET usr_Style = "skin-blue";
 
 ALTER TABLE `config_cfg`
-ADD COLUMN `cfg_order` INT NULL COMMENT '' AFTER `cfg_category`;
+ ADD COLUMN `cfg_order` INT NULL COMMENT '' AFTER `cfg_category`;

--- a/src/mysql/upgrade/update_config.sql
+++ b/src/mysql/upgrade/update_config.sql
@@ -7,9 +7,6 @@ SET time_zone = "+00:00";
 /*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
 /*!40101 SET NAMES utf8 */;
 
-ALTER TABLE `config_cfg`
-ADD COLUMN `cfg_order` INT NULL COMMENT '' AFTER `cfg_category`;
-
 UPDATE `config_cfg` SET `cfg_category`='Step1', `cfg_order`='0' WHERE `cfg_id`='1003';
 UPDATE `config_cfg` SET `cfg_category`='Step1', `cfg_order`='1' WHERE `cfg_id`='1004';
 UPDATE `config_cfg` SET `cfg_category`='Step1', `cfg_order`='2' WHERE `cfg_id`='1005';


### PR DESCRIPTION
this fixes a bug where the user is unable to restore a 2.0.0 database into 2.0.0 code.   The restore fails because the "ALTER TABLE" command fails while trying to add the 'cfg_category' column to the 'config_cfg' table.

Since we have finalized the schema for 2.0.0, we only need to add the column if coming from a previous version.