### PR TITLE
Moved from Custom github action for Release Notes to github builtin 

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -7,11 +7,11 @@ changelog:
     authors:
       - octocat
   categories:
-    - title: Breaking Changes 🛠
+    - title: 🛠 Breaking Changes 
       labels:
         - Semver-Major
         - breaking-change
-    - title: Exciting New Features 🎉
+    - title: 🎉 Exciting New Features 
       labels:
         - Semver-Minor
         - enhancement
@@ -19,7 +19,7 @@ changelog:
         - new
         - UI
         - API 
-    - title: Bugs
+    - title: 🪲 Bugs
       labels:
         - bug
         - 'P0 - Urgent'
@@ -27,7 +27,7 @@ changelog:
       labels:
         - 'Installation and Upgrade'
         - Configuration
-    - title: Localization
+    - title: 💬 Localization
       labels:
         - Localization
     - title: 'Inner Beauty'
@@ -36,7 +36,7 @@ changelog:
         - build
         - 'Code Smell'
         - 'Backend System'
-    - title: Dependencies 👒
+    - title: 👒 Dependencies 
       labels:
         - dependencies
         - 'Package Dependencies'


### PR DESCRIPTION
#### What does PR do? Any background context you want to provide?
- delete git hub action for release notes when would run  on release close 
- created the release.yml with our labels and grouping 

NOTE: This was merged to master to test.