### PR TITLE
User buttons moved to a new line

### DIFF
--- a/src/PersonView.php
+++ b/src/PersonView.php
@@ -390,12 +390,6 @@ $bOkToEdit = (
     </div>
     <div class="col-lg-9 col-md-9 col-sm-9">
         <div class="box box-primary box-body">
-            <?php if ($per_ID == AuthenticationManager::GetCurrentUser()->getPersonId()) {
-                        ?>
-                <a class="btn btn-app" href="<?= SystemURLs::getRootPath() ?>/SettingsIndividual.php"><i class="fa fa-cog"></i> <?= gettext("Change Settings") ?></a>
-                <a class="btn btn-app" href="<?= SystemURLs::getRootPath() ?>/v2/user/current/changepassword"><i class="fa fa-key"></i> <?= gettext("Change Password") ?></a>
-                <?php
-                    } ?>
             <a class="btn btn-app" href="<?= SystemURLs::getRootPath() ?>/PrintView.php?PersonID=<?= $iPersonID ?>"><i class="fa fa-print"></i> <?= gettext("Printable Page") ?></a>
             <a class="btn btn-app AddToPeopleCart" id="AddPersonToCart" data-cartpersonid="<?= $iPersonID ?>"><i class="fa fa-cart-plus"></i><span class="cartActionDescription"><?= gettext("Add to Cart") ?></span></a>
             <?php if (AuthenticationManager::GetCurrentUser()->isNotesEnabled()) {
@@ -408,12 +402,17 @@ $bOkToEdit = (
                 ?>
                 <a class="btn btn-app" id="addGroup"><i class="fa fa-users"></i> <?= gettext("Assign New Group") ?></a>
                 <?php
-            }
+            } ?>
+            <a class="btn btn-app" role="button" href="<?= SystemURLs::getRootPath() ?>/v2/people"><i class="fa fa-list"></i> <?= gettext("List Members") ?></span></a>
+            <?php
             if (AuthenticationManager::GetCurrentUser()->isDeleteRecordsEnabled()) {
                 ?>
                 <a class="btn btn-app bg-maroon delete-person" data-person_name="<?= $person->getFullName()?>" data-person_id="<?= $iPersonID ?>"><i class="fa fa-trash-o"></i> <?= gettext("Delete this Record") ?></a>
                 <?php
             }
+            ?>
+            <br/>
+            <?php
             if (AuthenticationManager::GetCurrentUser()->isAdmin()) {
                 if (!$person->isUser()) {
                     ?>
@@ -423,14 +422,16 @@ $bOkToEdit = (
                     ?>
                     <a class="btn btn-app" href="<?= SystemURLs::getRootPath() ?>/UserEditor.php?PersonID=<?= $iPersonID ?>"><i class="fa fa-user-secret"></i> <?= gettext('Edit User') ?></a>
                     <a class="btn btn-app" href="<?= SystemURLs::getRootPath() ?>/v2/user/<?= $iPersonID ?>"><i class="fa fa-eye"></i> <?= gettext('View User') ?></a>
+                    <a class="btn btn-app" href="<?= SystemURLs::getRootPath() ?>/v2/user/<?= $iPersonID ?>/changePassword"><i class="fa fa-key"></i> <?= gettext("Change Password") ?></a>
                     <?php
                 }
-            } elseif ($person->isUser() && $person->getId() == AuthenticationManager::GetCurrentUser()->getId()) {
+            } else if ($person->isUser() && $person->getId() == AuthenticationManager::GetCurrentUser()->getId()) {
                 ?>
                 <a class="btn btn-app" href="<?= SystemURLs::getRootPath() ?>/v2/user/<?= $iPersonID ?>"><i class="fa fa-eye"></i> <?= gettext('View User') ?></a>
-            <?php
+                <a class="btn btn-app" href="<?= SystemURLs::getRootPath() ?>/v2/user/current/changepassword"><i class="fa fa-key"></i> <?= gettext("Change Password") ?></a>
+                <?php
             } ?>
-            <a class="btn btn-app" role="button" href="<?= SystemURLs::getRootPath() ?>/v2/people"><i class="fa fa-list"></i> <?= gettext("List Members") ?></span></a>
+
         </div>
     </div>
     <div class="col-lg-9 col-md-9 col-sm-9">


### PR DESCRIPTION
#### What's this PR do?
cleaned up so that the buttons don't move around when the person is a user

#### Screenshots (if appropriate)

User viewing self

![image](https://user-images.githubusercontent.com/554959/99891598-6f21e500-2c20-11eb-83f1-8361cc8b64e0.png)

Admin viewing user
![image](https://user-images.githubusercontent.com/554959/99891605-8bbe1d00-2c20-11eb-8128-e380d4b9eef9.png)

Admin viewing none-user 
![image](https://user-images.githubusercontent.com/554959/99891618-9a0c3900-2c20-11eb-9e17-613d60b56bac.png)
