### PR TITLE
Fixed database connection to correctly implement port number

### DIFF
--- a/src/Include/LoadConfigs.php
+++ b/src/Include/LoadConfigs.php
@@ -70,7 +70,7 @@ try {
 SystemURLs::checkAllowedURL($bLockURL, $URL);
 
 // Due to mysqli handling connections on 'localhost' via socket only, we need to tease out this case and handle
-// TCP/IP connections separately defaulting $dbPort to 3306 for the general case when$dbPort is not set.
+// TCP/IP connections separately defaulting $dbPort to 3306 for the general case when $dbPort is not set.
 if ($sSERVERNAME == "localhost") {
     $cnInfoCentral = mysqli_connect($sSERVERNAME, $sUSER, $sPASSWORD)
     or system_failure('Could not connect to MySQL on <strong>'.$sSERVERNAME.'</strong> as <strong>'.$sUSER.'</strong>. Please check the settings in <strong>Include/Config.php</strong>.<br/>MySQL Error: '.mysqli_error($cnInfoCentral));
@@ -78,7 +78,9 @@ if ($sSERVERNAME == "localhost") {
     if (!isset($dbPort)) {
         $dbPort=3306;
     }
-    $cnInfoCentral = mysqli_connect($sSERVERNAME.':'.$dbPort, $sUSER, $sPASSWORD)
+    // Connect via TCP to specified port and pass a 'null' for database name.
+    // We specify the database name in a different call, ie 'mysqli_select_db()' just below here
+    $cnInfoCentral = mysqli_connect($sSERVERNAME, $sUSER, $sPASSWORD, null, $dbPort)
         or system_failure('Could not connect to MySQL on <strong>'.$sSERVERNAME.'</strong> on port <strong>'.$dbPort.'</strong> as <strong>'.$sUSER.'</strong>. Please check the settings in <strong>Include/Config.php</strong>.<br/>MySQL Error: '.mysqli_error($cnInfoCentral));
 }
 


### PR DESCRIPTION
Fixed database connection to correctly implement port number (regression bug introduced in #4071)


#### What's this PR do?
Fixes a bug introduced when connecting to MySQL using TCP/IP. Bug introduced in PR #4071 

#### Screenshots (if appropriate)

#### What Issues does it Close?

Closes #4413
Closes #4203

#### What are the relevant tickets?
#4413 and #4203 

#### Any background context you want to provide?
Basically the carry-over from the old `mysql_connect()` days where you could use `host:port`, eg `127.0.0.1:3306` as the connection target won't work in the new shiny `mysqli_connect()` method. The newer `mysqli` library expects the database connection to be passed the hostname, user, password, database name *then* port number. As we call `mysqli_select_db()` after making the connection, the fix is to pass an explicit `null` as the database name so the positional parameter for port number is passed to `mysqli_connect` in the expected position. This will affect anyone not using UNIX Sockets or Windows named pipes for DB connections.

I create a quick hack using the same logic as the `LoadConfigs.php` which can be run via CLI or called from a web browser. It is **NOT** secure as should be used only for testing/development *ONLY*.
(See following attachment).
[testdb.php.zip](https://github.com/ChurchCRM/CRM/files/2327302/testdb.php.zip)

#### Where should the reviewer start?
#4055 then look at #4071 then this PR.

#### How should this be manually tested?
1. Connect with `Config.php` with `$sSERVERNAME='localhost';`.
2. Change `Config.php` to use `$sSERVERNAME = '127.0.0.1';` and connect again.

Both connections should be successful.

#### How should the automated tests treat this?
No special handling required.

#### Questions:
- Is there a related website / article to substantiate / explain this change?
  -  [ ] Yes - Link:
  -  [x] No

- Does the development wiki need an update?
  -  [ ] Yes - Link:
  -  [x] No

- Does the user documentation wiki need an update?
  -  [ ] Yes - Link:
  -  [x] No

- Does this add new dependencies?
  -  [ ] Yes
  -  [x] No

- Does this need to add new data to the demo database
  -  [ ] Yes
  -  [x] No
