### PR TITLE
2.4.3 fix show since date on family view

### DIFF
--- a/src/FamilyView.php
+++ b/src/FamilyView.php
@@ -51,7 +51,7 @@ $rsFunds = RunQuery($sSQL);
 if (isset($_POST["UpdatePledgeTable"]) && $_SESSION['bFinance']) {
   $_SESSION['sshowPledges'] = isset($_POST["ShowPledges"]);
   $_SESSION['sshowPayments'] = isset($_POST["ShowPayments"]);
-  $_SESSION['sshowSince'] = FilterInput($_POST["ShowSinceDate"]);
+  $_SESSION['sshowSince'] = DateTime::createFromFormat("Y-m-d",FilterInput($_POST["ShowSinceDate"]) ) ;
 }
 
 $dSQL = "SELECT fam_ID FROM family_fam order by fam_Name";
@@ -682,7 +682,7 @@ if ($iFamilyID == $fam_ID) {
                       if ((($_SESSION['sshowPledges'] && $plg_PledgeOrPayment == 'Pledge') ||
                           ($_SESSION['sshowPayments'] && $plg_PledgeOrPayment == 'Payment')
                         ) &&
-                        ($_SESSION['sshowSince'] == "" || $plg_date > $_SESSION['sshowSince'])
+                        ($_SESSION['sshowSince'] == "" ||  DateTime::createFromFormat("Y-m-d",$plg_date) > $_SESSION['sshowSince']  )
                       ) {
                         //Alternate the row style
                         if ($tog)


### PR DESCRIPTION
closes #1583 

this is caused by the date being in String Format when we call the ```format()``` function..  

![image](https://cloud.githubusercontent.com/assets/11679900/21502328/01ab5086-cc1d-11e6-9b82-f6ef44a8f582.png)


Patched to use ```DateTime()``` type so that date format localization will work in the future.