### PR TITLE
move views to "every upgrade" file

### DIFF
--- a/src/ChurchCRM/Service/SystemService.php
+++ b/src/ChurchCRM/Service/SystemService.php
@@ -89,6 +89,7 @@ class SystemService
         FileSystemUtils::recursiveRemoveDirectory($restoreResult->backupRoot,true);
         $restoreResult->UpgradeStatus = UpgradeService::upgradeDatabaseVersion();
         SQLUtils::sqlImport(SystemURLs::getDocumentRoot() . '/mysql/upgrade/rebuild_nav_menus.sql', $connection);
+        SQLUtils::sqlImport(SystemURLs::getDocumentRoot() . '/mysql/upgrade/rebuild_views.sql', $connection);
         //When restoring a database, do NOT let the database continue to create remote backups.
         //This can be very troublesome for users in a testing environment.
         SystemConfig::setValue('bEnableExternalBackupTarget', '0');

--- a/src/ChurchCRM/Service/UpgradeService.php
+++ b/src/ChurchCRM/Service/UpgradeService.php
@@ -53,6 +53,7 @@ class UpgradeService
         }
         // always rebuild the menu
         SQLUtils::sqlImport(SystemURLs::getDocumentRoot() . '/mysql/upgrade/rebuild_nav_menus.sql', $connection);
+        SQLUtils::sqlImport(SystemURLs::getDocumentRoot() . '/mysql/upgrade/rebuild_views.sql', $connection);
 
         return true;
     }

--- a/src/mysql/upgrade/2.10.0.sql
+++ b/src/mysql/upgrade/2.10.0.sql
@@ -1,15 +1,2 @@
 ALTER TABLE `events_event` 
   ADD COLUMN `event_publicly_visible` BOOLEAN DEFAULT FALSE AFTER `event_grpid`;
-
-DROP VIEW IF EXISTS email_list;
-CREATE VIEW email_list AS
-    SELECT fam_Email AS email, 'family' AS type, fam_id AS id FROM family_fam WHERE fam_email IS NOT NULL AND fam_email != '' 
-    UNION 
-    SELECT per_email AS email, 'person_home' AS type, per_id AS id FROM person_per WHERE per_email IS NOT NULL AND per_email != '' 
-    UNION 
-    SELECT per_WorkEmail AS email, 'person_work' AS type, per_id AS id FROM person_per WHERE per_WorkEmail IS NOT NULL AND per_WorkEmail != '';
-    
-    
-DROP VIEW IF EXISTS email_count; 
-CREATE VIEW email_count AS    
-    SELECT email, COUNT(*) AS total FROM email_list group by email;

--- a/src/mysql/upgrade/rebuild_views.sql
+++ b/src/mysql/upgrade/rebuild_views.sql
@@ -1,0 +1,12 @@
+DROP VIEW IF EXISTS email_list;
+CREATE VIEW email_list AS
+    SELECT fam_Email AS email, 'family' AS type, fam_id AS id FROM family_fam WHERE fam_email IS NOT NULL AND fam_email != '' 
+    UNION 
+    SELECT per_email AS email, 'person_home' AS type, per_id AS id FROM person_per WHERE per_email IS NOT NULL AND per_email != '' 
+    UNION 
+    SELECT per_WorkEmail AS email, 'person_work' AS type, per_id AS id FROM person_per WHERE per_WorkEmail IS NOT NULL AND per_WorkEmail != '';
+    
+    
+DROP VIEW IF EXISTS email_count; 
+CREATE VIEW email_count AS    
+    SELECT email, COUNT(*) AS total FROM email_list group by email;


### PR DESCRIPTION
#### What's this PR do?
Moves creation of SQL views into a new SQL file that gets executed with any database restore or database upgrade.

#### Screenshots (if appropriate)

#### What Issues does it Close?

Closes #3881 

#### Any background context you want to provide?
Currently, the database backup algorithm produces ```DEFINER``` statements in the SQL clause which include the database user used to initiate the backup.  

#3858 was added with the intention of ignoring _only_ the definer clause; however, the result was that *ANY* statement including ```DEFINER``` was not executed.  This resulted in none of the SQL views being restored from a database backup that actually included views!   Since views are ephemeral, we can simply re-create them on upgrade / restore so that we can be sure the view actually provides the data expected by the current code version.,

#### How should this be manually tested?
1)  Restore a 2.10.2 backup into 2.10.3.   #3881 should not occur, and the ```/api/emails/duplicates``` endpoint should function.