### PR TITLE
Fix sMailtoDelimiter User Config Access While Generating Mailto Links

### DIFF
--- a/src/GroupView.php
+++ b/src/GroupView.php
@@ -103,6 +103,7 @@ require 'Include/Header.php';
             AND p2g2r_grp_ID = ".$iGroupID;
     $rsEmailList = RunQuery($sSQL);
     $sEmailLink = '';
+    $sMailtoDelimiter = SessionUser::getUser()->getUserConfigString("sMailtoDelimiter");
     while (list($per_Email, $fam_Email, $virt_RoleName) = mysqli_fetch_row($rsEmailList)) {
         $sEmail = SelectWhichInfo($per_Email, $fam_Email, false);
         if ($sEmail) {

--- a/src/Include/Functions.php
+++ b/src/Include/Functions.php
@@ -17,6 +17,7 @@ use ChurchCRM\Service\PersonService;
 use ChurchCRM\Service\SystemService;
 use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
+use ChurchCRM\SessionUser;
 
 $personService = new PersonService();
 $systemService = new SystemService();
@@ -1682,6 +1683,7 @@ function random_color()
 
 function generateGroupRoleEmailDropdown($roleEmails, $href)
 {
+    $sMailtoDelimiter = SessionUser::getUser()->getUserConfigString("sMailtoDelimiter");
     foreach ($roleEmails as $role => $Email) {
         if (SystemConfig::getValue('sToEmailAddress') != '' && !stristr($Email, SystemConfig::getValue('sToEmailAddress'))) {
             $Email .= $sMailtoDelimiter.SystemConfig::getValue('sToEmailAddress');

--- a/src/PeopleDashboard.php
+++ b/src/PeopleDashboard.php
@@ -24,7 +24,7 @@ $personCount = $dashboardService->getPersonCount();
 $personStats = $dashboardService->getPersonStats();
 $familyCount = $dashboardService->getFamilyCount();
 $groupStats = $dashboardService->getGroupStats();
-//$ageStats = $dashboardService->getAgeStats();
+$ageStats = $dashboardService->getAgeStats();
 $demographicStats = ListOptionQuery::create()->filterByID('2')->find();
 
 $sSQL = 'select count(*) as numb, per_Gender from person_per, family_fam

--- a/src/PeopleDashboard.php
+++ b/src/PeopleDashboard.php
@@ -24,7 +24,7 @@ $personCount = $dashboardService->getPersonCount();
 $personStats = $dashboardService->getPersonStats();
 $familyCount = $dashboardService->getFamilyCount();
 $groupStats = $dashboardService->getGroupStats();
-$ageStats = $dashboardService->getAgeStats();
+//$ageStats = $dashboardService->getAgeStats();
 $demographicStats = ListOptionQuery::create()->filterByID('2')->find();
 
 $sSQL = 'select count(*) as numb, per_Gender from person_per, family_fam
@@ -60,15 +60,13 @@ $sSQL = "SELECT per_Email, fam_Email, lst_OptionName as virt_RoleName FROM perso
 
 $rsEmailList = RunQuery($sSQL);
 $sEmailLink = '';
+$sMailtoDelimiter = SessionUser::getUser()->getUserConfigString("sMailtoDelimiter");
 while (list($per_Email, $fam_Email, $virt_RoleName) = mysqli_fetch_row($rsEmailList)) {
     $sEmail = SelectWhichInfo($per_Email, $fam_Email, false);
     if ($sEmail) {
-        /* if ($sEmailLink) // Don't put delimiter before first email
-            $sEmailLink .= $sMailtoDelimiter; */
-        // Add email only if email address is not already in string
         if (!stristr($sEmailLink, $sEmail)) {
             $sEmailLink .= $sEmail .= $sMailtoDelimiter;
-            $roleEmails->$virt_RoleName .= $sEmail .= $sMailtoDelimiter;
+            $roleEmails->$virt_RoleName .= $sEmail;
         }
     }
 }

--- a/src/sundayschool/SundaySchoolClassView.php
+++ b/src/sundayschool/SundaySchoolClassView.php
@@ -71,6 +71,7 @@ require '../Include/Header.php';
   </div>
   <div class="box-body">
     <?php
+    $sMailtoDelimiter = SessionUser::getUser()->getUserConfigString("sMailtoDelimiter");
     $allEmails = array_unique(array_merge($ParentsEmails, $KidsEmails, $TeachersEmails));
     $roleEmails->Parents = implode($sMailtoDelimiter, $ParentsEmails).',';
     $roleEmails->Teachers = implode($sMailtoDelimiter, $TeachersEmails).',';


### PR DESCRIPTION
#### What's this PR do?
Fixes the missing email delimiter in the mailto buttons caused by a user setting variable no longer being at the global scope.

#### What Issues does it Close?

Closes #4693 
