### PR TITLE
Addresses issue #4215

### DIFF
--- a/src/Include/Config.php.example
+++ b/src/Include/Config.php.example
@@ -21,7 +21,7 @@ $sDATABASE = '||DB_NAME||';
 // - if you will be accessing from http://www.yourdomain.com then you would enter '' ... an empty string for a top level installation.
 //
 // NOTE:
-// - the path SHOULD Start end with slash, if not ''.
+// - the path SHOULD Start with slash, if not ''.
 // - the path SHOULD NOT end with slash.
 // - the is case sensitive.
 $sRootPath = '||ROOT_PATH||';

--- a/src/setup/templates/setup-steps.php
+++ b/src/setup/templates/setup-steps.php
@@ -76,7 +76,7 @@ require '../Include/HeaderNotLoggedIn.php';
                     <p/>
                     <i><b>NOTE:</b></i>
                     <p/>
-                    SHOULD Start end with slash.<br/>
+                    SHOULD Start with slash.<br/>
                     SHOULD NOT end with slash.<br/>
                     It is case sensitive.
                     </ul>


### PR DESCRIPTION
setup page typo,

reads "the path SHOULD Start end with slash"
should read "the path SHOULD Start with slash"


#### What's this PR do?
Corrects typo in setup pages

#### Screenshots (if appropriate)
![start end](https://user-images.githubusercontent.com/79247/38461068-f6e8d1fc-3abe-11e8-8fe6-62a4c76b2793.png)

#### What Issues does it Close?

Closes
#4215 
#### What are the relevant tickets?
#4215 
#### Any background context you want to provide?

#### Where should the reviewer start?

#### How should this be manually tested?

#### How should the automated tests treat this?

#### Questions:
- Is there a related website / article to substantiate / explain this change?
  -  [ ] Yes - Link:
  -  [x ] No

- Does the development wiki need an update?
  -  [ ] Yes - Link:
  -  [ x] No

- Does the user documentation wiki need an update?
  -  [ ] Yes - Link:
  -  [ x] No

- Does this add new dependencies?
  -  [ ] Yes
  -  [x ] No

- Does this need to add new data to the demo database
  -  [ ] Yes
  -  [x ] No

