### PR TITLE
Fix SQL auto-install.  

### DIFF
--- a/src/Include/LoadConfigs.php
+++ b/src/Include/LoadConfigs.php
@@ -122,8 +122,6 @@ $resultset = $statement->execute();
 $results = $statement->fetchAll(\PDO::FETCH_ASSOC);
 
 if (count($results) == 0) {
-  //echo "db not installed";
-  //exit;
   $systemService = new SystemService();
   $setupQueries = dirname(__file__) . '/../mysql/install/Install.sql';
   $systemService->playbackSQLtoDatabase($setupQueries);

--- a/src/IntegrityCheck.php
+++ b/src/IntegrityCheck.php
@@ -26,13 +26,13 @@ if ($IntegrityCheckDetails->status == "failure")
       if(count($IntegrityCheckDetails->files) > 0 )
       {
         ?>
-        <p><?= gettext("Files failing integrity check:") ?>
+        <p><?= gettext("Files failing integrity check") ?>:
         <ul>
           <?php
           foreach ($IntegrityCheckDetails->files as $file)
           {
             ?>
-            <li>FileName: <?= $file->filename ?>
+            <li><?= gettext("Filename")?>: <?= $file->filename ?>
               <?php 
               if($file->status == "File Missing")
               {
@@ -46,8 +46,8 @@ if ($IntegrityCheckDetails->status == "failure")
               {
                 ?>
                 <ul>
-                 <li><?= gettext("Expected Hash:")?> <?= $file->expectedhash ?></li>
-                 <li><?= gettext("Actual Hash:") ?> <?= $file->actualhash ?></li>
+                 <li><?= gettext("Expected Hash")?>: <?= $file->expectedhash ?></li>
+                 <li><?= gettext("Actual Hash") ?>: <?= $file->actualhash ?></li>
                 </ul>
                 <?php
               }

--- a/src/Service/SystemService.php
+++ b/src/Service/SystemService.php
@@ -457,30 +457,36 @@ class SystemService
   {
     $CRMInstallRoot = dirname(__DIR__);
     $signatureFile = $CRMInstallRoot."/signatures.json";
-    $signatureData = json_decode(file_get_contents($signatureFile));
     $signatureFailures = array();
-   
-    if (sha1(json_encode($signatureData->files)) == $signatureData->sha1)
+    if (file_exists($signatureFile))
     {
-      foreach ($signatureData->files as $file)
+      $signatureData = json_decode(file_get_contents($signatureFile));
+      if (sha1(json_encode($signatureData->files)) == $signatureData->sha1)
       {
-        if(file_exists($CRMInstallRoot."/".$file->filename))
+        foreach ($signatureData->files as $file)
         {
-          $actualHash = sha1_file($CRMInstallRoot."/".$file->filename);
-          if ( $actualHash != $file->sha1 )
+          if(file_exists($CRMInstallRoot."/".$file->filename))
           {
-            array_push($signatureFailures, array("filename"=>$file->filename,"status"=>"Hash Mismatch", "expectedhash"=>$file->sha1,"actualhash"=>$actualHash));
+            $actualHash = sha1_file($CRMInstallRoot."/".$file->filename);
+            if ( $actualHash != $file->sha1 )
+            {
+              array_push($signatureFailures, array("filename"=>$file->filename,"status"=>"Hash Mismatch", "expectedhash"=>$file->sha1,"actualhash"=>$actualHash));
+            }
+          }
+          else
+          {
+            array_push($signatureFailures, array("filename"=>$file->filename,"status"=>"File Missing"));
           }
         }
-        else
-        {
-          array_push($signatureFailures, array("filename"=>$file->filename,"status"=>"File Missing"));
-        }
+      }
+      else
+      {
+        return array("status"=>"failure","message"=>"Signature Definition file signature failed validation");
       }
     }
     else
     {
-      return array("status"=>"failure","message"=>"Signature Definition file signature failed validation");
+      return array("status"=>"failure","message"=>"Signature Definition File Missing");
     }
     
     if(count($signatureFailures) > 0 )

--- a/src/Service/SystemService.php
+++ b/src/Service/SystemService.php
@@ -481,19 +481,19 @@ class SystemService
       }
       else
       {
-        return array("status"=>"failure","message"=>"Signature Definition file signature failed validation");
+        return array("status"=>"failure","message"=>gettext("Signature definition file signature failed validation"));
       }
     }
     else
     {
-      return array("status"=>"failure","message"=>"Signature Definition File Missing");
+      return array("status"=>"failure","message"=>gettext("Signature definition File Missing"));
     }
     
     if(count($signatureFailures) > 0 )
     {
-      return array("status"=>"failure","files"=>$signatureFailures);
+      return array("status"=>"failure","message"=>gettext("One or more files failed signature validation"),"files"=>$signatureFailures);
     }
-    else 
+    else  
     {
        return array("status"=>"success");
     }


### PR DESCRIPTION
closes #1248 

To test this:
* On RC2 Code, Attempt to run ChurchCRM with a username, password, and database in the config file; howevever, ensure that the database does not contain any tables.
  *  ChurchCRM is supposed to see that the DB is empty, and it's supposed to install the tables.  This fails, and causes a nastygram for the user
* In this PR, the same actions should successfully install the DB tables without error