### PR TITLE
Fixed  new system setup error in 4.5.0

### DIFF
--- a/src/ChurchCRM/dto/SystemConfig.php
+++ b/src/ChurchCRM/dto/SystemConfig.php
@@ -5,6 +5,7 @@ namespace ChurchCRM\dto;
 use ChurchCRM\Config;
 use ChurchCRM\data\Countries;
 use ChurchCRM\ListOptionQuery;
+use Exception;
 use Monolog\Logger;
 
 class SystemConfig
@@ -62,11 +63,16 @@ class SystemConfig
 
     public static function getFamilyRoleChoices() 
     {
-      $familyRoles = ListOptionQuery::create()->getFamilyRoles();
       $roles = [];
-      foreach ($familyRoles as $familyRole) {
-        array_push($roles, $familyRole->getOptionName().":".$familyRole->getOptionId());
-      }
+      try {
+        $familyRoles = ListOptionQuery::create()->getFamilyRoles();
+        
+        foreach ($familyRoles as $familyRole) {
+          array_push($roles, $familyRole->getOptionName().":".$familyRole->getOptionId());
+        }
+      } catch (Exception $e) {
+        
+      } 
       return ["Choices" => $roles];
     }
 


### PR DESCRIPTION
#### What's this PR do?
- ensure the system settings load when there is no db connection setup. This was a bug that is introduced in 4.5.0 

#### What Issues does it Close?

Closes #6072
