### PR TITLE
Fix TaxReport Classification Selection Bug

### DIFF
--- a/src/Reports/TaxReport.php
+++ b/src/Reports/TaxReport.php
@@ -80,9 +80,6 @@ $sSQL = 'SELECT fam_ID, fam_Name, fam_Address1, fam_Address2, fam_City, fam_Stat
 	INNER JOIN pledge_plg ON fam_ID=plg_FamID
 	LEFT JOIN donationfund_fun ON plg_fundID=fun_ID';
 
-if ($classList[0]) {
-    $sSQL .= ' LEFT JOIN person_per ON fam_ID=per_fam_ID';
-}
 $sSQL .= " WHERE plg_PledgeOrPayment='Payment' ";
 
 // Add  SQL criteria
@@ -147,7 +144,7 @@ if (!empty($_POST['family'])) {
 }
 
 if ($classList[0]) {
-    $q = ' per_cls_ID IN '.$inClassList.' AND per_fam_ID NOT IN (SELECT DISTINCT per_fam_ID FROM person_per WHERE per_cls_ID IN '.$notInClassList.')';
+    $q = ' plg_famID IN (SELECT DISTINCT per_fam_ID FROM person_per WHERE per_cls_ID IN '.$inClassList.')';
 
     $sSQL .= ' AND'.$q;
 }


### PR DESCRIPTION
#### What's this PR do?
Adjusts the TaxReport query to *not* join with the person table, but rather use a sub query to find the family IDs with any person in the desired classifications and use the `SELECT IN` syntax to limit families to this result set.

#### What Issues does it Close?

Closes #3861
