### PR TITLE
Add React Enviornment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ src/tmp_attach
 src/logs/*.log
 
 error.log
+/src/skin/js-react/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,6 +14,8 @@ Vagrant.configure("2") do |config|
   config.vm.network "private_network", ip: "192.168.33.10"
   config.vm.hostname = "ChurchCRM"
   config.vm.synced_folder "src", "/var/www/public", :mount_options => ["dmode=777", "fmode=666"]
+  config.vm.synced_folder "node_modules", "/home/vagrant/host_node_modules", :mount_options => ["dmode=777", "fmode=666"]
+
 
   config.vm.provision :shell, :path => "vagrant/bootstrap.sh", :args =>["php7"]
 end

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     },
     "scripts": {
         "install": "grunt clean && grunt updateVersions && grunt curl-dir && grunt copy && grunt sass",
-        "postinstall": "grunt genLocaleJSFiles && cp  -R -L ./node_modules/* /home/vagrant/host_node_modules",
+        "postinstall": "grunt genLocaleJSFiles && scripts/sync-react.sh",
         "locale-gen": "locale/update-locale.sh",
         "locale-download": "grunt updateFromPOeditor && grunt genLocaleJSFiles",
         "package": "grunt generateSignatures && grunt compress",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,15 @@
     },
     "homepage": "http://www.churchcrm.io",
     "devDependencies": {
+        "@types/jquery": "^3.3.1",
+        "@types/react": "^16.1.0",
+        "@types/react-bootstrap": "^0.32.6",
+        "@types/react-dom": "^16.0.4",
+        "@types/react-modal": "^3.1.2",
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.4",
+        "babel-preset-react": "^6.24.1",
         "grunt": "1.0.1",
         "grunt-confirm": "^1.0.7",
         "grunt-contrib-clean": "1.0.0",
@@ -26,10 +35,19 @@
         "grunt-contrib-sass": "1.0.0",
         "grunt-curl": "2.2.0",
         "grunt-poeditor-ab": "0.1.9",
-        "node-sha1": "1.0.1"
+        "node-sha1": "1.0.1",
+        "react": "^16.3.0",
+        "react-bootstrap": "^0.32.1",
+        "react-dom": "^16.3.0",
+        "react-modal": "^3.3.2",
+        "ts-loader": "^4.1.0",
+        "typescript": "^2.8.1",
+        "webpack": "^4.4.1",
+        "webpack-cli": "^2.0.13"
     },
     "dependencies": {
         "admin-lte": "2.3.7",
+        "babel-preset-env": "^1.6.1",
         "bootbox": "4.4.0",
         "bootstrap-show-password": "^1.1.1",
         "bootstrap-toggle": "2.2.2",
@@ -49,7 +67,7 @@
     },
     "scripts": {
         "install": "grunt clean && grunt updateVersions && grunt curl-dir && grunt copy && grunt sass",
-        "postinstall": "grunt genLocaleJSFiles",
+        "postinstall": "grunt genLocaleJSFiles && cp  -R -L ./node_modules/* /home/vagrant/host_node_modules",
         "locale-gen": "locale/update-locale.sh",
         "locale-download": "grunt updateFromPOeditor && grunt genLocaleJSFiles",
         "package": "grunt generateSignatures && grunt compress",
@@ -61,6 +79,7 @@
         "composer-install": "cd src/ && composer install",
         "composer-update": " cd src/ && composer update && composer dump-autoload && cd ../tests/ && composer update",
         "tests-install": "scripts/tests-install.sh",
-        "test": "scripts/tests-run.sh"
+        "test": "scripts/tests-run.sh",
+        "build-react": "webpack"
     }
 }

--- a/scripts/sync-react.sh
+++ b/scripts/sync-react.sh
@@ -1,0 +1,15 @@
+#! /bin/bash
+
+# Oh, the terrible things we need to do to make NPM work happily
+# and still supply developer-side react tooling on the VM Host 
+# While preserving the automation on both Travis CI and local Vagrant.
+
+mountpoint /home/vagrant/host_node_modules > /dev/null
+ISMOUNTPOINT=$?
+
+if [ $ISMOUNTPOINT -eq 0 ]; then 
+    echo "/home/vagrant/host_node_modules is a mountpoint - sync node_modules with host"
+    cp  -R -L /home/vagrant/node_modules/* /home/vagrant/host_node_modules
+else
+    echo "/home/vagrant/host_node_modules is not a mountpoint - do nothing"
+fi

--- a/src/.babelrc
+++ b/src/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["env", "react"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["es2015", "es2017", "dom"],
+    "sourceMap": true,
+    "jsx": "react"
+  },
+  "exclude": [
+    "node_modules",
+    "src/vendor",
+    "tests/vendor"
+  ]
+}

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -75,7 +75,8 @@ VERSION="$(npm --version)"
 echo "Node vesrion: $VERSION"
 
 # NPM does not function nicely with Vagrant's "shared folders," so 
-# create a mountpoint to a folder in the guest-only filesystem
+# create a mount point so that node_modules can exist 
+# locally in the guest's filesystem
 
 mountpoint /vagrant/node_modules/ > /dev/null
 ISMOUNTPOINT=$?

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -73,7 +73,10 @@ echo "=========================================================="
 
 VERSION="$(npm --version)"
 echo "Node vesrion: $VERSION"
-    
+
+# NPM does not function nicely with Vagrant's "shared folders," so 
+# create a mountpoint to a folder in the guest-only filesystem
+
 mountpoint /vagrant/node_modules/ > /dev/null
 ISMOUNTPOINT=$?
 

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -84,9 +84,7 @@ ISMOUNTPOINT=$?
 if [ $ISMOUNTPOINT -eq 0 ]; then 
     echo "/vagrant/node_modules is a mountpoint - don't touch"
 else
-    echo "/vagrant/node_modules is not a mountpoint - nuke and mount"
-    sudo rm -rf /vagrant/node_modules
-    sudo mkdir /vagrant/node_modules
+    echo "/vagrant/node_modules is not a mountpoint - mount on local filesystem"
     mkdir -p /home/vagrant/node_modules /vagrant/node_modules
     sudo mount --bind /home/vagrant/node_modules/ /vagrant/node_modules
     echo "/home/vagrant/node_modules/ has been mounted to /vagrant/node_modules"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,23 @@
+const path = require('path');
+module.exports = {
+  entry: {
+    //define entry poins for react apps.
+  },
+  output: {
+    path:path.resolve('./src/skin/js-react'),
+    filename:'[name]-app.js'
+  },
+  resolve: {
+    extensions: [".ts", ".tsx", ".js"]
+  },
+
+  module: {
+    rules: [
+      // all files with a `.ts` or `.tsx` extension will be handled by `ts-loader`
+      { 
+        test: /\.tsx?$/, 
+        loader: "ts-loader" 
+      }
+    ]
+  }
+}


### PR DESCRIPTION
#### What's this PR do?
* Adds support for react environment to development environment
* Also maps a new directory for a "read-only" copy of `node_modules` on the VM host so that developer tooling can leverage TypeScript type files provided by "guest side" NPM.   NOTE that NPM in the guest responds extremely poorly to working _directly_ out of a VirtualBox mapped drive; hence the need for a *copy* operation.