### PR TITLE
fix select2 on PledgeEditor

### DIFF
--- a/src/PledgeEditor.php
+++ b/src/PledgeEditor.php
@@ -731,7 +731,7 @@ require 'Include/Header.php';
           data: "",
           processResults: function (data, params) {
             var results = [];
-            var families = JSON.parse(data).Families
+            var families = data?.Families ?? [];
             $.each(families, function(key, object) {
               results.push({
                 id: object.Id,
@@ -765,9 +765,7 @@ require 'Include/Header.php';
   {
     if ($("#Method option:selected").val()==="CHECK") {
       $("#checkNumberGroup").show();
-    }
-    else
-    {
+    } else {
       $("#checkNumberGroup").hide();
       $("#CheckNo").val('');
     }
@@ -776,8 +774,7 @@ require 'Include/Header.php';
     var Total = 0;
       $(".FundAmount").each(function(object){
         var FundAmount = Number($(this).val());
-        if (FundAmount >0 )
-        {
+        if (FundAmount > 0) {
           Total += FundAmount;
         }
       });

--- a/src/PledgeEditor.php
+++ b/src/PledgeEditor.php
@@ -406,7 +406,8 @@ if (isset($_POST['PledgeSubmit']) || isset($_POST['PledgeSubmitAndAdd'])) {
             $rsFam = RunQuery($sSQL);
             $numRows = mysqli_num_rows($rsFam);
             if ($numRows) {
-                $iFamily = $rsFam['fam_ID'];
+                $aRow = mysqli_fetch_array($rsDeposit);
+                $iFamily = $aRow['fam_ID'];
             }
         }
     } else {


### PR DESCRIPTION
# Description & Issue number it closes 
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->

queried families is already returned as object, re-parsing breaks select2

## Screenshots (if appropriate)
Before:
<img width="631" alt="image" src="https://github.com/ChurchCRM/CRM/assets/5031018/477ae38c-e060-4a72-9308-9db986be21c5">

After:
<img width="634" alt="image" src="https://github.com/ChurchCRM/CRM/assets/5031018/8d01ccba-4d80-4289-a2ca-d03b7876a5db">


## How to test the changes?
attempted to follow steps in #6738

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
