### PR TITLE
add NPM script for propel XML to SQL build

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
         "demosite": "scripts/demosite.sh",
         "changelog-gen": "grunt exec:updatechangelog",
         "orm-gen": "php src/vendor/propel/propel/bin/propel.php --config-dir=propel model:build && cd src/ && composer dump-autoload",
+        "sql-gen": "php src/vendor/propel/propel/bin/propel.php --config-dir=propel sql:build",
         "graph-viz": "php src/vendor/propel/propel/bin/propel.php --config-dir=propel graphviz:generate",
         "datadictionary": "php src/vendor/propel/propel/bin/propel.php --config-dir=propel datadictionary:generate",
         "composer-install": "cd src/ && composer install && cd .. && grunt lineending",

--- a/propel/schema.xml
+++ b/propel/schema.xml
@@ -764,7 +764,7 @@
     <table name="record2property_r2p" idMethod="native" phpName="RecordProperty" isCrossRef="true" description="This table indicates which persons, families, or groups are assigned specific properties and what the values of those properties are.">
         <column name="r2p_pro_ID" phpName="PropertyId" type="SMALLINT" size="8" sqlType="mediumint(8) unsigned" required="true"  primaryKey="true"/>
         <column name="r2p_record_ID" phpName="RecordId" type="SMALLINT" size="8" sqlType="mediumint(8) unsigned" required="true"  primaryKey="true"/>
-        <column name="r2p_Value" phpName="PropertyValue" type="LONGVARCHAR" required="true"  defaultValue=""/>
+        <column name="r2p_Value" phpName="PropertyValue" type="LONGVARCHAR" required="true" />
 
         <foreign-key foreignTable="property_pro" description="This contains the definition of all person, family, and group properties">
             <reference local="r2p_pro_ID" foreign="pro_ID"/>


### PR DESCRIPTION
adds `npm run sql-gen` to create a SQL install script from the Propel Model XML