### PR TITLE
Fixed lock box ids

### DIFF
--- a/src/Login.php
+++ b/src/Login.php
@@ -267,9 +267,9 @@ require 'Include/HeaderNotLoggedIn.php';
     <!-- lockscreen credentials (contains the form) -->
     <form class="lockscreen-credentials" role="form" method="post" name="LoginForm" action="Login.php">
       <div class="input-group">
-        <input type="hidden" id="UserBox" name="User" class="form-control" value="<?= $urlUserName ?>">
+        <input type="hidden" id="UserBoxLock" name="User" class="form-control" value="<?= $urlUserName ?>">
 
-        <input type="password" id="PasswordBox" name="Password" class="form-control" placeholder="<?= gettext('Password')?>">
+        <input type="password" id="PasswordBoxLock" name="Password" class="form-control" placeholder="<?= gettext('Password')?>">
 
         <div class="input-group-btn">
           <button type="submit"  class="btn"><i class="fa fa-arrow-right text-muted"></i></button>


### PR DESCRIPTION
#### What's this PR do?
- Lock and Login had the same html input ids this was showing as JS errors in the Dev Tools 

#### How should this be manually tested?

- Login then lock the user 
- Login via the lock screen 
