### PR TITLE
Don't display modal dialog if an XHR was aborted locally.

### DIFF
--- a/src/skin/js/CRMJSOM.js
+++ b/src/skin/js/CRMJSOM.js
@@ -527,7 +527,8 @@
         } catch(err) {
           var errortext = textStatus + " " + errorThrown;
         }
-        if (suppressErrorDialog !== true) {
+        
+        if ( !(textStatus == "abort" || suppressErrorDialog) ) {
           if(CRMResponse) {
              window.CRM.DisplayErrorMessage(jqXHR.url, CRMResponse);
           }


### PR DESCRIPTION
#### What's this PR do?
Don't show XHR errors if status is `abort` 

#### What Issues does it Close?

Closes #4436 
Closes #4409 
Closes #4283
