### PR TITLE
Add Cell Format Localization

### DIFF
--- a/src/ChurchCRM/dto/SystemConfig.php
+++ b/src/ChurchCRM/dto/SystemConfig.php
@@ -115,6 +115,7 @@ class SystemConfig
         "bEnableSelfRegistration" => new ConfigItem(80, "bEnableSelfRegistration", "boolean", "0", gettext("Set true to enable family self registration.")),
         "sPhoneFormat" => new ConfigItem(100, "sPhoneFormat", "text", "(999) 999-9999"),
         "sPhoneFormatWithExt" => new ConfigItem(101, "sPhoneFormatWithExt", "text", "(999) 999-9999 x99999"),
+        "sPhoneFormatCell" => new ConfigItem(111, "sPhoneFormatCell", "text", "(999) 999-9999"),
         "sDateFormatLong" => new ConfigItem(102, "sDateFormatLong", "text", "m/d/Y"),
         "sDateFormatNoYear" => new ConfigItem(103, "sDateFormatNoYear", "text", "m/d"),
         "sDateFormatShort" => new ConfigItem(104, "sDateFormatShort", "text", "j/m/y"),
@@ -239,7 +240,7 @@ class SystemConfig
       gettext('System Settings')  => ["sLogLevel", "bRegistered","sGZIPname","sZIPname","sPGPname","bCSVAdminOnly","sHeader","bEnableIntegrityCheck","iIntegrityCheckInterval","sLastIntegrityCheckTimeStamp", "iPhotoClientCacheDuration","bHSTSEnable"],
       gettext('Quick Search') => ["bSearchIncludePersons","bSearchIncludePersonsMax","bSearchIncludeAddresses", "bSearchIncludeAddressesMax", "bSearchIncludeFamilies","bSearchIncludeFamiliesMax","bSearchIncludeFamilyHOH","bSearchIncludeFamilyHOHMax","bSearchIncludeGroups","bSearchIncludeGroupsMax","bSearchIncludeDeposits", "bSearchIncludeDepositsMax", "bSearchIncludePayments", "bSearchIncludePaymentsMax"],
       gettext('Backup')  => ["sLastBackupTimeStamp","bEnableExternalBackupTarget","sExternalBackupType","sExternalBackupAutoInterval","sExternalBackupEndpoint","sExternalBackupUsername","sExternalBackupPassword"],
-      gettext('Localization')  => ["sLanguage","sDistanceUnit","sPhoneFormat","sPhoneFormatWithExt","sDateFormatLong","sDateFormatNoYear","sDateFormatShort","sDateTimeFormat","sDateFilenameFormat","sCSVExportDelemiter","sCSVExportCharset","sDatePickerFormat","sDatePickerPlaceHolder"],
+      gettext('Localization')  => ["sLanguage","sDistanceUnit","sPhoneFormat","sPhoneFormatWithExt","sPhoneFormatCell","sDateFormatLong","sDateFormatNoYear","sDateFormatShort","sDateTimeFormat","sDateFilenameFormat","sCSVExportDelemiter","sCSVExportCharset","sDatePickerFormat","sDatePickerPlaceHolder"],
       gettext('Integration')  => ["sMailChimpApiKey","sGoogleTrackingID","bEnableGravatarPhotos","bEnableGooglePhotos","iRemotePhotoCacheDuration","sNexmoAPIKey","sNexmoAPISecret","sNexmoFromNumber","sOLPURL","sOLPUserName","sOLPPassword","bEnableExternalCalendarAPI"],
       gettext('Church Services')  => ["iPersonConfessionFatherCustomField","iPersonConfessionDateCustomField"],
       gettext('Events')  => ["bEventsOnDashboardPresence","iEventsOnDashboardPresenceTimeOut","iEventsInMenuBarIntervalTime"]

--- a/src/FamilyEditor.php
+++ b/src/FamilyEditor.php
@@ -760,7 +760,7 @@ require 'Include/Header.php';
 						<div class="input-group-addon">
 							<i class="fa fa-phone"></i>
 						</div>
-						<input type="text" name="CellPhone" value="<?= htmlentities(stripslashes($sCellPhone)) ?>" size="30" maxlength="30" class="form-control" data-inputmask='"mask": "<?= SystemConfig::getValue('sPhoneFormat')?>"' data-mask>
+						<input type="text" name="CellPhone" value="<?= htmlentities(stripslashes($sCellPhone)) ?>" size="30" maxlength="30" class="form-control" data-inputmask='"mask": "<?= SystemConfig::getValue('sPhoneFormatCell')?>"' data-mask>
 						<input type="checkbox" name="NoFormat_CellPhone" value="1" <?= $bNoFormat_CellPhone ? ' checked' : '' ?>><?= gettext('Do not auto-format') ?>
 					</div>
 				</div>

--- a/src/PersonEditor.php
+++ b/src/PersonEditor.php
@@ -1017,7 +1017,7 @@ require 'Include/Header.php';
                         </div>
                         <input type="text" name="CellPhone"
                                value="<?= htmlentities(stripslashes($sCellPhone), ENT_NOQUOTES, 'UTF-8') ?>" size="30"
-                               maxlength="30" class="form-control" data-inputmask='"mask": "<?= SystemConfig::getValue('sPhoneFormat')?>"' data-mask>
+                               maxlength="30" class="form-control" data-inputmask='"mask": "<?= SystemConfig::getValue('sPhoneFormatCell')?>"' data-mask>
                         <br><input type="checkbox" name="NoFormat_CellPhone"
                                    value="1" <?php if ($bNoFormat_CellPhone) {
                             echo ' checked';


### PR DESCRIPTION
Adds support to customise the formatting for cell/mobile phone numbers in both the Person and Family editing pages.


#### What's this PR do?

Adds support to customise the formatting for cell/mobile phone numbers in both the Person and Family editing pages.

#### What Issues does it Close?

#3524

#### Where should the reviewer start?

src/ChruchCRM/dto/SystemConfig.php

#### How should this be manually tested?

1. Go to Localization settings tab in General Settings
2. There should be a configuration for 'sPhoneFormatCell'
3. Edit step 2 as desired.
4. Edit a family or person - cell phone format should reflect the setting in  step 3.
5. Verify cell phone is display correctly when viewing a person or family.

#### How should the automated tests treat this?

The same as other phone format settings.

#### Any background context you want to provide?

In Australia, we format land-lines as (99) 9999-9999 but, cell/mobile numbers are formatted (9999) 999-999. Having the ability to localize this makes it more intuitive for local users.

#### What are the relevant tickets?

#3524

#### Screenshots (if appropriate)

#### Questions:
- Is there a related website / article to substantiate / explain this change? 
  - No
- Does the development wiki need an update?
  - No
- Does the user documentation wiki need an update?
  - No
- Does this add new dependencies?
  - No