### PR TITLE
setlocale() use array setting, merge en-US and en_US array.

### DIFF
--- a/src/ChurchCRM/Bootstrapper.php
+++ b/src/ChurchCRM/Bootstrapper.php
@@ -108,18 +108,7 @@ namespace ChurchCRM
               $LocalReplaceArray[$i] = str_replace("-", "_", $LocalReplaceArray[$i]);
           }
 
-          $LocalMergeArray = array_merge($localeInfo->getLocaleArray(), $LocalReplaceArray);
-
-          if (PHP_VERSION_ID >= 40300) {
-              setlocale(LC_ALL, $LocalMergeArray);
-          } else {
-              foreach ($LocalMergeArray as $l) {
-                  $result = setlocale(LC_ALL, $l);
-                  if ($result) {
-                      break;
-                  }
-              }
-          }
+          setlocale(LC_ALL, array_merge($localeInfo->getLocaleArray(), $LocalReplaceArray));
 
           // Get numeric and monetary locale settings.
           $aLocaleInfo = $localeInfo->getLocaleInfo();

--- a/src/ChurchCRM/Bootstrapper.php
+++ b/src/ChurchCRM/Bootstrapper.php
@@ -104,7 +104,7 @@ namespace ChurchCRM
           self::$bootStrapLogger->debug("Setting locale to: " . $localeInfo->getLocale());
           $LocalReplaceArray = $localeInfo->getLocaleArray();
 
