### PR TITLE
bugfix/3665-Fix CKEditor missing CSS file in dist

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -98,7 +98,7 @@ module.exports = function (grunt) {
                     {
                         expand: true,
                         cwd:'node_modules/ckeditor/',
-                        src: ['*.js','*.json','lang/**/*','adapters/**/*','plugins/**/*','skins/**/*'],
+                        src: ['*.js','*.css','*.json','lang/**/*','adapters/**/*','plugins/**/*','skins/**/*'],
                         dest: 'src/skin/external/ckeditor/'
                     },
                     {


### PR DESCRIPTION
#### What's this PR do?
Adds the ckeditor contents.css file to the vendor directory as part of the build process (just like the other vendor plugins)

#### What Issues does it Close?

Closes #3665 
Closes #3666 

#### Where should the reviewer start?
1)  Open dev tools to the network tab
2)  Open the calendar (or any other place CK editor is used)
3)  Watch that ```contents.css?t=<Rand>``` loads correctly.

#### How should this be manually tested?

#### How should the automated tests treat this?

#### Any background context you want to provide?

#### What are the relevant tickets?

#### Screenshots (if appropriate)

#### Questions:
- Is there a related website / article to substantiate / explain this change?
- Does the development wiki need an update?
- Does the user documentation wiki need an update?
- Does this add new dependencies?
