### PR TITLE
Email dashboard: Dup Emails 

### DIFF
--- a/src/api/routes/people/people-email.php
+++ b/src/api/routes/people/people-email.php
@@ -38,7 +38,7 @@ function getEmailDupes(Request $request, Response $response, array $p_args)
         $families = [];
         $dbFamilies = FamilyQuery::create()->findByEmail($email);
         foreach ($dbFamilies as $family) {
-            array_push($families, ["id" => $family->getId(), "nane" => $family->getName()]);
+            array_push($families, ["id" => $family->getId(), "name" => $family->getName()]);
         }
         array_push($emails, [
             "email" => $email,

--- a/src/api/routes/people/people-email.php
+++ b/src/api/routes/people/people-email.php
@@ -6,8 +6,8 @@ use Propel\Runtime\Propel;
 use Slim\Http\Request;
 use Slim\Http\Response;
 
-$app->group('/emails', function () {
-    $this->get('/duplicates', 'getEmailDupes');
+$app->group('/persons', function () {
+    $this->get('/duplicate/emails', 'getEmailDupes');
 });
 
 
@@ -40,11 +40,12 @@ function getEmailDupes(Request $request, Response $response, array $p_args)
         foreach ($dbFamilies as $family) {
             array_push($families, ["id" => $family->getId(), "nane" => $family->getName()]);
         }
-        $emails[$email] = [
+        array_push($emails, [
+            "email" => $email,
             "people" => $people,
             "families" => $families
-        ];
+        ]);
     }
 
-    return $response->withJson($emails);
+    return $response->withJson(["emails" => $emails]);
 }

--- a/src/v2/routes/email.php
+++ b/src/v2/routes/email.php
@@ -1,21 +1,23 @@
 <?php
 
-use Slim\Http\Request;
-use Slim\Http\Response;
 use ChurchCRM\dto\ChurchMetaData;
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\dto\SystemURLs;
 use ChurchCRM\Service\MailChimpService;
-use Slim\Views\PhpRenderer;
 use ChurchCRM\Slim\Middleware\AdminRoleAuthMiddleware;
 use PHPMailer\PHPMailer\PHPMailer;
+use Slim\Http\Request;
+use Slim\Http\Response;
+use Slim\Views\PhpRenderer;
 
 $app->group('/email', function () {
     $this->get('/debug', 'testEmailConnection')->add(new AdminRoleAuthMiddleware());
     $this->get('/dashboard', 'getEmailDashboard');
+    $this->get('/duplicate', 'getDuplicateEmails');
 });
 
-function getEmailDashboard(Request $request, Response $response, array $args) {
+function getEmailDashboard(Request $request, Response $response, array $args)
+{
     $renderer = new PhpRenderer('templates/email/');
     $mailchimp = new MailChimpService();
 
@@ -66,4 +68,10 @@ function testEmailConnection(Request $request, Response $response, array $args)
     ];
 
     return $renderer->render($response, 'debug.php', $pageArgs);
+}
+
+function getDuplicateEmails(Request $request, Response $response, array $args)
+{
+    $renderer = new PhpRenderer('templates/email/');
+    return $renderer->render($response, 'duplicate.php');
 }

--- a/src/v2/templates/email/dashboard.php
+++ b/src/v2/templates/email/dashboard.php
@@ -13,6 +13,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
     </div>
     <div class="box-body">
         <a href="<?= SystemURLs::getRootPath()?>/email/MemberEmailExport.php" class="btn btn-app"><i class="fa fa-table"></i><?= gettext('Email Export') ?></a>
+        <a href="<?= SystemURLs::getRootPath()?>/v2/email/duplicate" class="btn btn-app"><i class="fa fa-exclamation-triangle"></i><?= gettext('Find Duplicate Emails') ?></a>
         <?php if (SessionUser::isAdmin()) { ?>
         <a href="<?= SystemURLs::getRootPath()?>/v2/email/debug" class="btn btn-app"><i class="fa fa-stethoscope"></i><?= gettext('Debug') ?></a>
         <?php } ?>

--- a/src/v2/templates/email/duplicate.php
+++ b/src/v2/templates/email/duplicate.php
@@ -1,0 +1,83 @@
+<?php
+
+use ChurchCRM\dto\SystemURLs;
+
+require SystemURLs::getDocumentRoot() . '/Include/SimpleConfig.php';
+require SystemURLs::getDocumentRoot() . '/Include/Header.php';
+
+?>
+
+<div class="row">
+    <div class="col-lg-12">
+        <div class="box">
+            <div class="box-header">
+                <h3 class="box-title"><?= _("Duplicate Emails") ?></h3>
+            </div>
+            <div class="box-body">
+                <table id="dupEmails" class="table table-striped table-bordered table-responsive data-table">
+                    <tbody></tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+
+
+<script nonce="<?= SystemURLs::getCSPNonce() ?>">
+    $(document).ready(function () {
+        $("#dupEmails").DataTable({
+            "language": {
+                "url": window.CRM.plugin.dataTable.language.url
+            },
+            ajax: {
+                url: window.CRM.root + "/api/persons/duplicate/emails",
+                dataSrc: 'emails'
+            },
+            "dom": window.CRM.plugin.dataTable.dom,
+            "tableTools": {
+                "sSwfPath": window.CRM.plugin.dataTable.tableTools.sSwfPath
+            },
+            responsive: true,
+            columns: [
+                {
+                    title: i18next.t('Email'),
+                    data: 'email',
+                },
+                {
+                    title: i18next.t('People'),
+                    data: 'people',
+                    render: function ( data, type, row ){
+                        var render ="<ul>";
+                        $.each( data, function( key, value ) {
+                            render += "<li><a href='"+ window.CRM.root + "/PersonView.php?PersonID=" +value.id + "' target='user' />"+ value.name + "</a></li>";
+                        });
+                        render += "</ul>"
+                        return render;
+                    },
+                    searchable: true
+                },
+                {
+                    title: i18next.t('Families'),
+                    data: 'families',
+                    render: function ( data, type, row ){
+                        var render ="<ul>";
+                        $.each( data, function( key, value ) {
+                            render += "<li><a href='"+ window.CRM.root + "/FamilyView.php?FamilyID=" +value.id + "' target='family' />"+ value.name + "</a></li>";
+                        });
+                        render += "</ul>"
+                        return render;
+                    },
+                    searchable: true
+                }
+            ]
+        });
+    });
+
+    function peopleToString(people) {
+        return people.lengh;
+    }
+</script>
+
+<?php
+require SystemURLs::getDocumentRoot() . '/Include/Footer.php';
+?>


### PR DESCRIPTION
#### What's this PR do?
- cleanup of the dup email api for use by datatable
- cleanup of the dup email api to match path
- new page for displaying dup emails in a table
- new button on email dashbaord

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/554959/37108798-041cc850-21ed-11e8-8bed-7342c17e0ed1.png)


#### What Issues does it Close?

Closes #3862

#### Where should the reviewer start?
- email dashboard

#### How should this be manually tested?
- api for emails