-          for($i = 0; $i < count($LocalReplaceArray); $i++) {
+          for ($i = 0; $i < count($LocalReplaceArray); $i++) {
               $LocalReplaceArray[$i] = str_replace("-", "_", $LocalReplaceArray[$i]);
           }
 
@@ -112,11 +112,12 @@ namespace ChurchCRM
 
           if (PHP_VERSION_ID >= 40300) {
               setlocale(LC_ALL, $LocalMergeArray);
-          }
-          else {
+          } else {
               foreach ($LocalMergeArray as $l) {
                   $result = setlocale(LC_ALL, $l);
-                  if ($result) break;
+                  if ($result) {
+                      break;
+                  }
               }
           }
 

--- a/src/ChurchCRM/Bootstrapper.php
+++ b/src/ChurchCRM/Bootstrapper.php
@@ -102,7 +102,23 @@ namespace ChurchCRM
 
           $localeInfo = Bootstrapper::GetCurrentLocale();
           self::$bootStrapLogger->debug("Setting locale to: " . $localeInfo->getLocale());
-          setlocale(LC_ALL, $localeInfo->getLocale());
+          $LocalReplaceArray = $localeInfo->getLocaleArray();
+
+          for($i = 0; $i < count($LocalReplaceArray); $i++) {
+              $LocalReplaceArray[$i] = str_replace("-", "_", $LocalReplaceArray[$i]);
+          }
+
+          $LocalMergeArray = array_merge($localeInfo->getLocaleArray(), $LocalReplaceArray);
+
+          if (PHP_VERSION_ID >= 40300) {
+              setlocale(LC_ALL, $LocalMergeArray);
+          }
+          else {
+              foreach ($LocalMergeArray as $l) {
+                  $result = setlocale(LC_ALL, $l);
+                  if ($result) break;
+              }
+          }
 
           // Get numeric and monetary locale settings.
           $aLocaleInfo = $localeInfo->getLocaleInfo();

--- a/src/Include/Functions.php
+++ b/src/Include/Functions.php
@@ -11,6 +11,7 @@
  ******************************************************************************/
 
 use ChurchCRM\Utils\LoggerUtils;
+use ChurchCRM\dto\LocaleInfo;
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\dto\Cart;
 use ChurchCRM\Service\PersonService;
@@ -436,7 +437,23 @@ function FormatDate($dDate, $bWithTime = false)
 
     $fmt = FormatDateOutput();
 
-    setlocale(LC_ALL, SystemConfig::getValue("sLanguage"));
+    $LocalReplaceArray = $localeInfo->getLocaleArray();
+
+    for($i = 0; $i < count($LocalReplaceArray); $i++) {
+        $LocalReplaceArray[$i] = str_replace("-", "_", $LocalReplaceArray[$i]);
+    }
+
+    $LocalMergeArray = array_merge($localeInfo->getLocaleArray(), $LocalReplaceArray);
+
+    if (PHP_VERSION_ID >= 40300) {
+        setlocale(LC_ALL, $LocalMergeArray);
+    }
+    else {
+        foreach ($LocalMergeArray as $l) {
+            $result = setlocale(LC_ALL, $l);
+            if ($result) break;
+        }
+    }
 
     if ($bWithTime) {
         return utf8_encode(strftime("$fmt %H:%M $sAMPM", strtotime($dDate)));
@@ -562,7 +579,7 @@ function ExpandPhoneNumber($sPhoneNumber, $sPhoneCountry, &$bWeird)
           return $sPhoneNumber;
       }
       break;
-    
+
     // If the country is unknown, we don't know how to format it, so leave it untouched
     default:
       return $sPhoneNumber;

--- a/src/Include/Functions.php
+++ b/src/Include/Functions.php
@@ -439,7 +439,7 @@ function FormatDate($dDate, $bWithTime = false)
 
     $LocalReplaceArray = $localeInfo->getLocaleArray();
 
-    for($i = 0; $i < count($LocalReplaceArray); $i++) {
+    for ($i = 0; $i < count($LocalReplaceArray); $i++) {
         $LocalReplaceArray[$i] = str_replace("-", "_", $LocalReplaceArray[$i]);
     }
 
@@ -447,11 +447,12 @@ function FormatDate($dDate, $bWithTime = false)
 
     if (PHP_VERSION_ID >= 40300) {
         setlocale(LC_ALL, $LocalMergeArray);
-    }
-    else {
+    } else {
         foreach ($LocalMergeArray as $l) {
             $result = setlocale(LC_ALL, $l);
-            if ($result) break;
+            if ($result) {
+                break;
+            }
         }
     }
 

--- a/src/Include/Functions.php
+++ b/src/Include/Functions.php
@@ -443,18 +443,7 @@ function FormatDate($dDate, $bWithTime = false)
         $LocalReplaceArray[$i] = str_replace("-", "_", $LocalReplaceArray[$i]);
     }
 
-    $LocalMergeArray = array_merge($localeInfo->getLocaleArray(), $LocalReplaceArray);
-
-    if (PHP_VERSION_ID >= 40300) {
-        setlocale(LC_ALL, $LocalMergeArray);
-    } else {
-        foreach ($LocalMergeArray as $l) {
-            $result = setlocale(LC_ALL, $l);
-            if ($result) {
-                break;
-            }
-        }
-    }
+    setlocale(LC_ALL, array_merge($localeInfo->getLocaleArray(), $LocalReplaceArray));
 
     if ($bWithTime) {
         return utf8_encode(strftime("$fmt %H:%M $sAMPM", strtotime($dDate)));


### PR DESCRIPTION
#### What's this PR do?
PHP >=4.3.0 version use setlocale(LC_ALL, "en-US", "en-US.utf8", "en-US.UTF8", "en-US.utf-8", "en-US.UTF-8", "en_US", "en_US.utf8", "en_US.UTF8", "en_US.utf-8", "en_US.UTF-8");
Support Linux system locale use "en_US.utf8", for example: Synology DSM.

#### Screenshots (if appropriate)

#### What Issues does it Close?

Closes

#### What are the relevant tickets?

#### Any background context you want to provide?

#### Where should the reviewer start?

#### How should this be manually tested?

#### How should the automated tests treat this?

#### Questions:
- Is there a related website / article to substantiate / explain this change?
  -  [ ] Yes - Link:
  -  [ ] No

- Does the development wiki need an update?
  -  [ ] Yes - Link:
  -  [ ] No

- Does the user documentation wiki need an update?
  -  [ ] Yes - Link:
  -  [ ] No

- Does this add new dependencies?
  -  [ ] Yes
  -  [ ] No

- Does this need to add new data to the demo database
  -  [ ] Yes
  -  [ ] No

