### PR TITLE
updated npm devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "ChurchCRM",
-    "version": "3.1.2",
+    "version": "3.2.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -19,10 +19,10 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
             "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
             "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.1.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
             }
         },
         "amdefine": {
@@ -51,15 +51,15 @@
             "integrity": "sha1-TyGU1tj5nfP1MeaIHxTxXVX6ryI=",
             "dev": true,
             "requires": {
-                "archiver-utils": "1.3.0",
-                "async": "2.6.1",
-                "buffer-crc32": "0.2.13",
-                "glob": "7.1.2",
-                "lodash": "4.17.10",
-                "readable-stream": "2.3.6",
-                "tar-stream": "1.6.1",
-                "walkdir": "0.0.11",
-                "zip-stream": "1.2.0"
+                "archiver-utils": "^1.3.0",
+                "async": "^2.0.0",
+                "buffer-crc32": "^0.2.1",
+                "glob": "^7.0.0",
+                "lodash": "^4.8.0",
+                "readable-stream": "^2.0.0",
+                "tar-stream": "^1.5.0",
+                "walkdir": "^0.0.11",
+                "zip-stream": "^1.1.0"
             }
         },
         "archiver-utils": {
@@ -68,12 +68,12 @@
             "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
             "dev": true,
             "requires": {
-                "glob": "7.1.2",
-                "graceful-fs": "4.1.11",
-                "lazystream": "1.0.0",
-                "lodash": "4.17.10",
-                "normalize-path": "2.1.1",
-                "readable-stream": "2.3.6"
+                "glob": "^7.0.0",
+                "graceful-fs": "^4.1.0",
+                "lazystream": "^1.0.0",
+                "lodash": "^4.8.0",
+                "normalize-path": "^2.0.0",
+                "readable-stream": "^2.0.0"
             }
         },
         "are-we-there-yet": {
@@ -81,17 +81,25 @@
             "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
             "integrity": "sha1-SzXClE8GKov82mZBB2A1D+nd/CE=",
             "requires": {
-                "delegates": "1.0.0",
-                "readable-stream": "2.3.6"
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
             }
         },
         "argparse": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
             "requires": {
-                "sprintf-js": "1.0.3"
+                "sprintf-js": "~1.0.2"
+            },
+            "dependencies": {
+                "sprintf-js": {
+                    "version": "1.0.3",
+                    "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                    "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+                    "dev": true
+                }
             }
         },
         "array-find-index": {
@@ -104,7 +112,7 @@
             "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
             "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
             "requires": {
-                "safer-buffer": "2.1.2"
+                "safer-buffer": "~2.1.0"
             }
         },
         "assert-plus": {
@@ -117,7 +125,7 @@
             "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
             "integrity": "sha1-skWiPKcZMAROxT+kaqAKPofGphA=",
             "requires": {
-                "lodash": "4.17.10"
+                "lodash": "^4.17.10"
             }
         },
         "async-foreach": {
@@ -157,7 +165,7 @@
             "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
             "optional": true,
             "requires": {
-                "tweetnacl": "0.14.5"
+                "tweetnacl": "^0.14.3"
             }
         },
         "bl": {
@@ -166,8 +174,8 @@
             "integrity": "sha1-oWCRFxcQPAdBDO9j71Gzl8Alr5w=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.6",
-                "safe-buffer": "5.1.2"
+                "readable-stream": "^2.3.5",
+                "safe-buffer": "^5.1.1"
             }
         },
         "block-stream": {
@@ -175,21 +183,15 @@
             "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
             "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
             "requires": {
-                "inherits": "2.0.3"
+                "inherits": "~2.0.0"
             }
-        },
-        "bluebird": {
-            "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-            "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
-            "dev": true
         },
         "boom": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.0.tgz",
             "integrity": "sha1-K/8kpVVldn/ehp7ICDF+sQxI6WY=",
             "requires": {
-                "hoek": "5.0.4"
+                "hoek": "5.x.x"
             }
         },
         "bootbox": {
@@ -228,8 +230,8 @@
             "integrity": "sha1-47rGjHP9JW44CWVR78CfUEhzyMg=",
             "optional": true,
             "requires": {
-                "boom": "7.2.0",
-                "hoek": "5.0.4"
+                "boom": "7.x.x",
+                "hoek": "5.x.x"
             }
         },
         "brace-expansion": {
@@ -237,7 +239,7 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -247,8 +249,8 @@
             "integrity": "sha1-U8+YJBEACZ6e6uIO5tUdIbFuVB4=",
             "dev": true,
             "requires": {
-                "base64-js": "1.3.0",
-                "ieee754": "1.1.12"
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4"
             }
         },
         "buffer-alloc": {
@@ -257,8 +259,8 @@
             "integrity": "sha1-iQ3ZDZI6hz4I4Q5f1RpX5bfM4Ow=",
             "dev": true,
             "requires": {
-                "buffer-alloc-unsafe": "1.1.0",
-                "buffer-fill": "1.0.0"
+                "buffer-alloc-unsafe": "^1.1.0",
+                "buffer-fill": "^1.0.0"
             }
         },
         "buffer-alloc-unsafe": {
@@ -294,8 +296,8 @@
             "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
             "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
             "requires": {
-                "camelcase": "2.1.1",
-                "map-obj": "1.0.1"
+                "camelcase": "^2.0.0",
+                "map-obj": "^1.0.0"
             }
         },
         "caseless": {
@@ -308,11 +310,11 @@
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
             "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
             }
         },
         "chownr": {
@@ -332,9 +334,9 @@
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
             "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
             "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wrap-ansi": "2.1.0"
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wrap-ansi": "^2.0.0"
             }
         },
         "co": {
@@ -347,15 +349,30 @@
             "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
             "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
-        "coffee-script": {
+        "coffeescript": {
             "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.10.0.tgz",
-            "integrity": "sha1-EpOLz5vhlI+gBvkuDEyegXBRCMA=",
+            "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.10.0.tgz",
+            "integrity": "sha1-56qDAZF+9iGzXYo580jc3R234z4=",
+            "dev": true
+        },
+        "color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "requires": {
+                "color-name": "1.1.3"
+            }
+        },
+        "color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
             "dev": true
         },
         "colors": {
             "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+            "resolved": "http://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
             "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
             "dev": true
         },
@@ -364,14 +381,8 @@
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
             "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
             "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
             }
