### PR TITLE
closes #2366

### DIFF
--- a/src/skin/js/DepositSlipEditor.js
+++ b/src/skin/js/DepositSlipEditor.js
@@ -131,7 +131,7 @@ function initDepositSlipEditor()
     }
   });
 
-  $(document).on('click',".paymentRow", function() {
+  $(document).on('click',".paymentRow", function(event) {
     if (! ($(event.target).hasClass("details-control") || $(event.target).hasClass("fa")))
     {
       $(this).toggleClass('selected');


### PR DESCRIPTION
fixes selecting payment rows in deposit slip editor on FireFox.

closes #2366 