### PR TITLE
CSP reporting and HSTS System Config

### DIFF
--- a/src/ChurchCRM/dto/SystemConfig.php
+++ b/src/ChurchCRM/dto/SystemConfig.php
@@ -216,7 +216,8 @@ class SystemConfig
         "iPhotoClientCacheDuration" => new ConfigItem(2038, "iPhotoClientCacheDuration", "number", "3600", gettext("Client cache seconds for images")),
         "iRemotePhotoCacheDuration" => new ConfigItem(2039, "iRemotePhotoCacheDuration", "number", "72 hours", gettext("Server cache time for remote images")),
         "iPersonConfessionFatherCustomField" => new ConfigItem(2040, "iPersonConfessionFatherCustomField", "ajax", "", gettext("Field where Father Of Confession is listed, must be a people of group type"), "", "/api/system/custom-fields/person/?typeId=9"),
-        "iPersonConfessionDateCustomField" => new ConfigItem(2041, "iPersonConfessionDateCustomField", "ajax", "", gettext("Field where last Confession is stored, must be a date type"), "", "/api/system/custom-fields/person/?typeId=2")
+        "iPersonConfessionDateCustomField" => new ConfigItem(2041, "iPersonConfessionDateCustomField", "ajax", "", gettext("Field where last Confession is stored, must be a date type"), "", "/api/system/custom-fields/person/?typeId=2"),
+        "bHSTSEnable" => new ConfigItem(20142,"bHSTSEnable","boolean","0",gettext("Require that this ChurchCRM Database is accessed over HTTPS"))
     );
   }
 
@@ -230,7 +231,7 @@ class SystemConfig
       gettext('Map Settings')  => ["sGeoCoderProvider","sGoogleMapKey","sBingMapKey","sGMapIcons", "iMapZoom","sISTusername","sISTpassword"],
       gettext('Report Settings')  => ["sQBDTSettings","leftX","incrementY","sTaxReport1","sTaxReport2","sTaxReport3","sTaxSigner","sReminder1","sReminderSigner","sReminderNoPledge","sReminderNoPayments","sConfirm1","sConfirm2","sConfirm3","sConfirm4","sConfirm5","sConfirm6","sDear","sConfirmSincerely","sConfirmSigner","sPledgeSummary1","sPledgeSummary2","sDirectoryDisclaimer1","sDirectoryDisclaimer2","bDirLetterHead","sZeroGivers","sZeroGivers2","sZeroGivers3", "iPDFOutputType"],
       gettext('Financial Settings') => ["sDepositSlipType","iChecksPerDepositForm","bDisplayBillCounts","bUseScannedChecks","sElectronicTransactionProcessor","bEnableNonDeductible","iFYMonth","bUseDonationEnvelopes","aFinanceQueries"],
-      gettext('System Settings')  => ["sLogLevel", "bRegistered","sGZIPname","sZIPname","sPGPname","bCSVAdminOnly","sHeader","bEnableIntegrityCheck","iIntegrityCheckInterval","sLastIntegrityCheckTimeStamp", "iPhotoClientCacheDuration"],
+      gettext('System Settings')  => ["sLogLevel", "bRegistered","sGZIPname","sZIPname","sPGPname","bCSVAdminOnly","sHeader","bEnableIntegrityCheck","iIntegrityCheckInterval","sLastIntegrityCheckTimeStamp", "iPhotoClientCacheDuration","bHSTSEnable"],
       gettext('Quick Search') => ["bSearchIncludePersons","bSearchIncludePersonsMax","bSearchIncludeAddresses", "bSearchIncludeAddressesMax", "bSearchIncludeFamilies","bSearchIncludeFamiliesMax","bSearchIncludeFamilyHOH","bSearchIncludeFamilyHOHMax","bSearchIncludeGroups","bSearchIncludeGroupsMax","bSearchIncludeDeposits", "bSearchIncludeDepositsMax", "bSearchIncludePayments", "bSearchIncludePaymentsMax"],
       gettext('Backup')  => ["sLastBackupTimeStamp","bEnableExternalBackupTarget","sExternalBackupType","sExternalBackupAutoInterval","sExternalBackupEndpoint","sExternalBackupUsername","sExternalBackupPassword"],
       gettext('Localization')  => ["sLanguage","sDistanceUnit","sPhoneFormat","sPhoneFormatWithExt","sDateFormatLong","sDateFormatNoYear","sDateFormatShort","sDateTimeFormat","sDateFilenameFormat","sCSVExportDelemiter","sCSVExportCharset","sDatePickerFormat","sDatePickerPlaceHolder"],

--- a/src/ChurchCRM/dto/SystemURLs.php
+++ b/src/ChurchCRM/dto/SystemURLs.php
@@ -13,6 +13,7 @@ class SystemURLs
     private static $rootPath;
     private static $urls;
     private static $documentRoot;
+    private static $CSPNonce;
     private static $supportURL = "https://github.com/ChurchCRM/CRM/wiki";
 
     public static function init($rootPath, $urls, $documentRoot)
@@ -24,6 +25,7 @@ class SystemURLs
         self::$rootPath = $rootPath;
         self::$urls = $urls;
         self::$documentRoot = $documentRoot;
+        self::$CSPNonce = base64_encode(random_bytes(16));
     }
 
     public static function getRootPath()
