### PR TITLE
CodeSmell: RestfulAPIs: withStatus reason / codes

### DIFF
--- a/src/ChurchCRM/Slim/Middleware/AuthMiddleware.php
+++ b/src/ChurchCRM/Slim/Middleware/AuthMiddleware.php
@@ -27,7 +27,7 @@ class AuthMiddleware {
             }
 
             if (empty($this->user)) {
-                return $response->withStatus(401)->withJson(["message" => gettext('No logged in user')]);
+                return $response->withStatus(401, gettext('No logged in user'));
             }
 
 

--- a/src/ChurchCRM/Slim/Middleware/PublicCalendarAPIMiddleware.php
+++ b/src/ChurchCRM/Slim/Middleware/PublicCalendarAPIMiddleware.php
@@ -11,7 +11,7 @@ class PublicCalendarAPIMiddleware
     public function __invoke(Request $request, Response $response, callable $next)
     {
         if (!SystemConfig::getBooleanValue("bEnableExternalCalendarAPI")) {
-            return $response->withStatus(403)->withJson(["message" => gettext("External Calendar API is disabled")]);
+            return $response->withStatus(403, gettext("External Calendar API is disabled"));
         }
         return $next($request, $response);
     }

--- a/src/ChurchCRM/Slim/Middleware/Role/BaseAuthRoleMiddleware.php
+++ b/src/ChurchCRM/Slim/Middleware/Role/BaseAuthRoleMiddleware.php
@@ -18,7 +18,7 @@ abstract class BaseAuthRoleMiddleware
     {
         $this->user = $_SESSION['user'];
         if (empty($this->user) || !$this->hasRole()) {
-            return $response->withStatus(401)->withJson(["message" => $this->noRoleMessage()]);
+            return $response->withStatus(401, $this->noRoleMessage());
         }
         return $next($request, $response);
     }

