### PR TITLE
Bugfix/4678 missing email buttons permission

### DIFF
--- a/src/GroupView.php
+++ b/src/GroupView.php
@@ -23,6 +23,7 @@ use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\ListOptionQuery;
 use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\dto\SystemURLs;
+use ChurchCRM\SessionUser;
 
 //Get the GroupID out of the querystring
 $iGroupID = InputUtils::LegacyFilterInput($_GET['GroupID'], 'int');

--- a/src/GroupView.php
+++ b/src/GroupView.php
@@ -121,7 +121,7 @@ require 'Include/Header.php';
         }
         $sEmailLink = urlencode($sEmailLink);  // Mailto should comply with RFC 2368
 
-        if ($bEmailMailto) { // Does user have permission to email groups
+        if (SessionUser::getUser()->isEmailEnabled()) { // Does user have permission to email groups
         // Display link
         ?>
         <div class="btn-group">
@@ -177,7 +177,7 @@ require 'Include/Header.php';
         }
     }
     if ($sPhoneLink) {
-        if ($bEmailMailto) { // Does user have permission to email groups
+        if (SessionUser::getUser()->isEmailEnabled()) { // Does user have permission to email groups
             // Display link
             echo '<a class="btn btn-app" href="javascript:void(0)" onclick="allPhonesCommaD()"><i class="fa fa-mobile-phone"></i>'.gettext('Text Group').'</a>';
             echo '<script nonce="'. SystemURLs::getCSPNonce() .'">function allPhonesCommaD() {prompt("'.gettext("Press CTRL + C to copy all group members\' phone numbers").'", "'.mb_substr($sPhoneLink, 0, -2).'")};</script>';

--- a/src/PeopleDashboard.php
+++ b/src/PeopleDashboard.php
@@ -88,7 +88,7 @@ while (list($per_Email, $fam_Email, $virt_RoleName) = mysqli_fetch_row($rsEmailL
             $sEmailLink .= $sMailtoDelimiter.SystemConfig::getValue('sToEmailAddress');
         }
         $sEmailLink = urlencode($sEmailLink);  // Mailto should comply with RFC 2368
-       if ($bEmailMailto) { // Does user have permission to email groups
+       if (SessionUser::getUser()->isEmailEnabled()) { // Does user have permission to email groups
       // Display link
        ?>
         <div class="btn-group">

--- a/src/sundayschool/SundaySchoolClassView.php
+++ b/src/sundayschool/SundaySchoolClassView.php
@@ -8,6 +8,7 @@ use ChurchCRM\Service\SundaySchoolService;
 use ChurchCRM\dto\SystemURLs;
 use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\MiscUtils;
+use ChurchCRM\SessionUser;
 
 $sundaySchoolService = new SundaySchoolService();
 

--- a/src/sundayschool/SundaySchoolClassView.php
+++ b/src/sundayschool/SundaySchoolClassView.php
@@ -81,7 +81,7 @@ require '../Include/Header.php';
     }
     $sEmailLink = urlencode($sEmailLink);  // Mailto should comply with RFC 2368
 
-    if ($bEmailMailto) { // Does user have permission to email groups
+    if (SessionUser::getUser()->isEmailEnabled()) { // Does user have permission to email groups
       // Display link
       ?>
       <div class="btn-group">


### PR DESCRIPTION
#### What's this PR do?
Fixes the security check for sending email

#### What Issues does it Close?

Closes #4678 

#### Any background context you want to provide?
The refactor of the bootstrapper removed the global variables used for checking user permissions in favor of calling permission check methods on the `SystemUser` static object.  This reference to `$bEmailMailto` was missed in the refactor