### PR TITLE
catch errors parsing BuildConfig.json

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -35,7 +35,7 @@ module.exports = function (grunt) {
                 grunt.log.writeln("Using BuildConfig.json");
                 return grunt.file.readJSON('BuildConfig.json');
             }
-            catch {
+            catch (e) {
                 grunt.log.writeln("BuildConfig.json not found, using defaults");
                 return grunt.file.readJSON('BuildConfig.json.example');
             }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,7 +30,15 @@ module.exports = function (grunt) {
     grunt.initConfig({
         package: grunt.file.readJSON('package.json'),
         pkg: grunt.file.readJSON('package.json'),
-        buildConfig: grunt.file.readJSON('BuildConfig.json'),
+        buildConfig: () => { 
+            try {
+                return grunt.file.readJSON('BuildConfig.json')
+            }
+            catch {
+                grunt.log.writeln("BuildConfig.json not found, using defaults");
+                return {}
+            }
+        },
         projectFiles: [
             '**',
             '**/.*',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,15 +30,16 @@ module.exports = function (grunt) {
     grunt.initConfig({
         package: grunt.file.readJSON('package.json'),
         pkg: grunt.file.readJSON('package.json'),
-        buildConfig: () => { 
+        buildConfig: (function() { 
             try {
+                grunt.log.writeln("Using BuildConfig.json");
                 return grunt.file.readJSON('BuildConfig.json');
             }
             catch {
                 grunt.log.writeln("BuildConfig.json not found, using defaults");
                 return {};
             }
-        },
+        })(),
         projectFiles: [
             '**',
             '**/.*',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -32,11 +32,11 @@ module.exports = function (grunt) {
         pkg: grunt.file.readJSON('package.json'),
         buildConfig: () => { 
             try {
-                return grunt.file.readJSON('BuildConfig.json')
+                return grunt.file.readJSON('BuildConfig.json');
             }
             catch {
                 grunt.log.writeln("BuildConfig.json not found, using defaults");
-                return {}
+                return {};
             }
         },
         projectFiles: [

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,7 +37,7 @@ module.exports = function (grunt) {
             }
             catch {
                 grunt.log.writeln("BuildConfig.json not found, using defaults");
-                return {};
+                return grunt.file.readJSON('BuildConfig.json.example');
             }
         })(),
         projectFiles: [


### PR DESCRIPTION
Don't fail on `npm install` when `BuildConfig.json` is missing.  Developers should be able to run `npm install` immediately after a clone, without copying the `.example` file.