--- a/src/ChurchCRM/Slim/Middleware/Role/BaseAuthRoleMiddleware.php
+++ b/src/ChurchCRM/Slim/Middleware/Role/BaseAuthRoleMiddleware.php
@@ -17,8 +17,12 @@ abstract class BaseAuthRoleMiddleware
     public function __invoke(Request $request, Response $response, callable $next)
     {
         $this->user = $_SESSION['user'];
-        if (empty($this->user) || !$this->hasRole()) {
-            return $response->withStatus(401, $this->noRoleMessage());
+        if (empty($this->user)) {
+            return $response->withStatus(401, gettext('No logged in user'));
+        }
+
+        if (!$this->hasRole()) {
+            return $response->withStatus(403, $this->noRoleMessage());
         }
         return $next($request, $response);
     }

--- a/src/api/routes/calendar/calendar.php
+++ b/src/api/routes/calendar/calendar.php
@@ -21,7 +21,7 @@ $app->group('/calendars', function () {
     $this->get('/{id}/fullcalendar', 'getUserCalendarFullCalendarEvents');
     $this->post('/{id}/NewAccessToken', 'NewAccessToken')->add(new AddEventsRoleAuthMiddleware());
     $this->delete('/{id}/AccessToken', 'DeleteAccessToken')->add(new AddEventsRoleAuthMiddleware());
-    
+
 });
 
 
@@ -151,12 +151,12 @@ function NewAccessToken($request, Response $response, $args)
 function DeleteAccessToken($request, Response $response, $args)
 {
   if (!isset($args['id'])) {
-    return $response->withStatus(400)->withJson(array("status" => gettext("Invalid request: Missing calendar id")));
+    return $response->withStatus(400, gettext("Invalid request: Missing calendar id"));
   }
   $Calendar = CalendarQuery::create()
       ->findOneById($args['id']);
   if (!$Calendar) {
-    return $response->withStatus(404)->withJson(array("status" => gettext("Not Found: Unknown calendar id") . ": " . $args['id']));
+    return $response->withStatus(404, gettext("Not Found: Unknown calendar id") . ": " . $args['id']);
   }
   $Calendar->setAccessToken(null);
   $Calendar->save();
@@ -172,18 +172,18 @@ function NewCalendar(Request $request, Response $response, $args)
   $Calendar->setBackgroundColor($input->BackgroundColor);
   $Calendar->save();
   return $response->withJson($Calendar->toArray());
-  
+
 }
 
 function deleteUserCalendar(Request $request, Response $response, $args)
 {
    if (!isset($args['id'])) {
-        return $response->withStatus(400)->withJson(array("status" => gettext("Invalid request: Missing calendar id")));
+        return $response->withStatus(400, gettext("Invalid request: Missing calendar id"));
     }
     $Calendar = CalendarQuery::create()
         ->findOneById($args['id']);
     if (!$Calendar) {
-        return $response->withStatus(404)->withJson(array("status" => gettext("Not Found: Unknown calendar id") . ": " . $args['id']));
+        return $response->withStatus(404, gettext("Not Found: Unknown calendar id") . ": " . $args['id']);
     }
     $Calendar->delete();
     return $response->withJson(array("status"=>"success"));

--- a/src/api/routes/calendar/calendar.php
+++ b/src/api/routes/calendar/calendar.php
@@ -136,12 +136,12 @@ function NewAccessToken($request, Response $response, $args)
 {
 
     if (!isset($args['id'])) {
-        return $response->withStatus(400)->withJson(array("status" => gettext("Invalid request: Missing calendar id")));
+        return $response->withStatus(400, gettext("Invalid request: Missing calendar id"));
     }
     $Calendar = CalendarQuery::create()
         ->findOneById($args['id']);
     if (!$Calendar) {
-        return $response->withStatus(404)->withJson(array("status" => gettext("Not Found: Unknown calendar id") . ": " . $args['id']));
+        return $response->withStatus(404, gettext("Not Found: Unknown calendar id") . ": " . $args['id']);
     }
     $Calendar->setAccessToken(ChurchCRM\Utils\MiscUtils::randomToken());
     $Calendar->save();

--- a/src/api/routes/calendar/events.php
+++ b/src/api/routes/calendar/events.php
@@ -125,14 +125,14 @@ function newEvent($request, $response, $args)
     $type = EventTypeQuery::Create()
         ->findOneById($input->eventTypeID);
     if (!$type) {
-        return $response->withStatus(400)->withJSON(array("status" => "invalid event type id"));
+        return $response->withStatus(400, gettext("invalid event type id"));
     }
 
     $calendars = CalendarQuery::create()
         ->filterById($input->eventCalendars)
         ->find();
     if (count($calendars) != count($input->eventCalendars)) {
-        return $response->withStatus(400)->withJSON(array("status" => "invalid calendar pinning"));
+        return $response->withStatus(400, gettext("invalid calendar pinning"));
     }
 
     // we have event type and pined calendars.  now create the event.

--- a/src/api/routes/geocoder.php
+++ b/src/api/routes/geocoder.php
@@ -24,5 +24,5 @@ function getGeoLocals(Request $request, Response $response, array $p_args)
     if (!empty($input)) {
         return $response->withJson(GeoUtils::getLatLong($input->address));
     }
-    return $response->withStatus(404);
+    return $response->withStatus(400); // bad request
 }

--- a/src/api/routes/people/people-families.php
+++ b/src/api/routes/people/people-families.php
@@ -191,6 +191,6 @@ $app->group('/families', function () {
 
             return $response->withJson($geoLocationInfo);
         }
-        return $response->withStatus(404, gettext("FamilyId".  ": " . $familyId . " " . gettext("not found"));
+        return $response->withStatus(404, gettext("FamilyId").  ": " . $familyId . " " . gettext("not found"));
     });
 });

--- a/src/api/routes/people/people-families.php
+++ b/src/api/routes/people/people-families.php
@@ -125,7 +125,7 @@ $app->group('/families', function () {
                 throw new \Exception($email->getError());
             }
         } else {
-            $response = $response->withStatus(404)->getBody()->write("familyId: " . $familyId . " " . gettext("not found"));
+            $response = $response->withStatus(404, gettext("FamilyId") . " " . $familyId . " " . gettext("not found"));
         }
         return $response;
     });
@@ -137,7 +137,7 @@ $app->group('/families', function () {
             $family->verify();
             $response = $response->withStatus(200);
         } else {
-            $response = $response->withStatus(404)->getBody()->write("familyId: " . $familyId . " not found");
+            $response = $response->withStatus(404, gettext("FamilyId"). ": " . $familyId . " ". gettext("not found"));
         }
         return $response;
     });
@@ -191,6 +191,6 @@ $app->group('/families', function () {
 
             return $response->withJson($geoLocationInfo);
         }
-        return $response->withStatus(404)->getBody()->write("familyId: " . $familyId . " not found");
+        return $response->withStatus(404, gettext("FamilyId".  ": " . $familyId . " " . gettext("not found"));
     });
 });

