### PR TITLE
fix class errors in system service

### DIFF
--- a/src/CheckVersion.php
+++ b/src/CheckVersion.php
@@ -28,7 +28,10 @@
 require 'Include/Config.php';
 require 'Include/Functions.php';
 
-use ChurchCRM\VersionQuery;
+use ChurchCRM\Service\SystemService;
+
+$systemService = new SystemService();
+$_SESSION['latestVersion'] = $systemService->getLatestRelese();
 
 if ($systemService->checkDatabaseVersion())  //either the DB is good, or the upgrade was successful.
 {

--- a/src/Login.php
+++ b/src/Login.php
@@ -282,8 +282,6 @@ if ($iUserID > 0)
             RunQuery($sSQL);
         }
 
-        $systemService = new SystemService();
-        $_SESSION['latestVersion'] = $systemService->getLatestRelese();
         Redirect('CheckVersion.php');
         exit;
     }

--- a/src/Service/SystemService.php
+++ b/src/Service/SystemService.php
@@ -50,7 +50,7 @@ class SystemService
   function restoreDatabaseFromBackup()
   {
     requireUserGroupMembership("bAdmin");
-    $restoreResult = new StdClass();
+    $restoreResult = new \stdClass();
     $restoreResult->Messages = array();
     global $sUSER, $sPASSWORD, $sDATABASE, $cnInfoCentral, $sGZIPname;
     $file = $_FILES['restoreFile'];
@@ -101,7 +101,7 @@ class SystemService
     requireUserGroupMembership("bAdmin");
     global $sUSER, $sPASSWORD, $sDATABASE, $sSERVERNAME, $sGZIPname, $sZIPname, $sPGPname;
 
-    $backup = new StdClass();
+    $backup = new \stdClass();
     $backup->root = dirname(dirname(__FILE__));
     $backup->backupRoot = "$backup->root/tmp_attach/ChurchCRMBackups";
     $backup->imagesRoot = "Images";
@@ -183,7 +183,7 @@ class SystemService
     global $sExternalBackupType, $sExternalBackupUsername, $sExternalBackupPassword, $sExternalBackupEndpoint;
     if (strcasecmp($sExternalBackupType, "WebDAV") == 0) {
       if ($sExternalBackupUsername && $sExternalBackupPassword && $sExternalBackupEndpoint) {
-        $params = new stdClass();
+        $params = new \stdClass();
         $params->iArchiveType = 3;
         $backup = $this->getDatabaseBackup($params);
         $backup->credentials = $sExternalBackupUsername . ":" . $sExternalBackupPassword;
@@ -300,11 +300,11 @@ class SystemService
       if (in_array($db_version, $dbUpdate["versions"])) {
         $version = new Version();
         $version->setVersion($dbUpdate["dbVersion"]);
-        $version->setUpdateStart(new DateTime());
+        $version->setUpdateStart(new \DateTime());
         foreach ($dbUpdate["scripts"] as $dbScript) {
           $this->rebuildWithSQL($dbScript);
         }
-        $version->setUpdateEnd(new DateTime());
+        $version->setUpdateEnd(new \DateTime());
         $version->save();
         return true;
       }


### PR DESCRIPTION
Database restores are broken in develop now after the classes USE vs REQUIRE.