### PR TITLE
Use system configuration to format dates.

### DIFF
--- a/src/Reports/ConfirmReport.php
+++ b/src/Reports/ConfirmReport.php
@@ -219,7 +219,7 @@ while ($aFam = mysqli_fetch_array($rsFamilies)) {
         $pdf->WriteAtCell($XRole, $curY, $XEmail - $XRole, $sFamRole);
         $pdf->WriteAtCell($XEmail, $curY, $XBirthday - $XEmail, $per_Email);
 
-        $birthdayStr = MiscUtils::FormatBirthDate($per_BirthYear, $per_BirthMonth, $per_BirthDay);
+        $birthdayStr = MiscUtils::FormatBirthDate($per_BirthYear, $per_BirthMonth, $per_BirthDay, $null, $null);
         //If the "HideAge" check box is true, then create a Yes/No representation of the check box.
         if ($per_Flags) {
             $hideAgeStr = gettext('Yes');

--- a/src/Reports/ConfirmReport.php
+++ b/src/Reports/ConfirmReport.php
@@ -14,6 +14,7 @@ require '../Include/ReportFunctions.php';
 
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\Reports\ChurchInfoReport;
+use ChurchCRM\Utils\MiscUtils;
 
 class PDF_ConfirmReport extends ChurchInfoReport
 {
@@ -149,7 +150,9 @@ while ($aFam = mysqli_fetch_array($rsFamilies)) {
     $pdf->SetFont('Times', 'B', 10);
     $pdf->WriteAtCell(SystemConfig::getValue('leftX'), $curY, $dataCol - SystemConfig::getValue('leftX'), gettext('Anniversary Date'));
     $pdf->SetFont('Times', '', 10);
-    $pdf->WriteAtCell($dataCol, $curY, $dataWid, FormatDate($fam_WeddingDate));
+    if ($fam_WeddingDate != "") {
+        $pdf->WriteAtCell($dataCol, $curY, $dataWid, date_format(date_create($fam_WeddingDate), SystemConfig::getValue("sDateFormatLong")));
+    }
     $curY += SystemConfig::getValue('incrementY');
 
     $pdf->SetFont('Times', 'B', 10);
@@ -215,13 +218,8 @@ while ($aFam = mysqli_fetch_array($rsFamilies)) {
         $pdf->WriteAtCell($XGender, $curY, $XRole - $XGender, $genderStr);
         $pdf->WriteAtCell($XRole, $curY, $XEmail - $XRole, $sFamRole);
         $pdf->WriteAtCell($XEmail, $curY, $XBirthday - $XEmail, $per_Email);
-        if ($per_BirthYear) {
-            $birthdayStr = $per_BirthYear.'-'.$per_BirthMonth.'-'.$per_BirthDay;
-        } elseif ($per_BirthMonth) {
-            $birthdayStr = $per_BirthMonth.'-'.$per_BirthDay;
-        } else {
-            $birthdayStr = '';
-        }
+
+        $birthdayStr = MiscUtils::FormatBirthDate($per_BirthYear, $per_BirthMonth, $per_BirthDay);
         //If the "HideAge" check box is true, then create a Yes/No representation of the check box.
         if ($per_Flags) {
             $hideAgeStr = gettext('Yes');


### PR DESCRIPTION
#### What's this PR do?

On the PDF confirm report:

- Uses MiscUtils::FormatBirthDate to format the birthdays
- Uses sDateFormatLong to format the wedding anniversary

#### What Issues does it Close?

Closes #4476

#### What are the relevant tickets?

#### Any background context you want to provide?

#### Where should the reviewer start?

Generate a confirm report:

1. On a Family View page, click the Verify Info button.
2. Click PDF Report button

#### How should this be manually tested?

Try changing the system settings for dates:

- Birthdays: sDateFormatNoYear sDateFormatLong
- Wedding anniversary: sDateFormatLong

Try having families with no anniversary, people with birthdays with different parts.

#### How should the automated tests treat this?

#### Questions:
- Is there a related website / article to substantiate / explain this change?
  -  [X] No

- Does the development wiki need an update?
  -  [X] No

- Does the user documentation wiki need an update?
  -  [X] No

- Does this add new dependencies?
  -  [X] No

- Does this need to add new data to the demo database
  -  [X] No

