### PR TITLE
Readd backupRemote api endpoint

### DIFF
--- a/src/api/routes/database.php
+++ b/src/api/routes/database.php
@@ -11,6 +11,11 @@ $app->group('/database', function () {
         echo json_encode($backup);
     });
 
+    $this->post('/backupRemote', function() use ($app, $systemService) {
+        $backup = $this->SystemService->copyBackupToExternalStorage();
+        echo json_encode($backup);
+    });
+
     $this->post('/restore', function ($request, $response, $args) {
       
       if ( $_SERVER['REQUEST_METHOD'] == 'POST' && empty($_POST) &&


### PR DESCRIPTION
It seems like the backupRemote endpoint was removed at some point. This re-adds it. The issue was originally reported as  #2902.

I tested it with local "remote" backups.