### PR TITLE
Improve Calendar Legend layout

### DIFF
--- a/src/skin/js/Calendar.js
+++ b/src/skin/js/Calendar.js
@@ -691,7 +691,7 @@ function getCalendarFilterElement(calendar,type,parent) {
               '<div class="box-body">'+
                '<label for="display-'+boxId+'" style="font-size:10pt">Show On Calendar</label>' +
                "<input type='checkbox' id='display-"+boxId+"' class='calendarSelectionBox' data-calendartype='"+type+"' data-calendarname='"+calendar.Name+"' data-calendarid='"+calendar.Id+"'/>" +
-               (type === "user"  ? '<a class="btn btn-primary calendarproperties" data-calendarid="'+calendar.Id+'" style="white-space: unset; font-size:10pt">Edit Calendar Properties</a>' : "") +
+               (type === "user"  ? '<br/><a class="btn btn-primary calendarproperties" data-calendarid="'+calendar.Id+'" style="white-space: unset; font-size:10pt">Edit Calendar Properties</a>' : "") +
               '</div>'+
             '</div>'+
           '</div>';

--- a/src/skin/js/Calendar.js
+++ b/src/skin/js/Calendar.js
@@ -677,16 +677,24 @@ function initializeCalendar() {
   });
 };
 
-function getCalendarFilterElement(calendar,type) {
-  return "<div class='row calendar-filter-row'>" + 
-          "<div class='col-xs-1'>" +
-            "<input type='checkbox' class='calendarSelectionBox' data-calendartype='"+type+"' data-calendarname='"+calendar.Name+"' data-calendarid='"+calendar.Id+"'/>"+ 
-          "</div>"+
-          "<div class='col-xs-7'><label for='"+calendar.Name+"'>"+calendar.Name+"</label></div>"+
-          "<div class='col-xs-4'>"+
-            "<div class='calendar-filter-text' style=' color:#"+calendar.ForegroundColor+"; background-color:#"+calendar.BackgroundColor+";'><i class='fa fa-calendar' aria-hidden='true'></i></div>"+
-            (type === "user"  ? "<div class='calendar-filter-text'><i class='calendarproperties fa fa-eye' aria-hidden='true' data-calendarid='"+calendar.Id+"' ></i></div>" :"") +
-        "</div>";
+function getCalendarFilterElement(calendar,type,parent) {
+  boxId = type+calendar.Id;
+  return '<div class="panel box box-primary">'+
+            '<div class="box-header with-border" style="background-color:#'+calendar.BackgroundColor+'">' +
+              '<h4 class="box-title">' +
+                '<a data-toggle="collapse" data-parent="#'+parent+'" href="#'+boxId+'" aria-expanded="false" class="" style="color:#'+calendar.ForegroundColor+'">' +
+                  calendar.Name+
+                '</a>'+
+              '</h4>'+
+            '</div>'+
+           ' <div id="'+boxId+'" class="panel-collapse collapse" aria-expanded="false" style="">'+
+              '<div class="box-body">'+
+               '<label for="display-'+boxId+'">Show On Calendar</label>' +
+               "<input type='checkbox' id='display-"+boxId+"' class='calendarSelectionBox' data-calendartype='"+type+"' data-calendarname='"+calendar.Name+"' data-calendarid='"+calendar.Id+"'/>" +
+               '<a class="btn btn-primary calendarproperties" data-calendarid="'+calendar.Id+'" style="white-space: unset">Edit Calendar Properties</a>'+
+              '</div>'+
+            '</div>'+
+          '</div>';
 }
 
 function registerCalendarSelectionEvents() {
@@ -732,7 +740,7 @@ function initializeFilterSettings() {
   }).done(function (calendars) {
     $("#userCalendars").empty();
     $.each(calendars.Calendars,function(idx,calendar) {
-      $("#userCalendars").append(getCalendarFilterElement(calendar,"user"))
+      $("#userCalendars").append(getCalendarFilterElement(calendar,"user",'userCalendars'))
     });
     $("#userCalendars .calendarSelectionBox").click();
   });
@@ -743,7 +751,7 @@ function initializeFilterSettings() {
   }).done(function (calendars) {
     $("#systemCalendars").empty();
     $.each(calendars.Calendars,function(idx,calendar) {
-      $("#systemCalendars").append(getCalendarFilterElement(calendar,"system"))
+      $("#systemCalendars").append(getCalendarFilterElement(calendar,"system",'systemCalendars'))
     });
     $("#systemCalendars .calendarSelectionBox").click();
   });

