### PR TITLE
fix login on restart vm

### DIFF
--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -55,6 +55,12 @@ sudo mysql -u"$CRM_DB_USER" -p"$CRM_DB_PASS" "$CRM_DB_NAME" < $CRM_DB_VAGRANT_SC
 sudo mysql -u"$DB_USER" -p"$DB_PASS" -e "INSERT INTO churchcrm.version_ver (ver_version, ver_update_start) VALUES ('$CODE_VER', now());"
 echo "Database: development seed data deployed"
 
+echo "=========================================================="
+echo "=================   Clearing Sessions  ==================="
+echo "=========================================================="
+
+sudo rm /var/lib/php/sessions/*
+
 cp /vagrant/vagrant/Config.php /vagrant/src/Include/
 cp /vagrant/BuildConfig.json.example /vagrant/BuildConfig.json
 echo "copied Config.php "


### PR DESCRIPTION
clear the php session cookies when rebuilding the vagrant vm

closes #1997 

to test:
1. log into vagrant box
2. run vagrant provision
3. refresh 192.168.33.10
4  if successful, you'll see the login page.  If unsuccessful, you'll see a broken menu page.