### PR TITLE
bugfix/3748 Timeline Note Creation from Person ORM

### DIFF
--- a/src/ChurchCRM/model/ChurchCRM/Person.php
+++ b/src/ChurchCRM/model/ChurchCRM/Person.php
@@ -91,7 +91,7 @@ class Person extends BasePerson implements iPhoto
 
     public function postInsert(ConnectionInterface $con = null)
     {
-      $this->createTimeLineNote(true);
+      $this->createTimeLineNote('create');
       if (!empty(SystemConfig::getValue("sNewPersonNotificationRecipientIDs")))
       {
         $NotificationEmail = new NewPersonOrFamilyEmail($this);
@@ -103,24 +103,29 @@ class Person extends BasePerson implements iPhoto
 
     public function postUpdate(ConnectionInterface $con = null)
     {
-        $this->createTimeLineNote(false);
+      if (!empty($this->getDateLastEdited())) {
+        $this->createTimeLineNote('edit');
+      }
     }
 
-    private function createTimeLineNote($new)
+    private function createTimeLineNote($type)
     {
         $note = new Note();
         $note->setPerId($this->getId());
+        $note->setType($type);
+        $note->setDateEntered(new DateTime());
 
-        if ($new) {
-            $note->setText(gettext('Created'));
-            $note->setType('create');
-            $note->setEnteredBy($this->getEnteredBy());
-            $note->setDateEntered($this->getDateEntered());
-        } else {
-            $note->setText(gettext('Updated'));
-            $note->setType('edit');
-            $note->setEnteredBy($this->getEditedBy());
-            $note->setDateLastEdited($this->getDateLastEdited());
+         switch ($type) {
+            case "create":
+              $note->setText(gettext('Created'));
+              $note->setEnteredBy($this->getEnteredBy());
+              $note->setDateEntered($this->getDateEntered());
+              break;
+            case "edit":
+              $note->setText(gettext('Updated'));
+              $note->setEnteredBy($this->getEditedBy());
+              $note->setDateEntered($this->getDateLastEdited());
+              break;
         }
 
         $note->save();


### PR DESCRIPTION
#### What's this PR do?
Fixes the ORM code for person note generation

#### What Issues does it Close?

Closes #3748 

#### Where should the reviewer start?
Without this patch, the changes in #3659 will cause a failure when saving edits to an existing person.

#### How should this be manually tested?
on #3659, edit an existing person and try to save.  The page crashes.

#### How should the automated tests treat this?

#### Any background context you want to provide?

#### What are the relevant tickets?

#### Screenshots (if appropriate)

#### Questions:
- Is there a related website / article to substantiate / explain this change?
- Does the development wiki need an update?
- Does the user documentation wiki need an update?
- Does this add new dependencies?
