### PR TITLE
add email searching

### DIFF
--- a/src/api/routes/search.php
+++ b/src/api/routes/search.php
@@ -32,6 +32,7 @@ $app->get('/search/{query}', function ($request, $response, $args) {
 						filterByFirstName($searchLikeString, Criteria::LIKE)->
 							_or()->filterByLastName($searchLikeString, Criteria::LIKE)->
 							_or()->filterByEmail($searchLikeString, Criteria::LIKE)->
+              _or()->filterByWorkEmail($searchLikeString, Criteria::LIKE)->
 							_or()->filterByHomePhone($searchLikeString, Criteria::LIKE)->
 							_or()->filterByCellPhone($searchLikeString, Criteria::LIKE)->
 							_or()->filterByWorkPhone($searchLikeString, Criteria::LIKE)->
@@ -113,6 +114,7 @@ $app->get('/search/{query}', function ($request, $response, $args) {
           $families = FamilyQuery::create()->
           		filterByName("%$query%", Criteria::LIKE)->
               _or()->filterByHomePhone($searchLikeString, Criteria::LIKE)->
+              _or()->filterByEmail($searchLikeString, Criteria::LIKE) ->
 							_or()->filterByCellPhone($searchLikeString, Criteria::LIKE)->
 							_or()->filterByWorkPhone($searchLikeString, Criteria::LIKE)->
               limit(SystemConfig::getValue("bSearchIncludeFamiliesMax"))->find();


### PR DESCRIPTION
#### What's this PR do?
allows text entered in the search box to match person-> work email or family->email addresses in the results.

#### What Issues does it Close?

Closes #3801 

#### Where should the reviewer start?
note the additional OR clause on the search queries.

#### How should this be manually tested?
Search for a known family email address - the family should appear in search results.

#### How should the automated tests treat this?
no.

#### Any background context you want to provide?
When parsing NDRs from bulk-sent email, it would be useful to be able to search by email address in ChurchCRM to identify invalid addresses.

#### What are the relevant tickets?

#### Screenshots (if appropriate)

#### Questions:
- Is there a related website / article to substantiate / explain this change?
- Does the development wiki need an update?
- Does the user documentation wiki need an update?
- Does this add new dependencies?
