### PR TITLE
Fix wrong backup type generated during upgrade

### DIFF
--- a/src/UpgradeCRM.php
+++ b/src/UpgradeCRM.php
@@ -152,7 +152,7 @@ Header_body_scripts();
       method : 'POST',
       path : 'database/backup',
       data : JSON.stringify({
-        'iArchiveType' : 3
+        'BackupType' : 3
       })
     })
     .done(function(data) {


### PR DESCRIPTION
#### What's this PR do?
Changes the backup type generated in the upgrade wizard from sql.gz to tar.gz. 

#### What Issues does it Close?

Closes #4673 
