### PR TITLE
Remove undesired whitespace & clarify purpose of Month/Day/Year fields in Family Editor

### DIFF
--- a/src/FamilyEditor.php
+++ b/src/FamilyEditor.php
@@ -944,9 +944,9 @@ require 'Include/Header.php';
 			<th><?= gettext('Suffix') ?></th>
 			<th><?= gettext('Gender') ?></th>
 			<th><?= gettext('Role') ?></th>
-			<th><?= gettext('Month') ?></th>
-			<th><?= gettext('Day') ?></th>
-			<th><?= gettext('Year') ?></th>
+			<th><?= gettext('Birth Month') ?></th>
+			<th><?= gettext('Birth Day') ?></th>
+			<th><?= gettext('Birth Year') ?></th>
 			<th><?= gettext('Classification') ?></th>
 		</tr>
 		</thead>

--- a/src/FamilyEditor.php
+++ b/src/FamilyEditor.php
@@ -1082,7 +1082,6 @@ require 'Include/Header.php';
                 } else {
                     $UpdateBirthYear = 0;
                 } ?>
-				&nbsp;
 			</td>
 			<td>
 				<select name="Classification<?php echo $iCount ?>">


### PR DESCRIPTION
Minor fix to keep all family member fields in line. & to clarify purpose of Month/Day/Year fields in Family Editor.


#### What's this PR do?
Fixes field displayed out of line & clarifies purpose of date fields in "Family Members" section of the Family Editor

#### Screenshots (if appropriate)

#### What Issues does it Close?
None

- Does the development wiki need an update?
  -  [ ] Yes - Link:
  -  [x] No

- Does the user documentation wiki need an update?
  -  [ ] Yes - Link:
  -  [x] No

- Does this add new dependencies?
  -  [ ] Yes
  -  [x] No

- Does this need to add new data to the demo database
  -  [ ] Yes
  -  [x] No

