### PR TITLE
Simplified initial fetching for families

### DIFF
--- a/src/ChurchCRM/dto/Photo.php
+++ b/src/ChurchCRM/dto/Photo.php
@@ -228,11 +228,8 @@ class Photo {
     }
     elseif ($this->photoType == "Family" )
     {
-      $fullNameArr = explode(" ",  FamilyQuery::create()->findOneById($this->id)->getName());
-      foreach ($fullNameArr as $name)
-      {
-        $retstr .= substr($name, 0,1);
-      }
+      $fullNameArr = FamilyQuery::create()->findOneById($this->id)->getName();
+        $retstr .= strtoupper(substr($fullNameArr, 0,1));
     }
     return $retstr;
   }


### PR DESCRIPTION
#### What's this PR do?
Simple bug fix that renders a default image for families by forcing a single uppercase letter.

#### What Issues does it Close?

Closes #3495.

#### Where should the reviewer start?
1. Go to /dto/Photo.php.
1. Look at the `getInitialString()` function.
1. Examine the behavior when the `photoType` is equal to "Family".

#### How should this be manually tested?
1. Create a new person with a new family name containing multiple words, such as "(FirstName) John (MiddleName) Jacob (LastName) Jingleheimer Schmidt"
1. Navigate to the newly created family name - the default photo should contain a single uppercase "J".
1. Good luck getting that [song](https://www.youtube.com/watch?v=fovP6lAUVP0) out of your head

#### Any background context you want to provide?
I had started rewriting some of this logic in PR #3502 to address issues fetching the initials for a person, but I had neglected to take a look at the last name.

