### PR TITLE
Add table-responsive to tables to make tables scrollable on mobile(#1927)

### DIFF
--- a/src/BatchWinnerEntry.php
+++ b/src/BatchWinnerEntry.php
@@ -53,7 +53,7 @@ if (isset($_POST['EnterWinners'])) {
 // Get Items for the drop-down
 $sDonatedItemsSQL = "SELECT di_ID, di_Item, di_title, di_multibuy
                      FROM donateditem_di
-                     WHERE di_FR_ID = '".$iCurrentFundraiser."' ORDER BY SUBSTR(di_Item,1,1), CONVERT(SUBSTR_Item,2,3),SIGNED)";
+                     WHERE di_FR_ID = '".$iCurrentFundraiser."' ORDER BY SUBSTR(di_Item,1,1), CONVERT(SUBSTR(di_Item,2,3),SIGNED)";
 $rsDonatedItems = RunQuery($sDonatedItemsSQL);
 
 //Get Paddles for the drop-down
@@ -68,10 +68,10 @@ $rsPaddles = RunQuery($sPaddleSQL);
 require 'Include/Header.php';
 
 ?>
-
+<div class="box box-body">
 <form method="post" action="BatchWinnerEntry.php?<?= 'CurrentFundraiser='.'&linkBack='.$linkBack ?>" name="BatchWinnerEntry">
-
-<table cellpadding="3" align="center">
+<div class="table-responsive">
+<table class="table" cellpadding="2" align="center">
 	<tr>
 		<td class="LabelColumn"><?= gettext('Item') ?></td>
 		<td class="LabelColumn"><?= gettext('Winner') ?></td>
@@ -109,8 +109,8 @@ require 'Include/Header.php';
     }
 ?>
 	<tr>
-		<td align="center">
-			<input type="submit" class="btn" value="<?= gettext('Enter Winners') ?>" name="EnterWinners">
+		<td colspan="2" align="center">
+			<input type="submit" class="btn btn-primary" value="<?= gettext('Enter Winners') ?>" name="EnterWinners">
 			<input type="button" class="btn" value="<?= gettext('Cancel') ?>" name="Cancel" onclick="javascript:document.location='<?php if (strlen($linkBack) > 0) {
     echo $linkBack;
 } else {
@@ -119,6 +119,8 @@ require 'Include/Header.php';
 		</td>
 	</tr>
 	</table>
+</div>
 </form>
+</div>
 
 <?php require 'Include/Footer.php' ?>

--- a/src/CanvassEditor.php
+++ b/src/CanvassEditor.php
@@ -150,25 +150,14 @@ $rsBraveCanvassers = CanvassGetCanvassers(gettext('BraveCanvassers'));
 require 'Include/Header.php';
 ?>
 
+<div class="box box-body">
 <form method="post" action="CanvassEditor.php?<?= 'FamilyID='.$iFamily.'&FYID='.$iFYID.'&CanvassID='.$iCanvassID.'&linkBack='.$linkBack ?>" name="CanvassEditor">
-
-<table cellpadding="3" align="center">
-
-	<tr>
-		<td align="center">
-			<input type="submit" class="btn" value="<?= gettext('Save') ?>" name="Submit">
-			<input type="button" class="btn" value="<?= gettext('Cancel') ?>" name="Cancel" onclick="javascript:document.location='<?php if (strlen($linkBack) > 0) {
-    echo $linkBack;
-} else {
-    echo 'Menu.php';
-} ?>';">
-		</td>
-	</tr>
+<div class="table-responsive">
+<table class="table" cellpadding="3" align="center">
 
 	<tr>
 
 		<td>
-		<table cellpadding="3">
 
 			<?php
             if (($rsBraveCanvassers != 0 && mysqli_num_rows($rsBraveCanvassers) > 0) ||
@@ -245,9 +234,19 @@ require 'Include/Header.php';
 				<td class="LabelColumn"><?= gettext('Why Not Interested?') ?></td>
 				<td><textarea name="WhyNotInterested" rows="1" cols="90"><?= $tWhyNotInterested ?></textarea></td>
 			</tr>
+    </table>
+</div>
+    <div>
+            <input type="submit" class="btn btn-primary" value="<?= gettext('Save') ?>" name="Submit">
+            <input type="button" class="btn" value="<?= gettext('Cancel') ?>" name="Cancel" onclick="javascript:document.location='<?php if (strlen($linkBack) > 0) {
+                echo $linkBack;
+            } else {
+                echo 'Menu.php';
+            } ?>';">
 
-		</table>
-		</td>
+    </div>
+
 	</form>
-</table>
+</div>
+
 <?php require 'Include/Footer.php'; ?>

--- a/src/CartToFamily.php
+++ b/src/CartToFamily.php
@@ -129,7 +129,7 @@ require 'Include/Header.php';
 echo $sError;
 ?>
 <div class="box">