-        },
-        "commander": {
-            "version": "2.17.1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-            "integrity": "sha1-vXerfebelCBc6sxy8XFtKfIKd78=",
-            "dev": true
         },
         "compress-commons": {
             "version": "1.2.2",
@@ -379,10 +390,10 @@
             "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "0.2.13",
-                "crc32-stream": "2.0.0",
-                "normalize-path": "2.1.1",
-                "readable-stream": "2.3.6"
+                "buffer-crc32": "^0.2.1",
+                "crc32-stream": "^2.0.0",
+                "normalize-path": "^2.0.0",
+                "readable-stream": "^2.0.0"
             }
         },
         "concat-map": {
@@ -406,7 +417,7 @@
             "integrity": "sha1-rWAmnCyFb4wpnixMwN5FVpFAVsY=",
             "dev": true,
             "requires": {
-                "buffer": "5.2.0"
+                "buffer": "^5.1.0"
             }
         },
         "crc32-stream": {
@@ -415,8 +426,8 @@
             "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
             "dev": true,
             "requires": {
-                "crc": "3.8.0",
-                "readable-stream": "2.3.6"
+                "crc": "^3.4.4",
+                "readable-stream": "^2.0.0"
             }
         },
         "cross-spawn": {
@@ -424,8 +435,8 @@
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
             "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
             "requires": {
-                "lru-cache": "4.1.5",
-                "which": "1.3.1"
+                "lru-cache": "^4.0.1",
+                "which": "^1.2.9"
             }
         },
         "cryptiles": {
@@ -434,21 +445,15 @@
             "integrity": "sha1-NjyatchZ2p0tb7kBtk2YCWYYEYQ=",
             "optional": true,
             "requires": {
-                "boom": "7.2.0"
+                "boom": "7.x.x"
             }
-        },
-        "ctype": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
-            "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8=",
-            "dev": true
         },
         "currently-unhandled": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
             "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
             "requires": {
-                "array-find-index": "1.0.2"
+                "array-find-index": "^1.0.1"
             }
         },
         "dashdash": {
@@ -456,7 +461,7 @@
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             }
         },
         "dateformat": {
@@ -465,8 +470,8 @@
             "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
             "dev": true,
             "requires": {
-                "get-stdin": "4.0.1",
-                "meow": "3.7.0"
+                "get-stdin": "^4.0.1",
+                "meow": "^3.3.0"
             }
         },
         "decamelize": {
@@ -481,7 +486,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "mimic-response": "1.0.1"
+                "mimic-response": "^1.0.0"
             }
         },
         "deep-extend": {
@@ -514,8 +519,8 @@
             "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
             "optional": true,
             "requires": {
-                "jsbn": "0.1.1",
-                "safer-buffer": "2.1.2"
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
             }
         },
         "end-of-stream": {
@@ -524,7 +529,7 @@
             "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
             "dev": true,
             "requires": {
-                "once": "1.4.0"
+                "once": "^1.4.0"
             }
         },
         "error-ex": {
@@ -532,7 +537,7 @@
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
             "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
             "requires": {
-                "is-arrayish": "0.2.1"
+                "is-arrayish": "^0.2.1"
             }
         },
         "escape-string-regexp": {
@@ -548,7 +553,7 @@
         },
         "eventemitter2": {
             "version": "0.4.14",
-            "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+            "resolved": "http://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
             "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
             "dev": true
         },
@@ -596,17 +601,17 @@
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
             "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
             "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             }
         },
         "findup-sync": {
             "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
+            "resolved": "http://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
             "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
             "dev": true,
             "requires": {
-                "glob": "5.0.15"
+                "glob": "~5.0.0"
             },
             "dependencies": {
                 "glob": {
@@ -615,11 +620,11 @@
                     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                     "dev": true,
                     "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 }
             }
@@ -629,8 +634,8 @@
             "resolved": "https://registry.npmjs.org/flopmang/-/flopmang-0.0.1.tgz",
             "integrity": "sha1-c+SBTu65S0S1rP2CBtknVqzfs+g=",
             "requires": {
-                "underscore": "1.9.1",
-                "underscore.string": "2.4.0"
+                "underscore": "^1.6.0",
+                "underscore.string": "^2.3.3"
             }
         },
         "font-awesome": {
@@ -648,9 +653,9 @@
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
             "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
             "requires": {
-                "asynckit": "0.4.0",
+                "asynckit": "^0.4.0",
                 "combined-stream": "1.0.6",
-                "mime-types": "2.1.19"
+                "mime-types": "^2.1.12"
             }
         },
         "fs-constants": {
@@ -669,10 +674,10 @@
             "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
             "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
             "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
             }
         },
         "fullcalendar": {
@@ -680,8 +685,8 @@
             "resolved": "https://registry.npmjs.org/fullcalendar/-/fullcalendar-3.0.1.tgz",
             "integrity": "sha1-YUlMzemNOSFSnPe4CKr0nT7zLPc=",
             "requires": {
-                "jquery": "3.3.1",
-                "moment": "2.22.2"
+                "jquery": ">=2.0.0",
+                "moment": ">=2.9.0"
             }
         },
         "gauge": {
@@ -689,14 +694,14 @@
             "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
             "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
             "requires": {
-                "aproba": "1.2.0",
-                "console-control-strings": "1.1.0",
-                "has-unicode": "2.0.1",
-                "object-assign": "4.1.1",
-                "signal-exit": "3.0.2",
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wide-align": "1.1.3"
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
             }
         },
         "gaze": {
@@ -704,22 +709,7 @@
             "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
             "integrity": "sha1-xEFzPhO5J6yMD/C0w7Az8ogSkko=",
             "requires": {
-                "globule": "1.2.1"
-            }
-        },
-        "generate-function": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-            "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-            "dev": true
-        },
-        "generate-object-property": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-            "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-            "dev": true,
-            "requires": {
-                "is-property": "1.0.2"
+                "globule": "^1.0.0"
             }
         },
         "get-caller-file": {
@@ -743,7 +733,7 @@
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             }
         },
         "github-from-package": {
@@ -758,12 +748,12 @@
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
             "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
             "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "globule": {
@@ -771,9 +761,9 @@
             "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
             "integrity": "sha1-Xf+xsZHyLSB5epNptJ6rTpg5aW0=",
             "requires": {
-                "glob": "7.1.2",
-                "lodash": "4.17.10",
-                "minimatch": "3.0.4"
+                "glob": "~7.1.1",
+                "lodash": "~4.17.10",
+                "minimatch": "~3.0.2"
             }
         },
         "graceful-fs": {
@@ -782,27 +772,28 @@
             "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
         },
         "grunt": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.0.1.tgz",
-            "integrity": "sha1-6HeHZOlEsY8yuw8QuQeEdcnftWs=",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.0.3.tgz",
+            "integrity": "sha512-/JzmZNPfKorlCrrmxWqQO4JVodO+DVd5XX4DkocL/1WlLlKVLE9+SdEIempOAxDhWPysLle6afvn/hg7Ck2k9g==",
             "dev": true,
             "requires": {
-                "coffee-script": "1.10.0",
-                "dateformat": "1.0.12",
-                "eventemitter2": "0.4.14",
-                "exit": "0.1.2",
-                "findup-sync": "0.3.0",
-                "glob": "7.0.6",
-                "grunt-cli": "1.2.0",
-                "grunt-known-options": "1.1.1",
-                "grunt-legacy-log": "1.0.2",
-                "grunt-legacy-util": "1.0.0",
-                "iconv-lite": "0.4.23",
-                "js-yaml": "3.5.5",
-                "minimatch": "3.0.4",
-                "nopt": "3.0.6",
-                "path-is-absolute": "1.0.1",
-                "rimraf": "2.2.8"
+                "coffeescript": "~1.10.0",
+                "dateformat": "~1.0.12",
+                "eventemitter2": "~0.4.13",
+                "exit": "~0.1.1",
+                "findup-sync": "~0.3.0",
+                "glob": "~7.0.0",
+                "grunt-cli": "~1.2.0",
+                "grunt-known-options": "~1.1.0",
+                "grunt-legacy-log": "~2.0.0",
+                "grunt-legacy-util": "~1.1.1",
+                "iconv-lite": "~0.4.13",
+                "js-yaml": "~3.5.2",
+                "minimatch": "~3.0.2",
+                "mkdirp": "~0.5.1",
+                "nopt": "~3.0.6",
+                "path-is-absolute": "~1.0.0",
+                "rimraf": "~2.6.2"
             },
             "dependencies": {
                 "glob": {
@@ -811,31 +802,25 @@
                     "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.2",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "grunt-cli": {
                     "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.2.0.tgz",
+                    "resolved": "http://registry.npmjs.org/grunt-cli/-/grunt-cli-1.2.0.tgz",
                     "integrity": "sha1-VisRnrsGndtGSs4oRVAb6Xs1tqg=",
                     "dev": true,
                     "requires": {
-                        "findup-sync": "0.3.0",
-                        "grunt-known-options": "1.1.1",
-                        "nopt": "3.0.6",
-                        "resolve": "1.1.7"
+                        "findup-sync": "~0.3.0",
+                        "grunt-known-options": "~1.1.0",
+                        "nopt": "~3.0.6",
+                        "resolve": "~1.1.0"
                     }
-                },
-                "rimraf": {
-                    "version": "2.2.8",
-                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-                    "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
-                    "dev": true
                 }
             }
         },
