### PR TITLE
composer dump-autoload after update

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
         "graph-viz": "src/vendor/propel/propel/bin/propel --config-dir=propel graphviz:generate",
         "datadictionary": "src/vendor/propel/propel/bin/propel --config-dir=propel datadictionary:generate",
         "composer-install": "cd src/ && composer install",
-        "composer-update": " cd src/ && composer update && cd ../tests/ && composer update",
+        "composer-update": " cd src/ && composer update && composer dump-autoload && cd ../tests/ && composer update",
         "tests-install": "scripts/tests-install.sh",
         "test": "scripts/tests-run.sh"
     }


### PR DESCRIPTION
#### What's this PR do?
ensure we get the most updated values from the ORM etc after running `npm run composer-update`
