### PR TITLE
Add logging to external backup

### DIFF
--- a/src/ChurchCRM/Service/SystemService.php
+++ b/src/ChurchCRM/Service/SystemService.php
@@ -375,7 +375,11 @@ class SystemService
       }
       $tz = new \DateTimeZone(SystemConfig::getValue('sTimeZone'));
       $now = new \DateTime("now", $tz);  //get the current time
-      $previous = \DateTime::createFromFormat(SystemConfig::getValue('sDateTimeFormat'),$LastTime, $tz); // get a DateTime object for the last time a backup was done.
+      $previous = \DateTime::createFromFormat(SystemConfig::getValue('sDateFilenameFormat'),$LastTime, $tz); // get a DateTime object for the last time a backup was done.
+      if ($previous === false)
+      {
+        return true;
+      }
       $diff = abs($now->getTimestamp() - $previous->getTimestamp()) / 60 / 60 ;
       return $diff->h >= $ThresholdHours;
     }
@@ -391,7 +395,7 @@ class SystemService
               LoggerUtils::getAppLogger()->addInfo("Starting a backup job.  Last backup run: ".SystemConfig::getValue('sLastBackupTimeStamp'));   
               $backup = self::copyBackupToExternalStorage();  // Tell system service to do an external storage backup.
               $now = new \DateTime();  // update the LastBackupTimeStamp.
-              SystemConfig::setValue('sLastBackupTimeStamp', $now->format(SystemConfig::getValue('sDateTimeFormat')));
+              SystemConfig::setValue('sLastBackupTimeStamp', $now->format(SystemConfig::getValue('sDateFilenameFormat')));
               LoggerUtils::getAppLogger()->addInfo("Backup job successful: '".$backup->filename."' (".$backup->filesize." bytes) copied to '".$backup->remoteUrl."'");
             }
             else {
@@ -410,7 +414,7 @@ class SystemService
                 $appIntegrity = AppIntegrityService::verifyApplicationIntegrity();
                 file_put_contents($integrityCheckFile, json_encode($appIntegrity));
                 $now = new \DateTime();  // update the LastBackupTimeStamp.
-                SystemConfig::setValue('sLastIntegrityCheckTimeStamp', $now->format(SystemConfig::getValue('sDateTimeFormat')));
+                SystemConfig::setValue('sLastIntegrityCheckTimeStamp', $now->format(SystemConfig::getValue('sDateFilenameFormat')));
                 if ($appIntegrity['result'] == 'success')
                 {
                   LoggerUtils::getAppLogger()->addInfo("Application integrity check passed");

--- a/src/ChurchCRM/Service/SystemService.php
+++ b/src/ChurchCRM/Service/SystemService.php
@@ -377,7 +377,6 @@ class SystemService
       $now = new \DateTime("now", $tz);  //get the current time
       $previous = \DateTime::createFromFormat(SystemConfig::getValue('sDateTimeFormat'),$LastTime, $tz); // get a DateTime object for the last time a backup was done.
       $diff = abs($now->getTimestamp() - $previous->getTimestamp()) / 60 / 60 ;
-      LoggerUtils::getAppLogger()->addInfo("Difference from '". $previous->format(SystemConfig::getValue('sDateTimeFormat'))."' to '".$now->format(SystemConfig::getValue('sDateTimeFormat'))."' is: ".$diff." hours");
       return $diff->h >= $ThresholdHours;
     }
 
@@ -396,7 +395,7 @@ class SystemService
               LoggerUtils::getAppLogger()->addInfo("Backup job successful: '".$backup->filename."' (".$backup->filesize." bytes) copied to '".$backup->remoteUrl."'");
             }
             else {
-              LoggerUtils::getAppLogger()->addInfo("Not starting a backup job.  Last backup run: ".SystemConfig::getValue('sLastBackupTimeStamp').". ".$diff->h." hours since last backup is less than the threshold of ".SystemConfig::getValue('sExternalBackupAutoInterval'));  
+              LoggerUtils::getAppLogger()->addInfo("Not starting a backup job.  Last backup run: ".SystemConfig::getValue('sLastBackupTimeStamp').".");  
             }
           } catch (\Exception $exc) {
               // an error in the auto-backup shouldn't prevent the page from loading...

--- a/src/ChurchCRM/utils/LoggerUtils.php
+++ b/src/ChurchCRM/utils/LoggerUtils.php
@@ -9,6 +9,8 @@ use ChurchCRM\dto\SystemURLs;
 
 class LoggerUtils
 {
+    private static $appLogger;
+    private static $cspLogger; 
     public static function getLogLevel()
     {
         return intval(SystemConfig::getValue("sLogLevel"));
@@ -24,16 +26,20 @@ class LoggerUtils
      */
     public static function getAppLogger()
     {
-        $logger = new Logger('defaultLogger');
-        $logger->pushHandler(new StreamHandler(self::buildLogFilePath("app"), self::getLogLevel()));
-        return $logger;
+      if (is_null(self::$appLogger)){
+        self::$appLogger = new Logger('defaultLogger');
+        self::$appLogger->pushHandler(new StreamHandler(self::buildLogFilePath("app"), self::getLogLevel()));
+      }
+      return self::$appLogger;
     }
 
     public static function getCSPLogger()
     {
-        $logger = new Logger('cspLogger');
-        $logger->pushHandler(new StreamHandler(self::buildLogFilePath("csp"), self::getLogLevel()));
-        return $logger;
+      if (is_null(self::$cspLogger)){
+        self::$cspLogger = new Logger('cspLogger');
+        self::$cspLogger->pushHandler(new StreamHandler(self::buildLogFilePath("csp"), self::getLogLevel()));
+      }
+      return self::$cspLogger;
     }
 
 }


### PR DESCRIPTION
#### What's this PR do?
Adds application logging to timer jobs (backup and integrity check).
fixes issue where external backups sometimes fail.

#### What Issues does it Close?

Closes #4457 

#### How should this be manually tested?

Configure a WebDav or local "external" backup.  
Monitor the application event log.

Manipulate `sLastBackupTimeStamp` and `sLastIntegrityCheckTimeStamp` to ensure application always behaves correctly.
