### PR TITLE
No Longer Support PHP 8.0

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,14 +1,36 @@
 # Security Policy
 
-Do **NOT** conduct penetration/security testing on the ChurchCRM demo site without discussing first with code owners (via support ticket or [Gitter](https://gitter.im/ChurchCRM/CRM) ). This can (*and often does*) generate hundreds of bogus support cases, which is unhelpful. All security testing should be done in your hosting environment unless you have explicit permission from site owners to test their deployments (including the ChurchCRM demo system).
+## Reporting a Vulnerability
+
+At ChurchCRM, we take the security of our software seriously. If you discover any security issues, we appreciate your cooperation in responsibly disclosing the information to us.
+
+To report a security vulnerability, file a github issue include the following details:
+
+- Description of the vulnerability
+- Steps to reproduce the vulnerability
+- Any relevant information on the environment and configurations
+
+## Scope
+
+Please note that the following activities are considered within the scope of our responsible disclosure process:
+
+- Reporting security vulnerabilities directly to us
+- Providing details necessary for us to reproduce and validate the vulnerability
+
+## No Security Testing on Demo Sites
+
+For security and stability reasons, we kindly request that you do not perform any security testing on the demo sites provided by ChurchCRM. The demo sites are for showcasing purposes only, and any attempts to identify or exploit security vulnerabilities on these sites may lead to unintended disruptions.
+
+If you are interested in security testing or assessments, please focus your efforts on your local development environments or any instances you have set up for testing purposes.
+
+Thank you for your understanding and cooperation in making ChurchCRM a more secure platform.
 
 ## Supported Versions
 
-| Version | Supported          | PHP Version | 
-| ------- | ------------------ | ------------
-| 5.x +   | :white_check_mark: | 8.x |
-| 4.0.x   | :x:                | 7.2.x 7.3.x |
-| 3.0.x   | :x:                | 7.x |
-| 2.0.x   | :x:                | 5.6 7.0 7.1  | 
-
-Please disclose security issues to info@churchcrm.io
+| Version     | Supported          | PHP Version |
+|-------------| ------------------ |-------------
+| 5.3 +       | :white_check_mark: | 8.x         |
+| 5.0 - 5.2.x | :x:                | 8.1         |
+| 4.0.x       | :x:                | 7.2.x 7.3.x |
+| 3.0.x       | :x:                | 7.x         |
+| 2.0.x       | :x:                | 5.6 7.0 7.1 |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,7 +29,7 @@ Thank you for your understanding and cooperation in making ChurchCRM a more secu
 
 | Version     | Supported          | PHP Version |
 |-------------| ------------------ |-------------
-| 5.3 +       | :white_check_mark: | 8.x         |
+| 5.3 +       | :white_check_mark: | >=8.1         |
 | 5.0 - 5.2.x | :x:                | 8.1         |
 | 4.0.x       | :x:                | 7.2.x 7.3.x |
 | 3.0.x       | :x:                | 7.x         |

--- a/src/index.php
+++ b/src/index.php
@@ -1,7 +1,7 @@
 <?php
 
 $phpVersion = phpversion();
-if (version_compare($phpVersion, '8.0.0', '<=')) {
+if (version_compare($phpVersion, '8.1.0', '<=')) {
     $redirectHeader = 'Location: php-error.html';
     if ($phpVersion) {
         header('X-PHP-Version: '.$phpVersion);

--- a/src/setup/routes/setup.php
+++ b/src/setup/routes/setup.php
@@ -8,7 +8,7 @@ $app->group('/', function () use ($app) {
     $app->get('', function ($request, $response, $args) {
         $renderer = new PhpRenderer('templates/');
         $renderPage = 'setup-steps.php';
-        if (version_compare(phpversion(), '8.0.0', '<')) {
+        if (version_compare(phpversion(), '8.1.0', '<')) {
             $renderPage = 'setup-error.php';
         }
 


### PR DESCRIPTION
# Description & Issue number it closes 
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->

update min version of PHP to 8.1 as 8.0 support ends 26 Nov 2023 https://www.php.net/supported-versions.php
