### PR TITLE
add admin task to warn about short execution times

### DIFF
--- a/src/ChurchCRM/Service/TaskService.php
+++ b/src/ChurchCRM/Service/TaskService.php
@@ -17,6 +17,7 @@ use ChurchCRM\Tasks\PersonRoleDataCheck;
 use ChurchCRM\Tasks\PrerequisiteCheckTask;
 use ChurchCRM\Tasks\RegisteredTask;
 use ChurchCRM\Tasks\UpdateFamilyCoordinatesTask;
+use ChurchCRM\Tasks\CheckExecutionTimeTask;
 
 class TaskService
 {
@@ -41,7 +42,8 @@ class TaskService
             new PersonClassificationDataCheck(),
             new PersonRoleDataCheck(),
             new UpdateFamilyCoordinatesTask(),
-            new CheckUploadSizeTask()
+            new CheckUploadSizeTask(),
+            new CheckExecutionTimeTask()
         ];
 
         $this->notificationClasses = [

--- a/src/ChurchCRM/tasks/CheckExecutionTimeTask.php
+++ b/src/ChurchCRM/tasks/CheckExecutionTimeTask.php
@@ -1,0 +1,41 @@
+<?php
+
+
+namespace ChurchCRM\Tasks;
+
+
+class CheckExecutionTimeTask
+{
+    private $executionTime;
+
+    public function __construct()
+    {
+        $this->executionTime = ini_get('max_execution_time');
+    }
+
+    public function isActive()
+    {
+        return $this->sizeBytes < 120;
+    }
+
+    public function isAdmin()
+    {
+        return true;
+    }
+
+    public function getLink()
+    {
+        return 'https://github.com/ChurchCRM/CRM/wiki/PHP-Max-Execution-Time';
+    }
+
+    public function getTitle()
+    {
+        return gettext('PHP Max Execution Time is too Short') . " (" . $this->executionTime . ")";
+    }
+
+    public function getDesc()
+    {
+        return gettext("Increase the PHP execution time limit to allow for backup and restore.");
+    }
+
+}


### PR DESCRIPTION
#### What's this PR do?
Adds an admin task if the PHP `max_execution_time` is too short.  This can present a common failure for database backups and restores

#### What Issues does it Close?

Closes #4451 


Relates to: https://github.com/ChurchCRM/CRM/wiki/PHP-Max-Execution-Time