### PR TITLE
Bugfix/3637 individual deposit report

### DIFF
--- a/src/FinancialReports.php
+++ b/src/FinancialReports.php
@@ -311,12 +311,6 @@ if ($sReportType == '') {
         echo '<td class=TextColumnWithBottomBorder><input name=RequireDonationYears type=text value=0 size=5></td></tr>';
     }
 
-    if ($sReportType == 'Individual Deposit Report') {
-        echo '<tr><td class=LabelColumn>'.gettext('Report Type:').'</td>'
-            ."<td class=TextColumnWithBottomBorder><input name=report_type type=radio value='Bank'>".gettext('Deposit Slip')
-            ." <input name=report_type type=radio value='' checked>".gettext('Deposit Report').'</td></tr>';
-    }
-
     if ((($_SESSION['bAdmin'] && $bCSVAdminOnly) || !$bCSVAdminOnly)
         && ($sReportType == 'Pledge Summary' || $sReportType == 'Giving Report' || $sReportType == 'Individual Deposit Report' || $sReportType == 'Advanced Deposit Report' || $sReportType == 'Zero Givers')) {
         echo '<tr><td class=LabelColumn>'.gettext('Output Method:').'</td>';

--- a/src/Reports/PrintDeposit.php
+++ b/src/Reports/PrintDeposit.php
@@ -1,0 +1,64 @@
+<?php
+/*******************************************************************************
+*
+*  filename    : Reports/PrintDeposit.php
+*  last change : 2013-02-21
+*  description : Creates a PDF of the current deposit slip
+*
+*  ChurchCRM is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2 of the License, or
+*  (at your option) any later version.
+*
+******************************************************************************/
+
+global $iChecksPerDepositForm;
+
+require "../Include/Config.php";
+require "../Include/Functions.php";
+require "../Include/ReportFunctions.php";
+
+use ChurchCRM\Utils\InputUtils;
+use ChurchCRM\dto\SystemURLs;
+
+//Security
+if (!$_SESSION['bFinance'] && !$_SESSION['bAdmin']) {
+    Redirect("Menu.php");
+    exit;
+}
+
+$iBankSlip = 0;
+if (array_key_exists("BankSlip", $_GET)) {
+    $iBankSlip = InputUtils::LegacyFilterInput($_GET["BankSlip"], 'int');
+}
+if (!$iBankSlip && array_key_exists("report_type", $_POST)) {
+    $iBankSlip = InputUtils::LegacyFilterInput($_POST["report_type"], 'int');
+}
+
+$output = "pdf";
+if (array_key_exists("output", $_POST)) {
+    $output = InputUtils::LegacyFilterInput($_POST["output"]);
+}
+
+
+$iDepositSlipID = 0;
+if (array_key_exists("deposit", $_POST)) {
+    $iDepositSlipID = InputUtils::LegacyFilterInput($_POST["deposit"], "int");
+}
+    
+if (!$iDepositSlipID && array_key_exists('iCurrentDeposit', $_SESSION)) {
+    $iDepositSlipID = $_SESSION['iCurrentDeposit'];
+}
+
+// If CSVAdminOnly option is enabled and user is not admin, redirect to the menu.
+// If no DepositSlipId, redirect to the menu
+if ((!$_SESSION['bAdmin'] && $bCSVAdminOnly && $output != "pdf") || !$iDepositSlipID) {
+    Redirect("Menu.php");
+    exit;
+}
+
+if ($output == "pdf") {
+    header('Location: '.SystemURLs::getRootPath()."/api/deposits/".$iDepositSlipID."/pdf");
+} elseif ($output == "csv") {
+    header('Location: '.SystemURLs::getRootPath()."/api/deposits/".$iDepositSlipID."/csv");
+}


### PR DESCRIPTION
#### What's this PR do?
Allows the user to leverage the Report Functions | Individual Deposit Report feature that was previously broken

#### What Issues does it Close?

Closes #3637 

#### Where should the reviewer start?
1) Start with a ChurchCRM database containing at least one deposit


#### How should this be manually tested?
2) navigate to Deposit | Deposit Reports
3) select "Individual Deposit Report" report type
4) Select a deposit form the dropdown
5) verify that both PDF and CSV files are generated by clicking "Create Report" with the respective "Output Method" radio buttons checked.

#### How should the automated tests treat this?
N/A

#### Any background context you want to provide?

#### What are the relevant tickets?

#### Screenshots (if appropriate)

#### Questions:
- Is there a related website / article to substantiate / explain this change?
- Does the development wiki need an update?
- Does the user documentation wiki need an update?
- Does this add new dependencies?
