### PR TITLE
fixed session login 404/500 error

### DIFF
--- a/src/ChurchCRM/utils/RedirectUtils.php
+++ b/src/ChurchCRM/utils/RedirectUtils.php
@@ -4,11 +4,27 @@ namespace ChurchCRM\Utils;
 
 use ChurchCRM\dto\SystemURLs;
 
-class RedirectUtils {
-  
-  public static function Redirect($sRelativeURL) {
-    // Convert a relative URL into an absolute URL and redirect the browser there.
-    header('Location: ' . SystemURLs::getRootPath() .'/'. $sRelativeURL);
-    exit;
-  }
+class RedirectUtils
+{
+
+    /**
+     * Convert a relative URL into an absolute URL and redirect the browser there.
+     * @param string $sRelativeURL
+     * @throws \Exception
+     */
+    public static function Redirect($sRelativeURL = "Menu.php")
+    {
+        LoggerUtils::getAppLogger()->info("Redirect Request: " . $sRelativeURL);
+        if (substr($sRelativeURL, 0,1) != "/") {
+            $sRelativeURL = "/" . $sRelativeURL;
+        }
+        if (substr($sRelativeURL, 0, strlen(SystemURLs::getRootPath())) != SystemURLs::getRootPath()) {
+            $finalLocation = SystemURLs::getRootPath() . $sRelativeURL;
+        } else {
+            $finalLocation = $sRelativeURL;
+        }
+        LoggerUtils::getAppLogger()->info("Redirect Final: " . $finalLocation);
+        header('Location: ' . $finalLocation);
+        exit;
+    }
 }


### PR DESCRIPTION
#### What's this PR do?
- Ensure the URL redirect is correct for sites with `""` or `"/xxx"` rootpath

#### What Issues does it Close?

Closes #4034

#### How should this be manually tested?
- set the session length to 30 sec visit a deep page and the dashboard and ensure both timeout and can login back

Example pages
```
http://demo.churchcrm.io/master/Login.php?location=Menu.php
http://demo.churchcrm.io/master/Login.php?location=/sundayschool/SundaySchoolDashboard.php
http://demo.churchcrm.io/master/Login.php?location=/master/sundayschool/SundaySchoolDashboard.php
```