--- a/src/api/routes/people/people-groups.php
+++ b/src/api/routes/people/people-groups.php
@@ -244,11 +244,11 @@ $app->group('/groups', function () {
                 $group->setActive($flag);
                 $group->save();
             } else {
-                return $response->withStatus(500)->withJson(['status' => "error", 'reason' => 'invalid group id']);
+                return $response->withStatus(500, gettext('invalid group id'));
             }
             return $response->withJson(['status' => "success"]);
         } else {
-            return $response->withStatus(500)->withJson(['status' => "error", 'reason' => 'invalid status value']);
+            return $response->withStatus(500, gettext('invalid status value'));
         }
     });
 
@@ -261,11 +261,11 @@ $app->group('/groups', function () {
                 $group->setIncludeInEmailExport($flag);
                 $group->save();
             } else {
-                return $response->withStatus(500)->withJson(['status' => "error", 'reason' => 'invalid group id']);
+                return $response->withStatus(500, gettext('invalid group id'));
             }
             return $response->withJson(['status' => "success"]);
         } else {
-            return $response->withStatus(500)->withJson(['status' => "error", 'reason' => 'invalid export value']);
+            return $response->withStatus(500, gettext('invalid export value'));
         }
     });
 });

--- a/src/api/routes/people/people-persons.php
+++ b/src/api/routes/people/people-persons.php
@@ -78,7 +78,7 @@ $app->group('/persons', function () {
          */
         $sessionUser = $_SESSION['user'];
         if (!$sessionUser->isDeleteRecordsEnabled()) {
-            return $response->withStatus(401);
+            return $response->withStatus(403);
         }
         $personId = $args['personId'];
         if ($sessionUser->getId() == $personId) {

--- a/src/api/routes/people/people-roles.php
+++ b/src/api/routes/people/people-roles.php
@@ -15,7 +15,7 @@ $app->group('/roles', function () {
 
     $this->post('/persons/assign', function ($request, $response, $args) {
         if (!$_SESSION['user']->isEditRecordsEnabled()) {
-            return $response->withStatus(401);
+            return $response->withStatus(403);
         }
 
         $data = $request->getParsedBody();

--- a/src/api/routes/public/public-user.php
+++ b/src/api/routes/public/public-user.php
@@ -48,8 +48,8 @@ function userPasswordReset(Request $request, Response $response, array $args)
             }
             return $response->withStatus(200)->withJson(['status' => "success"]);
         } else {
-            return $response->withStatus(404)->withJson(["Error" => gettext("User") . " [" . $userName . "] ". gettext("no found or user without an email")]);
+            return $response->withStatus(404, gettext("User") . " [" . $userName . "] ". gettext("no found or user without an email"));
         }
     }
-    return $response->withStatus(401)->withJson(["Error" => gettext("UserName not set")]);
+    return $response->withStatus(401, gettext("UserName not set"));
 }

--- a/src/api/routes/public/public-user.php
+++ b/src/api/routes/public/public-user.php
@@ -46,7 +46,7 @@ function userPasswordReset(Request $request, Response $response, array $args)
             if (!$email->send()) {
                 $logger->error($email->getError());
             }
-            return $response->withStatus(200)->withJson(['status' => "success"]);
+            return $response->withStatus(200);
         } else {
             return $response->withStatus(404, gettext("User") . " [" . $userName . "] ". gettext("no found or user without an email"));
         }

--- a/src/api/routes/public/public-user.php
+++ b/src/api/routes/public/public-user.php
@@ -24,7 +24,7 @@ function userLogin(Request $request, Response $response, array $args)
             if ($user->isPasswordValid($password)) {
                 return $response->withJson(["apiKey" => $user->getApiKey()]);
             } else {
-                return $response->withStatus(401);
+                return $response->withStatus(401, gettext('Invalid User/Password'));
             }
         }
     }
@@ -51,5 +51,5 @@ function userPasswordReset(Request $request, Response $response, array $args)
             return $response->withStatus(404, gettext("User") . " [" . $userName . "] ". gettext("no found or user without an email"));
         }
     }
-    return $response->withStatus(401, gettext("UserName not set"));
+    return $response->withStatus(400, gettext("UserName not set"));
 }

--- a/src/api/routes/system/system-custom-menu.php
+++ b/src/api/routes/system/system-custom-menu.php
@@ -35,7 +35,7 @@ function addMenu(Request $request, Response $response, array $args)
         $link->save();
         return $response->withJson($link->toArray());
     }
