### PR TITLE
closes #3856.  Don't Execute DEFINER clauses

### DIFF
--- a/src/ChurchCRM/SQLUtils.php
+++ b/src/ChurchCRM/SQLUtils.php
@@ -139,12 +139,12 @@ namespace ChurchCRM
 
       private static function query($sql, $mysqli)
       {
-        if(preg_match("/DEFINER\s*=.*@.*/", $sql)) {
-         return;
-        }
-        if (!$query = $mysqli->query($sql)) {
-          throw new \Exception("Cannot execute request to the database {$sql}: ".$mysqli->error);
-        }
+          if (preg_match("/DEFINER\s*=.*@.*/", $sql)) {
+              return;
+          }
+          if (!$query = $mysqli->query($sql)) {
+              throw new \Exception("Cannot execute request to the database {$sql}: ".$mysqli->error);
+          }
       }
   }
 

--- a/src/ChurchCRM/SQLUtils.php
+++ b/src/ChurchCRM/SQLUtils.php
@@ -139,9 +139,12 @@ namespace ChurchCRM
 
       private static function query($sql, $mysqli)
       {
-          if (!$query = $mysqli->query($sql)) {
-              throw new \Exception("Cannot execute request to the database {$sql}: ".$mysqli->error);
-          }
+        if(preg_match("/DEFINER\s*=.*@.*/", $sql)) {
+         return;
+        }
+        if (!$query = $mysqli->query($sql)) {
+          throw new \Exception("Cannot execute request to the database {$sql}: ".$mysqli->error);
+        }
       }
   }
 


### PR DESCRIPTION
#### What's this PR do?
Prevents executing SQL clauses that contain "DEFINER".  
Theses clauses are included by [ifSnop/MySQLDump](https://github.com/ifsnop/mysqldump-php/issues/126) when the backup is generated.   If the backup restore is attempted using an account other than the account that created the backup, the restore will fail.

The best solution is to *NOT* include the definer clause with the backup, but this is pending a fix from the upstream library.


#### What Issues does it Close?

Closes #3856 

#### How should this be manually tested?
Create a backup from a 2.10.0 system.
Restore the backup on another 2.10.x system where the MySQL user is different.
Before this PR, the restore would fail as described in #3856
