### PR TITLE
#4275 - Default non-deductible amount to empty string if there is no …

### DIFF
--- a/src/PledgeEditor.php
+++ b/src/PledgeEditor.php
@@ -736,7 +736,7 @@ require 'Include/Header.php';
                     if ($bEnableNonDeductible) {
                         ?>
                       <td class="TextColumn">
-                        <input   type="number" step="any" name="<?= $fun_id ?>_NonDeductible" id="<?= $fun_id ?>_NonDeductible" value="<?= $nNonDeductible[$fun_id]?>" />
+                        <input type="number" step="any" name="<?= $fun_id ?>_NonDeductible" id="<?= $fun_id ?>_NonDeductible" value="<?= ($nNonDeductible[$fun_id] ? $nNonDeductible[$fun_id] : "")?>" />
                         <br>
                         <font color="red"><?= $sNonDeductibleError[$fun_id]?></font>
                       </td>


### PR DESCRIPTION
#### What's this PR do?

If a non-deductible amount does not have a value for a fund, default to an empty string instead of zero. This makes saving payments without a value for the fund less cumbersome, as the non-deductible amount must be otherwise be blanked out manually.

#### Screenshots (if appropriate)

After trying to save without blanking out non-deductible amounts:

![Funds](https://user-images.githubusercontent.com/8531220/39013911-7696e682-43de-11e8-8236-ef9c4d80b3db.png)

#### What Issues does it Close?

Closes #4274.

#### What are the relevant tickets?

Caused initially by #3894. Should have been fixed #3961.

#### Any background context you want to provide?

No.

#### Where should the reviewer start?

1. Enable non-deductible payments ("bEnableNonDeductible" is true).
2. Create a new bank deposit.
3. Add new payment.

#### How should this be manually tested?

Make sure that the non-deductible amount fields are blank and that the payment can be saved without having to enter a total amount for all of the funds (assuming that there are more than two funds to begin with).

#### How should the automated tests treat this?

An automated test could be made, but I'm not sure if one exists.

Given a system user with Manage Donations and Finance access
And Non-deductible payments are enabled
When the user add a payment
Then the non-deductible amount fields are blank

#### Questions:
- Is there a related website / article to substantiate / explain this change?
  -  [ ] Yes - Link:
  -  [X] No

- Does the development wiki need an update?
  -  [ ] Yes - Link:
  -  [X] No
(I hope.)

- Does the user documentation wiki need an update?
  -  [ ] Yes - Link:
  -  [X] No
(I hope.)

- Does this add new dependencies?
  -  [ ] Yes
  -  [X] No

- Does this need to add new data to the demo database
  -  [ ] Yes
  -  [X] No

