### PR TITLE
Only display Fund Amount if value is non-zero

### DIFF
--- a/src/PledgeEditor.php
+++ b/src/PledgeEditor.php
@@ -729,7 +729,7 @@ require 'Include/Header.php';
                 <tr>
                   <td class="TextColumn"><?= $fun_name ?></td>
                   <td class="TextColumn">
-                    <input class="FundAmount" type="number" step="any" name="<?= $fun_id ?>_Amount" id="<?= $fun_id ?>_Amount" value="<?= $nAmount[$fun_id] ?>"><br>
+                    <input class="FundAmount" type="number" step="any" name="<?= $fun_id ?>_Amount" id="<?= $fun_id ?>_Amount" value="<?= ($nAmount[$fun_id] ? $nAmount[$fun_id] : "") ?>"><br>
                     <font color="red"><?= $sAmountError[$fun_id] ?></font>
                   </td>
                   <?php


### PR DESCRIPTION
#### What's this PR do?
When entering a payment, this changes the behavior of the Fund Split Amount, so that "0" value fund splits will display an empty text box, rather than a "0" filled text box.

This will improve the UX of fund entry.

#### What Issues does it Close?

Closes #3758 

#### Where should the reviewer start?

1)  Create a new deposit
2)  Create a new payment on the deposit for cash / anonymous.  Repeat for check / family based deposit
3)  Ensure that the new payment entry form does not display a "0" in the text box for Fund Split Amount
4)  Enter a value and save the deposit
5)  Edit the deposit, and ensure that the value previously entered is displayed correctly.