### PR TITLE
Fix #1814

### DIFF
--- a/src/ChurchCRM/tasks/PersonClassificationDataCheck.php
+++ b/src/ChurchCRM/tasks/PersonClassificationDataCheck.php
@@ -33,7 +33,7 @@ class PersonClassificationDataCheck implements iTask
 
     public function getTitle()
     {
-        return gettext('Missing Classification Data' . " (" . $this->count . ")");
+        return gettext('Missing Classification Data') . " (" . $this->count . ")";
     }
 
     public function getDesc()

--- a/src/ChurchCRM/tasks/PersonGenderDataCheck.php
+++ b/src/ChurchCRM/tasks/PersonGenderDataCheck.php
@@ -33,7 +33,7 @@ class PersonGenderDataCheck implements iTask
 
     public function getTitle()
     {
-        return gettext('Missing Gender Data' . " (" . $this->count . ")");
+        return gettext('Missing Gender Data') . " (" . $this->count . ")";
     }
 
     public function getDesc()

--- a/src/ChurchCRM/tasks/PersonRoleDataCheck.php
+++ b/src/ChurchCRM/tasks/PersonRoleDataCheck.php
@@ -34,7 +34,7 @@ class PersonRoleDataCheck implements iTask
 
     public function getTitle()
     {
-        return gettext('Missing Role Data' . " (" . $this->count . ")");
+        return gettext('Missing Role Data') . " (" . $this->count . ")";
     }
 
     public function getDesc()

--- a/src/ChurchCRM/tasks/UpdateFamilyCoordinatesTask.php
+++ b/src/ChurchCRM/tasks/UpdateFamilyCoordinatesTask.php
@@ -33,7 +33,7 @@ class UpdateFamilyCoordinatesTask
 
     public function getTitle()
     {
-        return gettext('Missing Coordinates' . " (" . $this->count . ")");
+        return gettext('Missing Coordinates') . " (" . $this->count . ")";
     }
 
     public function getDesc()


### PR DESCRIPTION
Fix #1814
Please, update term "Missing Gender Date (", "Missing Classification Data (", "Missing Coordinates (" and "Missing Role Date (" to "Missing Gender Date", "Missing Classification Data","Missing Coordinates"  and "Missing Role Date"  in POEditor.com