@@ -845,7 +830,7 @@
             "integrity": "sha1-GUQ6caDegsPn7U4oiQ2PaduTVBw=",
             "dev": true,
             "requires": {
-                "readline-sync": "1.4.9"
+                "readline-sync": "~1.4.9"
             }
         },
         "grunt-contrib-clean": {
@@ -854,8 +839,8 @@
             "integrity": "sha1-ay7ZQRfix//jLuBFeMlv5GJam20=",
             "dev": true,
             "requires": {
-                "async": "1.5.2",
-                "rimraf": "2.6.2"
+                "async": "^1.5.2",
+                "rimraf": "^2.5.1"
             },
             "dependencies": {
                 "async": {
@@ -872,12 +857,12 @@
             "integrity": "sha1-NiEum7tB6bQf9vvi/HcoHGmrAqA=",
             "dev": true,
             "requires": {
-                "archiver": "1.3.0",
-                "chalk": "1.1.3",
-                "iltorb": "1.3.10",
-                "lodash": "4.17.10",
-                "pretty-bytes": "3.0.1",
-                "stream-buffers": "2.2.0"
+                "archiver": "^1.0.0",
+                "chalk": "^1.1.1",
+                "iltorb": "^1.0.13",
+                "lodash": "^4.7.0",
+                "pretty-bytes": "^3.0.1",
+                "stream-buffers": "^2.1.0"
             }
         },
         "grunt-contrib-copy": {
@@ -886,257 +871,138 @@
             "integrity": "sha1-cGDGWB6QS4qw0A8HbgqPbj58NXM=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "file-sync-cmp": "0.1.1"
+                "chalk": "^1.1.1",
+                "file-sync-cmp": "^0.1.0"
             }
         },
         "grunt-curl": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/grunt-curl/-/grunt-curl-2.2.0.tgz",
-            "integrity": "sha1-gK6UIhaMgTyLkj7QsESB3f1vvzA=",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/grunt-curl/-/grunt-curl-2.5.0.tgz",
+            "integrity": "sha512-A8q8hdiGRMegMaH6jSxlON/O2uY6pgSVw8dYXdp6+ViO3D6lPMKgWK6eysyytGQZklJ8IvWHoNLs1yCzJMEnFw==",
             "dev": true,
             "requires": {
-                "async": "0.2.10",
-                "grunt-retro": "0.7.0",
-                "lodash": "2.4.2",
-                "request": "2.54.0"
+                "async": "~0.2.10",
+                "grunt-retro": "~0.7.0",
+                "lodash": "~4.17.11",
+                "request": "~2.83.0"
             },
             "dependencies": {
-                "asn1": {
-                    "version": "0.1.11",
-                    "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-                    "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc=",
-                    "dev": true
-                },
-                "assert-plus": {
-                    "version": "0.1.5",
-                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-                    "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
-                    "dev": true
-                },
                 "async": {
                     "version": "0.2.10",
-                    "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                    "resolved": "http://registry.npmjs.org/async/-/async-0.2.10.tgz",
                     "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
                     "dev": true
                 },
-                "aws-sign2": {
-                    "version": "0.5.0",
-                    "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
-                    "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM=",
-                    "dev": true
-                },
-                "bl": {
-                    "version": "0.9.5",
-                    "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
-                    "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": "1.0.34"
-                    }
-                },
                 "boom": {
-                    "version": "2.10.1",
-                    "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                    "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+                    "version": "4.3.1",
+                    "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+                    "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
                     "dev": true,
                     "requires": {
-                        "hoek": "2.16.3"
-                    }
-                },
-                "caseless": {
-                    "version": "0.9.0",
-                    "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
-                    "integrity": "sha1-t7Zc5r8UE4hlOc/VM/CzDv+pz4g=",
-                    "dev": true
-                },
-                "combined-stream": {
-                    "version": "0.0.7",
-                    "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-                    "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
-                    "dev": true,
-                    "requires": {
-                        "delayed-stream": "0.0.5"
+                        "hoek": "4.x.x"
                     }
                 },
                 "cryptiles": {
-                    "version": "2.0.5",
-                    "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                    "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+                    "version": "3.1.4",
+                    "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.4.tgz",
+                    "integrity": "sha512-8I1sgZHfVwcSOY6mSGpVU3lw/GSIZvusg8dD2+OGehCJpOhQRLNcH0qb9upQnOH4XhgxxFJSg6E2kx95deb1Tw==",
                     "dev": true,
                     "requires": {
-                        "boom": "2.10.1"
-                    }
-                },
-                "delayed-stream": {
-                    "version": "0.0.5",
-                    "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-                    "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8=",
-                    "dev": true
-                },
-                "form-data": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
-                    "integrity": "sha1-Jvi8JtpkQOKZy9z7aQNcT3em5GY=",
-                    "dev": true,
-                    "requires": {
-                        "async": "0.9.2",
-                        "combined-stream": "0.0.7",
-                        "mime-types": "2.0.14"
+                        "boom": "5.x.x"
                     },
                     "dependencies": {
-                        "async": {
-                            "version": "0.9.2",
-                            "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-                            "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
-                            "dev": true
+                        "boom": {
+                            "version": "5.2.0",
+                            "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+                            "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+                            "dev": true,
+                            "requires": {
+                                "hoek": "4.x.x"
+                            }
                         }
                     }
                 },
                 "har-validator": {
-                    "version": "1.8.0",
-                    "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
-                    "integrity": "sha1-2DhCsOtMQ1lgrrEIoGejqpTA7rI=",
+                    "version": "5.0.3",
+                    "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+                    "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
                     "dev": true,
                     "requires": {
-                        "bluebird": "2.11.0",
-                        "chalk": "1.1.3",
-                        "commander": "2.17.1",
-                        "is-my-json-valid": "2.19.0"
+                        "ajv": "^5.1.0",
+                        "har-schema": "^2.0.0"
                     }
                 },
                 "hawk": {
-                    "version": "2.3.1",
-                    "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-                    "integrity": "sha1-HnMc45RH+h0PbXB/e87r7A/R7B8=",
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+                    "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
                     "dev": true,
                     "requires": {
-                        "boom": "2.10.1",
-                        "cryptiles": "2.0.5",
-                        "hoek": "2.16.3",
-                        "sntp": "1.0.9"
+                        "boom": "4.x.x",
+                        "cryptiles": "3.x.x",
+                        "hoek": "4.x.x",
+                        "sntp": "2.x.x"
                     }
                 },
                 "hoek": {
-                    "version": "2.16.3",
-                    "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                    "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-                    "dev": true
-                },
-                "http-signature": {
-                    "version": "0.10.1",
-                    "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-                    "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
-                    "dev": true,
-                    "requires": {
-                        "asn1": "0.1.11",
-                        "assert-plus": "0.1.5",
-                        "ctype": "0.5.3"
-                    }
-                },
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "version": "4.2.1",
+                    "resolved": "http://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+                    "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
                     "dev": true
                 },
                 "lodash": {
-                    "version": "2.4.2",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-                    "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+                    "version": "4.17.11",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+                    "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
                     "dev": true
-                },
-                "mime-db": {
-                    "version": "1.12.0",
-                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
-                    "integrity": "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc=",
-                    "dev": true
-                },
-                "mime-types": {
-                    "version": "2.0.14",
-                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-                    "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
-                    "dev": true,
-                    "requires": {
-                        "mime-db": "1.12.0"
-                    }
-                },
-                "node-uuid": {
-                    "version": "1.4.8",
-                    "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-                    "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
-                    "dev": true
-                },
-                "oauth-sign": {
-                    "version": "0.6.0",
-                    "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
-                    "integrity": "sha1-fb6uRPbKRU4fFoRR1jB0ZzWBPOM=",
-                    "dev": true
-                },
-                "qs": {
-                    "version": "2.4.2",
-                    "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
-                    "integrity": "sha1-9854jld33wtQENp/fE5zujJHD1o=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
-                    }
                 },
                 "request": {
-                    "version": "2.54.0",
-                    "resolved": "https://registry.npmjs.org/request/-/request-2.54.0.tgz",
-                    "integrity": "sha1-oTkXzY6PpzMy2gvy+EowGB3vGVM=",
+                    "version": "2.83.0",
+                    "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+                    "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
                     "dev": true,
                     "requires": {
-                        "aws-sign2": "0.5.0",
-                        "bl": "0.9.5",
-                        "caseless": "0.9.0",
-                        "combined-stream": "0.0.7",
-                        "forever-agent": "0.6.1",
-                        "form-data": "0.2.0",
-                        "har-validator": "1.8.0",
-                        "hawk": "2.3.1",
-                        "http-signature": "0.10.1",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.0.14",
-                        "node-uuid": "1.4.8",
-                        "oauth-sign": "0.6.0",
-                        "qs": "2.4.2",
-                        "stringstream": "0.0.6",
-                        "tough-cookie": "2.4.3",
-                        "tunnel-agent": "0.4.3"
+                        "aws-sign2": "~0.7.0",
+                        "aws4": "^1.6.0",
+                        "caseless": "~0.12.0",
+                        "combined-stream": "~1.0.5",
+                        "extend": "~3.0.1",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.3.1",
+                        "har-validator": "~5.0.3",
+                        "hawk": "~6.0.2",
+                        "http-signature": "~1.2.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.17",
+                        "oauth-sign": "~0.8.2",
+                        "performance-now": "^2.1.0",
+                        "qs": "~6.5.1",
+                        "safe-buffer": "^5.1.1",
+                        "stringstream": "~0.0.5",
+                        "tough-cookie": "~2.3.3",
+                        "tunnel-agent": "^0.6.0",
+                        "uuid": "^3.1.0"
                     }
                 },
                 "sntp": {
-                    "version": "1.0.9",
-                    "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                    "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+                    "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
                     "dev": true,
                     "requires": {
-                        "hoek": "2.16.3"
+                        "hoek": "4.x.x"
                     }
                 },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                },
