### PR TITLE
3219 - Create Missing Photothumbnails

### DIFF
--- a/src/ChurchCRM/dto/Photo.php
+++ b/src/ChurchCRM/dto/Photo.php
@@ -108,12 +108,16 @@ class Photo
 
   public function getThumbnailURI()
   {
+    if (!file_exists($this->photoThumbURI))
+    {
+      $this->createThumbnail();
+    }
     return $this->photoThumbURI;
   }
   
   public function getPhotoURI()
   {
-    return $this->photoThumbURI;
+    return $this->photoURI;
   }
   
   public function isPhotoLocal()


### PR DESCRIPTION
Closes #3219.

replaces #3220 
replaces #3218

```getThumbnailURI()``` may return a blank string for a photo that does not yet have a thumbnail generated.

this causes```getThumbnailURI()```  to behave the same as ```getThumbnailBytes()``` when requesting a non-existant thumbnail - it will attempt to generate the thumbnail before returning the path.