### PR TITLE
fix deposit slip generation

### DIFF
--- a/src/ChurchCRM/Service/FinancialService.php
+++ b/src/ChurchCRM/Service/FinancialService.php
@@ -403,10 +403,17 @@ class FinancialService
 
     private function generateDepositSummary($thisReport): void
     {
+        $thisReport->depositSummaryParameters = new \stdClass();
+
+        $thisReport->depositSummaryParameters->title = new \stdClass();
         $thisReport->depositSummaryParameters->title->x = 85;
         $thisReport->depositSummaryParameters->title->y = 7;
+
+        $thisReport->depositSummaryParameters->date = new \stdClass();
         $thisReport->depositSummaryParameters->date->x = 185;
         $thisReport->depositSummaryParameters->date->y = 7;
+
+        $thisReport->depositSummaryParameters->summary = new \stdClass();
         $thisReport->depositSummaryParameters->summary->x = 12;
         $thisReport->depositSummaryParameters->summary->y = 15;
         $thisReport->depositSummaryParameters->summary->intervalY = 4;
@@ -415,6 +422,7 @@ class FinancialService
         $thisReport->depositSummaryParameters->summary->FromX = 80;
         $thisReport->depositSummaryParameters->summary->MemoX = 120;
         $thisReport->depositSummaryParameters->summary->AmountX = 185;
+
         $thisReport->depositSummaryParameters->aggregateX = 135;
         $thisReport->depositSummaryParameters->displayBillCounts = false;
 

--- a/src/ChurchCRM/model/ChurchCRM/Deposit.php
+++ b/src/ChurchCRM/model/ChurchCRM/Deposit.php
@@ -226,10 +226,17 @@ class Deposit extends BaseDeposit
 
     private function generateDepositSummary(\stdClass $thisReport): void
     {
+        $thisReport->depositSummaryParameters = new \stdClass();
+
+        $thisReport->depositSummaryParameters->title = new \stdClass();
         $thisReport->depositSummaryParameters->title->x = 85;
         $thisReport->depositSummaryParameters->title->y = 7;
+
+        $thisReport->depositSummaryParameters->date = new \stdClass();
         $thisReport->depositSummaryParameters->date->x = 185;
         $thisReport->depositSummaryParameters->date->y = 7;
+
+        $thisReport->depositSummaryParameters->summary = new \stdClass();
         $thisReport->depositSummaryParameters->summary->x = 12;
         $thisReport->depositSummaryParameters->summary->y = 15;
         $thisReport->depositSummaryParameters->summary->intervalY = 4;
@@ -238,6 +245,7 @@ class Deposit extends BaseDeposit
         $thisReport->depositSummaryParameters->summary->FromX = 80;
         $thisReport->depositSummaryParameters->summary->MemoX = 120;
         $thisReport->depositSummaryParameters->summary->AmountX = 185;
+
         $thisReport->depositSummaryParameters->aggregateX = 135;
 
         $thisReport->pdf->addPage();


### PR DESCRIPTION
# Description & Issue number it closes 
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->

>Thanks! It looks like this is a breaking change from PHP itself after the codebase was upgraded to >=8.0 compatibility.
>
>>Attempting to write to a property of a non-object. Previously this implicitly created an stdClass object for null, false and empty strings.
>(from https://www.php.net/manual/en/migration80.incompatible.php)
>
>Ideally, the application wouldn't use the unstructured stdClass object but a quick fix would be to instantiate each of these nested objects in this class.


Closes #6777