-                "tunnel-agent": {
-                    "version": "0.4.3",
-                    "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-                    "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-                    "dev": true
+                "tough-cookie": {
+                    "version": "2.3.4",
+                    "resolved": "http://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+                    "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+                    "dev": true,
+                    "requires": {
+                        "punycode": "^1.4.1"
+                    }
                 }
             }
         },
@@ -1151,7 +1017,7 @@
             "resolved": "https://registry.npmjs.org/grunt-git/-/grunt-git-1.0.10.tgz",
             "integrity": "sha512-dIRAjHytYkcebw8VNPUHM/aOfOSgDlotVqPUDXU4CIx2sRxxyUL/dEIpDw6WSxPmCGDh8HJrQsWvVN1e8Qlj1A==",
             "requires": {
-                "flopmang": "0.0.1"
+                "flopmang": "^0.0.1"
             }
         },
         "grunt-http": {
@@ -1159,93 +1025,105 @@
             "resolved": "https://registry.npmjs.org/grunt-http/-/grunt-http-2.3.1.tgz",
             "integrity": "sha1-RlMCpNTXXW0EWFhFUFQFvtqStGI=",
             "requires": {
-                "async": "2.6.1",
-                "aws-sign2": "0.7.0",
-                "form-data": "2.3.2",
-                "hawk": "7.0.7",
-                "http-signature": "1.2.0",
-                "oauth-sign": "0.8.2",
-                "request": "2.88.0",
-                "tough-cookie": "2.4.3",
-                "tunnel-agent": "0.6.0"
+                "async": "^2.6.0",
+                "aws-sign2": "^0.7.0",
+                "form-data": "^2.3.2",
+                "hawk": "^7.0.7",
+                "http-signature": "^1.2.0",
+                "oauth-sign": "^0.8.2",
+                "request": "^2.85.0",
+                "tough-cookie": "^2.3.4",
+                "tunnel-agent": "^0.6.0"
             }
         },
         "grunt-known-options": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-1.1.1.tgz",
-            "integrity": "sha1-bMCIEHvQIZ3F0+V9kZI/RpBZgE0=",
+            "integrity": "sha512-cHwsLqoighpu7TuYj5RonnEuxGVFnztcUqTqp5rXFGYL4OuPFofwC4Ycg7n9fYwvK6F5WbYgeVOwph9Crs2fsQ==",
             "dev": true
         },
         "grunt-legacy-log": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-1.0.2.tgz",
-            "integrity": "sha1-fXRAQmrOd7IG50+ZPjMuKhWjkE4=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-2.0.0.tgz",
+            "integrity": "sha512-1m3+5QvDYfR1ltr8hjiaiNjddxGdQWcH0rw1iKKiQnF0+xtgTazirSTGu68RchPyh1OBng1bBUjLmX8q9NpoCw==",
             "dev": true,
             "requires": {
-                "colors": "1.1.2",
-                "grunt-legacy-log-utils": "1.0.0",
-                "hooker": "0.2.3",
-                "lodash": "4.17.10"
+                "colors": "~1.1.2",
+                "grunt-legacy-log-utils": "~2.0.0",
+                "hooker": "~0.2.3",
+                "lodash": "~4.17.5"
             }
         },
         "grunt-legacy-log-utils": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-1.0.0.tgz",
-            "integrity": "sha1-p7ji0Ps1taUPSvmG/BEnSevJbz0=",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-2.0.1.tgz",
+            "integrity": "sha512-o7uHyO/J+i2tXG8r2bZNlVk20vlIFJ9IEYyHMCQGfWYru8Jv3wTqKZzvV30YW9rWEjq0eP3cflQ1qWojIe9VFA==",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "lodash": "4.3.0"
+                "chalk": "~2.4.1",
+                "lodash": "~4.17.10"
             },
             "dependencies": {
-                "lodash": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.3.0.tgz",
-                    "integrity": "sha1-79nEpuxT87BUEkKZFcPkgk5NJaQ=",
-                    "dev": true
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
                 }
             }
         },
         "grunt-legacy-util": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-1.0.0.tgz",
-            "integrity": "sha1-OGqnjcbtUJhsKxiVcmWxtIq7m4Y=",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-1.1.1.tgz",
+            "integrity": "sha512-9zyA29w/fBe6BIfjGENndwoe1Uy31BIXxTH3s8mga0Z5Bz2Sp4UCjkeyv2tI449ymkx3x26B+46FV4fXEddl5A==",
             "dev": true,
             "requires": {
-                "async": "1.5.2",
-                "exit": "0.1.2",
-                "getobject": "0.1.0",
-                "hooker": "0.2.3",
-                "lodash": "4.3.0",
-                "underscore.string": "3.2.3",
-                "which": "1.2.14"
+                "async": "~1.5.2",
+                "exit": "~0.1.1",
+                "getobject": "~0.1.0",
+                "hooker": "~0.2.3",
+                "lodash": "~4.17.10",
+                "underscore.string": "~3.3.4",
+                "which": "~1.3.0"
             },
             "dependencies": {
                 "async": {
                     "version": "1.5.2",
-                    "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                    "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
                     "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
                     "dev": true
                 },
-                "lodash": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.3.0.tgz",
-                    "integrity": "sha1-79nEpuxT87BUEkKZFcPkgk5NJaQ=",
-                    "dev": true
-                },
                 "underscore.string": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.2.3.tgz",
