### PR TITLE
Fix the issue reporter

### DIFF
--- a/src/ChurchCRM/Service/SystemService.php
+++ b/src/ChurchCRM/Service/SystemService.php
@@ -326,12 +326,15 @@ class SystemService
     static public function getPrerequisiteStatus() {
       if (AppIntegrityService::arePrerequisitesMet())
       {
-        return "All Prerequisites met";
+         return "All Prerequisites met";
       }
       else
       {
-        $missingPrerequisiteNames = array_map(create_function('$o','return $o["name"];'),AppIntegrityService::getUnmetPrerequisites());
-        return "Missing Prerequisites: ".json_encode($missingPrerequisiteNames);
+        $unmet = AppIntegrityService::getUnmetPrerequisites();
+        $unmetNames = array_map(function($o) {
+            return (string)($o->GetName());
+          }, $unmet);
+        return "Missing Prerequisites: ".json_encode($unmetNames);
       }
     }
 


### PR DESCRIPTION
#### What's this PR do?
Fix bug reporter so that array_map callback function uses GetName() method of Prerequisite class instead of trying to access the "name" key/value pair

#### What Issues does it Close?

Closes #4543 
