### PR TITLE
Bugfix/fix calendar required fields

### DIFF
--- a/react/components/EventPropertiesEditor.tsx
+++ b/react/components/EventPropertiesEditor.tsx
@@ -7,7 +7,7 @@ import Select from 'react-select';
 import DatePicker from 'react-datepicker';
 
 
-const EventPropertiesEditor: React.FunctionComponent<{ event: CRMEvent, calendars: Array<Calendar>, eventTypes: Array<EventType>, changeHandler: (event:React.ChangeEvent)=>void, handleStartDateChange: (date: any)=>void, handleEndDateChange: (date: any)=>void,  pinnedCalendarChanged: (event: Array<Object>) => void, eventTypeChanged: (event: Array<Object>) => void }> = ({ event, calendars, eventTypes, changeHandler, handleStartDateChange, handleEndDateChange, pinnedCalendarChanged, eventTypeChanged }) => {
+const EventPropertiesEditor: React.FunctionComponent<{ event: CRMEvent, calendars: Array<Calendar>, eventTypes: Array<EventType>, changeHandler: (event:React.ChangeEvent)=>void, handleStartDateChange: (date: any)=>void, handleEndDateChange: (date: any)=>void,  pinnedCalendarChanged: (event: Array<Object>) => void, eventTypeChanged: (event: Array<Object>) => void, isFormComplete: () => boolean }> = ({ event, calendars, eventTypes, changeHandler, handleStartDateChange, handleEndDateChange, pinnedCalendarChanged, eventTypeChanged, isFormComplete }) => {
   //map the Calendar data type (returned from CRM API) into something that react-select can present as dropdown choices
   var calendarOptions=calendars.map((Pcal:Calendar) => ({value: Pcal.Id,  label: Pcal.Name}) );
   var EventTypeOptions=eventTypes.map((eventType:EventType) => ({value: eventType.Id,  label: eventType.Name}) );
@@ -70,7 +70,8 @@ const EventPropertiesEditor: React.FunctionComponent<{ event: CRMEvent, calendar
         </tr>
         <tr>
           <td className="LabelColumn">
-          {window.i18next.t('Pinned Calendars')}
+          <span>{window.i18next.t('Pinned Calendars')}</span>
+          <span className={event.PinnedCalendars.length ==0 ? "RequiredFormFieldUnsatisfied" : "RequiredFormFieldSatisfied"}>{window.i18next.t('This field is required')}</span>
             </td>
           <td className="TextColumn">
             <Select name="PinnedCalendars" inputId="PinnedCalendars" options={calendarOptions} value={initialPinnedCalendarValue} onChange={pinnedCalendarChanged} isMulti="true"  />

--- a/react/components/EventPropertiesEditor.tsx
+++ b/react/components/EventPropertiesEditor.tsx
@@ -7,7 +7,7 @@ import Select from 'react-select';
 import DatePicker from 'react-datepicker';
 
 
-const EventPropertiesEditor: React.FunctionComponent<{ event: CRMEvent, calendars: Array<Calendar>, eventTypes: Array<EventType>, changeHandler: (event:React.ChangeEvent)=>void, handleStartDateChange: (date: any)=>void, handleEndDateChange: (date: any)=>void,  pinnedCalendarChanged: (event: Array<Object>) => void, eventTypeChanged: (event: Array<Object>) => void, isFormComplete: () => boolean }> = ({ event, calendars, eventTypes, changeHandler, handleStartDateChange, handleEndDateChange, pinnedCalendarChanged, eventTypeChanged, isFormComplete }) => {
+const EventPropertiesEditor: React.FunctionComponent<{ event: CRMEvent, calendars: Array<Calendar>, eventTypes: Array<EventType>, changeHandler: (event:React.ChangeEvent)=>void, handleStartDateChange: (date: any)=>void, handleEndDateChange: (date: any)=>void,  pinnedCalendarChanged: (event: Array<Object>) => void, eventTypeChanged: (event: Array<Object>) => void}> = ({ event, calendars, eventTypes, changeHandler, handleStartDateChange, handleEndDateChange, pinnedCalendarChanged, eventTypeChanged}) => {
   //map the Calendar data type (returned from CRM API) into something that react-select can present as dropdown choices
   var calendarOptions=calendars.map((Pcal:Calendar) => ({value: Pcal.Id,  label: Pcal.Name}) );
   var EventTypeOptions=eventTypes.map((eventType:EventType) => ({value: eventType.Id,  label: eventType.Name}) );

--- a/react/components/ExistingEvent.tsx
+++ b/react/components/ExistingEvent.tsx
@@ -129,6 +129,11 @@ class ExistingEvent extends React.Component<EventFormProps, EventFormState> {
     });
   }
 
+  isFormComplete(): boolean {
+    return this.state.event.PinnedCalendars.length >0 && this.state.event.Title.length >0 && this.state.event.Start != null && this.state.event.End != null;
+          
+  }
+
   exit() {
     this.props.onClose()
   }
@@ -188,12 +193,13 @@ class ExistingEvent extends React.Component<EventFormProps, EventFormState> {
     <Modal show={true} onHide={function () { }} >
       <Modal.Header>
       <input name="Title" value={this.state.event.Title} onChange={this.handleInputChange} placeholder={window.i18next.t("Event Title")}/>
+      <span className={this.state.event.Title.length ==0 ? "RequiredFormFieldUnsatisfied" : "RequiredFormFieldSatisfied"}>{window.i18next.t('This field is required')}</span>
       </Modal.Header>
       <Modal.Body>
-        <EventPropertiesEditor event={this.state.event} calendars={this.state.calendars} eventTypes={this.state.eventTypes} changeHandler={this.handleInputChange} handleStartDateChange={this.handleStartDateChange}  handleEndDateChange={this.handleEndDateChange} pinnedCalendarChanged={this.updatePinnedCalendar} eventTypeChanged={this.updateEventType} />
+        <EventPropertiesEditor event={this.state.event} calendars={this.state.calendars} eventTypes={this.state.eventTypes} changeHandler={this.handleInputChange} handleStartDateChange={this.handleStartDateChange}  handleEndDateChange={this.handleEndDateChange} pinnedCalendarChanged={this.updatePinnedCalendar} eventTypeChanged={this.updateEventType} isFormComplete={this.isFormComplete} />
       </Modal.Body>
       <Modal.Footer>
-        <button className="btn btn-success" onClick={this.save}>Save</button>
+        <button disabled={!this.isFormComplete()} className="btn btn-success" onClick={this.save}>Save</button>
         <button className="btn btn-danger pull-left" onClick={this.delete}>Delete</button>
         <button className="btn btn-default pull-right" onClick={this.exit}>Cancel</button>
       </Modal.Footer>

--- a/react/components/ExistingEvent.tsx
+++ b/react/components/ExistingEvent.tsx
@@ -196,7 +196,7 @@ class ExistingEvent extends React.Component<EventFormProps, EventFormState> {
       <span className={this.state.event.Title.length ==0 ? "RequiredFormFieldUnsatisfied" : "RequiredFormFieldSatisfied"}>{window.i18next.t('This field is required')}</span>
       </Modal.Header>
       <Modal.Body>
-        <EventPropertiesEditor event={this.state.event} calendars={this.state.calendars} eventTypes={this.state.eventTypes} changeHandler={this.handleInputChange} handleStartDateChange={this.handleStartDateChange}  handleEndDateChange={this.handleEndDateChange} pinnedCalendarChanged={this.updatePinnedCalendar} eventTypeChanged={this.updateEventType} isFormComplete={this.isFormComplete} />
+        <EventPropertiesEditor event={this.state.event} calendars={this.state.calendars} eventTypes={this.state.eventTypes} changeHandler={this.handleInputChange} handleStartDateChange={this.handleStartDateChange}  handleEndDateChange={this.handleEndDateChange} pinnedCalendarChanged={this.updatePinnedCalendar} eventTypeChanged={this.updateEventType} />
       </Modal.Body>
       <Modal.Footer>
         <button disabled={!this.isFormComplete()} className="btn btn-success" onClick={this.save}>Save</button>

--- a/src/skin/scss/_calendars.scss
+++ b/src/skin/scss/_calendars.scss
@@ -24,3 +24,13 @@
 .form-field-error { 
   color: red;
 }
+
+.RequiredFormFieldUnsatisfied {
+  color: red;
+  display: inline-block;
+  margin-left: 10px;
+}
+
+.RequiredFormFieldSatisfied {
+  visibility: hidden;
+}

--- a/tests/behat/features/Calendar/calendar.feature
+++ b/tests/behat/features/Calendar/calendar.feature
@@ -28,12 +28,16 @@ Feature: Calendar
     Then I click on "#calendar > div.fc-view-container > div > table > tbody > tr > td > div > div > div:nth-child(3) > div.fc-content-skeleton > table > tbody > tr:nth-child(1) > td:nth-child(3)"
     And I wait for AJAX to finish
     Then I should see "Save"
+    And the "Save" button should be disabled
+    And I should see "This field is required"
     And I fill in "Title" with "Selenium Test Event"
     And I update react-select with "EventType" with "Church Service"
     And I fill in "Desc" with "Test Description"
     And I fill in date "Start" with today
     And I fill in date "End" with today
     And I update react-select with "PinnedCalendars" with "Public Calendar"
+    And I should not see "This field is required"
+    And the "Save" button should be enabled
     And I fill in "Text" with "Test Text"
     Then I press "Save"
     And I wait for the calendar to load

--- a/tests/behat/features/bootstrap/FeatureContext.php
+++ b/tests/behat/features/bootstrap/FeatureContext.php
@@ -111,5 +111,22 @@ class FeatureContext extends MinkContext
         $this->getSession()->getPage()->fillField($field, $value);
     }
 
+    /**
+    * @Then /^the "(?P<ButtonName>(?:[^"]|\\")*)" button should be (disabled|enabled)$/
+     * @param   string       $state  "enabled" or "disabled"
+     * @param   string       $ButtonName    text for the button name
+    */
+    public function assertButtonEnabledOrDisabled($ButtonName,$state)
+    {
+        // Find by named selector: http://mink.behat.org/en/latest/guides/traversing-pages.html?highlight=find#named-selectors
+        $button = $this->getSession()->getPage()->find("named", array("button",$ButtonName));
+        if (empty($button)) {
+            throw new Exception($ButtonName . " button could not be found");
+        } else {
+            $isEnabled = $button->hasAttribute('disabled') == null;
+            return $state == "enabled" && $isEnabled | $state == "disabled" && !$isEnabled;            
+        }
+    }
+
 }
 

--- a/tests/behat/features/bootstrap/FeatureContext.php
+++ b/tests/behat/features/bootstrap/FeatureContext.php
@@ -116,15 +116,17 @@ class FeatureContext extends MinkContext
      * @param   string       $state  "enabled" or "disabled"
      * @param   string       $ButtonName    text for the button name
     */
-    public function assertButtonEnabledOrDisabled($ButtonName,$state)
+    public function assertButtonEnabledOrDisabled($ButtonName,$desiredState)
     {
         // Find by named selector: http://mink.behat.org/en/latest/guides/traversing-pages.html?highlight=find#named-selectors
         $button = $this->getSession()->getPage()->find("named", array("button",$ButtonName));
         if (empty($button)) {
             throw new Exception($ButtonName . " button could not be found");
         } else {
-            $isEnabled = $button->hasAttribute('disabled') == null;
-            return $state == "enabled" && $isEnabled | $state == "disabled" && !$isEnabled;            
+            $observedState = $button->hasAttribute('disabled') ? "disabled" : "enabled";
+            if ($desiredState != $observedState) {
+                throw new Exception("Button '$ButtonName' should have been '$desiredState' but was really '$observedState' ");
+            }
         }
     }
 


### PR DESCRIPTION
#### What's this PR do?
Forces entry of the title, event type, and pinned calendar fields for creating / editing events. 

#### Screenshots (if appropriate)

Screen capture of functional tests running:
![Bugfix 4791](https://user-images.githubusercontent.com/11679900/55595308-319dda80-5711-11e9-9d6c-38b999e56e21.gif)


#### What Issues does it Close?

Closes #4782

#### How should this be manually tested?
Attempt to create a new event without first entering title, event type, or pinned calendars.  The form should prevent you from creating the event until all required fields are satisfied.

#### How should the automated tests treat this?
Adds tests to make sure the save button is disabled, and that info text is displayed until the requirements are satisfied.

