### PR TITLE
Fix DatePicker Translation

### DIFF
--- a/src/Include/Footer.php
+++ b/src/Include/Footer.php
@@ -271,7 +271,7 @@ $isAdmin = $_SESSION['user']->isAdmin();
 <script src="<?= SystemURLs::getRootPath() ?>/skin/adminlte/plugins/input-mask/jquery.inputmask.date.extensions.js"></script>
 <script src="<?= SystemURLs::getRootPath() ?>/skin/adminlte/plugins/input-mask/jquery.inputmask.extensions.js"></script>
 <script src="<?= SystemURLs::getRootPath() ?>/skin/adminlte/plugins/datepicker/bootstrap-datepicker.js"></script>
-<script src="<?= SystemURLs::getRootPath() ?>/skin/adminlte/plugins/datepicker/locales/bootstrap-datepicker.<?= substr($localeInfo->getLocale(),0,2) ?>.js"></script>
+<script src="<?= SystemURLs::getRootPath() ?>/skin/adminlte/plugins/datepicker/locales/bootstrap-datepicker.<?= substr($localeInfo->getLocale(), 0, 2) ?>.js"></script>
 
 <script src="<?= SystemURLs::getRootPath() ?>/skin/adminlte/plugins/daterangepicker/daterangepicker.js"></script>
 <script src="<?= SystemURLs::getRootPath() ?>/skin/adminlte/plugins/timepicker/bootstrap-timepicker.js"></script>
@@ -285,9 +285,9 @@ $isAdmin = $_SESSION['user']->isAdmin();
 <script src="<?= SystemURLs::getRootPath() ?>/skin/adminlte/plugins/chartjs/Chart.min.js"></script>
 <script src="<?= SystemURLs::getRootPath() ?>/skin/adminlte/plugins/pace/pace.min.js"></script>
 <script src="<?= SystemURLs::getRootPath() ?>/skin/adminlte/plugins/select2/select2.full.min.js"></script>
-<script src="<?= SystemURLs::getRootPath() ?>/skin/adminlte/plugins/select2/i18n/<?= substr($localeInfo->getLocale(),0,2) ?>.js"></script>
+<script src="<?= SystemURLs::getRootPath() ?>/skin/adminlte/plugins/select2/i18n/<?= substr($localeInfo->getLocale(), 0, 2) ?>.js"></script>
 <script>
-	$(".multiSearch").select2.defaults.set("language", "<?= substr($localeInfo->getLocale(),0,2) ?>");
+	$(".multiSearch").select2.defaults.set("language", "<?= substr($localeInfo->getLocale(), 0, 2) ?>");
 </script>
 
 <script src="<?= SystemURLs::getRootPath() ?>/skin/bootbox/bootbox.min.js"></script>

--- a/src/Include/Footer.php
+++ b/src/Include/Footer.php
@@ -271,6 +271,8 @@ $isAdmin = $_SESSION['user']->isAdmin();
 <script src="<?= SystemURLs::getRootPath() ?>/skin/adminlte/plugins/input-mask/jquery.inputmask.date.extensions.js"></script>
 <script src="<?= SystemURLs::getRootPath() ?>/skin/adminlte/plugins/input-mask/jquery.inputmask.extensions.js"></script>
 <script src="<?= SystemURLs::getRootPath() ?>/skin/adminlte/plugins/datepicker/bootstrap-datepicker.js"></script>
+<script src="<?= SystemURLs::getRootPath() ?>/skin/adminlte/plugins/datepicker/locales/bootstrap-datepicker.<?= substr($localeInfo->getLocale(),0,2) ?>.js"></script>
+
 <script src="<?= SystemURLs::getRootPath() ?>/skin/adminlte/plugins/daterangepicker/daterangepicker.js"></script>
 <script src="<?= SystemURLs::getRootPath() ?>/skin/adminlte/plugins/timepicker/bootstrap-timepicker.js"></script>
 
@@ -283,6 +285,10 @@ $isAdmin = $_SESSION['user']->isAdmin();
 <script src="<?= SystemURLs::getRootPath() ?>/skin/adminlte/plugins/chartjs/Chart.min.js"></script>
 <script src="<?= SystemURLs::getRootPath() ?>/skin/adminlte/plugins/pace/pace.min.js"></script>
 <script src="<?= SystemURLs::getRootPath() ?>/skin/adminlte/plugins/select2/select2.full.min.js"></script>
+<script src="<?= SystemURLs::getRootPath() ?>/skin/adminlte/plugins/select2/i18n/<?= substr($localeInfo->getLocale(),0,2) ?>.js"></script>
+<script>
+	$(".multiSearch").select2.defaults.set("language", "<?= substr($localeInfo->getLocale(),0,2) ?>");
+</script>
 
 <script src="<?= SystemURLs::getRootPath() ?>/skin/bootbox/bootbox.min.js"></script>
 <script src="<?= SystemURLs::getRootPath() ?>/skin/fastclick/fastclick.js"></script>


### PR DESCRIPTION
closes #2717 

Better localisation for data-picker.
I substitute :
<script src="<?= SystemURLs::getRootPath() ?>/skin/fullcalendar/fullcalendar.js"></script>
to :
<script src="<?= SystemURLs::getRootPath() ?>/skin/adminlte/plugins/datepicker/locales/bootstrap-datepicker.<?= substr($localeInfo->getLocale(),0,2) ?>.js"></script>