@@ -95,5 +97,10 @@ class SystemURLs
                 exit;
             }
         }
+    }
+    
+    public static function getCSPNonce()
+    {
+      return self::$CSPNonce;
     }
 }

--- a/src/Include/Header-Minimal.php
+++ b/src/Include/Header-Minimal.php
@@ -9,6 +9,7 @@
  *  Copyright 2003 Chris Gebhardt
   *
  ******************************************************************************/
+require_once 'Header-Security.php';
 
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">

--- a/src/Include/Header-Security.php
+++ b/src/Include/Header-Security.php
@@ -7,6 +7,7 @@
  */
 
 use ChurchCRM\dto\SystemURLs;
+use ChurchCRM\dto\SystemConfig;
 
 $csp = array(
     "default-src 'self'",
@@ -20,6 +21,8 @@ $csp = array(
     "connect-src 'self'",
     "report-uri ".SystemURLs::getRootPath()."/api/system/csp-report"
 );
-
+if (SystemConfig::getBooleanValue("bHSTSEnable")){
+  header('Strict-Transport-Security: max-age=31536000; includeSubDomains');
+}
 header('X-Frame-Options: SAMEORIGIN');
 header("Content-Security-Policy-Report-Only:".join(";", $csp));

--- a/src/Include/Header-Security.php
+++ b/src/Include/Header-Security.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+use ChurchCRM\dto\SystemURLs;
+
+$csp = array(
+    "default-src 'self'",
+    "script-src 'unsafe-eval' 'self' 'nonce-".SystemURLs::getCSPNonce()."' sidecar.gitter.im browser-update.org",
+    "object-src 'none'",
+    "style-src 'self' 'unsafe-inline' fonts.googleapis.com",
+    "img-src 'self' data:",
+    "media-src 'self'",
+    "frame-src 'self'",
+    "font-src 'self' fonts.gstatic.com",
+    "connect-src 'self'",
+    "report-uri ".SystemURLs::getRootPath()."/api/system/csp-report"
+);
+
+header('X-Frame-Options: SAMEORIGIN');
+header("Content-Security-Policy-Report-Only:".join(";", $csp));

--- a/src/Include/Header-Short.php
+++ b/src/Include/Header-Short.php
@@ -11,6 +11,7 @@
  ******************************************************************************/
 
 require_once 'Header-function.php';
+require_once 'Header-Security.php';
 
 // Turn ON output buffering
 ob_start();

--- a/src/Include/Header.php
+++ b/src/Include/Header.php
@@ -28,6 +28,7 @@ $taskService = new TaskService();
 ob_start();
 
 require_once 'Header-function.php';
+require_once 'Header-Security.php';
 
 // Top level menu index counter
 $MenuFirst = 1;
@@ -154,7 +155,7 @@ $MenuFirst = 1;
       <!-- search form -->
       <form action="#" method="get" class="sidebar-form">
 
-        <select class="form-control multiSearch" style="width:100%">
+        <select class="form-control multiSearch">
         </select>
 
       </form>

--- a/src/Include/HeaderNotLoggedIn.php
+++ b/src/Include/HeaderNotLoggedIn.php
@@ -1,6 +1,8 @@
 <?php
 use ChurchCRM\dto\SystemURLs;
 
+require_once 'Header-Security.php';
+
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html>
@@ -25,7 +27,7 @@ use ChurchCRM\dto\SystemURLs;
 </head>
 <body class="hold-transition login-page">
 
-  <script language="javascript" type="text/javascript">
+  <script language="javascript" type="text/javascript" nonce="<?= SystemURLs::getCSPNonce() ?>">
     window.CRM = {
       root: "<?= SystemURLs::getRootPath() ?>"
     };

--- a/src/api/index.php
+++ b/src/api/index.php
@@ -72,5 +72,8 @@ require __DIR__.'/routes/events.php';
 
 require __DIR__.'/routes/custom-fields.php';
 
+require __DIR__.'/routes/system.php';
+
+
 // Run app
 $app->run();

--- a/src/api/routes/system.php
+++ b/src/api/routes/system.php
@@ -1,0 +1,17 @@
+<?php
+
+use ChurchCRM\dto\SystemURLs;
+/* 
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+
+$app->group('/system', function () {
+  $this->post('/csp-report', function ($request, $response, $args) {
+          $input = json_decode($request->getBody());
+          $log  = json_encode($input, JSON_PRETTY_PRINT);
+          $this->Logger->warn($log);
+  });
+});


### PR DESCRIPTION
First half of #2293.
This is the policy definition, and the code to handle reporting.

No scripts or other content is actually blocked, it is only reported.  These reports are our guide to hardening the app


https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP

General overview:
*  Only content from designated locations is loaded.
*  On-page scripts must have the same "nonce" that is sent in the headers to prevent XSS
*  Reports all content security violations to the new API endpoint at /api/system/csp-report.
    These reports are logged into the app log.
*  Allows user to set HSTS Header to force HTTPS for this database (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security)
 

CSP violations can be seen in "Console" view of chrome dev tools:

![image](https://user-images.githubusercontent.com/11679900/33248897-8303d34e-d2f5-11e7-8b1e-5885d0891165.png)


They'll also appear in the app.log file:
![image](https://user-images.githubusercontent.com/11679900/33248933-96236458-d2f5-11e7-932f-375ed8d7abac.png)
