### PR TITLE
Fix bug in next-release decision algorithm.  Remove ugly recursive code.

### DIFF
--- a/src/ChurchCRM/dto/ChurchCRMReleaseManager.php
+++ b/src/ChurchCRM/dto/ChurchCRMReleaseManager.php
@@ -109,7 +109,7 @@ class ChurchCRMReleaseManager {
         
     }
 
-    private static function getHighestReleaseInArray (array $eligibleUpgradeTargetReleases) : ?ChurchCRMRelease  {
+    private static function getHighestReleaseInArray (array $eligibleUpgradeTargetReleases)  {
         if (count($eligibleUpgradeTargetReleases) >0 ) {
             usort($eligibleUpgradeTargetReleases, function(ChurchCRMRelease $a, ChurchCRMRelease $b){
                 return $a->compareTo($b) < 0;
@@ -119,7 +119,7 @@ class ChurchCRMReleaseManager {
         return null;
     }
 
-    private static function getReleaseNextPatch(array $rs, ChurchCRMRelease $currentRelease) : ?ChurchCRMRelease {
+    private static function getReleaseNextPatch(array $rs, ChurchCRMRelease $currentRelease) {
         $eligibleUpgradeTargetReleases = array_values(array_filter($rs , function(ChurchCRMRelease $r) use ($currentRelease) {
             $isSameMajorAndMinorWithGreaterPatch = ($r->MAJOR == $currentRelease->MAJOR) && ($r->MINOR == $currentRelease->MINOR) && ($r->PATCH > $currentRelease->PATCH);
             LoggerUtils::getAppLogger()->addDebug("Release " . $r . " is" . ($isSameMajorAndMinorWithGreaterPatch ? " ":" not ")  . "a possible patch upgrade target");
@@ -128,7 +128,7 @@ class ChurchCRMReleaseManager {
         return self::getHighestReleaseInArray($eligibleUpgradeTargetReleases);
     }
 
-    private static function getReleaseNextMinor(array $rs, ChurchCRMRelease $currentRelease) : ?ChurchCRMRelease {
+    private static function getReleaseNextMinor(array $rs, ChurchCRMRelease $currentRelease) {
         $eligibleUpgradeTargetReleases = array_values(array_filter($rs , function(ChurchCRMRelease $r) use ($currentRelease) {
             $isSameMajorAndMinorWithGreaterPatch = ($r->MAJOR == $currentRelease->MAJOR) && ($r->MINOR > $currentRelease->MINOR);
             LoggerUtils::getAppLogger()->addDebug("Release " . $r . " is" . ($isSameMajorAndMinorWithGreaterPatch ? " ":" not ")  . "a possible minor upgrade target");
@@ -137,7 +137,7 @@ class ChurchCRMReleaseManager {
         return self::getHighestReleaseInArray($eligibleUpgradeTargetReleases);
     }
 
-    private static function getReleaseNextMajor(array $rs, ChurchCRMRelease $currentRelease) : ?ChurchCRMRelease {
+    private static function getReleaseNextMajor(array $rs, ChurchCRMRelease $currentRelease) {
         $eligibleUpgradeTargetReleases = array_values(array_filter($rs , function(ChurchCRMRelease $r) use ($currentRelease) {
             $isSameMajorAndMinorWithGreaterPatch = ($r->MAJOR > $currentRelease->MAJOR);
             LoggerUtils::getAppLogger()->addDebug("Release " . $r . " is" . ($isSameMajorAndMinorWithGreaterPatch ? " ":" not ")  . "a possible major upgrade target");

--- a/src/ChurchCRM/dto/ChurchCRMReleaseManager.php
+++ b/src/ChurchCRM/dto/ChurchCRMReleaseManager.php
@@ -109,6 +109,43 @@ class ChurchCRMReleaseManager {
         
     }
 
+    private static function getHighestReleaseInArray (array $eligibleUpgradeTargetReleases) : ?ChurchCRMRelease  {
+        if (count($eligibleUpgradeTargetReleases) >0 ) {
+            usort($eligibleUpgradeTargetReleases, function(ChurchCRMRelease $a, ChurchCRMRelease $b){
+                return $a->compareTo($b) < 0;
+            });
+            return $eligibleUpgradeTargetReleases[0];
+        }
+        return null;
+    }
+
+    private static function getReleaseNextPatch(array $rs, ChurchCRMRelease $currentRelease) : ?ChurchCRMRelease {
+        $eligibleUpgradeTargetReleases = array_values(array_filter($rs , function(ChurchCRMRelease $r) use ($currentRelease) {
+            $isSameMajorAndMinorWithGreaterPatch = ($r->MAJOR == $currentRelease->MAJOR) && ($r->MINOR == $currentRelease->MINOR) && ($r->PATCH > $currentRelease->PATCH);
+            LoggerUtils::getAppLogger()->addDebug("Release " . $r . " is" . ($isSameMajorAndMinorWithGreaterPatch ? " ":" not ")  . "a possible patch upgrade target");
+            return $isSameMajorAndMinorWithGreaterPatch; 
+        }));
+        return self::getHighestReleaseInArray($eligibleUpgradeTargetReleases);
+    }
+
+    private static function getReleaseNextMinor(array $rs, ChurchCRMRelease $currentRelease) : ?ChurchCRMRelease {
+        $eligibleUpgradeTargetReleases = array_values(array_filter($rs , function(ChurchCRMRelease $r) use ($currentRelease) {
+            $isSameMajorAndMinorWithGreaterPatch = ($r->MAJOR == $currentRelease->MAJOR) && ($r->MINOR > $currentRelease->MINOR);
+            LoggerUtils::getAppLogger()->addDebug("Release " . $r . " is" . ($isSameMajorAndMinorWithGreaterPatch ? " ":" not ")  . "a possible minor upgrade target");
+            return $isSameMajorAndMinorWithGreaterPatch; 
+        }));
+        return self::getHighestReleaseInArray($eligibleUpgradeTargetReleases);
+    }
+
+    private static function getReleaseNextMajor(array $rs, ChurchCRMRelease $currentRelease) : ?ChurchCRMRelease {
+        $eligibleUpgradeTargetReleases = array_values(array_filter($rs , function(ChurchCRMRelease $r) use ($currentRelease) {
+            $isSameMajorAndMinorWithGreaterPatch = ($r->MAJOR > $currentRelease->MAJOR);
+            LoggerUtils::getAppLogger()->addDebug("Release " . $r . " is" . ($isSameMajorAndMinorWithGreaterPatch ? " ":" not ")  . "a possible major upgrade target");
+            return $isSameMajorAndMinorWithGreaterPatch; 
+        }));
+        return self::getHighestReleaseInArray($eligibleUpgradeTargetReleases);
+    }
+
     public static function getNextReleaseStep(ChurchCRMRelease $currentRelease) : ChurchCRMRelease {
 
         LoggerUtils::getAppLogger()->addDebug("Determining the next-step release step for " . $currentRelease);
@@ -120,29 +157,23 @@ class ChurchCRMReleaseManager {
         // Of these releases, if there is one with a newer PATCH version,
         // We should use the newest patch.
         LoggerUtils::getAppLogger()->addDebug("Evaluating next-step release eligibility based on " . count($_SESSION['ChurchCRMReleases']) . " available releases ");
-        $eligibleUpgradeTargetReleases = array_values(array_filter($rs , function(ChurchCRMRelease $r) use ($currentRelease) {
-            $isSameMajorAndMinor = ($r->MAJOR == $currentRelease->MAJOR) && ($r->MINOR == $currentRelease->MINOR);
-            LoggerUtils::getAppLogger()->addDebug("Release " . $r . " is" . ($isSameMajorAndMinor ? " ":" not ")  . "a possible upgrade target");
-            return $isSameMajorAndMinor; 
-        }));
-
-        usort($eligibleUpgradeTargetReleases, function(ChurchCRMRelease $a, ChurchCRMRelease $b){
-            return $a->compareTo($b) < 0;
-        });
         
-        if (count($eligibleUpgradeTargetReleases) == 0 ) {
+        $nextStepRelease = self::getReleaseNextPatch($rs,$currentRelease);
+
+        if (null == $nextStepRelease)  {
+            $nextStepRelease = self::getReleaseNextMinor($rs,$currentRelease);
+        }
+
+        if (null == $nextStepRelease)  {
+            $nextStepRelease = self::getReleaseNextMajor($rs,$currentRelease);
+        }
+
+        if (null == $nextStepRelease)  {
             throw new \Exception("Could not identify a suitable upgrade target release.  Current software version: " . $currentRelease . ".  Highest available release: " . $rs[0] ) ;
         }
-
-        if ($currentRelease->equals($eligibleUpgradeTargetReleases[0])) {
-            // the current release is the same as the most recent patch release from github, so let's return the most recent overall release from GitHub
-            $nextStepRelease = ChurchCRMReleaseManager::getReleaseFromString($currentRelease->MAJOR . "." . ($currentRelease->MINOR+1) . ".0");
-            LoggerUtils::getAppLogger()->addInfo("The current release (".$currentRelease.") is the highest release of it's Major/Minor combination.");
-            LoggerUtils::getAppLogger()->addInfo("Looking for releases in series: " . $nextStepRelease);
-            return self::getNextReleaseStep($nextStepRelease); 
-        }
-        LoggerUtils::getAppLogger()->addInfo("Next upgrade step for " . $currentRelease. " is : " . $eligibleUpgradeTargetReleases[0]);
-        return $eligibleUpgradeTargetReleases[0];
+    
+        LoggerUtils::getAppLogger()->addInfo("Next upgrade step for " . $currentRelease. " is : " . $nextStepRelease);
+        return $nextStepRelease;
     }
 
 


### PR DESCRIPTION
#### What's this PR do?
Fixes the logic in the release manager so that upgrades are properly applied in the following order:

First, new patches
Next, most recent minor release
Finally, most recent major release


Scenario:

```
Given 3.5.3, 3.6.0, and 4.0.0 are available releases, and the current install is on 3.5.2:

`ChurchCRMReleaseManager` would first select the 3.5.3 upgrade.

After applying the 3.5.3 upgrade, `ChurchCRMReleaseManager` would select 3.6.0.

After applying 3.6.0, `ChurchCRMReleaseManager` would select 4.0.0
```
 
#### What Issues does it Close?

Closes #5023 

#### How should this be manually tested?


Change `GITHUB_USER_NAME` on line 14 of `ChurchCRMReleaseManager` to my repo (`crossan007`), and enable `bAllowPrereleaseUpgrade`.  This will force the application to check my fork's releases (https://github.com/crossan007/CRM/releases)

First, you should get a notice to update to `3.5.12` (arbitrary number).  

Next, manipulate your composer.json version number to be `3.5.12`; then you should receive a notice to update to `3.6.0`.  

Repeat the version manipulation for 3.6.0, and you should receive a `4.0.0` notice

