### PR TITLE
Use new MailChimp API Wrapper Class

### DIFF
--- a/src/ChurchCRM/Service/MailChimpService.php
+++ b/src/ChurchCRM/Service/MailChimpService.php
@@ -3,23 +3,41 @@
 namespace ChurchCRM\Service;
 
 use ChurchCRM\dto\SystemConfig;
+use \DrewM\MailChimp\MailChimp;
+use ChurchCRM\Utils\LoggerUtils;
 
 class MailChimpService
 {
     private $isActive = false;
     private $myMailchimp;
+    private $lists;
 
     public function __construct()
     {
         if (!empty(SystemConfig::getValue('sMailChimpApiKey'))) {
             $this->isActive = true;
-            $this->myMailchimp = new \Mailchimp(SystemConfig::getValue('sMailChimpApiKey'));
+            $this->myMailchimp = new MailChimp(SystemConfig::getValue('sMailChimpApiKey'));
         }
     }
 
     public function isActive()
     {
-        return $this->isActive;
+        return $this->isActive; 
+    }
+    private function getListsFromCache(){
+      if (!isset($_SESSION['MailChimpLists'])){
+        LoggerUtils::getAppLogger()->info("Updating MailChimp List Cache");
+        $lists = $this->myMailchimp->get("lists")['lists'];
+        foreach($lists as &$list) {
+          $listmembers = $this->myMailchimp->get('lists/'.$list['id'].'/members',['count' => 100000]);
+          $list['members'] = $listmembers['members'];
+        }
+        $_SESSION['MailChimpLists'] = $lists;
+      }
+      else{
+        LoggerUtils::getAppLogger()->info("Using cached MailChimp List");
+      }
+      return $_SESSION['MailChimpLists'];
     }
 
     public function isEmailInMailChimp($email)
@@ -27,19 +45,27 @@ class MailChimpService
         if (!$this->isActive) {
             return 'Mailchimp is not active';
         }
-
+        
         if ($email == '') {
             return 'No email';
         }
-
+        
         try {
-            $lists = $this->myMailchimp->helper->listsForEmail(['email' => $email]);
+            $lists = $this->getListsFromCache();
             $listNames = [];
-            foreach ($lists as $val) {
-                array_push($listNames, $val['name']);
+            foreach($lists as $list) {
+              foreach ($list['members'] as $listMember) {
+                if (strcmp(strtolower($listMember['email_address']), $email) == 0) {
+                  LoggerUtils::getAppLogger()->info("Found $email in ".$list['name']);
+                  array_push($listNames, $list['name']);
+                }
+              }
             }
 
-            return implode(',', $listNames);
+            $listMemberships = implode(',', $listNames);
+            LoggerUtils::getAppLogger()->info($email. "is a member of ".$listMemberships);
+
+            return $listMemberships;
         } catch (\Mailchimp_Invalid_ApiKey $e) {
             return 'Invalid ApiKey';
         } catch (\Mailchimp_List_NotSubscribed $e) {
@@ -54,12 +80,12 @@ class MailChimpService
     public function getLists()
     {
         if (!$this->isActive) {
-            return 'Mailchimp is not active';
+          return 'Mailchimp is not active';
         }
         try {
-            $result = $this->myMailchimp->lists->getList();
-
-            return $result['data'];
+            $result = $this->getListsFromCache();
+            
+            return $result;
         } catch (\Mailchimp_Invalid_ApiKey $e) {
             return 'Invalid ApiKey';
         } catch (\Exception $e) {

--- a/src/ChurchCRM/Service/MailChimpService.php
+++ b/src/ChurchCRM/Service/MailChimpService.php
@@ -55,7 +55,7 @@ class MailChimpService
             $listNames = [];
             foreach($lists as $list) {
               foreach ($list['members'] as $listMember) {
-                if (strcmp(strtolower($listMember['email_address']), $email) == 0) {
+                if (strcmp(strtolower($listMember['email_address']), strtolower($email)) == 0) {
                   LoggerUtils::getAppLogger()->info("Found $email in ".$list['name']);
                   array_push($listNames, $list['name']);
                 }

--- a/src/composer.json
+++ b/src/composer.json
@@ -30,7 +30,7 @@
     },
     "require": {
         "php": ">=5.6.0",
-        "mailchimp/mailchimp": "2.0.6",
+        "drewm/mailchimp-api": "^2.5",
         "slim/slim": "3.9.2",
         "slim/php-view": "2.2",
         "monolog/monolog": "^1.17",

--- a/src/composer.lock
+++ b/src/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "04b1798c1168ea02c38f2eeabc3b65ef",
+    "content-hash": "625a6db03f7680e59a24ebc489301072",
     "packages": [
         {
             "name": "authorizenet/authorizenet",
@@ -363,6 +363,49 @@
                 "parser"
             ],
             "time": "2014-09-09T13:34:57+00:00"
+        },
+        {
+            "name": "drewm/mailchimp-api",
+            "version": "v2.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/drewm/mailchimp-api.git",
+                "reference": "f532fa26cd6e7d17c9ba40a757d8c6bfee47dace"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/drewm/mailchimp-api/zipball/f532fa26cd6e7d17c9ba40a757d8c6bfee47dace",
+                "reference": "f532fa26cd6e7d17c9ba40a757d8c6bfee47dace",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "7.0.*",
+                "vlucas/phpdotenv": "^2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DrewM\\MailChimp\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Drew McLellan",
+                    "email": "drew.mclellan@gmail.com",
+                    "homepage": "http://allinthehead.com/"
+                }
+            ],
+            "description": "Super-simple, minimum abstraction MailChimp API v3 wrapper",
+            "homepage": "https://github.com/drewm/mailchimp-api",
+            "time": "2018-02-16T15:31:05+00:00"
         },
         {
             "name": "geocoder-php/bing-maps-provider",
@@ -1214,52 +1257,6 @@
                 "jwt"
             ],
             "time": "2017-09-01T08:23:26+00:00"
-        },
-        {
-            "name": "mailchimp/mailchimp",
-            "version": "2.0.6",
-            "source": {
-                "type": "git",
-                "url": "https://bitbucket.org/mailchimp/mailchimp-api-php.git",
-                "reference": "7ac99b5ac746d5875c5c350ad7e3b83674c83ec1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://bitbucket.org/mailchimp/mailchimp-api-php/get/7ac99b5ac746d5875c5c350ad7e3b83674c83ec1.zip",
-                "reference": "7ac99b5ac746d5875c5c350ad7e3b83674c83ec1",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.2.0"
-            },
-            "require-dev": {
-                "apigen/apigen": "dev-master"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "Mailchimp": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "MailChimp Devs",
-                    "email": "api@mailchimp.com",
-                    "homepage": "http://mailchimp.com",
-                    "role": "Developer"
-                }
-            ],
-            "description": "API client library for the MailChimp bulk email as a service platform",
-            "homepage": "https://bitbucket.org/mailchimp/mailchimp-api-php",
-            "keywords": [
-                "api",
-                "email"
-            ],
-            "time": "2014-10-30T20:38:12+00:00"
         },
         {
             "name": "monolog/monolog",

--- a/src/v2/templates/email/dashboard.php
+++ b/src/v2/templates/email/dashboard.php
@@ -56,7 +56,6 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
                     <ul>
                         <li>
                             <a href="<?= SystemURLs::getRootPath()?>/v2/email/missingfrommailchimp"><?= gettext('Missing emails report') ?> </a>
-                            (slow)
                         </li>
                     </ul>
                 </div>


### PR DESCRIPTION
#### What's this PR do?
Uses a light weight wrapper to interact with the MailChimp v3.0 API, instead of the non-maintained wrapper for the V2.0 API.  

Maintains compatibility with all existing MailChimp integration

greatly improves the speed of the Emails Missing from Mail Chimp report (originally 16 seconds, now 4 seconds for a 100 person DB).

Improves performance loading of PersonView.php by ~200 ms


#### What Issues does it Close?

Closes #4462
