### PR TITLE
Fix $_SESSION["user"] usage

### DIFF
--- a/src/PersonView.php
+++ b/src/PersonView.php
@@ -425,7 +425,7 @@ $bOkToEdit = (
                     <a class="btn btn-app" href="<?= SystemURLs::getRootPath() ?>/v2/user/<?= $iPersonID ?>"><i class="fa fa-eye"></i> <?= gettext('View User') ?></a>
                     <?php
                 }
-            } elseif ($person->isUser() && $person->getId() == $_SESSION["user"]->getId()) {
+            } elseif ($person->isUser() && $person->getId() == AuthenticationManager::GetCurrentUser()->getId()) {
                 ?>
                 <a class="btn btn-app" href="<?= SystemURLs::getRootPath() ?>/v2/user/<?= $iPersonID ?>"><i class="fa fa-eye"></i> <?= gettext('View User') ?></a>
             <?php

--- a/src/api/routes/system/system-database.php
+++ b/src/api/routes/system/system-database.php
@@ -10,7 +10,6 @@ use ChurchCRM\Person2group2roleP2g2rQuery;
 use ChurchCRM\PersonCustomQuery;
 use ChurchCRM\PersonQuery;
 use ChurchCRM\PersonVolunteerOpportunityQuery;
-use ChurchCRM\Service\SystemService;
 use ChurchCRM\Slim\Middleware\Request\Auth\AdminRoleAuthMiddleware;
 use ChurchCRM\UserQuery;
 use ChurchCRM\Utils\LoggerUtils;
@@ -20,9 +19,9 @@ use Slim\Http\Request;
 use Slim\Http\Response;
 use ChurchCRM\Backup\BackupJob;
 use ChurchCRM\Backup\RestoreJob;
-use ChurchCRM\Backup\BackupType;
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\Backup\BackupDownloader;
+use ChurchCRM\Authentication\AuthenticationManager;
 
 $app->group('/database', function () {
 
@@ -103,7 +102,7 @@ function clearPeopleTables(Request $request, Response $response, array $p_args)
 {
     $connection = Propel::getConnection();
     $logger = LoggerUtils::getAppLogger();
-    $curUserId = $_SESSION["user"]->getId();
+    $curUserId = AuthenticationManager::GetCurrentUser()->getId();
     $logger->info("People DB Clear started ");
 
 


### PR DESCRIPTION
#### What's this PR do?
Replace the use of `$_SESSION["user"]` with `AuthenticationManager::GetCurrentUser()`


#### What Issues does it Close?

Closes #5417