-                    "integrity": "sha1-gGmSYzZl1eX8tNsfs6hi62jp5to=",
-                    "dev": true
-                },
-                "which": {
-                    "version": "1.2.14",
-                    "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-                    "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+                    "version": "3.3.5",
+                    "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.5.tgz",
+                    "integrity": "sha512-g+dpmgn+XBneLmXXo+sGlW5xQEt4ErkS3mgeN2GFbremYeMBSJKr9Wf2KJplQVaiPY/f7FN6atosWYNm9ovrYg==",
                     "dev": true,
                     "requires": {
-                        "isexe": "2.0.0"
+                        "sprintf-js": "^1.0.3",
+                        "util-deprecate": "^1.0.2"
                     }
                 }
             }
@@ -1256,8 +1134,8 @@
             "integrity": "sha1-8vDCVSYWtYt8Calsg+bhQtPt7rY=",
             "dev": true,
             "requires": {
-                "colors": "0.6.2",
-                "request": "2.88.0",
+                "colors": "^0.6.2",
+                "request": "^2.53.0",
                 "wget": "0.0.1"
             },
             "dependencies": {
@@ -1290,8 +1168,8 @@
             "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
             "integrity": "sha1-RGV/VoiiLP1LckhugbOj+xF0LCk=",
             "requires": {
-                "ajv": "5.5.2",
-                "har-schema": "2.0.0"
+                "ajv": "^5.3.0",
+                "har-schema": "^2.0.0"
             }
         },
         "has-ansi": {
@@ -1299,8 +1177,14 @@
             "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
+        },
+        "has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+            "dev": true
         },
         "has-unicode": {
             "version": "2.0.1",
@@ -1313,10 +1197,10 @@
             "integrity": "sha1-oeuJeT8aRkwnH2jg+e7tyRDtDpA=",
             "optional": true,
             "requires": {
-                "boom": "7.2.0",
-                "cryptiles": "4.1.2",
-                "hoek": "5.0.4",
-                "sntp": "3.0.1"
+                "boom": "7.x.x",
+                "cryptiles": "4.x.x",
+                "hoek": "5.x.x",
+                "sntp": "3.x.x"
             }
         },
         "hoek": {
@@ -1340,9 +1224,9 @@
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.14.2"
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
             }
         },
         "i18next": {
@@ -1356,12 +1240,12 @@
             "integrity": "sha1-remTVgZfUXQtqeS8ece7SQWkuR0="
         },
         "iconv-lite": {
-            "version": "0.4.23",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-            "integrity": "sha1-KXhx9jvlB63Pv8pxXQzQ7thOmmM=",
+            "version": "0.4.24",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
             "dev": true,
             "requires": {
-                "safer-buffer": "2.1.2"
+                "safer-buffer": ">= 2.1.2 < 3"
             }
         },
         "ieee754": {
@@ -1377,10 +1261,10 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "detect-libc": "0.2.0",
-                "nan": "2.10.0",
-                "node-gyp": "3.8.0",
-                "prebuild-install": "2.5.3"
+                "detect-libc": "^0.2.0",
+                "nan": "^2.6.2",
+                "node-gyp": "^3.6.2",
+                "prebuild-install": "^2.3.0"
             }
         },
         "in-publish": {
@@ -1393,7 +1277,7 @@
             "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
             "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
             "requires": {
-                "repeating": "2.0.1"
+                "repeating": "^2.0.0"
             }
         },
         "inflight": {
@@ -1401,8 +1285,8 @@
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
@@ -1422,7 +1306,7 @@
             "resolved": "https://registry.npmjs.org/initial-js/-/initial-js-0.3.4.tgz",
             "integrity": "sha1-LoPs4EF0k77KjrDWZVVEUFWBc6E=",
             "requires": {
-                "randomcolor": "0.4.4"
+                "randomcolor": "^0.4.4"
             }
         },
         "invert-kv": {
@@ -1440,7 +1324,7 @@
             "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
             "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
             "requires": {
-                "builtin-modules": "1.1.1"
+                "builtin-modules": "^1.0.0"
             }
         },
         "is-finite": {
@@ -1448,7 +1332,7 @@
             "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
             "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
             "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
             }
         },
         "is-fullwidth-code-point": {
@@ -1456,33 +1340,8 @@
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
             "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
             "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
             }
-        },
-        "is-my-ip-valid": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-            "integrity": "sha1-ezUbjo7dTTmV1NBmaA5mTZRpaCQ=",
-            "dev": true
-        },
-        "is-my-json-valid": {
-            "version": "2.19.0",
-            "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.19.0.tgz",
-            "integrity": "sha1-j9bkA2PNBrlj+od9REv7Xt3GIXU=",
-            "dev": true,
-            "requires": {
-                "generate-function": "2.0.0",
-                "generate-object-property": "1.2.0",
-                "is-my-ip-valid": "1.0.0",
-                "jsonpointer": "4.0.1",
-                "xtend": "4.0.1"
-            }
-        },
-        "is-property": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-            "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-            "dev": true
         },
         "is-typedarray": {
             "version": "1.0.0",
@@ -1519,9 +1378,9 @@
             "resolved": "https://registry.npmjs.org/jquery-photo-uploader/-/jquery-photo-uploader-1.0.13.tgz",
             "integrity": "sha1-Rv2JaBUFJJPy0r7w69tf+wb7wJA=",
             "requires": {
-                "bootstrap": "3.3.7",
-                "font-awesome": "4.7.0",
-                "jquery": "3.3.1"
+                "bootstrap": "^3.3.7",
+                "font-awesome": "^4.7.0",
+                "jquery": "^3.1.1"
             }
         },
         "jquery-steps": {
@@ -1534,7 +1393,7 @@
             "resolved": "https://registry.npmjs.org/jquery-validation/-/jquery-validation-1.16.0.tgz",
             "integrity": "sha1-tuUnfrvWfB+rqyE+tEVO6oowlco=",
             "requires": {
-                "jquery": "3.3.1"
+                "jquery": "^1.7 || ^2.0 || ^3.1"
             }
         },
         "js-base64": {
@@ -1548,8 +1407,8 @@
             "integrity": "sha1-A3fDgBfKvHMisNH7zSWkkWQfL74=",
             "dev": true,
             "requires": {
-                "argparse": "1.0.10",
-                "esprima": "2.7.3"
+                "argparse": "^1.0.2",
+                "esprima": "^2.6.0"
             }
         },
         "jsbn": {
@@ -1573,12 +1432,6 @@
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
             "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
         },
-        "jsonpointer": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-            "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-            "dev": true
-        },
         "jsprim": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -1596,7 +1449,7 @@
             "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.6"
