### PR TITLE
iCheck is old and no longer needed

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -131,13 +131,6 @@ module.exports = function (grunt) {
                         expand: true,
                         filter: 'isFile',
                         flatten: true,
-                        src: ['node_modules/admin-lte/plugins/iCheck/icheck.min.js', 'node_modules/admin-lte/plugins/iCheck/square/blue.**'],
-                        dest: 'src/skin/external/iCheck/'
-                    },
-                    {
-                        expand: true,
-                        filter: 'isFile',
-                        flatten: true,
                         src: ['node_modules/bootstrap-toggle/css/bootstrap-toggle.css', 'node_modules/bootstrap-toggle/js/bootstrap-toggle.js'],
                         dest: 'src/skin/external/bootstrap-toggle/'
                     },

--- a/src/Include/FooterNotLoggedIn.php
+++ b/src/Include/FooterNotLoggedIn.php
@@ -13,8 +13,6 @@ use ChurchCRM\Bootstrapper;
 
   <!-- Bootstrap 3.3.5 -->
   <script src="<?= SystemURLs::getRootPath() ?>/skin/external/bootstrap/bootstrap.min.js"></script>
-  <!-- iCheck -->
-  <script src="<?= SystemURLs::getRootPath() ?>/skin/external/iCheck/icheck.min.js"></script>
 
   <!-- AdminLTE App -->
   <script src="<?= SystemURLs::getRootPath() ?>/skin/external/adminlte/adminlte.min.js"></script>
@@ -29,14 +27,6 @@ use ChurchCRM\Bootstrapper;
   <script src="<?= SystemURLs::getRootPath() ?>/locale/js/<?= Bootstrapper::GetCurrentLocale()->getLocale() ?>.js"></script>
 
   <script nonce="<?= SystemURLs::getCSPNonce() ?>">
-    $(function () {
-      $('input').iCheck({
-        checkboxClass: 'icheckbox_square-blue',
-        radioClass: 'iradio_square-blue',
-        increaseArea: '20%' // optional
-      });
-    });
-
     i18nextOpt = {
       lng:window.CRM.shortLocale,
       nsSeparator: false,

--- a/src/skin/churchcrm.scss
+++ b/src/skin/churchcrm.scss
@@ -16,7 +16,6 @@
 @import 'external/bootstrap-datepicker/bootstrap-datepicker.standalone.min.css';
 @import 'external/bootstrap-timepicker/bootstrap-timepicker.min.css';
 @import 'external/bootstrap-daterangepicker/daterangepicker.css';
-@import 'external/iCheck/blue.css';
 @import 'external/datatables/datatables.min.css';
 @import 'external/select2/select2.min.css';
 @import 'external/adminlte/AdminLTE.min.css';


### PR DESCRIPTION
#### What's this PR do?
removes icheck as a lib it is causing issues with the newer admin lte etc

it is only used once and it is causing issues, so removing 

#### Screenshots (if appropriate)

#### What Issues does it Close?

Closes #5011
