### PR TITLE
Fix creating new events in Firefox

### DIFF
--- a/src/skin/js/Calendar.js
+++ b/src/skin/js/Calendar.js
@@ -139,8 +139,8 @@ window.NewOrEditEventModal = {
 
       var eventPredication = CKEDITOR.instances['eventPredication'].getData();//$('form #eventPredication').val();
       var dateRange = $('#EventDateRange').val().split(" - ");
-      var start = moment(dateRange[0]).format();
-      var end = moment(dateRange[1]).format();
+      var start = moment(dateRange[0],"YYYY-MM-DD HH:mm:ss a").format();
+      var end = moment(dateRange[1],"YYYY-MM-DD HH:mm:ss a").format();
       var add = false;
       return {
           "eventTypeID": eventTypeID,


### PR DESCRIPTION
Force momentjs to parse the date according to the format forced by daterangepicker

closes #4343 