### PR TITLE
Move 3.5.0 Upgrade logic to PHP script 

### DIFF
--- a/src/mysql/upgrade.json
+++ b/src/mysql/upgrade.json
@@ -224,7 +224,8 @@
             "3.5.0"
         ],
         "scripts": [
-            "/mysql/upgrade/3.5.0.sql"
+            "/mysql/upgrade/3.5.0.sql",
+            "/mysql/upgrade/3.5.0.php"
         ],
         "dbVersion": "3.5.1"
     }

--- a/src/mysql/upgrade/3.5.0.php
+++ b/src/mysql/upgrade/3.5.0.php
@@ -1,0 +1,35 @@
+<?php
+
+use Propel\Runtime\Propel;
+use ChurchCRM\Utils\LoggerUtils;
+
+$connection = Propel::getConnection();
+$logger = LoggerUtils::getAppLogger();
+
+$logger->info("Dropping columns for 3.5.0 upgrade");
+
+
+try {
+  $q1 = "alter table family_custom_master drop column `fam_custom_Side`;";
+  $connection->exec($q1);
+} catch (\Exception $e){
+  $logger->warn("Could not remove `family_custom_master.fam_custom_Side`, but this is probably ok");
+}
+
+try {
+  $q2 = "alter table custom_master drop column `custom_Side`;";
+  $connection->exec($q2);
+} catch (\Exception $e){
+  $logger->warn("Could not remove `custom_master.custom_Side`, but this is probably ok");
+}
+
+
+try {
+  $q3 = "alter table person_custom_master drop column `custom_Side`;";
+  $connection->exec($q3);
+} catch (\Exception $e){
+  $logger->warn("Could not remove `person_custom_master.custom_Side`, but this is probably ok");
+}
+
+
+$logger->info("Finished dropping columns for 3.5.0 upgrade");

--- a/src/mysql/upgrade/3.5.0.sql
+++ b/src/mysql/upgrade/3.5.0.sql
@@ -1,5 +1,2 @@
-alter TABLE family_custom_master DROP fam_custom_Side;
-alter TABLE custom_master DROP custom_Side;
-
 delete from list_lst WHERE  lst_OptionName = 'bCommunication';
 delete from list_lst WHERE  lst_OptionName = 'bMenuOptions';


### PR DESCRIPTION
#### What's this PR do?
use a PHP script to drop the columns so that we can handle MySQLs  bad-tempered implementation of dropping columns.

#### What Issues does it Close?

Closes #4976 

#### Any background context you want to provide?
MySQL ERRORS if you try to drop a column that doesn't exist, and there is no `IF EXISTS` clause to gracefully handle this scenario:
*  https://chase-seibert.github.io/blog/2010/01/15/mysql-drop-column-if-exists.html
*  https://bugs.mysql.com/bug.php?id=10789
*  https://stackoverflow.com/questions/173814/using-alter-to-drop-a-column-if-it-exists-in-mysql

#### How should this be manually tested?
On a `3.5.0` system in an upgrade-failed state, make the changes in this pull request on the live system and re-try the built-in upgrade utility.

*NOTE:* if using this PR to recover a failed 3.5.0 upgrade, the `upgrade.json` db script will put you at `3.5.1`, so first adjust https://github.com/ChurchCRM/CRM/pull/4978/files#diff-731294b3e639f9ff9593f97d097249e6R230 to be 3.5.0 before attempting to recover a 3.5.0 upgrade.




Also discovered #4977 while creating this PR.