### PR TITLE
bugfix/3421 Correctly print special chars in person directory

### DIFF
--- a/src/ChurchCRM/Reports/PDF_Directory.php
+++ b/src/ChurchCRM/Reports/PDF_Directory.php
@@ -78,6 +78,7 @@ class PDF_Directory extends ChurchInfoReport
         $sContact = sprintf("%s\n%s, %s  %s\n\n%s\n\n", SystemConfig::getValue('sChurchAddress'), SystemConfig::getValue('sChurchCity'), SystemConfig::getValue('sChurchState'), SystemConfig::getValue('sChurchZip'), SystemConfig::getValue('sChurchPhone'));
         $this->MultiCell(197, 10, $sContact, 0, 'C');
         $this->Cell(10);
+        $sDirectoryDisclaimer = iconv('UTF-8', 'ISO-8859-1', $sDirectoryDisclaimer);
         $this->MultiCell(197, 10, $sDirectoryDisclaimer, 0, 'C');
         $this->AddPage();
     }


### PR DESCRIPTION
#### What's this PR do?
Allows for diacritic in Directory report disclaimer


#### What Issues does it Close?

Closes #3421 
(Possibly others as reported by @dleigh)

#### Where should the reviewer start?
Start with a populated ChurchCRM database 

#### How should this be manually tested?
1) Go to People Dashboard
2) Click on People Directory
3) Enter some text in the disclaimer box containing special characters.  For example:
> Les membres actuels du conseil sont : Nadine Adriano, Isabelle Beck, Denis Bouchet, Huguette Brand, Luc et Manuela Bussière (couple pastoral), Stéphan Haffner, David et Angela Leigh, Vito et Jocelyne Pascazio et Alana Smith
4) ensure the 'Use Title Page" box is checked
5) click "Create Directory"
6) ensure that the resultant text matches the input text.  Specifically, that it does not match this:
> Les membres actuels du conseil sont : Nadine Adriano, Isabelle Beck, Denis Bouchet,
Huguette Brand, Luc et Manuela BussiÃ¨re (couple pastoral), StÃ©phan Haffner,
David et Angela Leigh, Vito et Jocelyne Pascazio et Alana Smith

#### How should the automated tests treat this?
nope.

#### Any background context you want to provide?

#### What are the relevant tickets?

#### Screenshots (if appropriate)

#### Questions:
- Is there a related website / article to substantiate / explain this change?
- Does the development wiki need an update?
- Does the user documentation wiki need an update?
- Does this add new dependencies?