-    <form method="post">
+
 <?php
 if (count($_SESSION['aPeopleCart']) > 0) {
 
@@ -181,8 +181,10 @@ if (count($_SESSION['aPeopleCart']) > 0) {
     echo '</table>'; ?>
     </div>
     <div class="box">
-<table align="center" class="table table-responsive">
-	<tr>
+<form method="post">
+<div class="table-responsive">
+<table align="center" class="table table-hover">
+    <tr>
 		<td class="LabelColumn"><?= gettext('Add to Family') ?>:</td>
 		<td class="TextColumn">
 			<?php
@@ -314,7 +316,7 @@ if (count($_SESSION['aPeopleCart']) > 0) {
 	</tr>
 
 </table>
-
+</div>
 <p align="center">
 <BR>
 <input type="submit" class="btn" name="Submit" value="<?= gettext('Add to Family') ?>">

--- a/src/CartView.php
+++ b/src/CartView.php
@@ -285,8 +285,9 @@ if (count($_SESSION['aPeopleCart']) > 0) {
         <h3 class="box-title"><?= gettext('Your cart contains').' '.$iNumPersons.' '.gettext('persons from').' '.$iNumFamilies.' '.gettext('families') ?>.</h3>
     </div>
     <div class="box-body">
+        <div class="table-responsive">
         <table class="table table-hover">
-        <tr>
+            <tr>
             <th><?= gettext('Name') ?></th>
             <th><?=  gettext('Address') ?>?</th>
             <th><?=  gettext('Email') ?>?</th>
@@ -350,6 +351,7 @@ if (count($_SESSION['aPeopleCart']) > 0) {
 
     echo '</table>';
 } ?>
+</div>
 <!-- END CART LISTING -->
 
 <?php

--- a/src/DirectoryReports.php
+++ b/src/DirectoryReports.php
@@ -70,8 +70,8 @@ while ($aRow = mysqli_fetch_array($rsSecurityGrp)) {
 }
 
 ?>
-
-<table align="center" class="table">
+<div class="table-responsive">
+<table class="table" align="center" class="table">
 <?php if (!array_key_exists('cartdir', $_GET)) {
     ?>
     <tr>
@@ -275,6 +275,7 @@ while ($aRow = mysqli_fetch_array($rsSecurityGrp)) {
 
 
 </table>
+</div>
 
 <?php if (array_key_exists('cartdir', $_GET)) {
              echo '<input type="hidden" name="cartdir" value="M">';

--- a/src/ElectronicPaymentList.php
+++ b/src/ElectronicPaymentList.php
@@ -186,10 +186,11 @@ function CreatePaymentMethodsForChecked()
   }
 }
 </script>
+<div class="box box-body">
 
 <p align="center"><a href="AutoPaymentEditor.php?linkBack=ElectronicPaymentList.php"><?= gettext('Add a New Electronic Payment Method') ?></a></p>
-
-<table id="PaymentMethodTable" cellpadding="4" align="center" cellspacing="0" width="100%">
+<div class="table-responsive">
+<table class="table" id="PaymentMethodTable" cellpadding="4" align="center" cellspacing="0" width="100%">
 	<tr class="TableHeader">
 		<td>
 		<input type=checkbox onclick="toggle(this, 'SelectForAction')" />
@@ -291,13 +292,17 @@ while ($aRow = mysqli_fetch_array($rsAutopayments)) {
 }
 ?>
 </table>
-<b>With checked:</b>
+</div>
+    <div>
+
+<b>With checked:</b><br>
 <?php if (SystemConfig::getValue('sElectronicTransactionProcessor') == 'Vanco') {
     ?>
-<input type="button" id="CreatePaymentMethodsForChecked" value="Store Private Data at Vanco" onclick="CreatePaymentMethodsForChecked();" />
-<?php 
+<input type="button" class="btn" id="CreatePaymentMethodsForChecked" value="Store Private Data at Vanco" onclick="CreatePaymentMethodsForChecked();" />
+<?php
 } ?>
-<input type="button" id="DeleteChecked" value="Delete" onclick="DeleteChecked();" />
-<input type="button" id="DeleteChecked" value="Clear Account Numbers" onclick="ClearAccountsChecked();" />
-
+<input type="button" class="btn btn-warning" id="DeleteChecked" value="Delete" onclick="DeleteChecked();" />
+<input type="button" class="btn" id="DeleteChecked" value="Clear Account Numbers" onclick="ClearAccountsChecked();" />
+    </div>
+</div>
 <?php require 'Include/Footer.php' ?>

--- a/src/ElectronicPaymentList.php
+++ b/src/ElectronicPaymentList.php
@@ -300,6 +300,7 @@ while ($aRow = mysqli_fetch_array($rsAutopayments)) {
     ?>
 <input type="button" class="btn" id="CreatePaymentMethodsForChecked" value="Store Private Data at Vanco" onclick="CreatePaymentMethodsForChecked();" />
 <?php
+
 } ?>
 <input type="button" class="btn btn-warning" id="DeleteChecked" value="Delete" onclick="DeleteChecked();" />
 <input type="button" class="btn" id="DeleteChecked" value="Clear Account Numbers" onclick="ClearAccountsChecked();" />

--- a/src/FamilyCustomFieldsEditor.php
+++ b/src/FamilyCustomFieldsEditor.php
@@ -306,7 +306,8 @@ function confirmDeleteField( Field ) {
 		<?= gettext("Warning: Arrow and delete buttons take effect immediately.  Field name changes will be lost if you do not 'Save Changes' before using an up, down, delete or 'add new' button!") ?>
 </div>
 <form method="post" action="FamilyCustomFieldsEditor.php" name="FamilyCustomFieldsEditor">
-<table class="table">
+    <div class="table-responsive">
+<table class="table" class="table">
 
 <?php
 if ($numRows == 0) {
@@ -471,6 +472,7 @@ if ($numRows == 0) {
         </tr>
 
     </table>
+    </div>
     </form>
 </div>
 

--- a/src/FamilyEditor.php
+++ b/src/FamilyEditor.php
@@ -946,7 +946,8 @@ require 'Include/Header.php';
 		<div class="MediumText">
 			<center><?= $iFamilyID < 0 ? gettext('You may create family members now or add them later.  All entries will become <i>new</i> person records.') : '' ?></center>
 		</div><br><br>
-		<table class="horizontal-scroll" cellpadding="3" cellspacing="0" width="100%">
+            <div class="table-responsive">
+		<table cellpadding="3" cellspacing="0" width="100%">
 		<thead>
 		<tr class="TableHeader" align="center">
 			<th><?= gettext('First') ?></th>
@@ -1119,7 +1120,8 @@ require 'Include/Header.php';
                     }
             echo '</select></td></tr>';
         }
-        echo '</table>';
+        echo '</table></div>';
+
         echo '</div></div>';
     }
 

--- a/src/FundRaiserEditor.php
+++ b/src/FundRaiserEditor.php
@@ -186,8 +186,8 @@ require 'Include/Header.php';
 <div class="box box-body">
 <b><?= gettext('Donated items for this fundraiser') ?>:</b>
 <br>
-
-<table cellpadding="5" cellspacing="0" width="100%">
+<div class="table-responsive">
+<table class="table" cellpadding="5" cellspacing="0" width="100%">
 
 <tr class="TableHeader">
 	<td><?= gettext('Item') ?></td>
@@ -260,6 +260,6 @@ if ($rsDonatedItems != 0) {
 ?>
 
 </table>
-
+</div>
 </div>
 <?php require 'Include/Footer.php' ?>

--- a/src/GroupEditor.php
+++ b/src/GroupEditor.php
@@ -71,19 +71,19 @@ require 'Include/Header.php';
     <form name="groupEditForm" id="groupEditForm">
       <div class="form-group">
         <div class="row">
-          <div class="col-xs-4">
+          <div class="col-sm-4">
             <label for="Name"><?= gettext('Name') ?>:</label>
             <input class="form-control" type="text" Name="Name" value="<?= htmlentities(stripslashes($thisGroup->getName()), ENT_NOQUOTES, 'UTF-8') ?>">
           </div>
         </div>
         <div class="row">
-          <div class="col-xs-4">
+          <div class="col-sm-4">
             <label for="Description"><?= gettext('Description') ?>:</label>
             <textarea  class="form-control" name="Description" cols="40" rows="5"><?= htmlentities(stripslashes($thisGroup->getDescription()), ENT_NOQUOTES, 'UTF-8') ?></textarea></td>
           </div>
         </div>
         <div class="row">
-          <div class="col-xs-3">
+          <div class="col-sm-3">
             <label for="GroupType"><?= gettext('Type of Group') ?>:</label>
             <select class="form-control input-small" name="GroupType">
               <option value="0"><?= gettext('Unassigned') ?></option>
@@ -101,7 +101,7 @@ require 'Include/Header.php';
           </div>
         </div>
         <div class="row">
-          <div class="col-xs-3">
+          <div class="col-sm-3">
             <?php
 // Show Role Clone fields only when adding new group
             if (strlen($iGroupID) < 1) {
@@ -111,7 +111,7 @@ require 'Include/Header.php';
               <?= gettext('Clone roles') ?>:
               <input type="checkbox" name="cloneGroupRole" id="cloneGroupRole" value="1">
             </div>
-            <div class="col-xs-3" id="selectGroupIDDiv">
+            <div class="col-sm-3" id="selectGroupIDDiv">
               <?= gettext('from group') ?>:
               <select class="form-control input-small" name="seedGroupID" id="seedGroupID" >
                 <option value="0"><?php gettext('Select a group'); ?></option>
@@ -128,7 +128,7 @@ require 'Include/Header.php';
         </div>
         <br>
         <div class="row">
-          <div class="col-xs-6">
+          <div class="col-sm-6">
             <label for="UseGroupProps"><?= gettext('Group Specific Properties: ') ?></label>
 
             <?php
@@ -145,7 +145,7 @@ require 'Include/Header.php';
         </div>
         <br>
         <div class="row">
-          <div class="col-xs-3">
+          <div class="col-sm-3">
             <input type="submit" id="saveGroup" class="btn btn-primary" <?= 'value="'.gettext('Save').'"' ?> Name="GroupSubmit">
           </div>
         </div>
@@ -163,8 +163,10 @@ require 'Include/Header.php';
       <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>
       <strong></strong><?= gettext('Group role name changes are saved as soon as the box loses focus')?>
     </div>
-    <table class="table" id="groupRoleTable">
+      <div class="table-responsive">
+    <table class="table" class="table" id="groupRoleTable">
     </table>
+      </div>
     <label for="newRole"><?= gettext('New Role')?>: </label><input type="text" class="form-control" id="newRole" name="newRole">
     <br>
     <button type="button" id="addNewRole" class="btn btn-primary"><?= gettext('Add New Role')?></button>

--- a/src/GroupPropsFormEditor.php
+++ b/src/GroupPropsFormEditor.php
@@ -253,6 +253,7 @@ if (isset($_POST['SaveChanges'])) {
 
 <form method="post" action="GroupPropsFormEditor.php?GroupID=<?= $iGroupID ?>" name="GroupPropFormEditor">
 
+    <div class="table-responsive">
 <table class="table">
 
 <?php
@@ -418,6 +419,7 @@ if ($numRows == 0) {
 		</tr>
 
 	</table>
+    </div>
 	</form>
 
 </div>

--- a/src/Include/Functions.php
+++ b/src/Include/Functions.php
@@ -254,7 +254,7 @@ function CurrentFY()
 // PrintFYIDSelect: make a fiscal year selection menu.
 function PrintFYIDSelect($iFYID, $selectName)
 {
-    echo '<select name="'.$selectName.'">';
+    echo '<select class="form-control" name="'.$selectName.'">';
     echo '<option value="0">'.gettext('Select Fiscal Year').'</option>';
 
     for ($fy = 1; $fy < CurrentFY() + 2; $fy++) {

--- a/src/LettersAndLabels.php
+++ b/src/LettersAndLabels.php
@@ -56,23 +56,26 @@ if (isset($_POST['SubmitNewsLetter']) || isset($_POST['SubmitConfirmReport']) ||
       </div>
       <div class="box-body">
         <form method="post" action="LettersAndLabels.php">
+            <div class="table-responsive">
 
-          <table cellpadding="3" align="left">
+          <table class="table" cellpadding="3" align="left">
 <?php
 LabelSelect('labeltype');
 FontSelect('labelfont');
 FontSizeSelect('labelfontsize');
 ?>
 
-            <tr>
-              <td><input type="submit" class="btn" name="SubmitNewsLetter" value="<?= gettext('Newsletter labels') ?>"></td>
-              <td><input type="submit" class="btn" name="SubmitConfirmReport" value="<?= gettext('Confirm data letter') ?>"></td>
-              <td><input type="submit" class="btn" name="SubmitConfirmReportEmail" value="<?= gettext('Confirm data Email') ?>"></td>
-              <td><input type="submit" class="btn" name="SubmitConfirmLabels" value="<?= gettext('Confirm data labels') ?>"></td>
-              <td><input type="button" class="btn" name="Cancel" value="<?= gettext('Cancel') ?>" onclick="javascript:document.location = 'Menu.php';"></td>
-            </tr>
-
           </table>
+            </div>
+            <div>
+              <input type="submit" class="btn" name="SubmitNewsLetter" value="<?= gettext('Newsletter labels') ?>">
+              <input type="submit" class="btn" name="SubmitConfirmReport" value="<?= gettext('Confirm data letter') ?>">
+              <input type="submit" class="btn" name="SubmitConfirmReportEmail" value="<?= gettext('Confirm data Email') ?>">
+              <input type="submit" class="btn" name="SubmitConfirmLabels" value="<?= gettext('Confirm data labels') ?>">
+              <input type="button" class="btn" name="Cancel" value="<?= gettext('Cancel') ?>" onclick="javascript:document.location = 'Menu.php';">
+            </div>
+
+
 
         </form>
       </div>

--- a/src/PaddleNumEditor.php
+++ b/src/PaddleNumEditor.php
@@ -142,8 +142,8 @@ require 'Include/Header.php';
 ?>
 <div class="box box-body">
 <form method="post" action="PaddleNumEditor.php?<?= 'CurrentFundraiser='.$iCurrentFundraiser.'&PaddleNumID='.$iPaddleNumID.'&linkBack='.$linkBack ?>" name="PaddleNumEditor">
-
-<table cellpadding="3" align="center">
+<div class="table-responsive">
+<table class="table" cellpadding="3" align="center">
 	<tr>
 		<td align="center">
 			<input type="submit" class="btn" value="<?= gettext('Save') ?>" name="PaddleNumSubmit">
@@ -226,7 +226,7 @@ require 'Include/Header.php';
 			</table>
 			</tr>
 	</table>
-
+</div>
 </form>
 </div>
 <?php require 'Include/Footer.php' ?>

--- a/src/PersonCustomFieldsEditor.php
+++ b/src/PersonCustomFieldsEditor.php
@@ -288,7 +288,7 @@ require 'Include/Header.php'; ?>
     <?= gettext("Warning: Arrow and delete buttons take effect immediately.  Field name changes will be lost if you do not 'Save Changes' before using an up, down, delete or 'add new' button!") ?>
   </div>
   <form method="post" action="PersonCustomFieldsEditor.php" name="PersonCustomFieldsEditor">
-
+<div class="table-responsive">
     <table class="table">
 
       <?php
@@ -473,6 +473,7 @@ require 'Include/Header.php'; ?>
       </tr>
 
     </table>
+</div>
   </form>
 
 </div>

--- a/src/PledgeEditor.php
+++ b/src/PledgeEditor.php
@@ -558,6 +558,8 @@ if ($iFamily) {
 require 'Include/Header.php';
 
 ?>
+<div class="box">
+    <div class="box-body table-responsive">
 <form method="post" action="PledgeEditor.php?CurrentDeposit=<?= $iCurrentDeposit ?>&GroupKey=<?= $sGroupKey ?>&PledgeOrPayment=<?= $PledgeOrPayment ?>&linkBack=<?= $linkBack ?>" name="PledgeEditor">
 
 <input type="hidden" name="FamilyID" id="FamilyID" value="<?= $iFamily ?>">
@@ -888,5 +890,7 @@ $(document).ready(function() {
             } ?>
 </table>
 </form>
+</div>
+</div>
 
 <?php require 'Include/Footer.php' ?>

--- a/src/PropertyAssign.php
+++ b/src/PropertyAssign.php
@@ -179,6 +179,7 @@ require 'Include/Header.php';
 			<td><?= $sPrompt ?><br><textarea name="Value" cols="60" rows="10"><?= $sValue ?></textarea></td>
 		</tr>
 <?php
+
 } ?>
 </table>
 </div>

--- a/src/PropertyAssign.php
+++ b/src/PropertyAssign.php
@@ -163,7 +163,7 @@ require 'Include/Header.php';
 <form method="post" action="PropertyAssign.php<?= $sQuerystring.'&PropertyID='.$iPropertyID ?>">
 <input type="hidden" name="SecondPass" value="True">
 <input type="hidden" name="Action" value="<?= $sAction ?>">
-
+<div class="table-responsive">
 <table cellpadding="4">
 	<tr>
 		<td align="right"><b><?= $sTypeName ?>:</b></td>
@@ -178,9 +178,10 @@ require 'Include/Header.php';
 			<td align="right" valign="top"><b><?= gettext('Value') ?>:</b></td>
 			<td><?= $sPrompt ?><br><textarea name="Value" cols="60" rows="10"><?= $sValue ?></textarea></td>
 		</tr>
-<?php 
+<?php
 } ?>
 </table>
+</div>
 
 <p align="center"><input type="submit" class="btn" <?= 'value="'; if ($sAction == 'add') {
     echo gettext('Assign');

--- a/src/PropertyTypeEditor.php
+++ b/src/PropertyTypeEditor.php
@@ -83,41 +83,40 @@ require 'Include/Header.php';
 
 ?>
 <div class="box box-body">
-<form method="post" action="PropertyTypeEditor.php?PropertyTypeID=<?= $iPropertyTypeID ?>">
+<form class="form-horizontal" method="post" action="PropertyTypeEditor.php?PropertyTypeID=<?= $iPropertyTypeID ?>">
+    <div class="form-group">
+        <label class="control-label col-sm-2" for="class"><?= gettext('Class') ?>:</label>
+        <div class="col-sm-4">
+            <select class="form-control" id="class" name="Class">
+                <option value="p" <?= ($sClass == 'p' ? 'selected' : '') ?>><?= gettext('Person') ?></option>
+                <option value="f" <?= ($sClass == 'f' ? 'selected' : '') ?>><?= gettext('Family') ?></option>
+                <option value="g" <?= ($sClass == 'g' ? 'selected' : '') ?>><?= gettext('Group') ?></option>
+            </select>
+        </div>
+    </div>
+    <div class="form-group">
+        <label class="control-label col-sm-2" for="name"><?= gettext('Name') ?>:</label>
+        <div class="col-sm-4">
+            <input type="text" class="form-control" id="name" name="Name"
+                   value="<?= htmlentities(stripslashes($sName), ENT_NOQUOTES, 'UTF-8') ?>" size="40"><?= $sNameError ?>
+        </div>
+    </div>
+    <br>
+    <div class="form-group">
+        <label class="control-label col-sm-2" for="description"><?= gettext('Description') ?>:</label>
+        <div class="col-sm-4">
+            <textarea class="form-control" id="description" name="Description"
+                      rows="10"><?= htmlentities(stripslashes($sDescription), ENT_NOQUOTES, 'UTF-8') ?></textarea>
+        </div>
+    </div>
+    <div class="form-group">
+        <div class="col-sm-offset-2 col-sm-8">
+            <button type="submit" class="btn btn-primary" name="Submit"><?= gettext('Save') ?></button>
+            <button type="button" class="btn btn-default" name="Cancel"
+                    onclick="document.location='PropertyTypeList.php';"><?= gettext('Cancel') ?></button>
+        </div>
 
-<table class="table">
-	<tr>
-		<td align="right"><b><?= gettext('Class') ?>:</b></td>
-		<td>
-			<select name="Class">
-				<option value="p" <?php if ($sClass == 'p') {
-    echo 'selected';
-} ?>><?= gettext('Person') ?></option>
-				<option value="f" <?php if ($sClass == 'f') {
-    echo 'selected';
-} ?>><?= gettext('Family') ?></option>
-				<option value="g" <?php if ($sClass == 'g') {
-    echo 'selected';
-} ?>><?= gettext('Group') ?></option>
-			</select>
-		</td>
-	</tr>
-	<tr>
-		<td align="right"><b><?= gettext('Name') ?>:</b></td>
-		<td><input type="text" name="Name" value="<?= htmlentities(stripslashes($sName), ENT_NOQUOTES, 'UTF-8') ?>" size="40"> 			<?= $sNameError ?>
-		</td>
-	</tr>
-	<tr>
-		<td align="right" valign="top"><b><?= gettext('Description') ?>:</b></td>
-		<td><textarea name="Description" cols="60" rows="10"><?= htmlentities(stripslashes($sDescription), ENT_NOQUOTES, 'UTF-8') ?></textarea></td>
-	</tr>
-	<tr>
-		<td colspan="2" align="center">
-			<input type="submit" class="btn btn-primary" name="Submit" <?= 'value="'.gettext('Save').'"' ?>>&nbsp;<input type="button" class="btn btn-default" name="Cancel" <?= 'value="'.gettext('Cancel').'"' ?> onclick="document.location='PropertyTypeList.php';">
-		</td>
-	</tr>
-</table>
-
+    </div>
 </form>
 </div>
 

--- a/src/PropertyTypeList.php
+++ b/src/PropertyTypeList.php
@@ -27,13 +27,14 @@ $rsPropertyTypes = RunQuery($sSQL);
 require 'Include/Header.php';
 ?>
 <div class="box box-body">
+    <div class="table-responsive">
 <?php //Display the new property link
 if ($_SESSION['bMenuOptions']) {
     echo "<p align=\"center\"><a class='btn btn-primary' href=\"PropertyTypeEditor.php\">".gettext('Add a New Property Type').'</a></p>';
 }
 
 //Start the table
-echo "<table class='table'>";
+echo "<table class='table table-hover'>";
 echo '<tr>';
 echo '<th>'.gettext('Name').'</th>';
 echo '<th>'.gettext('Class').'</th>';
@@ -70,7 +71,7 @@ while ($aRow = mysqli_fetch_array($rsPropertyTypes)) {
 }
 
 //End the table
-echo '</table></div>';
+echo '</table></div></div>';
 
 require 'Include/Footer.php';
 

--- a/src/QueryView.php
+++ b/src/QueryView.php
@@ -203,6 +203,7 @@ function DoQuery()
             <?= $qry_Count ? mysqli_num_rows($rsQueryResults).gettext(' record(s) returned') : ''; ?>
         </p>
         
+        <div class="table-responsive">
         <table class="table table-striped">
             <thead>
                 <?php
@@ -243,13 +244,14 @@ function DoQuery()
     } ?>
             </tbody>
         </table>
+        </div>
     </div>
     
     <div class="box-footer">
         <p>
         <?php if (count($aHiddenFormField)): ?>
             <form method="post" action="CartView.php">
-            <div class="btn-group">
+            <div class="col-sm-offset-1">
                 <input type="hidden" value="<?= implode(',', $aHiddenFormField) ?>" name="BulkAddToCart">
                 <input type="submit" class="btn btn-primary btn-sm" name="AddToCartSubmit" value="<?= gettext('Add To Cart') ?>">
                 <input type="submit" class="btn btn-warning btn-sm" name="AndToCartSubmit" value="<?= gettext('Intersect With Cart') ?>">

--- a/src/ReminderReport.php
+++ b/src/ReminderReport.php
@@ -39,30 +39,25 @@ if (isset($_POST['Submit'])) {
 
 ?>
 
-<form method="post" action="ReminderReport.php">
+<div class="box box-body">
+    <form class="form-horizontal" method="post" action="Reports/ReminderReport.php">
+        <div class="form-group">
+            <label class="control-label col-sm-2" for="FYID"><?= gettext('Fiscal Year') ?>:</label>
+            <div class="col-sm-2">
+                <?php PrintFYIDSelect($iFYID, 'FYID') ?>
+            </div>
+        </div>
 
-<table cellpadding="3" align="left">
+        <div class="form-group">
+            <div class="col-sm-offset-2 col-sm-8">
+                <button type="submit" class="btn btn-primary" name="Submit"><?= gettext('Create Report') ?></button>
+                <button type="button" class="btn btn-default" name="Cancel"
+                        onclick="javascript:document.location='Menu.php';"><?= gettext('Cancel') ?></button>
+            </div>
+        </div>
 
-   <tr>
-      <td class="LabelColumn"><?= gettext('Fiscal Year') ?>:</td>
-      <td class="TextColumnWithBottomBorder">
-		<?php PrintFYIDSelect($iFYID, 'FYID') ?>
-      </td>
-   </tr>
-
-</table>
-
-<table cellpadding="3" align="left">
-   <tr>
-      <input type="submit" class="btn" name="Submit" value="<?= gettext('Create Report') ?>">
-      <input type="button" class="btn" name="Cancel" value="<?= gettext('Cancel') ?>" onclick="javascript:document.location='Menu.php';">
-   </tr>
-</table>
-
-
-</p>
-</form>
-
+    </form>
+</div>
 <?php
 require 'Include/Footer.php';
 ?>

--- a/src/SelectList.php
+++ b/src/SelectList.php
@@ -1000,6 +1000,7 @@ if (!isset($sPersonColumn5)) {
 
 // Header Row for results table
 echo '<form method="get" action="SelectList.php" name="ColumnOptions">';
+echo '<div class="table-responsive">';
 echo '<table cellpadding="4" align="center" cellspacing="0" width="100%">';
 echo '<tr><th></th><th><a href="SelectList.php?mode='.$sMode.'&amp;type='.$iGroupTypeMissing;
 echo '&amp;Sort=name&amp;Filter='.$sFilter.'">'.gettext('Name').'</a></th>';
@@ -1268,6 +1269,7 @@ while ($aRow = mysqli_fetch_array($rsPersons)) {
 ?>
 
 		</table>
+        </div>
 		</form>
 	</div>
 </div>

--- a/src/SettingsIndividual.php
+++ b/src/SettingsIndividual.php
@@ -100,6 +100,7 @@ $rsConfigs = RunQuery($sSQL);
 ?>
 <div class="box box-body">
 <form method=post action=SettingsIndividual.php>
+<div class="table-responsive">
 <table class="table">
 <tr><th><?= gettext('Variable name') ?></th>
 	<th><?= gettext('Current Value')?></th>
@@ -167,6 +168,7 @@ while (list($ucfg_per_id, $ucfg_id, $ucfg_name, $ucfg_value, $ucfg_type, $ucfg_t
 	</td>
 </tr>
 </table>
+</div>
 </form>
 </div>
 <?php

--- a/src/SettingsUser.php
+++ b/src/SettingsUser.php
@@ -87,7 +87,8 @@ $rsConfigs = RunQuery($sSQL);
 
 	<form method=post action=SettingsUser.php'>
 		<div class="callout callout-info"> <?= gettext('Set Permission True to give new users the ability to change their current value.<BR>'); ?></div>
-		<table class='table table-responsive'>
+        <div class="table-responsive">
+        <table class='table table-responsive'>
 		<tr>
 			<th> <?= gettext('Permission') ?></th>
 			<th><?= gettext('Variable name') ?></th>
@@ -163,13 +164,18 @@ while (list($ucfg_per_id, $ucfg_id, $ucfg_name, $ucfg_value, $ucfg_type, $ucfg_t
 
 ?>
 <tr>
-	<td colspan='4' class='text-center'>
+	<td colspan='3' class='text-center'>
 		<input type=submit class='btn btn-primary' name=save value="<?=  gettext('Save Settings') ?> ">
 		<input type=submit class=btn name=cancel value="<?= gettext('Cancel') ?>" onclick="javascript:document.location = 'Menu.php';">
 	</td>
 </tr>
 </table>
+        </div>
 </form>
+
+        </div>
+</div>
+
 <?php
 require 'Include/Footer.php';
 ?>

--- a/src/SystemSettings.php
+++ b/src/SystemSettings.php
@@ -144,6 +144,7 @@ require 'Include/Header.php';
             <div class="tab-pane <?php if ($category == 'Church Information') {
                     echo 'active';
                 } ?>" id="<?= str_replace(" ", '', $category) ?>">
+                <div class="table-responsive">
               <table class="table table-striped">
                 <tr>
                   <th width="150px"><?= gettext('Variable name') ?></th>
@@ -244,6 +245,7 @@ require 'Include/Header.php';
 
                   } ?>
               </table>
+                </div>
             </div>
           
           <?php

--- a/src/TaxReport.php
+++ b/src/TaxReport.php
@@ -36,26 +36,23 @@ if (isset($_POST['Submit'])) {
 
 ?>
 
-<form method="post" action="TaxReport.php">
+<div class="box box-body">
+    <form class="form-horizontal" method="post" action="TaxReport.php">
+        <div class="form-group">
+            <label class="control-label col-sm-2" for="Year"><?= gettext('Calendar Year') ?>:</label>
+            <div class="col-sm-2">
+                <input type="text" name="Year" id="Year" value="<?= $iYear ?>">
+            </div>
+        </div>
 
-<table cellpadding="3" align="left">
+        <div class="form-group">
+            <div class="col-sm-offset-2 col-sm-8">
+                <button type="submit" class="btn btn-primary" name="Submit"><?= gettext('Create Report') ?></button>
+                <button type="button" class="btn btn-default" name="Cancel"
+                        onclick="javascript:document.location='Menu.php';"><?= gettext('Cancel') ?></button>
+            </div>
+        </div>
 
-   <tr>
-      <td class="LabelColumn"><?= gettext('Calendar Year') ?>:</td>
-		<td class="TextColumn"><input type="text" name="Year" id="Year" value="<?= $iYear ?>"></td>
-   </tr>
-
-</table>
-
-<table cellpadding="3" align="left">
-   <tr>
-      <input type="submit" class="btn" name="Submit" value="<?= gettext('Create Report') ?>">
-      <input type="button" class="btn" name="Cancel" value="<?= gettext('Cancel') ?>" onclick="javascript:document.location='Menu.php';">
-   </tr>
-</table>
-
-
-</p>
-</form>
-
+    </form>
+</div>
 <?php require 'Include/Footer.php' ?>

--- a/src/UserEditor.php
+++ b/src/UserEditor.php
@@ -346,6 +346,7 @@ require 'Include/Header.php';
         <form method="post" action="UserEditor.php">
         <input type="hidden" name="Action" value="<?= $sAction ?>">
         <input type="hidden" name="NewUser" value="<?= $vNewUser ?>">
+            <div class="table-responsive">
         <table class="table table-hover">
 <?php
 
@@ -471,6 +472,7 @@ if ($bShowPersonSelect) {
         </td>
     </tr>
 </table>
+            </div>
     </div>
     <!-- /.box-body -->
 </div>
@@ -479,6 +481,7 @@ if ($bShowPersonSelect) {
 <div class="box">
     <div class="box-body box-danger">
         <div class="callout callout-info"><?= gettext('Set Permission True to give this user the ability to change their current value.') ?></div>
+        <div class="table-responsive">
         <table class="table">
             <tr>
                 <th><?= gettext('Permission') ?></h3></th>
@@ -563,12 +566,13 @@ while ($aDefaultRow = mysqli_fetch_row($rsDefault)) {
 ?>
 
     <tr>
-        <td colspan="4" class="text-center">
+        <td colspan="3" class="text-center">
             <input type="submit" class="btn btn-primary" name="save" value="<?= gettext('Save Settings') ?>">
             <input type="submit" class="btn" name="cancel" value="<?= gettext('Cancel') ?>">
         </td>
     </tr>
     </table>
+        </div>
 </form>
     </div>
     <!-- /.box-body -->

--- a/src/UserList.php
+++ b/src/UserList.php
@@ -56,6 +56,7 @@ require 'Include/Header.php';
     </div>
 <div class="box">
     <div class="box-body no-padding">
+        <div class="table-responsive">
         <table class="table table-hover">
             <tr>
                 <td><b><?= gettext('Edit') ?></b></td>
@@ -109,6 +110,7 @@ while ($aRow = mysqli_fetch_array($rsUsers)) {
 }
 ?>
 </table>
+        </div>
 	</div>
 	<!-- /.box-body -->
 </div>


### PR DESCRIPTION
Add table-responsive to tables to make tables scroll-able on mobile

Added <div class="table-responsive"> to most of the tables used to fix the mobile scrolling.
Couple of small forms rewritten to use bootstrap form elements and remove table.

fixes #1927