### PR TITLE
Ensure line endings on vendor code are lf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,9 @@ before_install:
 
 # prepare travis ci for the build process
 install:
+ - npm install
  - npm run composer-install
  - npm run orm-gen
- - npm install
  - npm run tests-install
 
 # linters

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -411,6 +411,17 @@ module.exports = function (grunt) {
             updatechangelog: {
                 cmd: "gren changelog --generate --override --token=<%= buildConfig.GitHub.token %>"
             }
+        },
+        lineending: {
+          dist: {
+            options: {
+              eol: 'lf',
+              overwrite: true
+            },
+            files: {
+              '': ['src/vendor/**/*.php', 'src/vendor/**/*.js', 'src/skin/external/**/*.php', 'src/skin/external/**/*.js']
+            }
+          }
         }
     });
 
@@ -559,5 +570,6 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-curl');
     grunt.loadNpmTasks('grunt-poeditor-ab');
     grunt.loadNpmTasks('grunt-exec');
+    grunt.loadNpmTasks('grunt-lineending');
 
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ChurchCRM",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2219,6 +2219,12 @@
           }
         }
       }
+    },
+    "grunt-lineending": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/grunt-lineending/-/grunt-lineending-1.0.0.tgz",
+      "integrity": "sha1-1+vETIp3Sf0smZYeaR9E1KdmgVg=",
+      "dev": true
     },
     "grunt-poeditor-ab": {
       "version": "0.1.9",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "grunt-curl": "^2.5.0",
         "grunt-exec": "^3.0.0",
         "grunt-github-release-notes": "^0.7.0",
+        "grunt-lineending": "^1.0.0",
         "grunt-poeditor-ab": "^0.1.9",
         "i18next-extract-gettext": "^3.2.1",
         "node-sha1": "^1.0.1"
@@ -59,6 +60,7 @@
     },
     "scripts": {
         "install": "grunt clean && grunt updateVersions && grunt curl-dir && grunt copy && grunt sass",
+        "line-endings": "grunt lineending",
         "updateVersions": "grunt updateVersions",
         "postinstall": "grunt genLocaleJSFiles",
         "locale-gen": "locale/update-locale.sh",

--- a/package.json
+++ b/package.json
@@ -59,8 +59,7 @@
         "pace-js": "^1.0.2"
     },
     "scripts": {
-        "install": "grunt clean && grunt updateVersions && grunt curl-dir && grunt copy && grunt sass",
-        "line-endings": "grunt lineending",
+        "install": "grunt clean && grunt updateVersions && grunt curl-dir && grunt copy && grunt sass && grunt lineending",
         "updateVersions": "grunt updateVersions",
         "postinstall": "grunt genLocaleJSFiles",
         "locale-gen": "locale/update-locale.sh",

--- a/package.json
+++ b/package.json
@@ -71,8 +71,8 @@
         "orm-gen": "php src/vendor/propel/propel/bin/propel.php --config-dir=propel model:build && cd src/ && composer dump-autoload",
         "graph-viz": "php src/vendor/propel/propel/bin/propel.php --config-dir=propel graphviz:generate",
         "datadictionary": "php src/vendor/propel/propel/bin/propel.php --config-dir=propel datadictionary:generate",
-        "composer-install": "cd src/ && composer install",
-        "composer-update": " cd src/ && composer update && composer dump-autoload && cd ../tests/ && composer update",
+        "composer-install": "cd src/ && composer install && grunt lineending",
+        "composer-update": " cd src/ && composer update && composer dump-autoload && cd ../tests/ && composer update && grunt lineending",
         "tests-install": "scripts/tests-install.sh",
         "test": "scripts/tests-run.sh"
     }

--- a/package.json
+++ b/package.json
@@ -71,8 +71,8 @@
         "orm-gen": "php src/vendor/propel/propel/bin/propel.php --config-dir=propel model:build && cd src/ && composer dump-autoload",
         "graph-viz": "php src/vendor/propel/propel/bin/propel.php --config-dir=propel graphviz:generate",
         "datadictionary": "php src/vendor/propel/propel/bin/propel.php --config-dir=propel datadictionary:generate",
-        "composer-install": "cd src/ && composer install && grunt lineending",
-        "composer-update": " cd src/ && composer update && composer dump-autoload && cd ../tests/ && composer update && grunt lineending",
+        "composer-install": "cd src/ && composer install && cd .. && grunt lineending",
+        "composer-update": " cd src/ && composer update && composer dump-autoload && cd ../tests/ && composer update && cd .. && grunt lineending",
         "tests-install": "scripts/tests-install.sh",
         "test": "scripts/tests-run.sh"
     }


### PR DESCRIPTION
#### What's this PR do?
updates line endings on all vendor code so to use `lf` instead of mixed `crlf`.  This prevents integrity check errors when users (or their FTP client) runs auto-crlf on the application as it's being uploaded

#### What Issues does it Close?

Closes #4684 

#### Where should the reviewer start?
Review the output of `npm install`, `npm composer-install`, and `npm composer-update` to ensure that the files supplied by vendors with `crlf` line endings are listed by the output of the `grunt lineendings` task with a status of `converted`
