### PR TITLE
Bugfix/5149 event types bugfixes

### DIFF
--- a/propel/schema.xml
+++ b/propel/schema.xml
@@ -504,6 +504,13 @@
         <column name="event_start" phpName="Start" type="TIMESTAMP" required="true"/>
         <column name="event_end" phpName="End" type="TIMESTAMP" required="true"/>
         <column name="inactive" phpName="InActive" type="INTEGER" size="1" required="true" defaultValue="0"/>
+        <!-- 
+            event_typename is deprecated, and should be removed with 4.1.0.
+            https://github.com/ChurchCRM/CRM/issues/5149
+            This field denormalizes the event type data by storing a string representation of the event type name
+            represented by the field in the event_types table having a foreign key relationship with this table's
+            event_type property.  This denormalized event type name storage is unnecessary.
+        -->
         <column name="event_typename" phpName="TypeName" type="VARCHAR" size="40" required="true" defaultValue=""/>
         <column name="location_id" phpName="LocationId" type="INTEGER" required="true" defaultValue="0"/>
         <column name="primary_contact_person_id" phpName="PrimaryContactPersonId" type="INTEGER" required="true" defaultValue="0"/>

--- a/react/interfaces/CRMEvent.ts
+++ b/react/interfaces/CRMEvent.ts
@@ -7,7 +7,6 @@ interface CRMEvent {
     Text?: string,
     Type?: number,
     Title?: string,
-    TypeName?: string,
     LocationId?: number,
     PrimaryContactPersonId?: number,
     SecondaryContactPersonId?: number,

--- a/src/EventEditor.php
+++ b/src/EventEditor.php
@@ -352,8 +352,7 @@ if ($sAction == 'Create Event' && !empty($tyid)) {
                      `event_text` = '".InputUtils::FilterHTML($sEventText)."',
                      `event_start` = '".InputUtils::LegacyFilterInput($sEventStart)."',
                      `event_end` = '".InputUtils::LegacyFilterInput($sEventEnd)."',
-                     `inactive` = '".InputUtils::LegacyFilterInput($iEventStatus)."',
-                     `event_typename` = '".InputUtils::LegacyFilterInput($sTypeName)."';";
+                     `inactive` = '".InputUtils::LegacyFilterInput($iEventStatus)."';";
             RunQuery($sSQL);
             $iEventID = mysqli_insert_id($cnInfoCentral);
             for ($c = 0; $c < $iNumCounts; $c++) {
@@ -376,9 +375,8 @@ if ($sAction == 'Create Event' && !empty($tyid)) {
                      `event_text` = '".InputUtils::FilterHTML($sEventText)."',
                      `event_start` = '".InputUtils::LegacyFilterInput($sEventStart)."',
                      `event_end` = '".InputUtils::LegacyFilterInput($sEventEnd)."',
-                     `inactive` = '".InputUtils::LegacyFilterInput($iEventStatus)."',
-                     `event_typename` = '".InputUtils::LegacyFilterInput($sTypeName)."'".
-                    " WHERE `event_id` = '".InputUtils::LegacyFilterInput($iEventID)."';";
+                     `inactive` = '".InputUtils::LegacyFilterInput($iEventStatus)."'
+                      WHERE `event_id` = '".InputUtils::LegacyFilterInput($iEventID)."';";
             echo $sSQL;
             RunQuery($sSQL);
             for ($c = 0; $c < $iNumCounts; $c++) {

--- a/src/ListEvents.php
+++ b/src/ListEvents.php
@@ -176,7 +176,7 @@ foreach ($allMonths as $mKey => $mVal) {
         extract($aRow);
 
         $aEventID[$row] = $event_id;
-        $aEventType[$row] = $event_typename;
+        $aEventType[$row] = $type_name;
         $aEventTitle[$row] = htmlentities(stripslashes($event_title), ENT_NOQUOTES, 'UTF-8');
         $aEventDesc[$row] = htmlentities(stripslashes($event_desc), ENT_NOQUOTES, 'UTF-8');
         $aEventText[$row] = htmlentities(stripslashes($event_text), ENT_NOQUOTES, 'UTF-8');

--- a/src/api/routes/calendar/events.php
+++ b/src/api/routes/calendar/events.php
@@ -109,7 +109,6 @@ function getEventAudience($request, Response $response, $args)
 function newEvent($request, $response, $args)
 {
     $input = (object)$request->getParsedBody();
-    $eventTypeName = "";
 
     //fetch all related event objects before committing this event.
     $type = EventTypeQuery::Create()

--- a/src/api/routes/calendar/events.php
+++ b/src/api/routes/calendar/events.php
@@ -128,7 +128,7 @@ function newEvent($request, $response, $args)
     // we have event type and pined calendars.  now create the event.
     $event = new Event;
     $event->setTitle($input->Title);
-    $event->setType($type);
+    $event->setEventType($type);
     $event->setDesc($input->Desc);
     $event->setStart(str_replace("T", " ", $input->Start));
     $event->setEnd(str_replace("T", " ", $input->End));


### PR DESCRIPTION
#### What's this PR do?
Fixes denormalized storage of event type names on event objects and instead uses the value for event type name as stored in the event_types table.

#### Screenshots (if appropriate)

#### What Issues does it Close?

Closes #5149 

#### What are the relevant tickets?

#### Any background context you want to provide?

#### Where should the reviewer start?

#### How should this be manually tested?

#### How should the automated tests treat this?

#### Questions:
- Is there a related website / article to substantiate / explain this change?
  -  [ ] Yes - Link:
  -  [ ] No

- Does the development wiki need an update?
  -  [ ] Yes - Link:
  -  [ ] No

- Does the user documentation wiki need an update?
  -  [ ] Yes - Link:
  -  [ ] No

- Does this add new dependencies?
  -  [ ] Yes
  -  [ ] No

- Does this need to add new data to the demo database
  -  [ ] Yes
  -  [ ] No

