### PR TITLE
add docker environment variable detection

### DIFF
--- a/src/Setup.php
+++ b/src/Setup.php
@@ -16,13 +16,12 @@ if (isset($_POST["Setup"])) {
   header("Location: index.php" );
   exit();
 }
-
-elseif ( isset( getenv('MARIADB_USER') )) {
+elseif (getenv('CRM_MARIADB_NAME')) {
   $template = file_get_contents("Include/Config.php.example");
   $template = str_replace("||DB_SERVER_NAME||", "crm-mariadb", $template);
-  $template = str_replace("||DB_NAME||", getenv("MARIADB_DATABASE") , $template);
-  $template = str_replace("||DB_USER||", getenv("MARIADB_USER"), $template);
-  $template = str_replace("||DB_PASSWORD||", getenv("MARIADB_PASSWORD"), $template);
+  $template = str_replace("||DB_NAME||", getenv("CRM_MARIADB_ENV_MARIADB_DATABASE") , $template);
+  $template = str_replace("||DB_USER||", getenv("CRM_MARIADB_ENV_MARIADB_USER"), $template);
+  $template = str_replace("||DB_PASSWORD||", getenv("CRM_MARIADB_ENV_MARIADB_PASSWORD"), $template);
   $template = str_replace("||ROOT_PATH||", "", $template);
   $template = str_replace("||URL||", "", $template);
   file_put_contents("Include/Config.php", $template);

--- a/src/Setup.php
+++ b/src/Setup.php
@@ -17,6 +17,19 @@ if (isset($_POST["Setup"])) {
   exit();
 }
 
+elseif ( isset( getenv('MARIADB_USER') )) {
+  $template = file_get_contents("Include/Config.php.example");
+  $template = str_replace("||DB_SERVER_NAME||", "crm-mariadb", $template);
+  $template = str_replace("||DB_NAME||", getenv("MARIADB_DATABASE") , $template);
+  $template = str_replace("||DB_USER||", getenv("MARIADB_USER"), $template);
+  $template = str_replace("||DB_PASSWORD||", getenv("MARIADB_PASSWORD"), $template);
+  $template = str_replace("||ROOT_PATH||", "", $template);
+  $template = str_replace("||URL||", "", $template);
+  file_put_contents("Include/Config.php", $template);
+  header("Location: index.php" );
+  exit();
+}
+
 if (isset($_GET['SystemIntegrityCheck']))
 {
 require_once 'Service/SystemService.php';  // don't depend on autoloader here, just in case validation doesn't pass.


### PR DESCRIPTION
This adds environment variable detection to the setup script.

If the setup page was served from a docker container that is also liked to the crm-mariadb container, then the environment variables should be present, and the setup should be fully automatic.
