### PR TITLE
Clarify the display of an admin user permissions

### DIFF
--- a/src/v2/templates/user/user.php
+++ b/src/v2/templates/user/user.php
@@ -42,14 +42,14 @@ include SystemURLs::getDocumentRoot() . '/Include/Header.php';
             </div>
             <div class="box-body">
                 <li><b><?= gettext("Admin") ?>:</b> <?= $user->isAdmin() ? _("Yes") : _("No") ?></li>
-                <li><b><?= gettext("Add Records") ?>:</b> <?= $user->isAddRecords() ? _("Yes") : _("No") ?></li>
-                <li><b><?= gettext("Edit Records") ?>:</b> <?= $user->isEditRecords() ? _("Yes") : _("No") ?></li>
-                <li><b><?= gettext("Delete Records") ?>:</b> <?= $user->isDeleteRecords() ? _("Yes") : _("No") ?></li>
-                <li><b><?= gettext("Manage Properties and Classifications") ?>:</b> <?= $user->isMenuOptions() ? _("Yes") : _("No") ?></li>
-                <li><b><?= gettext("Manage Groups and Roles") ?>:</b> <?= $user->isManageGroups() ? _("Yes") : _("No") ?></li>
-                <li><b><?= gettext("Manage Donations and Finance") ?>:</b> <?= $user->isFinance() ? _("Yes") : _("No") ?></li>
-                <li><b><?= gettext("Manage Notes") ?>:</b> <?= $user->isNotes() ? _("Yes") : _("No") ?></li>
-                <li><b><?= gettext("Canvasser") ?>:</b> <?= $user->isCanvasser() ? _("Yes") : _("No") ?></li>
+                <li><b><?= gettext("Add Records") ?>:</b> <?= $user->isAdmin() || $user->isAddRecords() ? _("Yes") : _("No") ?></li>
+                <li><b><?= gettext("Edit Records") ?>:</b> <?= $user->isAdmin() || $user->isEditRecords() ? _("Yes") : _("No") ?></li>
+                <li><b><?= gettext("Delete Records") ?>:</b> <?= $user->isAdmin() ||  $user->isDeleteRecords() ? _("Yes") : _("No") ?></li>
+                <li><b><?= gettext("Manage Properties and Classifications") ?>:</b> <?= $user->isAdmin() || $user->isMenuOptions() ? _("Yes") : _("No") ?></li>
+                <li><b><?= gettext("Manage Groups and Roles") ?>:</b> <?= $user->isAdmin() || $user->isManageGroups() ? _("Yes") : _("No") ?></li>
+                <li><b><?= gettext("Manage Donations and Finance") ?>:</b> <?= $user->isAdmin() || $user->isFinance() ? _("Yes") : _("No") ?></li>
+                <li><b><?= gettext("Manage Notes") ?>:</b> <?= $user->isAdmin() || $user->isNotes() ? _("Yes") : _("No") ?></li>
+                <li><b><?= gettext("Canvasser") ?>:</b> <?= $user->isAdmin() || $user->isCanvasser() ? _("Yes") : _("No") ?></li>
             </div>
         </div>
     </div>


### PR DESCRIPTION
#### What's this PR do?
The display of an admin user settings is confusing as it says you have no permissions. This PR changes that by changing the conditional check to include displaying _Yes_ for each permission if the user is an admin. Users who are not admin are not impacted. This is purely a visual change so is completely backwards compatible

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/1296369/109016103-b8fde980-76ad-11eb-8627-3dd4a8cf2b37.png)

![image](https://user-images.githubusercontent.com/1296369/109016320-fb272b00-76ad-11eb-8ae8-060d20d7ec61.png)


#### What Issues does it Close?

Closes #5657 

#### What are the relevant tickets?

#### Any background context you want to provide?
After user testing the users wondered why it said they had no permission to do anything and then went looking to see how to add the permission. 

#### Where should the reviewer start?

#### How should this be manually tested?

#### How should the automated tests treat this?

#### Questions:
- Is there a related website / article to substantiate / explain this change?
  -  [ ] Yes - Link:
  -  [x] No

- Does the development wiki need an update?
  -  [ ] Yes - Link:
  -  [x] No

- Does the user documentation wiki need an update?
  -  [ ] Yes - Link:
  -  [x] No

- Does this add new dependencies?
  -  [ ] Yes
  -  [x] No

- Does this need to add new data to the demo database
  -  [ ] Yes
  -  [x] No

