### PR TITLE
Add query cart operations

### DIFF
--- a/src/ChurchCRM/dto/Cart.php
+++ b/src/ChurchCRM/dto/Cart.php
@@ -26,7 +26,7 @@ class Cart
       throw new \Exception (gettext("PersonID for Cart must be numeric"),400);
     }
     if ($PersonID !== null && !in_array($PersonID, $_SESSION['aPeopleCart'], false)) {
-      array_push($_SESSION['aPeopleCart'], $PersonID);
+      array_push($_SESSION['aPeopleCart'], (int)$PersonID);
     }
   }
 

--- a/src/QueryView.php
+++ b/src/QueryView.php
@@ -213,6 +213,9 @@ function DoQuery()
                         if ($fieldInfo->name != 'AddToCart') {
                             echo '<th>'.$fieldInfo->name.'</th>';
                         }
+                        else {
+                            echo '<th></th>';
+                        }
                     } ?>
             </thead>
             <tbody>
@@ -230,6 +233,12 @@ function DoQuery()
             //If this field is called "AddToCart", add this to the hidden form field...
             $fieldInfo = mysqli_fetch_field_direct($rsQueryResults, $iCount);
             if ($fieldInfo->name == 'AddToCart') {
+                ?>
+                <td><a class="btn btn-app AddToPeopleCart" id="AddPersonToCart" data-cartpersonid="<?= $aRow[$iCount] ?>">
+                    <i class="fa fa-cart-plus"></i><span class="cartActionDescription"><?= gettext("Add to Cart") ?></span>
+                </a></td>
+                <?php
+
                 $aHiddenFormField[] = $aRow[$iCount];
             }
             //...otherwise just render the field


### PR DESCRIPTION
#### What's this PR do?
Adds options to the query results page to add individual query rows, or the aggregate set of query results to (or remove from) the cart.

#### Screenshots (if appropriate)
![5035-Cart](https://user-images.githubusercontent.com/11679900/66011803-81781700-e492-11e9-957b-83382737991e.gif)


#### What Issues does it Close?

Closes #5050 
Closes #5035 
Closes #4918 
Closes #4831
Closes #3791 
Closes #2755 

Helps with #4380 

Discovered #5049 