### PR TITLE
Fix sunday school graphs

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -195,7 +195,11 @@ module.exports = function (grunt) {
                         expand: true,
                         filter: 'isFile',
                         flatten: true,
-                        src: ['node_modules/flot/jquery.flot*.js'],
+                        src: [
+                            'node_modules/flot/source/jquery.canvaswrapper.js',
+                            'node_modules/flot/source/jquery.colorhelpers.js',
+                            'node_modules/flot/source/jquery.flot*.js'
+                        ],
                         dest: 'src/skin/external/flot/'
                     },
                     {

--- a/src/sundayschool/SundaySchoolClassView.php
+++ b/src/sundayschool/SundaySchoolClassView.php
@@ -467,7 +467,8 @@ function implodeUnique($array, $withQuotes)
       }
     },
     legend: {
-      show: false
+      show: false,
+      position: "sw",
     }
   });
   /*

--- a/src/sundayschool/SundaySchoolClassView.php
+++ b/src/sundayschool/SundaySchoolClassView.php
@@ -331,6 +331,10 @@ function implodeUnique($array, $withQuotes)
   <!-- /.modal-dialog -->
 </div><!-- /.modal -->
 
+<!-- JQUERY CANVAS WRAPPER for flot -->
+<script  src="<?= SystemURLs::getRootPath() ?>/skin/external/flot/jquery.canvaswrapper.js"></script>
+<!-- JQUERY COLOR HELPERS for flot -->
+<script  src="<?= SystemURLs::getRootPath() ?>/skin/external/flot/jquery.colorhelpers.js"></script>
 <!-- FLOT CHARTS -->
 <script  src="<?= SystemURLs::getRootPath() ?>/skin/external/flot/jquery.flot.js"></script>
 <!-- FLOT RESIZE PLUGIN - allows the chart to redraw when the window is resized -->
@@ -339,6 +343,14 @@ function implodeUnique($array, $withQuotes)
 <script  src="<?= SystemURLs::getRootPath() ?>/skin/external/flot/jquery.flot.pie.js"></script>
 <!-- FLOT CATEGORIES PLUGIN - Used to draw bar charts -->
 <script  src="<?= SystemURLs::getRootPath() ?>/skin/external/flot/jquery.flot.categories.js"></script>
+<!-- FLOT SATURATED PLUGIN -->
+<script  src="<?= SystemURLs::getRootPath() ?>/skin/external/flot/jquery.flot.saturated.js"></script>
+<!-- FLOT BROWSER PLUGIN -->
+<script  src="<?= SystemURLs::getRootPath() ?>/skin/external/flot/jquery.flot.browser.js"></script>
+<!-- FLOT DRAW SERIES PLUGIN -->
+<script  src="<?= SystemURLs::getRootPath() ?>/skin/external/flot/jquery.flot.drawSeries.js"></script>
+<!-- FLOT UI CONSTANTS -->
+<script  src="<?= SystemURLs::getRootPath() ?>/skin/external/flot/jquery.flot.uiConstants.js"></script>
 
 <script nonce="<?= SystemURLs::getCSPNonce() ?>">
   $(document).ready(function () {


### PR DESCRIPTION
# Description & Issue number it closes 
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->

Sunday school graphs were not loading because of a myriad of errors.

I did what I needed to do to fix it but there's lots of things I don't like that we should probably look into:
 * Why are we using Flot AND Chart.js? Why aren't we consistently using 1 charting library (like the better maintained Chart.js)?
 * If we plan to continue to use Flot, why are we copying in unminified source?
 * (overall direction question) Should ChurchCRM continue to do this much for sunday school or should we just become a small integration layer over something like Moodle?

(side note: wow, how long was this broken?)

Closes #6640

## Screenshots (if appropriate)

<img width="1068" alt="image" src="https://github.com/ChurchCRM/CRM/assets/5031018/28a2a41c-de0a-46d3-95ac-150e6458c1d4">


## How to test the changes?

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

View the page.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
    - maybe @tobsowo can help write the test here?
- [x] Any dependent changes have been merged and published in downstream modules

