### PR TITLE
Replaced legacy variables to use new Bootstrapper equivalents.

### DIFF
--- a/src/ChurchCRM/Bootstrapper.php
+++ b/src/ChurchCRM/Bootstrapper.php
@@ -165,8 +165,8 @@ namespace ChurchCRM
                   SystemConfig::init();
               }
               // Log the error to the application log, and show an error page to user.
-              LoggerUtils::getAppLogger()->error("ERROR connecting to database at '".self::$databaseServerName."' on port '".self::$databasePort."' as user '".$sUSER."' -  MySQL Error: '".$sMYSQLERROR."'");
-              Bootstrapper::system_failure('Could not connect to MySQL on <strong>'.self::$databaseServerName.'</strong> on port <strong>'.self::$databasePort.'</strong> as <strong>'.$sUSER.'</strong>. Please check the settings in <strong>Include/Config.php</strong>.<br/>MySQL Error: '.$sMYSQLERROR, 'Database Connection Failure');
+              LoggerUtils::getAppLogger()->error("ERROR connecting to database at '".self::$databaseServerName."' on port '".self::$databasePort."' as user '".self::$databaseUser."' -  MySQL Error: '".$sMYSQLERROR."'");
+              Bootstrapper::system_failure('Could not connect to MySQL on <strong>'.self::$databaseServerName.'</strong> on port <strong>'.self::$databasePort.'</strong> as <strong>'.self::$databaseUser.'</strong>. Please check the settings in <strong>Include/Config.php</strong>.<br/>MySQL Error: '.$sMYSQLERROR, 'Database Connection Failure');
           }
       }
       private static function initPropel()


### PR DESCRIPTION
#### What's this PR do?

Corrects a problem where database usernames were not being displayed correctly when a MySQL connection error occurred.

#### Screenshots (if appropriate)

Text in highlighted boxes was missing prior to this PR
<img width="1157" alt="Screen Shot 2019-07-04 at 11 06 22 am" src="https://user-images.githubusercontent.com/6720584/60633117-9110a100-9e4c-11e9-8d71-47ae8594e022.png">

#### What Issues does it Close?

Closes #4855 

#### What are the relevant tickets?

#4855 

#### Any background context you want to provide?

This seems to simply be a hang-over from when the old connection handling routines were ported to the `Bootstrapper.php` and the old MySQL user name variable was left behind.

#### Where should the reviewer start?


#### How should this be manually tested?

1. Start with a working DB connection
2. Create an intentionally failing DB connection
3. The on-screen error message should display all relevant information, including usernames (see screen shot above).

#### How should the automated tests treat this?

No changes required - cosmetic changes only.

#### Questions:
- Is there a related website / article to substantiate / explain this change?
  -  [ ] Yes - Link:
  -  [X] No

- Does the development wiki need an update?
  -  [ ] Yes - Link:
  -  [X] No

- Does the user documentation wiki need an update?
  -  [ ] Yes - Link:
  -  [X] No

- Does this add new dependencies?
  -  [ ] Yes
  -  [X] No

- Does this need to add new data to the demo database
  -  [ ] Yes
  -  [X] No