### PR TITLE
Log CSP Error/Events only if the system is in debug mode

### DIFF
--- a/src/ChurchCRM/Emails/BaseEmail.php
+++ b/src/ChurchCRM/Emails/BaseEmail.php
@@ -7,7 +7,6 @@ use ChurchCRM\dto\SystemURLs;
 use ChurchCRM\dto\ChurchMetaData;
 use Mustache_Engine;
 use Mustache_Loader_FilesystemLoader;
-use Monolog\Logger;
 use PHPMailer\PHPMailer\PHPMailer;
 use ChurchCRM\Service\SystemService;
 
@@ -48,7 +47,7 @@ abstract class BaseEmail
             $this->mail->Username = SystemConfig::getValue("sSMTPUser");
             $this->mail->Password = SystemConfig::getValue("sSMTPPass");
         }
-        if (SystemConfig::getValue("sLogLevel") == Logger::DEBUG) {
+        if (SystemConfig::debugEnabled()) {
             $this->mail->SMTPDebug = 1;
             $this->mail->Debugoutput = "error_log";
         }

--- a/src/ChurchCRM/dto/SystemConfig.php
+++ b/src/ChurchCRM/dto/SystemConfig.php
@@ -3,8 +3,8 @@
 namespace ChurchCRM\dto;
 
 use ChurchCRM\Config;
-use ChurchCRM\dto\ConfigItem;
 use ChurchCRM\data\Countries;
+use Monolog\Logger;
 
 class SystemConfig
 {
@@ -30,14 +30,14 @@ class SystemConfig
     {
         return [
             "Choices" => [
-                gettext("DEBUG").":100",
-                gettext("INFO").":200",
-                gettext("NOTICE").":250",
-                gettext("WARNING").":300",
-                gettext("ERROR").":400",
-                gettext("CRITICAL").":500",
-                gettext("ALERT").":550",
-                gettext("EMERGENCY").":600"
+                gettext("DEBUG").":".Logger::DEBUG,
+                gettext("INFO").":".Logger::INFO,
+                gettext("NOTICE").":".Logger::NOTICE,
+                gettext("WARNING").":".Logger::WARNING,
+                gettext("ERROR").":".Logger::ERROR,
+                gettext("CRITICAL").":".Logger::CRITICAL,
+                gettext("ALERT").":".Logger::ALERT,
+                gettext("EMERGENCY").":".Logger::EMERGENCY
             ]
         ];
     }
@@ -391,4 +391,11 @@ class SystemConfig
        return (!empty(self::getValue("sOLPURL")));
     }
 
+
+    public static function debugEnabled() {
+        if (self::getValue("sLogLevel") == Logger::DEBUG) {
+            return true;
+        }
+        return false;
+    }
 }

--- a/src/Include/Header-Minimal.php
+++ b/src/Include/Header-Minimal.php
@@ -1,15 +1,9 @@
 <?php
-/*******************************************************************************
- *
- *  filename    : Include/Header-Minimal.php
- *  last change : 2003-05-29
- *  description : page header (Bare minimum, not for use with Footer.php)
- *
- *  http://www.churchcrm.io/
- *  Copyright 2003 Chris Gebhardt
-  *
- ******************************************************************************/
-require_once 'Header-Security.php';
+use ChurchCRM\dto\SystemConfig;
+
+if (SystemConfig::debugEnabled()) {
+    require_once 'Header-Security.php';
+}
 
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">

--- a/src/Include/Header-Short.php
+++ b/src/Include/Header-Short.php
@@ -1,17 +1,11 @@
 <?php
-/*******************************************************************************
- *
- *  filename    : Include/Header-Short.php
- *  last change : 2003-05-29
- *  description : page header (simplified version with no menubar)
- *
- *  http://www.churchcrm.io/
- *  Copyright 2001-2002 Phillip Hullquist, Deane Barker
-  *
- ******************************************************************************/
+
+use ChurchCRM\dto\SystemConfig;
 
 require_once 'Header-function.php';
-require_once 'Header-Security.php';
+if (SystemConfig::debugEnabled()) {
+    require_once 'Header-Security.php';
+}
 
 // Turn ON output buffering
 ob_start();

--- a/src/Include/Header.php
+++ b/src/Include/Header.php
@@ -1,21 +1,10 @@
 <?php
-/*******************************************************************************
- *
- *  filename    : Include/Header.php
- *  website     : http://www.churchcrm.io
- *  description : page header used for most pages
- *
- *  Copyright 2001-2004 Phillip Hullquist, Deane Barker, Chris Gebhardt, Michael Wilt
- *  Copyright 2017 Philippe Logel
- ******************************************************************************/
 
-use ChurchCRM\Service\SystemService;
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\view\MenuRenderer;
 use ChurchCRM\dto\SystemURLs;
 use ChurchCRM\dto\Cart;
 use ChurchCRM\Service\TaskService;
-use ChurchCRM\Utils\RedirectUtils;
 use ChurchCRM\Authentication\AuthenticationManager;
 use ChurchCRM\Authentication\AuthenticationProviders\LocalAuthentication;
 
@@ -26,7 +15,9 @@ $taskService = new TaskService();
 ob_start();
 
 require_once 'Header-function.php';
-require_once 'Header-Security.php';
+if (SystemConfig::debugEnabled()) {
+    require_once 'Header-Security.php';
+}
 
 // Top level menu index counter
 $MenuFirst = 1;

--- a/src/Include/HeaderNotLoggedIn.php
+++ b/src/Include/HeaderNotLoggedIn.php
@@ -5,8 +5,6 @@ use ChurchCRM\dto\SystemConfig;
 if (SystemConfig::debugEnabled()) {
     require_once 'Header-Security.php';
 }
