### PR TITLE
Event check-in time only shows date

### DIFF
--- a/src/Checkin.php
+++ b/src/Checkin.php
@@ -350,9 +350,9 @@ if (isset($_POST['EventID'])) {
                         <td><img src="<?= SystemURLs::getRootPath() . '/api/person/' . $per->getPersonId() . '/thumbnail' ?>"
                                  class="direct-chat-img initials-image">&nbsp
                             <a href="PersonView.php?PersonID=<?= $per->getPersonId() ?>"><?= $sPerson ?></a></td>
-                        <td><?= date_format($per->getCheckinDate(), SystemConfig::getValue('sDateFormatLong')) ?></td>
+                        <td><?= date_format($per->getCheckinDate(), SystemConfig::getValue('sDateTimeFormat')) ?></td>
                         <td><?= $sCheckinby ?></td>
-                        <td><?= date_format($per->getCheckoutDate(), SystemConfig::getValue('sDateFormatLong')) ?></td>
+                        <td><?= date_format($per->getCheckoutDate(), SystemConfig::getValue('sDateTimeFormat')) ?></td>
                         <td><?= $sCheckoutby ?></td>
 
                         <td align="center">


### PR DESCRIPTION
Event check-in time to show date and time of checkin/checkout rather than only date


#### What's this PR do?
Event checkin/checkout time to show date and time of checkin/checkout rather than only date

#### Screenshots (if appropriate)

#### What Issues does it Close?

Closes #3747

#### What are the relevant tickets?
#3747
#### Any background context you want to provide?

#### Where should the reviewer start?

#### How should this be manually tested?

#### How should the automated tests treat this?

#### Questions:
- Is there a related website / article to substantiate / explain this change?
  -  [ ] Yes - Link:
  -  [ x] No

- Does the development wiki need an update?
  -  [ ] Yes - Link:
  -  [x ] No

- Does the user documentation wiki need an update?
  -  [ ] Yes - Link:
  -  [ x] No

- Does this add new dependencies?
  -  [ ] Yes
  -  [x ] No

- Does this need to add new data to the demo database
  -  [ ] Yes
  -  [x ] No

