### PR TITLE
Enable only Admin tests for Cypress

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,8 +64,7 @@ before_script:
 
 # execute tests
 script:
-# - npm test
-  - echo "Skip tests :("
+ - npm test
 
 before_deploy:
  - npm run package

--- a/travis-ci/cypress.json
+++ b/travis-ci/cypress.json
@@ -1,5 +1,6 @@
 {
     "baseUrl": "http://127.0.0.1",
+    "integrationFolder": "cypress/integration/admin",
     "chromeWebSecurity": false,
     "pageLoadTimeout": 1000000,
     "defaultCommandTimeout": 200000,


### PR DESCRIPTION
#### What's this PR do?
Since the travis server crashes when running all of cypress test, this will only run admin tests