+                "readable-stream": "^2.0.5"
             }
         },
         "lcid": {
@@ -1604,7 +1457,7 @@
             "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
             "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
             "requires": {
-                "invert-kv": "1.0.0"
+                "invert-kv": "^1.0.0"
             }
         },
         "load-json-file": {
@@ -1612,11 +1465,11 @@
             "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
             "requires": {
-                "graceful-fs": "4.1.11",
-                "parse-json": "2.2.0",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "strip-bom": "2.0.0"
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "strip-bom": "^2.0.0"
             }
         },
         "lodash": {
@@ -1644,8 +1497,8 @@
             "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
             "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
             "requires": {
-                "currently-unhandled": "0.4.1",
-                "signal-exit": "3.0.2"
+                "currently-unhandled": "^0.4.1",
+                "signal-exit": "^3.0.0"
             }
         },
         "lru-cache": {
@@ -1653,8 +1506,8 @@
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
             "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
             "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.1.2"
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
             }
         },
         "map-obj": {
@@ -1667,16 +1520,16 @@
             "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
             "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
             "requires": {
-                "camelcase-keys": "2.1.0",
-                "decamelize": "1.2.0",
-                "loud-rejection": "1.6.0",
-                "map-obj": "1.0.1",
-                "minimist": "1.2.0",
-                "normalize-package-data": "2.4.0",
-                "object-assign": "4.1.1",
-                "read-pkg-up": "1.0.1",
-                "redent": "1.0.0",
-                "trim-newlines": "1.0.0"
+                "camelcase-keys": "^2.0.0",
+                "decamelize": "^1.1.2",
+                "loud-rejection": "^1.0.0",
+                "map-obj": "^1.0.1",
+                "minimist": "^1.1.3",
+                "normalize-package-data": "^2.3.4",
+                "object-assign": "^4.0.1",
+                "read-pkg-up": "^1.0.1",
+                "redent": "^1.0.0",
+                "trim-newlines": "^1.0.0"
             }
         },
         "mime-db": {
@@ -1689,7 +1542,7 @@
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
             "integrity": "sha1-ceRkU3p++BwV8tudl+kT/A/2BvA=",
             "requires": {
-                "mime-db": "1.35.0"
+                "mime-db": "~1.35.0"
             }
         },
         "mimic-response": {
@@ -1704,7 +1557,7 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
             "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
@@ -1744,7 +1597,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "semver": "5.5.1"
+                "semver": "^5.4.1"
             }
         },
         "node-gyp": {
@@ -1752,18 +1605,18 @@
             "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
             "integrity": "sha1-VAMEJhwzDoDQ1e3OJTpoyzlkIYw=",
             "requires": {
-                "fstream": "1.0.11",
-                "glob": "7.1.2",
-                "graceful-fs": "4.1.11",
-                "mkdirp": "0.5.1",
-                "nopt": "3.0.6",
-                "npmlog": "4.1.2",
-                "osenv": "0.1.5",
-                "request": "2.88.0",
-                "rimraf": "2.6.2",
-                "semver": "5.3.0",
-                "tar": "2.2.1",
-                "which": "1.3.1"
+                "fstream": "^1.0.0",
+                "glob": "^7.0.3",
+                "graceful-fs": "^4.1.2",
+                "mkdirp": "^0.5.0",
+                "nopt": "2 || 3",
+                "npmlog": "0 || 1 || 2 || 3 || 4",
+                "osenv": "0",
+                "request": "^2.87.0",
+                "rimraf": "2",
+                "semver": "~5.3.0",
+                "tar": "^2.0.0",
+                "which": "1"
             },
             "dependencies": {
                 "semver": {
@@ -1778,25 +1631,25 @@
             "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.11.0.tgz",
             "integrity": "sha512-bHUdHTphgQJZaF1LASx0kAviPH7sGlcyNhWade4eVIpFp6tsn7SV8xNMTbsQFpEV9VXpnwTTnNYlfsZXgGgmkA==",
             "requires": {
-                "async-foreach": "0.1.3",
-                "chalk": "1.1.3",
-                "cross-spawn": "3.0.1",
-                "gaze": "1.1.3",
-                "get-stdin": "4.0.1",
-                "glob": "7.1.2",
-                "in-publish": "2.0.0",
-                "lodash.assign": "4.2.0",
-                "lodash.clonedeep": "4.5.0",
-                "lodash.mergewith": "4.6.1",
-                "meow": "3.7.0",
-                "mkdirp": "0.5.1",
-                "nan": "2.10.0",
-                "node-gyp": "3.8.0",
-                "npmlog": "4.1.2",
-                "request": "2.88.0",
-                "sass-graph": "2.2.4",
-                "stdout-stream": "1.4.1",
-                "true-case-path": "1.0.3"
+                "async-foreach": "^0.1.3",
+                "chalk": "^1.1.1",
+                "cross-spawn": "^3.0.0",
+                "gaze": "^1.0.0",
+                "get-stdin": "^4.0.1",
+                "glob": "^7.0.3",
+                "in-publish": "^2.0.0",
+                "lodash.assign": "^4.2.0",
+                "lodash.clonedeep": "^4.3.2",
+                "lodash.mergewith": "^4.6.0",
+                "meow": "^3.7.0",
+                "mkdirp": "^0.5.1",
+                "nan": "^2.10.0",
+                "node-gyp": "^3.8.0",
+                "npmlog": "^4.0.0",
+                "request": "^2.88.0",
+                "sass-graph": "^2.2.4",
+                "stdout-stream": "^1.4.0",
+                "true-case-path": "^1.0.2"
             }
         },
         "node-sha1": {
@@ -1817,7 +1670,7 @@
             "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
             "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
             "requires": {
-                "abbrev": "1.1.1"
+                "abbrev": "1"
             }
         },
         "normalize-package-data": {
@@ -1825,10 +1678,10 @@
             "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
             "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
             "requires": {
-                "hosted-git-info": "2.7.1",
-                "is-builtin-module": "1.0.0",
-                "semver": "5.5.1",
-                "validate-npm-package-license": "3.0.4"
+                "hosted-git-info": "^2.1.4",
+                "is-builtin-module": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
             }
         },
         "normalize-path": {
@@ -1837,7 +1690,7 @@
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "dev": true,
             "requires": {
-                "remove-trailing-separator": "1.1.0"
+                "remove-trailing-separator": "^1.0.1"
             }
         },
         "npmlog": {
@@ -1845,10 +1698,10 @@
             "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
             "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
             "requires": {
-                "are-we-there-yet": "1.1.5",
-                "console-control-strings": "1.1.0",
-                "gauge": "2.7.4",
-                "set-blocking": "2.0.0"
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
             }
         },
         "number-is-nan": {
@@ -1859,8 +1712,7 @@
         "oauth-sign": {
             "version": "0.8.2",
             "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-            "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-            "optional": true
+            "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
         },
         "object-assign": {
             "version": "4.1.1",
@@ -1872,7 +1724,7 @@
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
             }
         },
         "os-homedir": {
@@ -1885,7 +1737,7 @@
             "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
             "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
             "requires": {
-                "lcid": "1.0.0"
+                "lcid": "^1.0.0"
             }
         },
         "os-tmpdir": {
@@ -1898,8 +1750,8 @@
             "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
             "integrity": "sha1-hc36+uso6Gd/QW4odZK18/SepBA=",
             "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
             }
         },
         "parse-json": {
@@ -1907,7 +1759,7 @@
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
             "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
             "requires": {
-                "error-ex": "1.3.2"
+                "error-ex": "^1.2.0"
             }
         },
         "path-exists": {
@@ -1915,7 +1767,7 @@
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
             "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
             "requires": {
-                "pinkie-promise": "2.0.1"
+                "pinkie-promise": "^2.0.0"
             }
         },
         "path-is-absolute": {
@@ -1928,9 +1780,9 @@
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
             "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
             "requires": {
-                "graceful-fs": "4.1.11",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
+                "graceful-fs": "^4.1.2",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             }
         },
         "performance-now": {
@@ -1953,7 +1805,7 @@
             "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
             "requires": {
-                "pinkie": "2.0.4"
+                "pinkie": "^2.0.0"
             }
         },
         "prebuild-install": {
@@ -1963,21 +1815,21 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "detect-libc": "1.0.3",
-                "expand-template": "1.1.1",
+                "detect-libc": "^1.0.3",
+                "expand-template": "^1.0.2",
                 "github-from-package": "0.0.0",
-                "minimist": "1.2.0",
-                "mkdirp": "0.5.1",
-                "node-abi": "2.4.3",
-                "noop-logger": "0.1.1",
-                "npmlog": "4.1.2",
-                "os-homedir": "1.0.2",
-                "pump": "2.0.1",
-                "rc": "1.2.8",
-                "simple-get": "2.8.1",
-                "tar-fs": "1.16.3",
-                "tunnel-agent": "0.6.0",
-                "which-pm-runs": "1.0.0"
+                "minimist": "^1.2.0",
+                "mkdirp": "^0.5.1",
+                "node-abi": "^2.2.0",
+                "noop-logger": "^0.1.1",
+                "npmlog": "^4.0.1",
+                "os-homedir": "^1.0.1",
+                "pump": "^2.0.1",
+                "rc": "^1.1.6",
+                "simple-get": "^2.7.0",
+                "tar-fs": "^1.13.0",
+                "tunnel-agent": "^0.6.0",
+                "which-pm-runs": "^1.0.0"
             },
             "dependencies": {
                 "detect-libc": {
@@ -1995,7 +1847,7 @@
             "integrity": "sha1-J9AAjXeAY6C0gRuzXHnxvV1fvM8=",
             "dev": true,
             "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
             }
         },
         "process-nextick-args": {
@@ -2020,8 +1872,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "end-of-stream": "1.4.1",
-                "once": "1.4.0"
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
             }
         },
         "punycode": {
@@ -2046,10 +1898,10 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "deep-extend": "0.6.0",
-                "ini": "1.3.5",
-                "minimist": "1.2.0",
-                "strip-json-comments": "2.0.1"
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
             }
         },
         "read-pkg": {
@@ -2057,9 +1909,9 @@
             "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
             "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
             "requires": {
-                "load-json-file": "1.1.0",
-                "normalize-package-data": "2.4.0",
-                "path-type": "1.1.0"
+                "load-json-file": "^1.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^1.0.0"
             }
         },
         "read-pkg-up": {
@@ -2067,8 +1919,8 @@
             "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
             "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
             "requires": {
-                "find-up": "1.1.2",
-                "read-pkg": "1.1.0"
+                "find-up": "^1.0.0",
+                "read-pkg": "^1.0.0"
             }
         },
         "readable-stream": {
@@ -2076,13 +1928,13 @@
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
             "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.2",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
             }
         },
         "readline-sync": {
@@ -2096,8 +1948,8 @@
             "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
             "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
             "requires": {
-                "indent-string": "2.1.0",
-                "strip-indent": "1.0.1"
+                "indent-string": "^2.1.0",
+                "strip-indent": "^1.0.1"
             }
         },
         "remove-trailing-separator": {
@@ -2111,7 +1963,7 @@
             "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
             "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
             "requires": {
-                "is-finite": "1.0.2"
+                "is-finite": "^1.0.0"
             }
         },
         "request": {
@@ -2119,26 +1971,26 @@
             "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
             "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
             "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.8.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.6",
-                "extend": "3.0.2",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.2",
-                "har-validator": "5.1.0",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.19",
-                "oauth-sign": "0.9.0",
-                "performance-now": "2.1.0",
-                "qs": "6.5.2",
-                "safe-buffer": "5.1.2",
-                "tough-cookie": "2.4.3",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.3.2"
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.0",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.4.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.3.2"
             },
             "dependencies": {
                 "oauth-sign": {
@@ -2160,7 +2012,7 @@
         },
         "resolve": {
             "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+            "resolved": "http://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
             "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
             "dev": true
         },
@@ -2169,7 +2021,7 @@
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
             "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
             "requires": {
-                "glob": "7.1.2"
+                "glob": "^7.0.5"
             }
         },
         "safe-buffer": {
@@ -2187,10 +2039,10 @@
             "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
             "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
             "requires": {
-                "glob": "7.1.2",
-                "lodash": "4.17.10",
-                "scss-tokenizer": "0.2.3",
-                "yargs": "7.1.0"
+                "glob": "^7.0.0",
+                "lodash": "^4.0.0",
+                "scss-tokenizer": "^0.2.3",
+                "yargs": "^7.0.0"
             }
         },
         "scss-tokenizer": {
@@ -2198,8 +2050,8 @@
             "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
             "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
             "requires": {
-                "js-base64": "2.4.9",
-                "source-map": "0.4.4"
+                "js-base64": "^2.1.8",
+                "source-map": "^0.4.2"
             }
         },
         "semver": {
@@ -2231,9 +2083,9 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "decompress-response": "3.3.0",
-                "once": "1.4.0",
-                "simple-concat": "1.0.0"
+                "decompress-response": "^3.3.0",
+                "once": "^1.3.1",
+                "simple-concat": "^1.0.0"
             }
         },
         "sntp": {
@@ -2242,10 +2094,10 @@
             "integrity": "sha1-GqkIjT64ROqMCYD84Yd4hNQRfQk=",
             "optional": true,
             "requires": {
-                "boom": "7.2.0",
-                "bounce": "1.2.0",
-                "hoek": "5.0.4",
-                "teamwork": "3.0.1"
+                "boom": "7.x.x",
+                "bounce": "1.x.x",
+                "hoek": "5.x.x",
+                "teamwork": "3.x.x"
             }
         },
         "source-map": {
@@ -2253,7 +2105,7 @@
             "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
             "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
             "requires": {
-                "amdefine": "1.0.1"
+                "amdefine": ">=0.0.4"
             }
         },
         "spdx-correct": {
@@ -2261,8 +2113,8 @@
             "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
             "integrity": "sha1-BaW01xU6GVvJLDxCW2nzsqlSTII=",
             "requires": {
-                "spdx-expression-parse": "3.0.0",
-                "spdx-license-ids": "3.0.0"
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-exceptions": {
@@ -2275,8 +2127,8 @@
             "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
             "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
             "requires": {
-                "spdx-exceptions": "2.1.0",
-                "spdx-license-ids": "3.0.0"
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-license-ids": {
@@ -2285,9 +2137,9 @@
             "integrity": "sha1-enzShHDMbToc/m1miG9rxDDTrIc="
         },
         "sprintf-js": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+            "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
             "dev": true
         },
         "sshpk": {
@@ -2295,15 +2147,15 @@
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
             "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
             "requires": {
-                "asn1": "0.2.4",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.2",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.2",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "safer-buffer": "2.1.2",
-                "tweetnacl": "0.14.5"
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
+                "tweetnacl": "~0.14.0"
             }
         },
         "stdout-stream": {
@@ -2311,7 +2163,7 @@
             "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.1.tgz",
             "integrity": "sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==",
             "requires": {
-                "readable-stream": "2.3.6"
+                "readable-stream": "^2.0.1"
             }
         },
         "stream-buffers": {
@@ -2325,9 +2177,9 @@
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
             "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
             }
         },
         "string_decoder": {
@@ -2335,13 +2187,13 @@
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "~5.1.0"
             }
         },
         "stringstream": {
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
-            "integrity": "sha1-eIAiWw1K0Q4wkn0Weh1vL9OzOnI=",
+            "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
             "dev": true
         },
         "strip-ansi": {
@@ -2349,7 +2201,7 @@
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "strip-bom": {
@@ -2357,7 +2209,7 @@
             "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
             "requires": {
-                "is-utf8": "0.2.1"
+                "is-utf8": "^0.2.0"
             }
         },
         "strip-indent": {
@@ -2365,7 +2217,7 @@
             "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
             "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
             "requires": {
-                "get-stdin": "4.0.1"
+                "get-stdin": "^4.0.1"
             }
         },
         "strip-json-comments": {
@@ -2385,9 +2237,9 @@
             "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
             "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
             }
         },
         "tar-fs": {
@@ -2397,10 +2249,10 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "chownr": "1.0.1",
-                "mkdirp": "0.5.1",
-                "pump": "1.0.3",
-                "tar-stream": "1.6.1"
+                "chownr": "^1.0.1",
+                "mkdirp": "^0.5.1",
+                "pump": "^1.0.0",
+                "tar-stream": "^1.1.2"
             },
             "dependencies": {
                 "pump": {
@@ -2410,8 +2262,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "end-of-stream": "1.4.1",
-                        "once": "1.4.0"
+                        "end-of-stream": "^1.1.0",
+                        "once": "^1.3.1"
                     }
                 }
             }
