### PR TITLE
Ensure Menu Dashboard render all times

### DIFF
--- a/src/ChurchCRM/Dashboard/FamilyDashboardItem.php
+++ b/src/ChurchCRM/Dashboard/FamilyDashboardItem.php
@@ -61,7 +61,7 @@ class FamilyDashboardItem implements DashboardItemInterface {
   }
 
   public static function shouldInclude($PageName) {
-    return $PageName == "/Menu.php"; // this ID would be found on all pages.
+    return $PageName=="/Menu.php" || $PageName=="/menu";
   }
 
 }

--- a/src/ChurchCRM/Dashboard/FamilyDashboardItem.php
+++ b/src/ChurchCRM/Dashboard/FamilyDashboardItem.php
@@ -61,7 +61,7 @@ class FamilyDashboardItem implements DashboardItemInterface {
   }
 
   public static function shouldInclude($PageName) {
-    return $PageName=="/Menu.php" || $PageName=="/menu";
+    return $PageName == "/Menu.php" || $PageName == "/menu";
   }
 
 }

--- a/src/ChurchCRM/Dashboard/GroupsDashboardItem.php
+++ b/src/ChurchCRM/Dashboard/GroupsDashboardItem.php
@@ -30,7 +30,7 @@ class GroupsDashboardItem implements DashboardItemInterface {
   }
 
   public static function shouldInclude($PageName) {
-    return $PageName=="/Menu.php";
+    return $PageName=="/Menu.php" || $PageName=="/menu";
   }
 
 }

--- a/src/ChurchCRM/Dashboard/GroupsDashboardItem.php
+++ b/src/ChurchCRM/Dashboard/GroupsDashboardItem.php
@@ -30,7 +30,7 @@ class GroupsDashboardItem implements DashboardItemInterface {
   }
 
   public static function shouldInclude($PageName) {
-    return $PageName=="/Menu.php" || $PageName=="/menu";
+      return $PageName == "/Menu.php" || $PageName == "/menu";
   }
 
 }

--- a/src/ChurchCRM/Dashboard/PersonDashboardItem.php
+++ b/src/ChurchCRM/Dashboard/PersonDashboardItem.php
@@ -53,7 +53,7 @@ class PersonDashboardItem implements DashboardItemInterface {
   
 
   public static function shouldInclude($PageName) {
-    return $PageName=="/Menu.php"; // this ID would be found on all pages.
+    return $PageName=="/Menu.php" || $PageName=="/menu"; // this ID would be found on all pages.
   }
 
 }

--- a/src/ChurchCRM/Dashboard/PersonDashboardItem.php
+++ b/src/ChurchCRM/Dashboard/PersonDashboardItem.php
@@ -53,7 +53,7 @@ class PersonDashboardItem implements DashboardItemInterface {
   
 
   public static function shouldInclude($PageName) {
-    return $PageName=="/Menu.php" || $PageName=="/menu"; // this ID would be found on all pages.
+      return $PageName == "/Menu.php" || $PageName == "/menu";
   }
 
 }

--- a/src/Include/Header-function.php
+++ b/src/Include/Header-function.php
@@ -105,7 +105,7 @@ function Header_body_scripts()
                             "<'row'<'col-sm-4'l><'col-sm-4'i><'col-sm-4'p>>"
                 }
             },
-            PageName:"<?= $_SERVER['PHP_SELF']?>"
+            PageName:"<?= $_SERVER['REQUEST_URI'];?>"
         };
     </script>
     <script src="<?= SystemURLs::getRootPath() ?>/skin/js/CRMJSOM.js"></script>

--- a/tests/behat/features/dashboard.feature
+++ b/tests/behat/features/dashboard.feature
@@ -1,0 +1,20 @@
+Feature: Dashboard
+  In order to manage the system
+  As a User
+  I am able to visit the dashboard
+
+  Scenario: Dashboard at Menu.php
+    Given I am authenticated as "admin" using "changeme"
+    And  I am on "/Menu.php"
+    And I wait for AJAX to finish
+    Then I should see "92" in the "#peopleStatsDashboard" element
+    And I should see "18" in the "#familyCountDashboard" element
+    And I should see "1931 Edwards Rd"
+
+  Scenario: Dashboard at menu
+    Given I am authenticated as "admin" using "changeme"
+    And  I am on "/menu"
+    And I wait for AJAX to finish
+    Then I should see "92" in the "#peopleStatsDashboard" element
+    And I should see "18" in the "#familyCountDashboard" element
+    And I should see "1931 Edwards Rd"


### PR DESCRIPTION
#### What's this PR do?

we have the menu pages at /Menu.php and /menu,  /menu did not work with the AJAX call.

1. Support Menu.php and menu on all dashboard Items.
2. Read the URL not the page name in the case of /menu (was reading index.php)

#### What Issues does it Close?

Closes #4492

#### Any background context you want to provide?

#### How should this be manually tested?
- view /Menu.php
- view /menu

you should see the same data.
