### PR TITLE
No default skin

### DIFF
--- a/src/ChurchCRM/model/ChurchCRM/User.php
+++ b/src/ChurchCRM/model/ChurchCRM/User.php
@@ -310,8 +310,9 @@ class User extends BaseUser
     }
 
     public function getStyle(){
+        $skin = is_null($this->getSetting(UserSetting::UI_STYLE)) ? "skin-red" : $this->getSetting(UserSetting::UI_STYLE);
         $cssClasses = [];
-        array_push($cssClasses, $this->getSetting(UserSetting::UI_STYLE));
+        array_push($cssClasses, $skin);
         array_push($cssClasses, $this->getSetting(UserSetting::UI_BOXED));
         array_push($cssClasses, $this->getSetting(UserSetting::UI_SIDEBAR));
         return implode(" ", $cssClasses);


### PR DESCRIPTION
Apologies if this doesn't match your coding style etc I am still learning your codebase

#### What's this PR do?
#5567 introduced changes to the way skins are configured.

Before that PR there was a default skin of "skin-red" which was read from the database table user_usr in the field usr_Style. Now the only skin that is loaded is that configured for a user and saved as ui.style in the user_settings table.

As a result on a CLEAN install (not an upgrade or demo) when you login for the first time you have a user menu dropdown with white text on a white background.

![image](https://user-images.githubusercontent.com/1296369/109052215-44d63c80-76d3-11eb-9140-610342c90503.png)

There are many different ways that this could be resolved but this PR is the method I chose to use "skin-red" if there is no ui.style

If nothing else then hopefully this PR is revealing what and where the bug exists

#### What Issues does it Close?

Closes #5638 

#### What are the relevant tickets?

#### Any background context you want to provide?

#### Where should the reviewer start?

#### How should this be manually tested?

#### How should the automated tests treat this?

#### Questions:
- Is there a related website / article to substantiate / explain this change?
  -  [ ] Yes - Link:
  -  [ ] No

- Does the development wiki need an update?
  -  [ ] Yes - Link:
  -  [ ] No

- Does the user documentation wiki need an update?
  -  [ ] Yes - Link:
  -  [ ] No

- Does this add new dependencies?
  -  [ ] Yes
  -  [ ] No

- Does this need to add new data to the demo database
  -  [ ] Yes
  -  [ ] No

