### PR TITLE
User Database Session Presence Check

### DIFF
--- a/src/Include/Functions.php
+++ b/src/Include/Functions.php
@@ -27,10 +27,19 @@ $_SESSION['sSoftwareInstalledVersion'] = SystemService::getInstalledVersion();
 
 if (empty($bSuppressSessionTests)) {  // This is used for the login page only.
     // Basic security: If the UserID isn't set (no session), redirect to the login page
-    if (!isset($_SESSION['iUserID'])) {
+    if (!isset($_SESSION['user'])) {
         RedirectUtils::Redirect('Login.php');
         exit;
     }
+    
+    try {
+      $_SESSION['user']->reload();
+    }
+    catch (\Exception $exc) {
+      RedirectUtils::Redirect('Login.php');
+      exit;
+    }
+    
 
     // Check for login timeout.  If login has expired, redirect to login page
     if (SystemConfig::getValue('iSessionTimeout') > 0) {

--- a/src/Include/Functions.php
+++ b/src/Include/Functions.php
@@ -33,11 +33,10 @@ if (empty($bSuppressSessionTests)) {  // This is used for the login page only.
     }
     
     try {
-      $_SESSION['user']->reload();
-    }
-    catch (\Exception $exc) {
-      RedirectUtils::Redirect('Login.php');
-      exit;
+        $_SESSION['user']->reload();
+    } catch (\Exception $exc) {
+        RedirectUtils::Redirect('Login.php');
+        exit;
     }
     
 


### PR DESCRIPTION
#### What's this PR do?
Ensures that the current user still exists in the database when validating page load authorization.


#### What Issues does it Close?

Closes #3846 

#### Where should the reviewer start?
Review the attempt to reload the ```$_SESSION['user']``` object during authorization checks.  A failure here indicates that the user no longer exists in the DB, and should be directed to the login page.


#### How should this be manually tested?
1)  Open two instances of ChurchCRM using two different accounts in two separate browsers at the same time
2)  Using one account / session, delete the other account
3)  Verify that the deleted account is redirected to the login screen instead of being able to continue operating in the CRM.

#### Questions:
- Is there a related website / article to substantiate / explain this change?
  -  [ ] Yes - Link:
  -  [x] No

- Does the development wiki need an update?
  -  [ ] Yes - Link:
  -  [x] No

- Does the user documentation wiki need an update?
  -  [ ] Yes - Link:
  -  [x] No

- Does this add new dependencies?
  -  [ ] Yes
  -  [x] No

- Does this need to add new data to the demo database
  -  [ ] Yes
  -  [x] No

