### PR TITLE
Fix i18next on not logged in pages

### DIFF
--- a/src/Include/FooterNotLoggedIn.php
+++ b/src/Include/FooterNotLoggedIn.php
@@ -1,6 +1,7 @@
 <?php
 use ChurchCRM\dto\SystemURLs;
 use ChurchCRM\Service\SystemService;
+use ChurchCRM\Bootstrapper;
 
 ?>
     <div style="background-color: white; padding-top: 5px; padding-bottom: 5px; text-align: center; position: fixed; bottom: 0; width: 100%">
@@ -23,9 +24,9 @@ use ChurchCRM\Service\SystemService;
   <script src="<?= SystemURLs::getRootPath() ?>/skin/external/inputmask/inputmask.date.extensions.min.js"></script>
   <script src="<?= SystemURLs::getRootPath() ?>/skin/external/inputmask/inputmask.extensions.min.js" ></script>
   <script src="<?= SystemURLs::getRootPath() ?>/skin/external/bootstrap-datepicker/bootstrap-datepicker.min.js" ></script>
-
-  <!-- Bootbox -->
   <script src="<?= SystemURLs::getRootPath() ?>/skin/external/bootbox/bootbox.min.js"></script>
+  <script src="<?= SystemURLs::getRootPath() ?>/skin/external/i18next/i18next.min.js"></script>
+  <script src="<?= SystemURLs::getRootPath() ?>/locale/js/<?= Bootstrapper::GetCurrentLocale()->getLocale() ?>.js"></script>
 
   <script nonce="<?= SystemURLs::getCSPNonce() ?>">
     $(function () {
@@ -35,6 +36,21 @@ use ChurchCRM\Service\SystemService;
         increaseArea: '20%' // optional
       });
     });
+
+    i18nextOpt = {
+      lng:window.CRM.shortLocale,
+      nsSeparator: false,
+      keySeparator: false,
+      pluralSeparator:false,
+      contextSeparator:false,
+      fallbackLng: false,
+      resources: { }
+    };
+
+    i18nextOpt.resources[window.CRM.shortLocale] = {
+      translation: window.CRM.i18keys
+    };
+    i18next.init(i18nextOpt);
   </script>
   <?php
 


### PR DESCRIPTION
closes #4935

To test:
1) while on master branch, Do something that causes an upgrade failure (add `throw new \Exception("Test");` to `downloadLatestRelease()` in SystemService)
1) Observe that the javascript console shows an i18next error, and no modal appears despite the HTTP/500 error:
![image](https://user-images.githubusercontent.com/11679900/63905711-07f88f00-c9e3-11e9-8900-388936a48836.png)

1) apply this branch, and cause the same exception
1) ensure that the error modal appears
![image](https://user-images.githubusercontent.com/11679900/63905740-23639a00-c9e3-11e9-8f5a-f3bce565d73c.png)

