### PR TITLE
Bug: Missing footer on login page & show password

### DIFF
--- a/src/Include/FooterNotLoggedIn.php
+++ b/src/Include/FooterNotLoggedIn.php
@@ -24,6 +24,7 @@ use ChurchCRM\Bootstrapper;
   <script src="<?= SystemURLs::getRootPath() ?>/skin/external/bootstrap-datepicker/bootstrap-datepicker.min.js" ></script>
   <script src="<?= SystemURLs::getRootPath() ?>/skin/external/bootbox/bootbox.min.js"></script>
   <script src="<?= SystemURLs::getRootPath() ?>/skin/external/i18next/i18next.min.js"></script>
+  <script src="<?= SystemURLs::getRootPath() ?>/skin/external/bootstrap-show-password/bootstrap-show-password.min.js"></script>
   <script src="<?= SystemURLs::getRootPath() ?>/locale/js/<?= Bootstrapper::GetCurrentLocale()->getLocale() ?>.js"></script>
 
   <script nonce="<?= SystemURLs::getCSPNonce() ?>">

--- a/src/session/templates/begin-session.php
+++ b/src/session/templates/begin-session.php
@@ -69,6 +69,7 @@ require SystemURLs::getDocumentRoot() . '/Include/HeaderNotLoggedIn.php';
         <!--<a href="external/family/verify" class="text-center">Verify Family Info</a> -->
 
     </div>
-
 <!-- /.login-box-body -->
 </div>
+<?php
+require SystemURLs::getDocumentRoot() . '/Include/FooterNotLoggedIn.php';


### PR DESCRIPTION
#### What's this PR do?
- Ensure Login page has a footer
- Included missing show password script on login page.

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/554959/112760123-c824cf80-8faa-11eb-911c-bb7ae9bcb463.png)
![image](https://user-images.githubusercontent.com/554959/112760316-4ed9ac80-8fab-11eb-8e5e-9af68e9ba8a6.png)

With footer
![image](https://user-images.githubusercontent.com/554959/112760335-65800380-8fab-11eb-97fe-24a50f91f67c.png)

