### PR TITLE
Ckeditor

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -103,7 +103,7 @@ module.exports = function (grunt) {
                     },
                     {
                         expand: true,
-                        cwd:'node_modules/ckeditor/',
+                        cwd:'node_modules/ckeditor4/',
                         src: ['*.js','*.css','*.json','lang/**/*','adapters/**/*','plugins/**/*','skins/**/*'],
                         dest: 'src/skin/external/ckeditor/'
                     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "bootstrap-toggle": "^2.2.2",
                 "bootstrap-validator": "^0.11.9",
                 "chart.js": "^2.9.4",
-                "ckeditor": "^4.12.1",
+                "ckeditor4": "4.22.1",
                 "daterangepicker": "^3.1.0",
                 "flag-icons": "^6.11.1",
                 "fullcalendar": "3.10.5",
@@ -3504,11 +3504,10 @@
             "integrity": "sha512-SXgeMX9VwDe7iFFaEWkA5AstuER9YKqy4EhHqr4DVqkwmD9rpVimkMKWHdjn30Ja45txyjhSn63lVX69eVCckg==",
             "optional": true
         },
-        "node_modules/ckeditor": {
-            "version": "4.12.1",
-            "resolved": "https://registry.npmjs.org/ckeditor/-/ckeditor-4.12.1.tgz",
-            "integrity": "sha512-pH2Su4oi0D4iN/3U8nUcwI7/lXHoOJi0aiN8e2zxnm4Ow5kq8eZP2ZGmpYyuqRyKZ2tHaU8+OyYi7laXcjiq9Q==",
-            "deprecated": "We have renamed the @ckeditor package. New versions are available under the @ckeditor4 name."
+        "node_modules/ckeditor4": {
+            "version": "4.22.1",
+            "resolved": "https://registry.npmjs.org/ckeditor4/-/ckeditor4-4.22.1.tgz",
+            "integrity": "sha512-Yj4vTHX5YxHwc48gNqUqTm+KLkRr9tuyb4O2VIABu4oKHWRNVIdLdy6vUNe/XNx+RiTavMejfA1MVOU/MxLjqQ=="
         },
         "node_modules/class-utils": {
             "version": "0.3.6",
@@ -17258,10 +17257,10 @@
             "integrity": "sha512-SXgeMX9VwDe7iFFaEWkA5AstuER9YKqy4EhHqr4DVqkwmD9rpVimkMKWHdjn30Ja45txyjhSn63lVX69eVCckg==",
             "optional": true
         },
-        "ckeditor": {
-            "version": "4.12.1",
-            "resolved": "https://registry.npmjs.org/ckeditor/-/ckeditor-4.12.1.tgz",
-            "integrity": "sha512-pH2Su4oi0D4iN/3U8nUcwI7/lXHoOJi0aiN8e2zxnm4Ow5kq8eZP2ZGmpYyuqRyKZ2tHaU8+OyYi7laXcjiq9Q=="
+        "ckeditor4": {
+            "version": "4.22.1",
+            "resolved": "https://registry.npmjs.org/ckeditor4/-/ckeditor4-4.22.1.tgz",
+            "integrity": "sha512-Yj4vTHX5YxHwc48gNqUqTm+KLkRr9tuyb4O2VIABu4oKHWRNVIdLdy6vUNe/XNx+RiTavMejfA1MVOU/MxLjqQ=="
         },
         "class-utils": {
             "version": "0.3.6",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
         "bootstrap-toggle": "^2.2.2",
         "bootstrap-validator": "^0.11.9",
         "chart.js": "^2.9.4",
-        "ckeditor": "^4.12.1",
+        "ckeditor4": "4.22.1",
         "daterangepicker": "^3.1.0",
         "flag-icons": "^6.11.1",
         "fullcalendar": "3.10.5",


### PR DESCRIPTION
#### What does PR do? Any background context you want to provide?
This updates the version of ckeditor to ckeditor4 and locks it to release 4.22.1 which is the last opensource release of the ckeditor4 series. (reference https://www.npmjs.com/package/ckeditor4)

Note that ckeditor5 is a different beast altogether

The path in the release does noty change so this should be 100% bc

#### What Issues does it Close? Any the relevant tickets?

Closes

#### Screenshots (if appropriate)


#### Where should the reviewer start?


#### How should this be manually tested?


#### Questions:
- Is there a related website / article to substantiate / explain this change?
  -  [ ] Yes - Link:
  -  [ ] No

- Does the development wiki need an update?
  -  [ ] Yes - Link:
  -  [ ] No

- Does the user documentation wiki need an update?
  -  [ ] Yes - Link:
  -  [ ] No

- Does this add new dependencies?
  -  [ ] Yes
  -  [ ] No

- Does this need to add new data to the demo database
  -  [ ] Yes
  -  [ ] No