### PR TITLE
redirect to the View all Deposits page when  no deposit has been created

### DIFF
--- a/src/DepositSlipEditor.php
+++ b/src/DepositSlipEditor.php
@@ -42,6 +42,9 @@ if ($iDepositSlipID) {
         RedirectUtils::Redirect('Menu.php');
         exit;
     }
+} elseif ($iDepositSlipID == 0) {
+    RedirectUtils::Redirect('FindDepositSlip.php');
+    exit;
 } else {
     RedirectUtils::Redirect('Menu.php');
 }


### PR DESCRIPTION
#### What's this PR do?

#4297 
#### Screenshots (if appropriate)

#### What Issues does it Close?

Closes
#4297 
#### What are the relevant tickets?

#### Any background context you want to provide?

#### Where should the reviewer start?

#### How should this be manually tested?
Try navigating to the **Edit Deposit Slip** page when there are no existing deposits
#### How should the automated tests treat this?

#### Questions:
- Is there a related website / article to substantiate / explain this change?
  -  [ ] Yes - Link:
  -  [x] No

- Does the development wiki need an update?
  -  [ ] Yes - Link:
  -  [x] No

- Does the user documentation wiki need an update?
  -  [ ] Yes - Link:
  -  [x] No

- Does this add new dependencies?
  -  [ ] Yes
  -  [x] No

- Does this need to add new data to the demo database
  -  [ ] Yes
  -  [x] No

