### PR TITLE
Fix PHP Strict Mode warning

### DIFF
--- a/src/ChurchCRM/Slim/Middleware/AuthMiddleware.php
+++ b/src/ChurchCRM/Slim/Middleware/AuthMiddleware.php
@@ -27,7 +27,7 @@ class AuthMiddleware {
                     session_destroy();
                 }
             }
-            if (empty($this->user)) {
+            if (empty($this->user) && array_key_exists("user", $_SESSION)) {
                 $this->user = $_SESSION['user'];
             } else {
                 $_SESSION['user'] = $this->user;


### PR DESCRIPTION
#### What's this PR do?
Don't try to access a key of the $_SESSION array that my not exist.


#### What Issues does it Close?

Closes #5017
