### PR TITLE
Use calendar name as page title

### DIFF
--- a/src/external/templates/calendar/calendar.php
+++ b/src/external/templates/calendar/calendar.php
@@ -3,7 +3,7 @@ use ChurchCRM\dto\ChurchMetaData;
 use ChurchCRM\dto\SystemURLs;
 
 // Set the page title and include HTML header
-$sPageTitle = gettext("Family Registration");
+$sPageTitle = $calendarName;
 require(SystemURLs::getDocumentRoot() . "/Include/HeaderNotLoggedIn.php");
 ?>
 <script src="<?= SystemURLs::getRootPath() ?>/skin/external/moment/moment-with-locales.min.js"></script>


### PR DESCRIPTION
#### What's this PR do?
Changes the public HTML calendar view to use the selected calendar's title as the ````<title>``` attribute

#### Screenshots (if appropriate)

#### What Issues does it Close?

Closes #4128 

#### What are the relevant tickets?

#### Any background context you want to provide?

#### Where should the reviewer start?

#### How should this be manually tested?

#### How should the automated tests treat this?

#### Questions:
- Is there a related website / article to substantiate / explain this change?
  -  [ ] Yes - Link:
  -  [ ] No

- Does the development wiki need an update?
  -  [ ] Yes - Link:
  -  [ ] No

- Does the user documentation wiki need an update?
  -  [ ] Yes - Link:
  -  [ ] No

- Does this add new dependencies?
  -  [ ] Yes
  -  [ ] No

- Does this need to add new data to the demo database
  -  [ ] Yes
  -  [ ] No