-    return $response->withStatus(401)->withJson(["error" => gettext("Validation Error"),
+    return $response->withStatus(400)->withJson(["error" => gettext("Validation Error"),
         "failures" => ORMUtils::getValidationErrors($link->getValidationFailures())]);
 }
 

--- a/src/api/routes/users.php
+++ b/src/api/routes/users.php
@@ -19,7 +19,7 @@ $app->group('/users', function () {
             $user->createTimeLineNote("password-reset");
             $email = new ResetPasswordEmail($user, $password);
             if ($email->send()) {
-                return $response->withStatus(200)->withJson(['status' => "success"]);
+                return $response->withStatus(200);
             } else {
                 $this->Logger->error($email->getError());
                 throw new \Exception($email->getError());
@@ -39,7 +39,7 @@ $app->group('/users', function () {
             if (!$email->send()) {
                 $this->Logger->warn($email->getError());
             }
-            return $response->withStatus(200)->withJson(['status' => "success"]);
+            return $response->withStatus(200);
         } else {
             return $response->withStatus(404);
         }
@@ -57,7 +57,7 @@ $app->group('/users', function () {
             if (!$email->send()) {
                 $this->Logger->warn($email->getError());
             }
-            return $response->withStatus(200)->withJson(['status' => "success"]);
+            return $response->withStatus(200);
         } else {
             return $response->withStatus(404);
         }
@@ -77,7 +77,7 @@ $app->post('/users/{userId:[0-9]+}/apikey/regen', function ($request, $response,
         $user->setApiKey(User::randomApiKey());
         $user->save();
         $user->createTimeLineNote("api-key-regen");
-        return $response->withStatus(200)->withJson(["apiKey" => $user->getApiKey()]);
+        return $response->withJson(["apiKey" => $user->getApiKey()]);
     } else {
         return $response->withStatus(404);
     }

--- a/src/api/routes/users.php
+++ b/src/api/routes/users.php
@@ -25,7 +25,7 @@ $app->group('/users', function () {
                 throw new \Exception($email->getError());
             }
         } else {
-            return $response->withStatus(404);
+            return $response->withStatus(404, gettext("Bad userId"));
         }
     });
 
@@ -41,7 +41,7 @@ $app->group('/users', function () {
             }
             return $response->withStatus(200);
         } else {
-            return $response->withStatus(404);
+            return $response->withStatus(404, gettext("Bad userId"));
         }
     });
 
@@ -59,7 +59,7 @@ $app->group('/users', function () {
             }
             return $response->withStatus(200);
         } else {
-            return $response->withStatus(404);
+            return $response->withStatus(404, gettext("Bad userId"));
         }
     });
 
@@ -70,7 +70,7 @@ $app->post('/users/{userId:[0-9]+}/apikey/regen', function ($request, $response,
     $curUser = $_SESSION['user'];
     $userId = $args['userId'];
     if (!$curUser->isAdmin() && $curUser->getId() != $userId) {
-        return $response->withStatus(401);
+        return $response->withStatus(403);
     }
     $user = UserQuery::create()->findPk($userId);
     if (!is_null($user)) {
@@ -79,6 +79,6 @@ $app->post('/users/{userId:[0-9]+}/apikey/regen', function ($request, $response,
         $user->createTimeLineNote("api-key-regen");
         return $response->withJson(["apiKey" => $user->getApiKey()]);
     } else {
-        return $response->withStatus(404);
+        return $response->withStatus(404, gettext("Bad userId"));
     }
 });

--- a/src/setup/routes/setup.php
+++ b/src/setup/routes/setup.php
@@ -17,7 +17,7 @@ $app->group('/', function () {
 
     $this->get('SystemPrerequisiteCheck', function ($request, $response, $args) {
         $required = ChurchCRM\Service\AppIntegrityService::getApplicationPrerequisites();
-        return $response->withStatus(200)->withJson($required);
+        return $response->withJson($required);
     });
 
     $this->post('', function ($request, $response, $args) {

--- a/src/v2/routes/user.php
+++ b/src/v2/routes/user.php
@@ -34,7 +34,7 @@ function viewUser(Request $request, Response $response, array $args)
     $userId = $args["id"];
 
     if (!$curUser->isAdmin() && $curUser->getId() != $userId) {
-        return $response->withStatus(401);
+        return $response->withStatus(403);
     }
 
     $user = UserQuery::create()->findPk($userId);


### PR DESCRIPTION
#### What's this PR do?
- Using gettext for response reason
- cleanup of withStatus 200 and useless success message
- cleanup the use of withStatus to pass the error message in the reason pram

```
 * @param string $reasonPhrase The reason phrase to use with the
     *     provided status code; if none is provided, implementations MAY
     *     use the defaults as suggested in the HTTP specification.
```
http://tools.ietf.org/html/rfc7231#section-6
http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml


