### PR TITLE
Render and use Locale-aware date time strings in JavaScript 

### DIFF
--- a/src/ChurchCRM/utils/PHPToMomentJSConverter.php
+++ b/src/ChurchCRM/utils/PHPToMomentJSConverter.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace ChurchCRM\Utils;
+
 /* 
  * To change this license header, choose License Headers in Project Properties.
  * To change this template file, choose Tools | Templates

--- a/src/ChurchCRM/utils/PHPToMomentJSConverter.php
+++ b/src/ChurchCRM/utils/PHPToMomentJSConverter.php
@@ -1,0 +1,54 @@
+<?php
+
+/* 
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+class PHPToMomentJSConverter {
+  private static $replacements = [
+        'd' => 'DD',
+        'D' => 'ddd',
+        'j' => 'D',
+        'l' => 'dddd',
+        'N' => 'E',
+        'S' => 'o',
+        'w' => 'e',
+        'z' => 'DDD',
+        'W' => 'W',
+        'F' => 'MMMM',
+        'm' => 'MM',
+        'M' => 'MMM',
+        'n' => 'M',
+        't' => '', // no equivalent
+        'L' => '', // no equivalent
+        'o' => 'YYYY',
+        'Y' => 'YYYY',
+        'y' => 'YY',
+        'a' => 'a',
+        'A' => 'A',
+        'B' => '', // no equivalent
+        'g' => 'h',
+        'G' => 'H',
+        'h' => 'hh',
+        'H' => 'HH',
+        'i' => 'mm',
+        's' => 'ss',
+        'u' => 'SSS',
+        'e' => 'zz', // deprecated since version 1.6.0 of moment.js
+        'I' => '', // no equivalent
+        'O' => '', // no equivalent
+        'P' => '', // no equivalent
+        'T' => '', // no equivalent
+        'Z' => '', // no equivalent
+        'c' => '', // no equivalent
+        'r' => '', // no equivalent
+        'U' => 'X',
+    ];
+  public static function ConvertFormatString($string){
+    //borrowed from https://stackoverflow.com/questions/30186611/php-dateformat-to-moment-js-format
+    $momentFormat = strtr($string, self::$replacements );
+    return $momentFormat;
+  }
+}

--- a/src/Include/Header-function.php
+++ b/src/Include/Header-function.php
@@ -18,7 +18,7 @@ use ChurchCRM\dto\SystemURLs;
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\MenuConfigQuery;
 use ChurchCRM\SessionUser;
-use PHPToMomentJSConverter;
+use ChurchCRM\Utils\PHPToMomentJSConverter;
 
 function Header_modals()
 {

--- a/src/Include/Header-function.php
+++ b/src/Include/Header-function.php
@@ -18,6 +18,7 @@ use ChurchCRM\dto\SystemURLs;
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\MenuConfigQuery;
 use ChurchCRM\SessionUser;
+use PHPToMomentJSConverter;
 
 function Header_modals()
 {
@@ -88,6 +89,9 @@ function Header_body_scripts()
             maxUploadSize: "<?= $systemService->getMaxUploadFileSize(true) ?>",
             maxUploadSizeBytes: "<?= $systemService->getMaxUploadFileSize(false) ?>",
             datePickerformat:"<?= SystemConfig::getValue('sDatePickerPlaceHolder') ?>",
+            systemConfigs: {
+              sDateTimeFormat: "<?= PHPToMomentJSConverter::ConvertFormatString(SystemConfig::getValue('sDateTimeFormat'))?>",
+            },
             iDasbhoardServiceIntervalTime:"<?= SystemConfig::getValue('iDasbhoardServiceIntervalTime') ?>",
             plugin: {
                 dataTable : {

--- a/src/skin/js/CRMJSOM.js
+++ b/src/skin/js/CRMJSOM.js
@@ -571,7 +571,7 @@
                 {
                   data: 'DateEntered',
                   render: function (data, type, row, meta) {
-                    return moment(data).format('MM-DD-YYYY hh:mm');
+                    return moment(data).format(window.CRM.systemConfigs.sDateTimeFormat);
                   }
                 }
               ]

--- a/src/skin/js/CRMJSOM.js
+++ b/src/skin/js/CRMJSOM.js
@@ -599,7 +599,7 @@
                 {
                   data: 'DateLastEdited',
                   render: function (data, type, row, meta) {
-                    return moment(data).format('MM-DD-YYYY hh:mm');
+                    return moment(data).format(window.CRM.systemConfigs.sDateTimeFormat);
                   }
                 }
               ]


### PR DESCRIPTION
#### What's this PR do?
Adds a PHP-to-MomentJS format string converter.
Renders `window.CRM.systemConfigs.sDateTimeFormat` by converting `sDateTimeFormat` from the PHP DateTime Format into the MomentJS DateTime format.
Adjusts the Dashboard rendering logic to use the new DateTime format string instead of the hard-coded value.

#### Screenshots (if appropriate)

#### What Issues does it Close?

Closes #3821 
Closes #3717

#### What are the relevant tickets?

#### Any background context you want to provide?

#### Where should the reviewer start?

#### How should this be manually tested?

#### How should the automated tests treat this?

#### Questions:
- Is there a related website / article to substantiate / explain this change?
  -  [ ] Yes - Link:
  -  [ ] No

- Does the development wiki need an update?
  -  [ ] Yes - Link:
  -  [ ] No

- Does the user documentation wiki need an update?
  -  [ ] Yes - Link:
  -  [ ] No

- Does this add new dependencies?
  -  [ ] Yes
  -  [ ] No

- Does this need to add new data to the demo database
  -  [ ] Yes
  -  [ ] No

