### PR TITLE
make sure dashed lines aren't selectable

### DIFF
--- a/src/CSVImport.php
+++ b/src/CSVImport.php
@@ -264,7 +264,7 @@ if (isset($_POST['UploadCSV'])) {
         <BR><BR>
         <select name="Classification">
             <option value="0"><?= gettext('Unassigned') ?></option>
-            <option value="0">-----------------------</option>
+            <option value="" disabled>-----------------------</option>
 
             <?php
             while ($aRow = mysqli_fetch_array($rsClassifications)) {

--- a/src/FamilyEditor.php
+++ b/src/FamilyEditor.php
@@ -1086,7 +1086,7 @@ require 'Include/Header.php';
                     <option value="0" <?php if ($aClassification[$iCount] == 0) {
                         echo 'selected';
                                       } ?>><?= gettext('Unassigned') ?></option>
-                    <option value="0" disabled>-----------------------</option>
+                    <option value="" disabled>-----------------------</option>
                     <?php
                     //Get Classifications for the drop-down
                     $sSQL = 'SELECT * FROM list_lst WHERE lst_ID = 1 ORDER BY lst_OptionSequence';

--- a/src/GroupEditor.php
+++ b/src/GroupEditor.php
@@ -94,7 +94,7 @@ require 'Include/Header.php';
             ?>
             <select class="form-control input-small" name="GroupType" <?= $hide ?>>
               <option value="0"><?= gettext('Unassigned') ?></option>
-              <option value="0">-----------------------</option>
+              <option value="" disabled>-----------------------</option>
               <?php
                 foreach ($rsGroupTypes as $groupType) {
                     echo '<option value="' . $groupType->getOptionId() . '"';

--- a/src/Include/Functions.php
+++ b/src/Include/Functions.php
@@ -817,7 +817,7 @@ function formCustomField($type, string $fieldname, $data, ?string $special, $bFi
                 echo ' selected';
             }
             echo '>' . gettext('Unassigned') . '</option>';
-            echo '<option value="0">-----------------------</option>';
+            echo '<option value="" disabled>-----------------------</option>';
 
             while ($aRow = mysqli_fetch_array($rsGroupPeople)) {
                 extract($aRow);
@@ -869,7 +869,7 @@ function formCustomField($type, string $fieldname, $data, ?string $special, $bFi
 
             echo '<select class="form-control" name="' . $fieldname . '">';
             echo '<option value="0" selected>' . gettext('Unassigned') . '</option>';
-            echo '<option value="0">-----------------------</option>';
+            echo '<option value="" disabled>-----------------------</option>';
 
             while ($aRow = mysqli_fetch_array($rsListOptions)) {
                 extract($aRow);

--- a/src/PersonEditor.php
+++ b/src/PersonEditor.php
@@ -640,7 +640,7 @@ require 'Include/Header.php';
                         <label><?= gettext('Gender') ?>:</label>
                         <select id="Gender" name="Gender" class="form-control">
                             <option value="0"><?= gettext('Select Gender') ?></option>
-                            <option value="0" disabled>-----------------------</option>
+                            <option value="" disabled>-----------------------</option>
                             <option value="1" <?php if ($iGender == 1) {
                                 echo 'selected';
                                               } ?>><?= gettext('Male') ?></option>
@@ -791,7 +791,7 @@ require 'Include/Header.php';
                 <label><?= gettext('Family Role') ?>:</label>
                 <select name="FamilyRole" class="form-control">
                     <option value="0"><?= gettext('Unassigned') ?></option>
-                    <option value="0" disabled>-----------------------</option>
+                    <option value="" disabled>-----------------------</option>
                     <?php while ($aRow = mysqli_fetch_array($rsFamilyRoles)) {
                         extract($aRow);
                         echo '<option value="' . $lst_OptionID . '"';
@@ -808,7 +808,7 @@ require 'Include/Header.php';
                 <select name="Family" id="famailyId" class="form-control">
                     <option value="0" selected><?= gettext('Unassigned') ?></option>
                     <option value="-1"><?= gettext('Create a new family (using last name)') ?></option>
-                    <option value="0" disabled>-----------------------</option>
+                    <option value="" disabled>-----------------------</option>
                     <?php while ($aRow = mysqli_fetch_array($rsFamilies)) {
                         extract($aRow);
 
@@ -1143,7 +1143,7 @@ require 'Include/Header.php';
                 <label><?= gettext('Classification') ?>:</label>
                 <select id="Classification" name="Classification" class="form-control">
                   <option value="0"><?= gettext('Unassigned') ?></option>
-                  <option value="0" disabled>-----------------------</option>
+                  <option value="" disabled>-----------------------</option>
                   <?php while ($aRow = mysqli_fetch_array($rsClassifications)) {
                             extract($aRow);
                             echo '<option value="' . $lst_OptionID . '"';


### PR DESCRIPTION
# Description & Issue number it closes 

having `Unassigned` and `-----------------------` yielding the same value is confusing. it looks like `-----------------------` is just used as a separator so I figured we can actually fix this and make sure the `-----------------------` value is not selectable

## Screenshots (if appropriate)

after:
<img width="288" alt="image" src="https://github.com/ChurchCRM/CRM/assets/5031018/de8243d8-5124-4c6e-8a42-eafc032800ca">
