### PR TITLE
Bugfix/3749 - Fix Dashboard display of families

### DIFF
--- a/src/ChurchCRM/Dashboard/FamilyDashboardItem.php
+++ b/src/ChurchCRM/Dashboard/FamilyDashboardItem.php
@@ -4,6 +4,7 @@ namespace ChurchCRM\Dashboard;
 
 use ChurchCRM\Dashboard\DashboardItemInterface;
 use ChurchCRM\FamilyQuery;
+use Propel\Runtime\ActiveQuery\Criteria;
 
 class FamilyDashboardItem implements DashboardItemInterface {
 
@@ -37,8 +38,10 @@ class FamilyDashboardItem implements DashboardItemInterface {
   private static function getUpdatedFamilies($limit = 12) {
     return FamilyQuery::create()
                     ->filterByDateDeactivated(null)
+                    ->filterByDateLastEdited(null, Criteria::NOT_EQUAL)
                     ->orderByDateLastEdited('DESC')
                     ->limit($limit)
+                    ->select(array("Id","Name","Address1","DateEntered","DateLastEdited"))
                     ->find()->toArray();
   }
 
@@ -51,9 +54,9 @@ class FamilyDashboardItem implements DashboardItemInterface {
 
     return FamilyQuery::create()
                     ->filterByDateDeactivated(null)
-                    ->filterByDateLastEdited(null)
                     ->orderByDateEntered('DESC')
                     ->limit($limit)
+                    ->select(array("Id","Name","Address1","DateEntered","DateLastEdited"))
                     ->find()->toArray();
   }
 


### PR DESCRIPTION
#### What's this PR do?
Only shows families with updates on the "Updated Families" list.  
Inserts do not count as updates.

Trims the data set returned in the AJAX call to the dashboard service.

#### What Issues does it Close?

Closes #3749 

#### Where should the reviewer start?

#### How should this be manually tested?

Follow the steps in ticket #3749 and ensure resolution.

#### How should the automated tests treat this?

#### Any background context you want to provide?

#### What are the relevant tickets?

#### Screenshots (if appropriate)

#### Questions:
- Is there a related website / article to substantiate / explain this change?
- Does the development wiki need an update?
- Does the user documentation wiki need an update?
- Does this add new dependencies?
