### PR TITLE
closes #4310 User listing to indicate time of last login rather than only date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,3 @@ src/tmp_attach
 src/logs/*.log
 
 error.log
-src/UserList.php.orig

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ src/tmp_attach
 src/logs/*.log
 
 error.log
+src/UserList.php.orig

--- a/src/UserList.php
+++ b/src/UserList.php
@@ -77,7 +77,7 @@ require 'Include/Header.php';
                     <td>
                         <a href="PersonView.php?PersonID=<?= $user->getId() ?>"> <?= $user->getPerson()->getFullName() ?></a>
                     </td>
-                    <td align="center"><?= $user->getLastLogin(SystemConfig::getValue('sDateFormatShort')) ?></td>
+                    <td align="center"><?= $user->getLastLogin(SystemConfig::getValue('sDateTimeFormat')) ?></td>
                     <td align="center"><?= $user->getLoginCount() ?></td>
                     <td align="center">
                         <?php if ($user->isLocked()) {


### PR DESCRIPTION
User listing to indicate time of last login rather than only date #4310


#### What's this PR do?
Allow user list to indicate date and time of last user login rather than only date

#### Screenshots (if appropriate)

#### What Issues does it Close?

Closes #4310

#### What are the relevant tickets?

#### Any background context you want to provide?

#### Where should the reviewer start?

#### How should this be manually tested?

#### How should the automated tests treat this?

#### Questions:
- Is there a related website / article to substantiate / explain this change?
  -  [ ] Yes - Link:
  -  [ ] No

- Does the development wiki need an update?
  -  [ ] Yes - Link:
  -  [ ] No

- Does the user documentation wiki need an update?
  -  [ ] Yes - Link:
  -  [ ] No

- Does this add new dependencies?
  -  [ ] Yes
  -  [ ] No

- Does this need to add new data to the demo database
  -  [ ] Yes
  -  [ ] No

