### PR TITLE
Improve age representation for person

### DIFF
--- a/src/ChurchCRM/model/ChurchCRM/Person.php
+++ b/src/ChurchCRM/model/ChurchCRM/Person.php
@@ -634,24 +634,10 @@ class Person extends BasePerson implements iPhoto
       }
       $age = date_diff($now,$birthDate);
 
-      if ($age->y < 1) {
-        $ageValue = $age->m;
-        if ($age->m > 1) {
-          $ageSuffix = gettext('mos old');
-        } else {
-          $ageSuffix = gettext('mo old');
-        }
-      } else {
-        $ageValue = $age->y;
-        if ($age->y > 1) {
-          $ageSuffix = gettext('yrs old');
-        } else {
-          $ageSuffix = gettext('yr old');
-        }
-      }
+      if ($age->y < 1)
+        return printf(ngettext('%d month old', '%d months old', $age->m), $age->m);
 
-      return $ageValue. " ".$ageSuffix;
-
+      return printf(ngettext('%d year old', '%d years old', $age->y), $age->y);
     }
     
     public function getNumericAge() {

--- a/src/ChurchCRM/utils/MiscUtils.php
+++ b/src/ChurchCRM/utils/MiscUtils.php
@@ -65,23 +65,10 @@ class MiscUtils {
       $now = date_create('today');
       $age = date_diff($now,$birthDate);
 
-      if ($age->y < 1) {
-        $ageValue = $age->m;
-        if ($age->m > 1) {
-          $ageSuffix = gettext('mos old');
-        } else {
-          $ageSuffix = gettext('mo old');
-        }
-      } else {
-        $ageValue = $age->y;
-        if ($age->y > 1) {
-          $ageSuffix = gettext('yrs old');
-        } else {
-          $ageSuffix = gettext('yr old');
-        }
-      }
+      if ($age->y < 1)
+        return printf(ngettext('%d month old', '%d months old', $age->m), $age->m);
 
-      return $ageValue. " ".$ageSuffix;
+      return printf(ngettext('%d year old', '%d years old', $age->y), $age->y);
     }
 
   // Format a BirthDate

--- a/tests/behat/features/Persons/PersonAdd.feature
+++ b/tests/behat/features/Persons/PersonAdd.feature
@@ -37,10 +37,10 @@ Feature: AddPerson
     And I fill in "BirthYear" with "1992"
     And I click the "#PersonSaveButton" element
     Then I should see "Birth Date: 03/04/1992"
-    And I should see "yrs old"
+    And I should see "years old"
 
     Then I click the "#EditPerson" element
     And I fill in "HideAge" with "checked"
     And I click the "#PersonSaveButton" element
     Then I should see "Birth Date: 03/04"
-    And I should not see "yrs old"
+    And I should not see "years old"


### PR DESCRIPTION
This improves the age representation for a person and also simplifies the code by using native gettext methods for singular/plural forms.

Having strings like "%d months old" makes it clear for a translator what is meant (while "mos old" was unclear to me). Also it allows the translator to place the digit anywhere, not just at the beginning.