### PR TITLE
fix tax report incorrect args in ChurchCRM\Reports\PdfTaxReport::finishPage()

### DIFF
--- a/src/Reports/TaxReport.php
+++ b/src/Reports/TaxReport.php
@@ -342,10 +342,21 @@ if ($output === 'pdf') {
                 }
             }
             $pdf->SetFont('Times', '', 10);
-            $pdf->finishPage($curY);
+            $pdf->finishPage(
+                $curY,
+                $fam_ID,
+                $fam_Name,
+                $fam_Address1,
+                $fam_Address2,
+                $fam_City,
+                $fam_State,
+                $fam_Zip,
+                $fam_Country
+            );
         }
 
         // Start Page for New Family
+        $cnt = 0;
         if ($fam_ID != $currentFamilyID) {
             $curY = $pdf->startNewPage($fam_ID, $fam_Name, $fam_Address1, $fam_Address2, $fam_City, $fam_State, $fam_Zip, $fam_Country, $fam_envelope);
             $summaryDateX = SystemConfig::getValue('leftX');
@@ -367,7 +378,6 @@ if ($output === 'pdf') {
             //$curY = $pdf->GetY();
             $totalAmount = 0;
             $totalNonDeductible = 0;
-            $cnt = 0;
             $currentFamilyID = $fam_ID;
         }
         // Format Data
@@ -453,7 +463,17 @@ if ($output === 'pdf') {
             }
         }
         $pdf->SetFont('Times', '', 10);
-        $pdf->finishPage($curY);
+        $pdf->finishPage(
+            $curY,
+            $fam_ID,
+            $fam_Name,
+            $fam_Address1,
+            $fam_Address2,
+            $fam_City,
+            $fam_State,
+            $fam_Zip,
+            $fam_Country
+        );
     }
 
     header('Pragma: public');  // Needed for IE when using a shared SSL certificate


### PR DESCRIPTION
# Description & Issue number it closes 
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->

TaxReport was using the incorrect args when calling finishPage, which caused it to fail.

Closes #6615

## How to test the changes?

See steps in linked issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Followed steps in steps in linked issue.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

