### PR TITLE
Delete php.ini_REGISTER_GLOBALS_OFF

### DIFF
--- a/src/php.ini_REGISTER_GLOBALS_OFF
+++ b/src/php.ini_REGISTER_GLOBALS_OFF
@@ -1,1 +1,0 @@
-register_globals = off


### PR DESCRIPTION
#### What's this PR do?
As the minimum php version is currently 7.3 there is no point in shipping the legacy file with instructions how to turn register globals off. They were removed completely from php as of 5.4

#### Screenshots (if appropriate)

#### What Issues does it Close?

Closes #5680 

#### What are the relevant tickets?

#### Any background context you want to provide?

#### Where should the reviewer start?

#### How should this be manually tested?

#### How should the automated tests treat this?

#### Questions:
- Is there a related website / article to substantiate / explain this change?
  -  [ ] Yes - Link:
  -  [ ] No

- Does the development wiki need an update?
  -  [ ] Yes - Link:
  -  [ ] No

- Does the user documentation wiki need an update?
  -  [ ] Yes - Link:
  -  [ ] No

- Does this add new dependencies?
  -  [ ] Yes
  -  [ ] No

- Does this need to add new data to the demo database
  -  [ ] Yes
  -  [ ] No

