### PR TITLE
fix gridlayout

### DIFF
--- a/src/PropertyEditor.php
+++ b/src/PropertyEditor.php
@@ -138,11 +138,10 @@ require "Include/Header.php";
 
 ?>
 <div class="box box-body">
-
-<form method="post" action="PropertyEditor.php?PropertyID=<?= $iPropertyID ?>&Type=<?= $sType ?>">
+  <form method="post" action="PropertyEditor.php?PropertyID=<?= $iPropertyID ?>&Type=<?= $sType ?>">
     <div class="form-group">
         <div class="row">
-            <div class="col-xs-3">
+            <div class="col-md-6">
                 <label for="Class"><?= gettext("Type:") ?></label>
                 <select  class="form-control input-small" name="Class">
                     <option value=""><?= gettext("Select Property Type") ?></option>
@@ -161,27 +160,27 @@ require "Include/Header.php";
             </div>
         </div>
         <div class="row">
-            <div class="col-xs-3">
+            <div class="col-md-6">
                 <label for="Name"><?= gettext("Name:") ?></label>
                 <input class="form-control input-small" type="text" name="Name" value="<?= htmlentities(stripslashes($sName),ENT_NOQUOTES, "UTF-8") ?>" size="50">
                 <?php echo $sNameError ?>
            </div>
        </div>
        <div class="row">
-            <div class="col-xs-3">
+            <div class="col-md-6">
                 <label for="Description">"<?= gettext("A") ?> <?php echo $sTypeName ?><BR><?= gettext("with this property..") ?>":</label>
                 <textarea class="form-control input-small" name="Description" cols="60" rows="3"><?= htmlentities(stripslashes($sDescription),ENT_NOQUOTES, "UTF-8") ?></textarea>
             </div>
         </div>
         <div class="row">
-            <div class="col-xs-3">
+            <div class="col-md-6">
                 <label for="Prompt"><?= gettext("Prompt:") ?></label>
                 <input class="form-control input-small" type="text" name="Prompt" value="<?php echo htmlentities(stripslashes($sPrompt),ENT_NOQUOTES, "UTF-8") ?>" size="50">
                 <span class="SmallText"><?= gettext("Entering a Prompt value will allow the association of a free-form value.") ?></span>
             </div>
         </div>
         <div class="row">
-          <div class="col-xs-3">
+          <div class="col-md-6">
             <input type="submit" class="btn" name="Submit" value="<?= gettext("Save") ?>">&nbsp;<input type="button" class="btn" name="Cancel" value="<?= gettext("Cancel") ?>" onclick="document.location='PropertyList.php?Type=<?= $sType ?>';">
         </div>
         </div>


### PR DESCRIPTION
Fixes grid layout of the property editor as described in #748:
![image](https://cloud.githubusercontent.com/assets/11679900/16532843/98b5efe8-3fa2-11e6-84fc-b25bd47608be.png)


To test, open CRM in a narrow browser, and attempt to edit person or family specific properties:
![image](https://cloud.githubusercontent.com/assets/11679900/16532835/9001cf02-3fa2-11e6-9102-e4ae0cae1f08.png)
