### PR TITLE
Mcrypt is no longer used

### DIFF
--- a/cloud9/upgradePhp7.sh
+++ b/cloud9/upgradePhp7.sh
@@ -5,7 +5,7 @@ sudo mv /etc/apache2/envvars /etc/apache2/envvars.bak
 sudo apt-get remove libapache2-mod-php5 -y
 sudo a2dismod php5
 
-sudo apt-get install php7.0-curl php7.0-cli php7.0-dev php7.0-gd php7.0-intl php7.0-mcrypt php7.0-json php7.0-mysql php7.0-opcache php7.0-bcmath php7.0-mbstring php7.0-soap php7.0-xml php7.0-zip -y
+sudo apt-get install php7.0-curl php7.0-cli php7.0-dev php7.0-gd php7.0-intl php7.0-json php7.0-mysql php7.0-opcache php7.0-bcmath php7.0-mbstring php7.0-soap php7.0-xml php7.0-zip -y
 
 sudo apt-get install libapache2-mod-php7.0 -y
 sudo cp /etc/apache2/envvars.bak /etc/apache2/envvars

--- a/install/CentOS7.sh
+++ b/install/CentOS7.sh
@@ -7,7 +7,7 @@ chkconfig --level 234 httpd on
 
 rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 rpm -Uvh https://mirror.webtatic.com/yum/el7/webtatic-release.rpm
-sudo yum install php70w php70w-pear php70w-mcrypt php70w-mysql php70w-zip php70w-phar php70w-gd php70w-mbstring -y
+sudo yum install php70w php70w-pear php70w-mysql php70w-zip php70w-phar php70w-gd php70w-mbstring -y
 service httpd start
 php --version
 

--- a/src/ChurchCRM/Service/AppIntegrityService.php
+++ b/src/ChurchCRM/Service/AppIntegrityService.php
@@ -122,7 +122,6 @@ class AppIntegrityService
       new Prerequisite('PHP XML', function() { return extension_loaded('xml'); }),
       new Prerequisite('PHP EXIF', function() { return extension_loaded('exif'); }),
       new Prerequisite('PHP iconv', function() { return extension_loaded('iconv'); }),
-      new Prerequisite('Mcrypt', function() { return extension_loaded('mcrypt'); }),
       new Prerequisite('Mod Rewrite', function() { return AppIntegrityService::hasModRewrite(); }),
       new Prerequisite('GD Library for image manipulation', function() { return (extension_loaded('gd') && function_exists('gd_info')); }),
       new Prerequisite('FileInfo Extension for image manipulation', function() { return extension_loaded('fileinfo'); }),
@@ -133,6 +132,13 @@ class AppIntegrityService
       new Prerequisite('PHP ZipArchive', function() { return extension_loaded('zip'); }),
       new Prerequisite('Mysqli Functions', function() { return function_exists('mysqli_connect'); })
     );
+
+
+    if (version_compare(PHP_VERSION, '5.6', '<=')) {
+     array_push($prerequisites,   new Prerequisite('Mcrypt', function () {
+            return extension_loaded('mcrypt');
+        }));
+    }
     return $prerequisites;
   }
   

--- a/src/ChurchCRM/Service/AppIntegrityService.php
+++ b/src/ChurchCRM/Service/AppIntegrityService.php
@@ -133,12 +133,6 @@ class AppIntegrityService
       new Prerequisite('Mysqli Functions', function() { return function_exists('mysqli_connect'); })
     );
 
-
-    if (version_compare(PHP_VERSION, '5.6', '<=')) {
-     array_push($prerequisites,   new Prerequisite('Mcrypt', function () {
-            return extension_loaded('mcrypt');
-        }));
-    }
     return $prerequisites;
   }
   


### PR DESCRIPTION
#### What's this PR do?
Removes the checks for Mcrypt as it is not used and is deprecated, it was part of the Auto Payment stuff that was removed 

#### What Issues does it Close?

Closes #4029
Closes #4760
Part of #4506 
