### PR TITLE
add codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Crossan007 @DawoudIO


### PR DESCRIPTION
I think that this should auto-request @DawoudIO and @crossan007 as reviewers for PRs created _after_ this PR is merged.