-
-
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html>

--- a/src/Include/HeaderNotLoggedIn.php
+++ b/src/Include/HeaderNotLoggedIn.php
@@ -2,7 +2,10 @@
 use ChurchCRM\dto\SystemURLs;
 use ChurchCRM\dto\SystemConfig;
 
-require_once 'Header-Security.php';
+if (SystemConfig::debugEnabled()) {
+    require_once 'Header-Security.php';
+}
+
 
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">

--- a/src/api/index.php
+++ b/src/api/index.php
@@ -17,7 +17,7 @@ $container = new Container;
 $container['cache'] = function () {
     return new CacheProvider();
 };
-if (SystemConfig::getValue("sLogLevel") == Logger::DEBUG) {
+if (SystemConfig::debugEnabled()) {
     $container["settings"]['displayErrorDetails'] = true;
 }
 

--- a/src/api/index.php
+++ b/src/api/index.php
@@ -7,7 +7,6 @@ require_once dirname(__FILE__) . '/../vendor/autoload.php';
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\Slim\Middleware\AuthMiddleware;
 use ChurchCRM\Slim\Middleware\VersionMiddleware;
-use Monolog\Logger;
 use Slim\App;
 use Slim\Container;
 use Slim\HttpCache\CacheProvider;

--- a/src/api/routes/system/system.php
+++ b/src/api/routes/system/system.php
@@ -18,7 +18,7 @@ function logCSPReportAPI(Request $request, Response $response, array $args)
 {
     $input = json_decode($request->getBody());
     $log = json_encode($input, JSON_PRETTY_PRINT);
-    LoggerUtils::getCSPLogger()->info($log);
+    LoggerUtils::getCSPLogger()->debug($log);
 }
 
 function getUiNotificationAPI(Request $request, Response $response, array $args)

--- a/src/external/index.php
+++ b/src/external/index.php
@@ -1,7 +1,6 @@
 <?php
 
 use ChurchCRM\dto\SystemConfig;
-use Monolog\Logger;
 
 require '../Include/Config.php';
 //require '../Include/Functions.php';

--- a/src/external/index.php
+++ b/src/external/index.php
@@ -12,7 +12,7 @@ require_once dirname(__FILE__) . '/../vendor/autoload.php';
 // Instantiate the app
 $app = new \Slim\App();
 $container = $app->getContainer();
-if (SystemConfig::getValue("sLogLevel") == Logger::DEBUG) {
+if (SystemConfig::debugEnabled()) {
     $container["settings"]['displayErrorDetails'] = true;
 }
 

--- a/src/kiosk/index.php
+++ b/src/kiosk/index.php
@@ -11,7 +11,7 @@ use Monolog\Logger;
 // Instantiate the app
 $app = new App();
 $container = $app->getContainer();
-if (SystemConfig::getValue("sLogLevel") == Logger::DEBUG) {
+if (SystemConfig::debugEnabled()) {
     $container["settings"]['displayErrorDetails'] = true;
 }
 

--- a/src/kiosk/index.php
+++ b/src/kiosk/index.php
@@ -6,7 +6,6 @@ require '../Include/Config.php';
 require_once dirname(__FILE__) . '/../vendor/autoload.php';
 
 use ChurchCRM\dto\SystemConfig;
-use Monolog\Logger;
 
 // Instantiate the app
 $app = new App();

--- a/src/session/index.php
+++ b/src/session/index.php
@@ -19,7 +19,7 @@ use Monolog\Logger;
 
 // Instantiate the app
 $container = new Container;
-if (SystemConfig::getValue("sLogLevel") == Logger::DEBUG) {
+if (SystemConfig::debugEnabled()) {
     $container["settings"]['displayErrorDetails'] = true;
 }
 // Add middleware to the application

--- a/src/session/index.php
+++ b/src/session/index.php
@@ -15,7 +15,6 @@ use Slim\Views\PhpRenderer;
 use ChurchCRM\dto\SystemURLs;
 use ChurchCRM\Slim\Middleware\VersionMiddleware;
 use ChurchCRM\dto\SystemConfig;
-use Monolog\Logger;
 
 // Instantiate the app
 $container = new Container;

--- a/src/setup/index.php
+++ b/src/setup/index.php
@@ -2,7 +2,6 @@
 
 use ChurchCRM\dto\SystemURLs;
 use ChurchCRM\dto\SystemConfig;
-use Monolog\Logger;
 
 error_reporting(E_ALL);
 ini_set('log_errors', 1);

--- a/src/setup/index.php
+++ b/src/setup/index.php
@@ -19,7 +19,7 @@ if (file_exists('../Include/Config.php')) {
 
     $app = new \Slim\App();
     $container = $app->getContainer();
-    if (SystemConfig::getValue("sLogLevel") == Logger::DEBUG) {
+    if (SystemConfig::debugEnabled()) {
         $container["settings"]['displayErrorDetails'] = true;
     }
 

--- a/src/v2/index.php
+++ b/src/v2/index.php
@@ -10,10 +10,9 @@ use Slim\App;
 use ChurchCRM\Slim\Middleware\VersionMiddleware;
 use ChurchCRM\Slim\Middleware\AuthMiddleware;
 use ChurchCRM\dto\SystemConfig;
-use Monolog\Logger;
 
 $container = new Container;
-if (SystemConfig::getValue("sLogLevel") == Logger::DEBUG) {
+if (SystemConfig::debugEnabled()) {
     $container["settings"]['displayErrorDetails'] = true;
 }
 


### PR DESCRIPTION
#### What's this PR do?
- The end user can't do anything about CSP events, so only log if we are in debug mode.
- cleanup checks for if we are in debug mode or not to use a new common method 
