### PR TITLE
keeping short_open_tag commented out

### DIFF
--- a/src/.htaccess
+++ b/src/.htaccess
@@ -9,4 +9,4 @@ RewriteEngine On
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteRule ^(.*)$ index.php [QSA,L]
 
-php_value short_open_tag 1
+# php_value short_open_tag 1


### PR DESCRIPTION
will ask people to enable it if they have issues with short_open_tag - as it does not work in hosted sites