### PR TITLE
adjsut sql gruop by

### DIFF
--- a/src/Include/LoadConfigs.php
+++ b/src/Include/LoadConfigs.php
@@ -67,7 +67,7 @@ function buildConnectionManagerConfig($sSERVERNAME, $sDATABASE, $sUSER, $sPASSWO
         'password' => $sPASSWORD,
         'settings' => [
             'charset' => 'utf8mb4',
-            'queries' => [],
+            'queries' => ["SET sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''))"],
         ],
         'classname' => $dbClassName,
         'model_paths' => [


### PR DESCRIPTION
Closes #1547 

Adds a query to the PDO initialization to remove ONLY_FULL_GROUP_BY from the ```sql_mode``` as per https://github.com/propelorm/Propel2/issues/1129.


To test this, 

1. start with clean ```vagrant provision``` or ```vagrant up``` on the **master** branch.
2. Upgrade the vagrant MySQL instance from 5.5 to 5.7:
```
wget http://dev.mysql.com/get/mysql-apt-config_0.8.0-1_all.deb
sudo dpkg -i mysql-apt-config_0.8.0-1_all.deb
sudo apt-get update
sudo apt-get install mysql-server
```
https://askubuntu.com/questions/750498/mysql-5-5-update-to-mysql-5-7

3. Log into the system, and go to the group view page.  It should fail.
4. switch to this branch.  It should succeed.
