### PR TITLE
Created DB connection failure log messaging

### DIFF
--- a/src/Include/LoadConfigs.php
+++ b/src/Include/LoadConfigs.php
@@ -28,6 +28,7 @@ use ChurchCRM\Utils\LoggerUtils;
 
 function system_failure($message, $header = 'Setup failure')
 {
+    $sPageTitle = $header;
     if (!SystemConfig::isInitialized()) {
         SystemConfig::init();
     }
@@ -72,16 +73,39 @@ SystemURLs::checkAllowedURL($bLockURL, $URL);
 // Due to mysqli handling connections on 'localhost' via socket only, we need to tease out this case and handle
 // TCP/IP connections separately defaulting $dbPort to 3306 for the general case when $dbPort is not set.
 if ($sSERVERNAME == "localhost") {
-    $cnInfoCentral = mysqli_connect($sSERVERNAME, $sUSER, $sPASSWORD)
-    or system_failure('Could not connect to MySQL on <strong>'.$sSERVERNAME.'</strong> as <strong>'.$sUSER.'</strong>. Please check the settings in <strong>Include/Config.php</strong>.<br/>MySQL Error: '.mysqli_error($cnInfoCentral));
+    $cnInfoCentral = mysqli_connect($sSERVERNAME, $sUSER, $sPASSWORD);
 } else {
     if (!isset($dbPort)) {
         $dbPort=3306;
     }
     // Connect via TCP to specified port and pass a 'null' for database name.
     // We specify the database name in a different call, ie 'mysqli_select_db()' just below here
-    $cnInfoCentral = mysqli_connect($sSERVERNAME, $sUSER, $sPASSWORD, null, $dbPort)
-        or system_failure('Could not connect to MySQL on <strong>'.$sSERVERNAME.'</strong> on port <strong>'.$dbPort.'</strong> as <strong>'.$sUSER.'</strong>. Please check the settings in <strong>Include/Config.php</strong>.<br/>MySQL Error: '.mysqli_error($cnInfoCentral));
+    $cnInfoCentral = mysqli_connect($sSERVERNAME, $sUSER, $sPASSWORD, null, $dbPort);
+}
+
+// Do we have a connection to the database? If not, log it and tell the user
+if (!$cnInfoCentral) {
+    
+    // Sanitise the mysqli_connect_error if required.
+    $sMYSQLERROR="none captured";
+    if( strlen( mysqli_connect_error() )>0 ) {
+        $sMYSQLERROR=mysqli_connect_error();
+    }
+
+    // If connecting via a socket, convert $dbPort to something sensible.
+    if ( $sSERVERNAME == "localhost" ){
+        $dbPort = "Unix socket";
+    }
+
+    // Need to initialise otherwise logging etc will fail!
+    if (!SystemConfig::isInitialized()) {
+        SystemConfig::init();
+    }
+
+    // Log the error to the application log, and show an error page to user.
+    LoggerUtils::getAppLogger()->error("ERROR connecting to database at '".$sSERVERNAME."' on port '".$dbPort."' as user '".$sUSER."' -  MySQL Error: '".$sMYSQLERROR."'");
+    system_failure('Could not connect to MySQL on <strong>'.$sSERVERNAME.'</strong> on port <strong>'.$dbPort.'</strong> as <strong>'.$sUSER.'</strong>. Please check the settings in <strong>Include/Config.php</strong>.<br/>MySQL Error: '.$sMYSQLERROR, 'Database Connection Failure');
+    
 }
 
 mysqli_set_charset($cnInfoCentral, 'utf8mb4');


### PR DESCRIPTION
Created DB connection failure log message and tidied up the 'system_failure()' function (in `LoadConfigs.php`) so the passed in `$header` is used as the page title for failure messages.

The changes made to `LoadConfigs.php` are as follows:
1. If a database connection could not be established, a log message is created in `logs/YYY-MM-DD-app.log`, for example:
`[2018-09-05 05:13:28] defaultLogger.ERROR: ERROR connecting to database at '127.0.0.1' on port '3306' as user 'churchcrm' -  MySQL Error: 'Access denied for user 'churchcrm'@'localhost' (using password: YES)' [] []`
2. Accomodation has been made to make sure Unix socket/named pipe connections on localhost, and TCP/IP host and port connections generate sane and descriptive messages distinguishing the different connection methods.
3. The `system_failure()` function now sets `$sPageTitle` to be the same as the `$header` variable in the function. This makes sure the HTML `<title>....</title>` tag matches the message in the body.
4. Replaced the `mysql_error($cnInfoCentral)` OO style references to the procedural `mysqli_connect_error()` function so the DB connection errors are captured correctly.

#### What's this PR do?
Closes #4458 

#### Screenshots (if appropriate)
![screen shot 2018-09-05 at 3 21 19 pm](https://user-images.githubusercontent.com/6720584/45072989-ae87b800-b120-11e8-9dbd-6c742eab24a0.png)

#### What Issues does it Close?

Closes #4458 

#### What are the relevant tickets?
#4458 

#### Any background context you want to provide?
This PR was born out of a discussion on ChurchCRM/CRM dev chat with @crossan007 regarding the need for more robust logging for ChurchCRM. As DB connections can often be a stumbling block for new users, this PR should allow us to better assist with support requests in future.

#### Where should the reviewer start?
Start with #4458. There's not a lot to this; it's mostly procedural code.

#### How should this be manually tested?
Testing the new code will only be possible with broken DB connection details in `Include/Config.php`. Consequently, start with a known-working configuration, then set an intentionally incorrect parameter (username, password, host or port) and verify the failure message reflects the failed setting (*such as the failed user/password combination in the description at the top*).

#### How should the automated tests treat this?
No different to normal testing. Automated tests shouldn't have broken DB configurations so should never hit this code.

#### Questions:
- Is there a related website / article to substantiate / explain this change?
  -  [ ] Yes - Link:
  -  [x] No

- Does the development wiki need an update?
  -  [ ] Yes - Link:
  -  [x] No

- Does the user documentation wiki need an update?
  -  [ ] Yes - Link:
  -  [x] No

- Does this add new dependencies?
  -  [ ] Yes
  -  [x] No

- Does this need to add new data to the demo database
  -  [ ] Yes
  -  [x] No
