### PR TITLE
Fixes 749 orientation

### DIFF
--- a/src/ImageUpload.php
+++ b/src/ImageUpload.php
@@ -69,8 +69,7 @@ if ($_SESSION['bAddRecords'] || $bOkToEdit) {
     
     $foo->file_new_name_body = $finalFileName;
     $foo->file_overwrite = true;
-    $foo->image_resize = true;
-    
+    $foo->image_resize = true; 
     $foo->image_ratio_fill = true;
     $foo->image_y = 250;
     $foo->image_x = 250;

--- a/src/ImageUpload.php
+++ b/src/ImageUpload.php
@@ -50,9 +50,37 @@ if ($_SESSION['bAddRecords'] || $bOkToEdit) {
     if (!$foo->processed) {
       echo 'error : ' . $foo->error;
     }
+    $exif = exif_read_data($foo->file_dst_pathname);
+    if (!empty($exif['Orientation'])) {
+        switch ($exif['Orientation']) {
+            case 3:
+                $foo->image_rotate = 180;
+                break;
+
+            case 6:
+                $foo->image_rotate =  90;
+                break;
+
+            case 8:
+                $foo->image_rotate = 270;
+                break;
+        }
+    }
+    
+    
+    if ($false) //  should we guess about orientation based on image size?
+    {
+      if($exif['Height'] > $exif['Width'])
+      {
+        $foo->image_rotate = 90;
+      }
+      
+      
+    }
     $foo->file_new_name_body = $finalFileName;
     $foo->file_overwrite = true;
     $foo->image_resize = true;
+    
     $foo->image_ratio_fill = true;
     $foo->image_y = 250;
     $foo->image_x = 250;

--- a/src/ImageUpload.php
+++ b/src/ImageUpload.php
@@ -50,26 +50,27 @@ if ($_SESSION['bAddRecords'] || $bOkToEdit) {
     if (!$foo->processed) {
       echo 'error : ' . $foo->error;
     }
+    
     $exif = exif_read_data($foo->file_dst_pathname);
-    if (!empty($exif['Orientation'])) {
-        switch ($exif['Orientation']) {
-            case 3:
-                $foo->image_rotate = 180;
-                break;
-
-            case 6:
-                $foo->image_rotate =  90;
-                break;
-
-            case 8:
-                $foo->image_rotate = 270;
-                break;
-        }
+    if ( !empty($exif['Orientation']) ) {
+      switch ( $exif['Orientation'] ) {
+        case 3:
+          $foo->image_rotate = 180;
+          break;
+        
+        case 6:
+          $foo->image_rotate =  90;
+          break;
+        
+        case 8:
+          $foo->image_rotate = 270;
+          break;
+      }
     }
     
     $foo->file_new_name_body = $finalFileName;
     $foo->file_overwrite = true;
-    $foo->image_resize = true; 
+    $foo->image_resize = true;
     $foo->image_ratio_fill = true;
     $foo->image_y = 250;
     $foo->image_x = 250;

--- a/src/ImageUpload.php
+++ b/src/ImageUpload.php
@@ -67,16 +67,6 @@ if ($_SESSION['bAddRecords'] || $bOkToEdit) {
         }
     }
     
-    
-    if ($false) //  should we guess about orientation based on image size?
-    {
-      if($exif['Height'] > $exif['Width'])
-      {
-        $foo->image_rotate = 90;
-      }
-      
-      
-    }
     $foo->file_new_name_body = $finalFileName;
     $foo->file_overwrite = true;
     $foo->image_resize = true;


### PR DESCRIPTION
This fixes image rotation issues that arise from uploading images that were not taken in the standard orientation #749 

Most OSs will interpret the Orientation flag of the EXIF so that the image is displayed "right-side-up", but ChurchCRM did not, so images would appear at various stages of rotation.   Especially prevalent when uploading images directly from a mobile device.

To test, open CRM from your phone's browser, and attempt uploading images from your phone's camera in various orientations.  They should all appear "right-side-up" in CRM