### PR TITLE
Global search box fixes

### DIFF
--- a/src/Include/Header-function.php
+++ b/src/Include/Header-function.php
@@ -151,8 +151,10 @@ function Header_body_scripts()
     }
 
     $(document).ajaxError(function (evt, xhr, settings) {
-        var CRMResponse = JSON.parse(xhr.responseText);
-        window.CRM.DisplayErrorMessage(settings.url, CRMResponse);
+        try {
+            var CRMResponse = JSON.parse(xhr.responseText);
+            window.CRM.DisplayErrorMessage(settings.url, CRMResponse);
+        } catch(err) {}
     });
 
     function LimitTextSize(theTextArea, size) {

--- a/src/api/routes/search.php
+++ b/src/api/routes/search.php
@@ -3,6 +3,8 @@ use ChurchCRM\dto\SystemURLs;
 use ChurchCRM\FamilyQuery;
 use ChurchCRM\GroupQuery;
 use Propel\Runtime\ActiveQuery\Criteria;
+use ChurchCRM\dto\SystemConfig;
+
 // Routes search
 
 // search for a string in Persons, families, groups, Financial Deposits and Payments
@@ -10,12 +12,20 @@ $app->get('/search/{query}', function ($request, $response, $args) {
     $query = $args['query'];
     $resultsArray = [];
 
+    //Person Search
     try {
         array_push($resultsArray, $this->PersonService->getPersonsJSON($this->PersonService->search($query)));
     } catch (Exception $e) {
     }
 
-    if ($_SESSION['bFinance']) {
+    //Family Search
+    try {
+        array_push($resultsArray, $this->FamilyService->getFamiliesJSON($this->FamilyService->search($query)));
+    } catch (Exception $e) {
+    }
+
+    //Envelopes Search
+    if ($_SESSION['bFinance'] && SystemConfig::getValue('bUseDonationEnvelopes') && is_numeric($query)) {
         try {
             $q = FamilyQuery::create()
                 ->filterByEnvelope($query)
@@ -27,13 +37,9 @@ $app->get('/search/{query}', function ($request, $response, $args) {
             array_push($resultsArray, str_replace('Families', 'Donation Envelopes', $q->toJSON()));
         } catch (Exception $ex) {
         }
-
-        try {
-            array_push($resultsArray, $this->FamilyService->getFamiliesJSON($this->FamilyService->search($query)));
-        } catch (Exception $e) {
-        }
     }
 
+    //Group Search
     try {
         $dbGroups = GroupQuery::create()
             ->filterByName("%$query%", Criteria::LIKE)
@@ -47,25 +53,29 @@ $app->get('/search/{query}', function ($request, $response, $args) {
     } catch (Exception $e) {
     }
 
-    try {
-        $q = \ChurchCRM\DepositQuery::create();
-        $q->filterByComment("%$query%", Criteria::LIKE)
-            ->_or()
-            ->filterById($query)
-            ->_or()
-            ->usePledgeQuery()
-            ->filterByCheckno("%$query%", Criteria::LIKE)
-            ->endUse()
-            ->withColumn('CONCAT("#",Deposit.Id," ",Deposit.Comment)', 'displayName')
-            ->withColumn('CONCAT("' . SystemURLs::getRootPath() . 'DepositSlipEditor.php?DepositSlipID=",Deposit.Id)', 'uri')
-            ->limit(5);
-        array_push($resultsArray, $q->find()->toJSON());
-    } catch (Exception $e) {
-    }
+    //Deposits Search
+    if ($_SESSION['bFinance']) {
+        try {
+            $q = \ChurchCRM\DepositQuery::create();
+            $q->filterByComment("%$query%", Criteria::LIKE)
+                ->_or()
+                ->filterById($query)
+                ->_or()
+                ->usePledgeQuery()
+                ->filterByCheckno("%$query%", Criteria::LIKE)
+                ->endUse()
+                ->withColumn('CONCAT("#",Deposit.Id," ",Deposit.Comment)', 'displayName')
+                ->withColumn('CONCAT("' . SystemURLs::getRootPath() . 'DepositSlipEditor.php?DepositSlipID=",Deposit.Id)', 'uri')
+                ->limit(5);
+            array_push($resultsArray, $q->find()->toJSON());
+        } catch (Exception $e) {
+        }
 
-    try {
-        array_push($resultsArray, $this->FinancialService->getPaymentJSON($this->FinancialService->searchPayments($query)));
-    } catch (Exception $e) {
+        //Search Payments
+        try {
+            array_push($resultsArray, $this->FinancialService->getPaymentJSON($this->FinancialService->searchPayments($query)));
+        } catch (Exception $e) {
+        }
     }
 
     $data = ['results' => array_filter($resultsArray)];

--- a/src/skin/churchcrm.scss
+++ b/src/skin/churchcrm.scss
@@ -13,7 +13,6 @@
 // and we don't want to incur IE's CSS limits.
 // ( http://spaceninja.com/2015/03/31/ie-css-limits/ )
 
-@import 'adminlte/plugins/select2/select2.min.css';
 @import 'adminlte/plugins/datepicker/datepicker3.css';
 @import 'adminlte/plugins/daterangepicker/daterangepicker.css';
 @import 'adminlte/plugins/timepicker/bootstrap-timepicker.min.css';
@@ -33,7 +32,7 @@
 
 @import 'adminlte/dist/css/AdminLTE.min.css';
 @import 'adminlte/dist/css/skins/_all-skins.min.css';
-
+@import 'adminlte/plugins/select2/select2.min.css';
 // Import ChurchCRM custom styles
 
 @import 'scss/dropdowns';


### PR DESCRIPTION
1.  Search Failure added try {} around ajaxError in header-function.php
2.  Added bUseDonationEnvelopes check for envelope search. Fixes #2013
3.  Added query string numeric check before envelop search.  without
this all members with 0 as envelope will get displayed as the string
will get converted to 0.
4. Added bFinance check for Deposits Search and Payments search
5. move select2.min.css below adminlte inside churchcrm.scss #1943

Fixes #1943 #1959 and #2013