### PR TITLE
Fixed Delete family member from Person page.

### DIFF
--- a/src/PersonView.php
+++ b/src/PersonView.php
@@ -552,11 +552,12 @@ $bOkToEdit = ($_SESSION['user']->isEditRecordsEnabled() ||
                         <i class="fa fa-pencil fa-stack-1x fa-inverse"></i>
                       </span>
                                             </a>
-                                            <a href="<?= SystemURLs::getRootPath() ?>/SelectDelete.php?mode=person&PersonID=<?= $tmpPersonId ?>">
-                      <span class="fa-stack">
-                        <i class="fa fa-square fa-stack-2x"></i>
-                        <i class="fa fa-trash-o fa-stack-1x fa-inverse"></i>
-                      </span>
+                                             <a class="delete-person" data-person_name="<?= $familyMember->getFullName() ?>"
+                                           data-person_id="<?= $familyMember->getId() ?>" data-view="family">
+                                                <span class="fa-stack">
+                                                    <i class="fa fa-square fa-stack-2x"></i>
+                                                    <i class="fa fa-trash-o fa-stack-1x fa-inverse btn-danger"></i>
+                                                </span>
                                             </a>
                                             <?php
                               } ?>


### PR DESCRIPTION
#### What's this PR do?
Fixes delete button on person from the person family view going to page that no longer support person delete.

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/554959/44622760-41e50180-a874-11e8-9627-3a0c3e8f1e73.png)

#### What Issues does it Close?

Closes #4435

#### Any background context you want to provide?
Old delete person code was removed without a full search on the codebase

#### Where should the reviewer start?
see issue for details 

