### PR TITLE
Fix upgrading

### DIFF
--- a/src/Service/SystemService.php
+++ b/src/Service/SystemService.php
@@ -291,12 +291,13 @@ class SystemService
 
   function checkDatabaseVersion()
   {
-    
+
     $db_version = $this->getDBVersion();
     if ($db_version == $_SESSION['sSoftwareInstalledVersion']) {
       return true;
     }
-   
+
+    //the database isn't at the current version.  Start the upgrade
     $dbUpdatesFile = file_get_contents(dirname(__FILE__) . "/../mysql/upgrade.json");
     $dbUpdates = json_decode($dbUpdatesFile, true);
     $upgradeSuccess = false;

--- a/src/Service/SystemService.php
+++ b/src/Service/SystemService.php
@@ -5,6 +5,7 @@ namespace ChurchCRM\Service;
 use Propel\Runtime\ActiveQuery\Criteria;
 use ChurchCRM\VersionQuery;
 use ChurchCRM\Version;
+use Propel\Runtime;
 
 class SystemService
 {
@@ -280,7 +281,7 @@ class SystemService
   }
 
   function getDBVersion() {
-    $connection = \Propel\Runtime\Propel::getConnection();
+    $connection = Runtime\Propel::getConnection();
     $query = "Select * from version_ver";
     $statement = $connection->prepare($query);
     $resultset = $statement->execute();

--- a/src/mysql/upgrade/2.0.0.sql
+++ b/src/mysql/upgrade/2.0.0.sql
@@ -1,3 +1,9 @@
+ALTER TABLE version_ver
+CHANGE COLUMN ver_date ver_update_start datetime default NULL;
+
+ALTER TABLE version_ver
+ADD COLUMN ver_update_end datetime default NULL AFTER ver_update_start;
+
 DELETE FROM config_cfg
 WHERE cfg_id IN (2, 4, 15, 17, 24, 32, 35, 999);
 

--- a/src/mysql/upgrade/2.1.0.sql
+++ b/src/mysql/upgrade/2.1.0.sql
@@ -1,11 +1,3 @@
-SET @upgradeStartTime = NOW();
-
-ALTER TABLE version_ver
-CHANGE COLUMN ver_date ver_update_start datetime default NULL;
-
-ALTER TABLE version_ver
-ADD COLUMN ver_update_end datetime default NULL AFTER ver_update_start;
-
 -- ------ Notes - start
 
 ALTER TABLE note_nte


### PR DESCRIPTION
This causes ChurchCRM to apply all available database upgrades at once.

Fxies #1130 

It also fixes an issue where restoring a 1.2.14  database fails.

See attached 1.2.14
[InfoCentral-Backup-20161012-115951.zip](https://github.com/ChurchCRM/CRM/files/525172/InfoCentral-Backup-20161012-115951.zip)
 DB

