### PR TITLE
fix grunt's upgrade logic

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -373,23 +373,28 @@ module.exports = function (grunt) {
 
     grunt.registerMultiTask('updateVersions', 'Update Files to match NPM version', function () {
         var version = this.data.version;
-        console.log("updating to: " + version);
 
-        // php composer
+      // php composer
         var file = 'src/composer.json';
-        console.log(file);
         var curFile = grunt.file.readJSON(file);
-        curFile.version = version;
-        var stringFile = JSON.stringify(curFile, null, 4);
-        grunt.file.write(file, stringFile);
+        if (curFile.version !== version)
+        {
+          console.log("updating composer file to: " + version);
+          curFile.version = version;
+          var stringFile = JSON.stringify(curFile, null, 4);
+          grunt.file.write(file, stringFile);
+        }
 
         // db update file
         file = 'src/mysql/upgrade.json';
-        console.log(file);
         curFile = grunt.file.readJSON(file);
-        curFile.current.dbVersion = version;
-        stringFile = JSON.stringify(curFile, null, 4);
-        grunt.file.write(file, stringFile);
+        if (curFile.current.dbVersion !== version)
+        {
+          console.log("updating database upgrade file to: " + version);
+          curFile.current.dbVersion = version;
+          stringFile = JSON.stringify(curFile, null, 4);
+          grunt.file.write(file, stringFile);
+        }
 
     });
 


### PR DESCRIPTION
only update the composer and dbupgrade  files if there is a version mismatch..

If the versions match, don't update the files and give Git a false trigger for file change