### PR TITLE
add group membership security

### DIFF
--- a/src/orm/model/ChurchCRM/Person2group2roleP2g2r.php
+++ b/src/orm/model/ChurchCRM/Person2group2roleP2g2r.php
@@ -16,5 +16,29 @@ use ChurchCRM\Base\Person2group2roleP2g2r as BasePerson2group2roleP2g2r;
  */
 class Person2group2roleP2g2r extends BasePerson2group2roleP2g2r
 {
-
+  public function preSave(\Propel\Runtime\Connection\ConnectionInterface $con = null)
+  {
+    requireUserGroupMembership("bManageGroups");
+    parent::preSave($con);
+    return true;
+  }
+  
+  public function preUpdate(\Propel\Runtime\Connection\ConnectionInterface $con = null)
+  {
+    requireUserGroupMembership("bManageGroups");
+    parent::preUpdate($con);
+    return true;
+  }
+  public function preDelete(\Propel\Runtime\Connection\ConnectionInterface $con = null)
+  {
+    requireUserGroupMembership("bManageGroups");
+    parent::preDelete($con);
+    return true;
+  }
+  public function preInsert(\Propel\Runtime\Connection\ConnectionInterface $con = null)
+  {
+    requireUserGroupMembership("bManageGroups");
+    parent::preInsert($con);
+    return true;
+  }
 }


### PR DESCRIPTION
currently users without manage group permissions can add/remove members from a group.  

Fix it with the security check on the activerecord model for person2group2role