### PR TITLE
Dynamically determine church name

### DIFF
--- a/src/ChurchCRM/Service/SystemService.php
+++ b/src/ChurchCRM/Service/SystemService.php
@@ -109,8 +109,12 @@ class SystemService
         mkdir($backup->backupDir,0750,true);
         $backup->headers = [];
         $backup->params = $params;
-        $backup->saveTo = "$backup->backupDir/" . SystemConfig::getValue('sChurchName') . "-" . date(SystemConfig::getValue("sDateFilenameFormat"));
-        $backup->SQLFile = "$backup->backupDir/" . SystemConfig::getValue('sChurchName') . "-Database.sql";
+        
+        $safeFileName = preg_replace('/[^a-zA-Z0-9\-_]/','', SystemConfig::getValue('sChurchName'));
+        $baseFileName = "$backup->backupDir/" . $safeFileName . "-";
+        
+        $backup->saveTo = $baseFileName . date(SystemConfig::getValue("sDateFilenameFormat"));
+        $backup->SQLFile = $baseFileName . "Database.sql";
 
         try {
             $dump = new Mysqldump('mysql:host=' . $sSERVERNAME . ';dbname=' . $sDATABASE, $sUSER, $sPASSWORD, ['add-drop-table' => true]);

--- a/src/ChurchCRM/Service/SystemService.php
+++ b/src/ChurchCRM/Service/SystemService.php
@@ -109,8 +109,8 @@ class SystemService
         mkdir($backup->backupDir,0750,true);
         $backup->headers = [];
         $backup->params = $params;
-        $backup->saveTo = "$backup->backupDir/ChurchCRM-" . date(SystemConfig::getValue("sDateFilenameFormat"));
-        $backup->SQLFile = "$backup->backupDir/ChurchCRM-Database.sql";
+        $backup->saveTo = "$backup->backupDir/" . SystemConfig::getValue('sChurchName') . "-" . date(SystemConfig::getValue("sDateFilenameFormat"));
+        $backup->SQLFile = "$backup->backupDir/" . SystemConfig::getValue('sChurchName') . "-Database.sql";
 
         try {
             $dump = new Mysqldump('mysql:host=' . $sSERVERNAME . ';dbname=' . $sDATABASE, $sUSER, $sPASSWORD, ['add-drop-table' => true]);


### PR DESCRIPTION
#### What's this PR do?
This pull request saves the backup database to a filename using the church name (sChurchName variable) defined in System Settings as opposed to a generic _ChurchCRM-{datetime}.ext_ filename.

#### What Issues does it Close?

Closes #2642.

#### Where should the reviewer start?
From a code review point of view, take a look at the `getDatabaseBackup()` function.  The `$backup-saveTo` and `$backup-SQLFile` variables replaced the hardcoded _ChurchCRM_ filename prefix with the dynamic _SystemConfig::getValue('sChurchName')_ value.

#### How should this be manually tested?
1. Go to _System Settings -> Church Information_ and set a custom sChurchName value.
2. Go to _System Settings -> Backup Database_.
3. Choose _Generate and Download Backup.

The resulting button title and downloaded file should contain your custom sChurchName value in the filename.

#### How should the automated tests treat this?

#### Any background context you want to provide?

#### What are the relevant tickets?

#### Screenshots (if appropriate)
**Before**
![image](https://user-images.githubusercontent.com/23409144/34324777-2e59ab7c-e84c-11e7-8c53-16a57ae657f7.png)

**After**
![image](https://user-images.githubusercontent.com/23409144/34324779-411268e4-e84c-11e7-96dd-4055447f8b4c.png)

