### PR TITLE
Added check to make sure per_Birthday and per_BirthMonth are greater than zero in PDF Church Directory

### DIFF
--- a/src/ChurchCRM/Reports/PDF_Directory.php
+++ b/src/ChurchCRM/Reports/PDF_Directory.php
@@ -270,7 +270,7 @@ class PDF_Directory extends ChurchInfoReport
     
     public function getBirthdayString($bDirBirthday, $per_BirthMonth, $per_BirthDay, $per_BirthYear, $per_Flags)
     {
-      if ($bDirBirthday ) {
+      if ($bDirBirthday && $per_BirthDay > 0 && $per_BirthMonth > 0) {
         return MiscUtils::FormatBirthDate($per_BirthYear, $per_BirthMonth, $per_BirthDay, "/", $per_Flags);
       }
       return '';


### PR DESCRIPTION
Simply adds a basic sanity check to ensure both the $per_Birthday and $per_BirthMonth columns are greater than zero. This makes sure in the default case, where a birthdate is unknown (day/month are zero), the PDF directory won't display the 30th of November.