@@ -2422,13 +2274,13 @@
             "integrity": "sha1-+E7xaWJp1iI8pI9uHu7eP36B85U=",
             "dev": true,
             "requires": {
-                "bl": "1.2.2",
-                "buffer-alloc": "1.2.0",
-                "end-of-stream": "1.4.1",
-                "fs-constants": "1.0.0",
-                "readable-stream": "2.3.6",
-                "to-buffer": "1.1.1",
-                "xtend": "4.0.1"
+                "bl": "^1.0.0",
+                "buffer-alloc": "^1.1.0",
+                "end-of-stream": "^1.0.0",
+                "fs-constants": "^1.0.0",
+                "readable-stream": "^2.3.0",
+                "to-buffer": "^1.1.0",
+                "xtend": "^4.0.0"
             }
         },
         "teamwork": {
@@ -2448,8 +2300,8 @@
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
             "integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
             "requires": {
-                "psl": "1.1.29",
-                "punycode": "1.4.1"
+                "psl": "^1.1.24",
+                "punycode": "^1.4.1"
             }
         },
         "trim-newlines": {
@@ -2462,7 +2314,7 @@
             "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.3.tgz",
             "integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
             "requires": {
-                "glob": "7.1.2"
+                "glob": "^7.1.2"
             }
         },
         "tunnel": {
@@ -2476,7 +2328,7 @@
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "^5.0.1"
             }
         },
         "tweetnacl": {
@@ -2510,8 +2362,8 @@
             "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
             "integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
             "requires": {
-                "spdx-correct": "3.0.0",
-                "spdx-expression-parse": "3.0.0"
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
             }
         },
         "verror": {
@@ -2519,9 +2371,9 @@
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "requires": {
-                "assert-plus": "1.0.0",
+                "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
+                "extsprintf": "^1.2.0"
             }
         },
         "walkdir": {
@@ -2544,7 +2396,7 @@
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
             "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
             "requires": {
-                "isexe": "2.0.0"
+                "isexe": "^2.0.0"
             }
         },
         "which-module": {
@@ -2564,7 +2416,7 @@
             "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
             "integrity": "sha1-rgdOa9wMFKQx6ATmJFScYzsABFc=",
             "requires": {
-                "string-width": "1.0.2"
+                "string-width": "^1.0.2 || 2"
             }
         },
         "wrap-ansi": {
@@ -2572,8 +2424,8 @@
             "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1"
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
             }
         },
         "wrappy": {
@@ -2602,19 +2454,19 @@
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
             "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
             "requires": {
-                "camelcase": "3.0.0",
-                "cliui": "3.2.0",
-                "decamelize": "1.2.0",
-                "get-caller-file": "1.0.3",
-                "os-locale": "1.4.0",
-                "read-pkg-up": "1.0.1",
-                "require-directory": "2.1.1",
-                "require-main-filename": "1.0.1",
-                "set-blocking": "2.0.0",
-                "string-width": "1.0.2",
-                "which-module": "1.0.0",
-                "y18n": "3.2.1",
-                "yargs-parser": "5.0.0"
+                "camelcase": "^3.0.0",
+                "cliui": "^3.2.0",
+                "decamelize": "^1.1.1",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^1.4.0",
+                "read-pkg-up": "^1.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^1.0.2",
+                "which-module": "^1.0.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^5.0.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -2629,7 +2481,7 @@
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
             "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
             "requires": {
-                "camelcase": "3.0.0"
+                "camelcase": "^3.0.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -2645,10 +2497,10 @@
             "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
             "dev": true,
             "requires": {
-                "archiver-utils": "1.3.0",
-                "compress-commons": "1.2.2",
-                "lodash": "4.17.10",
-                "readable-stream": "2.3.6"
+                "archiver-utils": "^1.3.0",
+                "compress-commons": "^1.2.0",
+                "lodash": "^4.8.0",
+                "readable-stream": "^2.0.0"
             }
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -372,7 +372,7 @@
         },
         "colors": {
             "version": "1.1.2",
-            "resolved": "http://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
             "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
             "dev": true
         },
@@ -553,7 +553,7 @@
         },
         "eventemitter2": {
             "version": "0.4.14",
-            "resolved": "http://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+            "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
             "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
             "dev": true
         },
@@ -607,7 +607,7 @@
         },
         "findup-sync": {
             "version": "0.3.0",
-            "resolved": "http://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
+            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
             "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
             "dev": true,
             "requires": {
@@ -1734,7 +1734,7 @@
         },
         "os-locale": {
             "version": "1.4.0",
-            "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
             "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
             "requires": {
                 "lcid": "^1.0.0"
@@ -2012,7 +2012,7 @@
         },
         "resolve": {
             "version": "1.1.7",
-            "resolved": "http://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
             "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
             "dev": true
         },
@@ -2102,7 +2102,7 @@
         },
         "source-map": {
             "version": "0.4.4",
-            "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
             "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
             "requires": {
                 "amdefine": ">=0.0.4"
@@ -2344,7 +2344,7 @@
         },
         "underscore.string": {
             "version": "2.4.0",
-            "resolved": "http://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+            "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
             "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs="
         },
         "util-deprecate": {
@@ -2421,7 +2421,7 @@
         },
         "wrap-ansi": {
             "version": "2.1.0",
-            "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "requires": {
                 "string-width": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -18,15 +18,15 @@
     },
     "homepage": "http://www.churchcrm.io",
     "devDependencies": {
-        "grunt": "1.0.1",
+        "grunt": "^1.0.3",
         "grunt-confirm": "^1.0.7",
-        "grunt-contrib-clean": "1.0.0",
-        "grunt-contrib-compress": "1.4.1",
-        "grunt-contrib-copy": "1.0.0",
-        "grunt-curl": "2.2.0",
+        "grunt-contrib-clean": "^1.0.0",
+        "grunt-contrib-compress": "^1.4.1",
+        "grunt-contrib-copy": "^1.0.0",
+        "grunt-curl": "^2.5.0",
         "grunt-exec": "^3.0.0",
-        "grunt-poeditor-ab": "0.1.9",
-        "node-sha1": "1.0.1"
+        "grunt-poeditor-ab": "^0.1.9",
+        "node-sha1": "^1.0.1"
     },
     "dependencies": {
         "admin-lte": "2.3.7",

--- a/src/composer.json
+++ b/src/composer.json
@@ -7,7 +7,7 @@
         "crm"
     ],
     "homepage": "http://www.churchcrm.io",
-    "time": "2018-12-28 19:12:27",
+    "time": "2018-12-30 18:12:97",
     "license": "MIT",
     "authors": [
         {


### PR DESCRIPTION
#### What's this PR do?
using `npm audit` to review and update packages that have issues.

#### Screenshots (if appropriate)

Before

```
found 12 vulnerabilities (3 low, 9 moderate) in 1477 scanned packages
  run `npm audit fix` to fix 10 of them.
  2 vulnerabilities require manual review. See the full report for details.
```

After 
```
found 1 moderate severity vulnerability in 1504 scanned packages
  1 vulnerability requires manual review. See the full report for details.
```