--- a/src/skin/js/Calendar.js
+++ b/src/skin/js/Calendar.js
@@ -679,19 +679,19 @@ function initializeCalendar() {
 
 function getCalendarFilterElement(calendar,type,parent) {
   boxId = type+calendar.Id;
-  return '<div class="panel box box-primary">'+
-            '<div class="box-header with-border" style="background-color:#'+calendar.BackgroundColor+'">' +
+  return '<div class="panel box box-primary" style="border-top: 0px">'+
+            '<div class="box-header" style="background-color:#'+calendar.BackgroundColor+'">' +
               '<h4 class="box-title">' +
-                '<a data-toggle="collapse" data-parent="#'+parent+'" href="#'+boxId+'" aria-expanded="false" class="" style="color:#'+calendar.ForegroundColor+'">' +
+                '<a data-toggle="collapse" data-parent="#'+parent+'" href="#'+boxId+'" aria-expanded="false" style="color:#'+calendar.ForegroundColor+'; font-size:10pt">' +
                   calendar.Name+
                 '</a>'+
               '</h4>'+
             '</div>'+
            ' <div id="'+boxId+'" class="panel-collapse collapse" aria-expanded="false" style="">'+
               '<div class="box-body">'+
-               '<label for="display-'+boxId+'">Show On Calendar</label>' +
+               '<label for="display-'+boxId+'" style="font-size:10pt">Show On Calendar</label>' +
                "<input type='checkbox' id='display-"+boxId+"' class='calendarSelectionBox' data-calendartype='"+type+"' data-calendarname='"+calendar.Name+"' data-calendarid='"+calendar.Id+"'/>" +
-               '<a class="btn btn-primary calendarproperties" data-calendarid="'+calendar.Id+'" style="white-space: unset">Edit Calendar Properties</a>'+
+               (type === "user"  ? '<a class="btn btn-primary calendarproperties" data-calendarid="'+calendar.Id+'" style="white-space: unset; font-size:10pt">Edit Calendar Properties</a>' : "") +
               '</div>'+
             '</div>'+
           '</div>';

--- a/src/v2/templates/calendar/calendar.php
+++ b/src/v2/templates/calendar/calendar.php
@@ -18,14 +18,14 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
     <!-- /. box -->
   </div>
    <div class="col-lg-2">
-     <div class="box">
-      <div class="box-header with-border">
-        <h3 class="box-title"><?= gettext('User Calendars') ?></h3>
-      </div>
-      <div class="box-body" >
-        <div id="userCalendars" class="container-fluid"></div>
-      </div>
-     </div>
+    <div class="box">
+        <div class="box-header with-border">
+          <h3 class="box-title"><?= gettext('User Calendars') ?></h3>
+        </div>
+        <div class="box-body" >
+        <div class="box-group" id="userCalendars"></div>
+        </div>
+    </div>
   </div>
   <div class="col-lg-2">
      <div class="box">
@@ -33,7 +33,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
         <h3 class="box-title"><?= gettext('System Calendars') ?></h3>
       </div>
       <div class="box-body">
-        <div  id="systemCalendars" class="container-fluid"></div>
+        <div class="box-group" id="systemCalendars"></div>
       </div>
      </div>
   </div>

--- a/src/v2/templates/calendar/calendar.php
+++ b/src/v2/templates/calendar/calendar.php
@@ -7,7 +7,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
 
 ?>
 <div class="row">
-  <div class="col-lg-10">
+  <div class="col-lg-9">
     <div class="box box-info">
         <div class="box-body no-padding">
             <!-- THE CALENDAR -->
@@ -17,23 +17,23 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
     </div>
     <!-- /. box -->
   </div>
-   <div class="col-lg-2">
+   <div class="col-lg-3">
     <div class="box">
         <div class="box-header with-border">
           <h3 class="box-title"><?= gettext('User Calendars') ?></h3>
         </div>
         <div class="box-body" >
-        <div class="box-group" id="userCalendars"></div>
+        <div class="box-group" style="height:25vh; overflow-y: scroll" id="userCalendars"></div>
         </div>
     </div>
   </div>
-  <div class="col-lg-2">
+  <div class="col-lg-3">
      <div class="box">
       <div class="box-header with-border">
         <h3 class="box-title"><?= gettext('System Calendars') ?></h3>
       </div>
       <div class="box-body">
-        <div class="box-group" id="systemCalendars"></div>
+        <div class="box-group" style="height:25vh; overflow-y: scroll" id="systemCalendars"></div>
       </div>
      </div>
   </div>


### PR DESCRIPTION
#### What's this PR do?
Rearrange the layout for the calendar legend / properties box.
Each calendar heading is now an accordion, with the edit actions inside the collapsible body.  Accordion header colors match the calendar event colors.

#### Screenshots (if appropriate)
After:
![image](https://user-images.githubusercontent.com/11679900/44613688-24b52200-a7e5-11e8-9114-9da1f0c9ece2.png)

Before:
![image](https://user-images.githubusercontent.com/11679900/44613692-44e4e100-a7e5-11e8-993b-fb9987a4d6b6.png)

#### What Issues does it Close?

Closes #4127 

#### What are the relevant tickets?

#### Any background context you want to provide?

#### Where should the reviewer start?

#### How should this be manually tested?

#### How should the automated tests treat this?

#### Questions:
- Is there a related website / article to substantiate / explain this change?
  -  [ ] Yes - Link:
  -  [ ] No

- Does the development wiki need an update?
  -  [ ] Yes - Link:
  -  [ ] No

- Does the user documentation wiki need an update?
  -  [ ] Yes - Link:
  -  [ ] No

- Does this add new dependencies?
  -  [ ] Yes
  -  [ ] No

- Does this need to add new data to the demo database
  -  [ ] Yes
  -  [ ] No

