### PR TITLE
Fixed db errors post upgrade

### DIFF
--- a/src/ChurchCRM/Service/UpgradeService.php
+++ b/src/ChurchCRM/Service/UpgradeService.php
@@ -54,6 +54,7 @@ class UpgradeService
                   if (!$errorFlag) {
                       $version->setUpdateEnd(new \DateTime());
                       $version->save();
+                      sleep(2);
                   }
                 // increment the number of scripts executed.
                 // If no scripts run, then there is no supported upgrade path defined in the JSON file


### PR DESCRIPTION
#### What's this PR do?
- Adds asleep between DB version upgrades, this is to ensure we have a different time stamp on each version_ver row. 



