### PR TITLE
Fix MySQL Upgrade Function

### DIFF
--- a/src/Service/SystemService.php
+++ b/src/Service/SystemService.php
@@ -8,7 +8,7 @@ class SystemService {
     $restoreQueries = file($fileName, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
     foreach ($restoreQueries as $line) {
       if ($line != '' && strpos($line, '--') === false) {
-        $query .= $line;
+        $query .= " $line";
         if (substr($query, -1) == ';') {
           $person = RunQuery($query);
           $query = '';

--- a/src/mysql/upgrade/1.2.14-2.0.0.sql
+++ b/src/mysql/upgrade/1.2.14-2.0.0.sql
@@ -1,8 +1,8 @@
 DELETE FROM config_cfg
- WHERE cfg_id IN (2, 4, 15, 17, 24, 32, 35, 999);
+WHERE cfg_id IN (2, 4, 15, 17, 24, 32, 35, 999);
 
 INSERT INTO `config_cfg` (`cfg_id`, `cfg_name`, `cfg_value`, `cfg_type`, `cfg_default`, `cfg_tooltip`, `cfg_section`, `cfg_category`) 
- VALUES
+VALUES
   (2, 'debug', '1', 'boolean', '1',
    'Set debug mode\r\nThis may be helpful for when you''re first setting up ChurchCRM, but you should\r\nprobably turn it off for maximum security otherwise.  If you are having trouble,\r\nplease enable this so that you''ll know what the errors are.  This is especially\r\nimportant if you need to report a problem on the help forums.',
    'General', NULL),
@@ -14,7 +14,7 @@ INSERT INTO `config_cfg` (`cfg_id`, `cfg_name`, `cfg_value`, `cfg_type`, `cfg_de
   (2001, 'mailChimpApiKey', '', 'text', '', 'see http://kb.mailchimp.com/accounts/management/about-api-keys', 'General', NULL),
   (1034, 'sChurchChkAcctNum', '111111111', 'text', '', 'Church Checking Account Number', 'ChurchInfoReport', NULL);
 UPDATE user_usr
- SET usr_Style = "skin-blue";
+SET usr_Style = "skin-blue";
 
 ALTER TABLE `config_cfg`
- ADD COLUMN `cfg_order` INT NULL COMMENT '' AFTER `cfg_category`;
+ADD COLUMN `cfg_order` INT NULL COMMENT '' AFTER `cfg_category`;

--- a/src/mysql/upgrade/1.3.0-2.0.0.sql
+++ b/src/mysql/upgrade/1.3.0-2.0.0.sql
@@ -1,8 +1,8 @@
 DELETE FROM config_cfg
- WHERE cfg_id IN (2, 4, 15, 17, 24, 32, 35, 999);
+WHERE cfg_id IN (2, 4, 15, 17, 24, 32, 35, 999);
 
 INSERT INTO `config_cfg` (`cfg_id`, `cfg_name`, `cfg_value`, `cfg_type`, `cfg_default`, `cfg_tooltip`, `cfg_section`, `cfg_category`) 
- VALUES
+VALUES
   (2, 'debug', '1', 'boolean', '1',
    'Set debug mode\r\nThis may be helpful for when you''re first setting up ChurchCRM, but you should\r\nprobably turn it off for maximum security otherwise.  If you are having trouble,\r\nplease enable this so that you''ll know what the errors are.  This is especially\r\nimportant if you need to report a problem on the help forums.',
    'General', NULL),
@@ -13,9 +13,9 @@ INSERT INTO `config_cfg` (`cfg_id`, `cfg_name`, `cfg_value`, `cfg_type`, `cfg_de
    'ChurchCRM has been registered.  The ChurchCRM team uses registration information to track usage.  This information is kept confidential and never released or sold.  If this field is true the registration option in the admin menu changes to update registration.', 'General', NULL),
   (1034, 'sChurchChkAcctNum', '111111111', 'text', '', 'Church Checking Account Number', 'ChurchInfoReport', NULL);
 UPDATE user_usr
- SET usr_Style = "skin-blue";
+SET usr_Style = "skin-blue";
 
 ALTER TABLE `config_cfg`
- ADD COLUMN `cfg_order` INT NULL COMMENT '' AFTER `cfg_category`;
+ADD COLUMN `cfg_order` INT NULL COMMENT '' AFTER `cfg_category`;
 
 INSERT IGNORE INTO version_ver (ver_version, ver_date) VALUES ('2.0.0',NOW());

--- a/src/mysql/upgrade/2.0.x-2.1.0.sql
+++ b/src/mysql/upgrade/2.0.x-2.1.0.sql
@@ -1,9 +1,9 @@
 SET @upgradeStartTime = NOW();
 
 ALTER TABLE `version_ver`
- CHANGE COLUMN `ver_date` `ver_update_start` datetime default NULL;
+CHANGE COLUMN `ver_date` `ver_update_start` datetime default NULL;
 
 ALTER TABLE `version_ver`
- ADD COLUMN `ver_update_end` datetime default NULL AFTER `ver_update_start`;
+ADD COLUMN `ver_update_end` datetime default NULL AFTER `ver_update_start`;
 
 INSERT IGNORE INTO version_ver (ver_version, ver_update_start, ver_update_end) VALUES ('2.1.0',@upgradeStartTime,NOW());


### PR DESCRIPTION
Fix multi line SQL statements in the upgrade scripts.


To test:

Try restoring a 2.0.1 database backup into the current people_timeline branch.  The restore fails.
in the current people_timeline branch, modify all of the multiline sql statements so that each line begins with a space.  the restore succeeds.

Now, try restoring a 2.0.1 database into this branch.   Notice that the multi line SQL statements in the upgrade files have been modified so that they no longer start with a space.  

This PR should fix the database restore issue in the current people_timeline branch.