### PR TITLE
add propel/propel 2.0.0-beta3 to composer.lock

### DIFF
--- a/src/composer.lock
+++ b/src/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4ab7608abafefd6e275a8ecc55ea8806",
+    "content-hash": "32520f33bbf9c95dcdc02dfe997fd86e",
     "packages": [
         {
             "name": "azuyalabs/yasumi",
@@ -2585,38 +2585,39 @@
         },
         {
             "name": "propel/propel",
-            "version": "2.0.0-alpha12",
+            "version": "2.0.0-beta3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/propelorm/Propel2.git",
-                "reference": "540769c4f1feb3faccb4f40f8d9aa5d79fc2b28a"
+                "reference": "011aaa77d09fd5357f17b60fa3c5ba488c1690ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/propelorm/Propel2/zipball/540769c4f1feb3faccb4f40f8d9aa5d79fc2b28a",
-                "reference": "540769c4f1feb3faccb4f40f8d9aa5d79fc2b28a",
+                "url": "https://api.github.com/repos/propelorm/Propel2/zipball/011aaa77d09fd5357f17b60fa3c5ba488c1690ae",
+                "reference": "011aaa77d09fd5357f17b60fa3c5ba488c1690ae",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2",
-                "psr/log": "^1.0",
-                "symfony/config": "^3.4.0||^4.0.0||^5.0.0",
-                "symfony/console": "^3.4.0||^4.0.0||^5.0.0",
-                "symfony/filesystem": "^3.4.0||^4.0.0||^5.0.0",
-                "symfony/finder": "^3.4.0||^4.0.0||^5.0.0",
-                "symfony/translation": "^3.4.0||^4.0.0||^5.0.0",
-                "symfony/validator": "^3.4.0||^4.0.0||^5.0.0",
-                "symfony/yaml": "^3.4.0||^4.0.0||^5.0.0"
+                "php": ">=7.4",
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
+                "symfony/config": "^4.4.0 || ^5.0.0 || ^6.0.0",
+                "symfony/console": "^4.4.0 || ^5.0.0 || ^6.0.0",
+                "symfony/filesystem": "^4.4.0 || ^5.0.0 || ^6.0.0",
+                "symfony/finder": "^4.4.0 || ^5.0.0 || ^6.0.0",
+                "symfony/translation": "^4.4.0 || ^5.0.0 || ^6.0.0",
+                "symfony/validator": "^4.4.0 || ^5.0.0 || ^6.0.0",
+                "symfony/yaml": "^4.4.0 || ^5.0.0 || ^6.0.0"
             },
             "require-dev": {
                 "ext-json": "*",
                 "ext-pdo": "*",
+                "ext-xml": "*",
                 "mikey179/vfsstream": "^1.6",
-                "monolog/monolog": "^1.3",
-                "phpstan/phpstan": "^0.12.4",
-                "phpunit/phpunit": "^8.0.0||^9.0.0",
-                "psalm/phar": "4.2.1",
-                "spryker/code-sniffer": "^0.15.6"
+                "monolog/monolog": "^1.3 || ^2.3 || ^3.0",
+                "phpstan/phpstan": "^1.2",
+                "phpunit/phpunit": "^9.5.0",
+                "psalm/phar": "^4.23",
+                "spryker/code-sniffer": "^0.17.2"
             },
             "suggest": {
                 "monolog/monolog": "The recommended logging library to use with Propel."
@@ -2654,9 +2655,9 @@
             ],
             "support": {
                 "issues": "https://github.com/propelorm/Propel2/issues",
-                "source": "https://github.com/propelorm/Propel2/tree/2.0.0-alpha12"
+                "source": "https://github.com/propelorm/Propel2/tree/2.0.0-beta3"
             },
-            "time": "2021-01-22T12:18:42+00:00"
+            "time": "2023-01-25T14:47:29+00:00"
         },
         {
             "name": "psr/cache",
@@ -5521,7 +5522,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "propel/propel": 15
+        "propel/propel": 10
     },
     "prefer-stable": false,
     "prefer-lowest": false,


### PR DESCRIPTION
#### What's this PR do?

commit 2088d6e60754071ae2c4d7a0fa27d81b729a9d98 (from #6541) added `"propel/propel": "2.0.0-beta3"` to the `composer.json` file without updating the `composer.lock` file, which caused errors to appear in CI. Adding the aforementioned `composer.lock` change allows the warning to go away.

#### Screenshots (if appropriate)

N/A

#### What Issues does it Close?

Closes errors raised in https://github.com/ChurchCRM/CRM/actions/runs/6600663726/job/17930922694

#### What are the relevant tickets?

N/A

#### Any background context you want to provide?

I wanted to help fix the build issues I saw in CI.

#### Where should the reviewer start?

N/A

#### How should this be manually tested?

N/A

#### How should the automated tests treat this?

Run the CI build?

#### Questions:
- Is there a related website / article to substantiate / explain this change?
  -  [x] Yes - Link: https://getcomposer.org/doc/03-cli.md#update-u-upgrade
      - any time `composer.json` is modified, `composer.lock` should probably be updated since `composer.lock` is the where specific versions of php packages to be installed are outlined (similar to package-lock.json in node/npm)
  -  [ ] No

- Does the development wiki need an update?
  -  [ ] Yes - Link:
  -  [x] No

- Does the user documentation wiki need an update?
  -  [ ] Yes - Link:
  -  [x] No

- Does this add new dependencies?
  -  [ ] Yes
  -  [x] No

- Does this need to add new data to the demo database
  -  [ ] Yes
  -  [x] No

