### PR TITLE
Fix Propel type of SQL colum fam_SendNewsLetter

### DIFF
--- a/propel/schema.xml
+++ b/propel/schema.xml
@@ -158,7 +158,8 @@
                 defaultValue="0"/>
         <column name="fam_scanCheck" phpName="ScanCheck" type="LONGVARCHAR"/>
         <column name="fam_scanCredit" phpName="ScanCredit" type="LONGVARCHAR"/>
-        <column name="fam_SendNewsLetter" phpName="SendNewsletter" type="BOOLEAN" required="true" defaultValue="FALSE"/>
+        <column name="fam_SendNewsLetter" phpName="SendNewsletter" type="CHAR" sqlType="enum('FALSE','TRUE')"
+                required="true" defaultValue="FALSE"/>
         <column name="fam_DateDeactivated" phpName="DateDeactivated" type="DATE"/>
         <column name="fam_OkToCanvass" phpName="OkToCanvass" type="CHAR" sqlType="enum('FALSE','TRUE')" required="true"
                 defaultValue="FALSE"/>


### PR DESCRIPTION
#### What's this PR do?
Changes the Propel schema to match existing (and newly deployed) database schema so that `fam_SendNewsLetter` is correctly filterable by true/false

#### What Issues does it Close?

Closes #4605

NOTE: To test this fix, the model must be regenerated by running `npm run orm-gen` from the project base directory, or simply by using the next auto-build