### PR TITLE
Introduced record counts on person list page

### DIFF
--- a/src/SelectList.php
+++ b/src/SelectList.php
@@ -785,7 +785,15 @@ if ($iMode == 1) {
     </div>
 	<div class="box-body">
 <?php
-
+// Display record count
+if ($Total == 1)
+	{
+	echo '<p align = "center">' . $Total . gettext(" record returned") . '</p>';
+	}
+  else
+	{
+	echo '<p align = "center">' . $Total . gettext(" records returned") . '</p>';
+	}
 // Create Sort Links
 echo '<div align="center">';
 echo "<a href=\"SelectList.php?mode=$sMode&amp;type=$iGroupTypeMissing&amp;Filter=$sFilter&amp;Classification=$iClassificationStr&amp;FamilyRole=$iFamilyRoleStr&amp;Gender=$iGenderStr&amp;grouptype=$iGroupTypeStr&amp;groupid=$iGroupIDStr&amp;grouproleid=$iRoleIDStr&amp;PersonProperties=$iPersonPropertyStr";

--- a/src/SelectList.php
+++ b/src/SelectList.php
@@ -786,14 +786,11 @@ if ($iMode == 1) {
 	<div class="box-body">
 <?php
 // Display record count
-if ($Total == 1)
-	{
-	echo '<p align = "center">' . $Total . gettext(" record returned") . '</p>';
-	}
-  else
-	{
-	echo '<p align = "center">' . $Total . gettext(" records returned") . '</p>';
-	}
+if ($Total == 1) {
+    echo '<p align = "center">' . $Total . gettext(" record returned") . '</p>';
+} else {
+      echo '<p align = "center">' . $Total . gettext(" records returned") . '</p>';
+  }
 // Create Sort Links
 echo '<div align="center">';
 echo "<a href=\"SelectList.php?mode=$sMode&amp;type=$iGroupTypeMissing&amp;Filter=$sFilter&amp;Classification=$iClassificationStr&amp;FamilyRole=$iFamilyRoleStr&amp;Gender=$iGenderStr&amp;grouptype=$iGroupTypeStr&amp;groupid=$iGroupIDStr&amp;grouproleid=$iRoleIDStr&amp;PersonProperties=$iPersonPropertyStr";

--- a/src/SelectList.php
+++ b/src/SelectList.php
@@ -789,8 +789,8 @@ if ($iMode == 1) {
 if ($Total == 1) {
     echo '<p align = "center">' . $Total . gettext(" record returned") . '</p>';
 } else {
-      echo '<p align = "center">' . $Total . gettext(" records returned") . '</p>';
-  }
+    echo '<p align = "center">' . $Total . gettext(" records returned") . '</p>';
+}
 // Create Sort Links
 echo '<div align="center">';
 echo "<a href=\"SelectList.php?mode=$sMode&amp;type=$iGroupTypeMissing&amp;Filter=$sFilter&amp;Classification=$iClassificationStr&amp;FamilyRole=$iFamilyRoleStr&amp;Gender=$iGenderStr&amp;grouptype=$iGroupTypeStr&amp;groupid=$iGroupIDStr&amp;grouproleid=$iRoleIDStr&amp;PersonProperties=$iPersonPropertyStr";


### PR DESCRIPTION
#### What's this PR do?
This introduces a simple counter displaying the number of records retrieved when performing a query on SelectList.php.

#### What Issues does it Close?

Closes #3664 

#### Where should the reviewer start?
The code is small and can be found in SelectList.php.  The variable `$Total` is already declared for other usage; I am just reusing it in a simple and easy-to-follow way.
#### How should this be manually tested?
1. Log in.
1. Choose _People -> View all Persons._
1. You should already see a count of people in the database.

**Advanced Tests**
- Try querying so that you are sure to return only one record - a different text is retrieved to qualify the singular result ("1 record returned")
- Try querying so that you are sure to return zero or more than one record - a different text is retrieved to qualify the plural result ("0 records returned").


#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/23409144/33801683-e4c6bc6e-dd30-11e7-8ab6-b0989add1422.png)
