### PR TITLE
Remove Menu.php

### DIFF
--- a/docker/cypress.config.ts
+++ b/docker/cypress.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     'admin.api.key': 'ajGwpy8Pdai22XDUpqjC5Ob04v0eG7EGgb4vz2bD2juT8YDmfM',
     'user.api.key': 'JZJApQ9XOnF7nvupWZlTWBRrqMtHE9eNcWBTUzEWGqL4Sdqp6C',
   },
+  retries: 2,
   e2e: {
     // We've imported your old cypress plugins here.
     // You may want to clean this up later by importing these.

--- a/src/BackupDatabase.php
+++ b/src/BackupDatabase.php
@@ -21,10 +21,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 // Security: User must be an Admin to access this page.
 // Otherwise, re-direct them to the main menu.
-if (!AuthenticationManager::getCurrentUser()->isAdmin()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isAdmin());
 
 
 // Set the page title and include HTML header

--- a/src/BackupDatabase.php
+++ b/src/BackupDatabase.php
@@ -22,7 +22,7 @@ use ChurchCRM\Utils\RedirectUtils;
 // Security: User must be an Admin to access this page.
 // Otherwise, re-direct them to the main menu.
 if (!AuthenticationManager::getCurrentUser()->isAdmin()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/BatchWinnerEntry.php
+++ b/src/BatchWinnerEntry.php
@@ -118,7 +118,7 @@ for ($row = 0; $row < 10; $row += 1) {
             <input type="button" class="btn btn-default" value="<?= gettext('Cancel') ?>" name="Cancel" onclick="javascript:document.location='<?php if (strlen($linkBack) > 0) {
                 echo $linkBack;
                                                                 } else {
-                                                                    echo 'Menu.php';
+                                                                    echo 'v2/dashboard';
                                                                 } ?>';">
         </td>
     </tr>

--- a/src/CSVImport.php
+++ b/src/CSVImport.php
@@ -27,7 +27,7 @@ use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
 if (!AuthenticationManager::getCurrentUser()->isAdmin()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/CSVImport.php
+++ b/src/CSVImport.php
@@ -26,10 +26,7 @@ use ChurchCRM\model\ChurchCRM\PersonCustom;
 use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
-if (!AuthenticationManager::getCurrentUser()->isAdmin()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isAdmin());
 
 /**
  * A monogamous society is assumed, however  it can be patriarchal or matriarchal

--- a/src/CanvassAutomation.php
+++ b/src/CanvassAutomation.php
@@ -24,7 +24,7 @@ $sPageTitle = gettext('Canvass Automation');
 
 // Security: User must have canvasser permission to use this form
 if (!AuthenticationManager::getCurrentUser()->isCanvasserEnabled()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/CanvassAutomation.php
+++ b/src/CanvassAutomation.php
@@ -23,10 +23,7 @@ use ChurchCRM\Utils\RedirectUtils;
 $sPageTitle = gettext('Canvass Automation');
 
 // Security: User must have canvasser permission to use this form
-if (!AuthenticationManager::getCurrentUser()->isCanvasserEnabled()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isCanvasserEnabled());
 
 $iFYID = CurrentFY();
 if (array_key_exists('idefaultFY', $_SESSION)) {

--- a/src/CanvassEditor.php
+++ b/src/CanvassEditor.php
@@ -19,10 +19,7 @@ use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
 // Security: User must have canvasser permission to use this form
-if (!AuthenticationManager::getCurrentUser()->isCanvasserEnabled()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isCanvasserEnabled());
 
 require 'Include/CanvassUtilities.php';
 

--- a/src/CanvassEditor.php
+++ b/src/CanvassEditor.php
@@ -20,7 +20,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 // Security: User must have canvasser permission to use this form
 if (!AuthenticationManager::getCurrentUser()->isCanvasserEnabled()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 
@@ -244,7 +244,7 @@ require 'Include/Header.php';
             <input type="button" class="btn btn-default" value="<?= gettext('Cancel') ?>" name="Cancel" onclick="javascript:document.location='<?php if (strlen($linkBack) > 0) {
                 echo $linkBack;
                                                                 } else {
-                                                                    echo 'Menu.php';
+                                                                    echo 'v2/dashboard';
                                                                 } ?>';">
 
     </div>

--- a/src/CartToEvent.php
+++ b/src/CartToEvent.php
@@ -25,10 +25,7 @@ use ChurchCRM\Utils\LoggerUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
 // Security: User must have Manage Groups & Roles permission
-if (!AuthenticationManager::getCurrentUser()->isManageGroupsEnabled()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isManageGroupsEnabled());
 
 // Was the form submitted?
 if (isset($_POST['Submit']) && count($_SESSION['aPeopleCart']) > 0 && isset($_POST['EventID'])) {

--- a/src/CartToEvent.php
+++ b/src/CartToEvent.php
@@ -26,7 +26,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 // Security: User must have Manage Groups & Roles permission
 if (!AuthenticationManager::getCurrentUser()->isManageGroupsEnabled()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/CartToFamily.php
+++ b/src/CartToFamily.php
@@ -21,10 +21,7 @@ use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
 // Security: User must have add records permission
-if (!AuthenticationManager::getCurrentUser()->isAddRecordsEnabled()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isAddRecordsEnabled());
 
 // Was the form submitted?
 if (isset($_POST['Submit']) && count($_SESSION['aPeopleCart']) > 0) {

--- a/src/CartToFamily.php
+++ b/src/CartToFamily.php
@@ -22,7 +22,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 // Security: User must have add records permission
 if (!AuthenticationManager::getCurrentUser()->isAddRecordsEnabled()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/CartToGroup.php
+++ b/src/CartToGroup.php
@@ -22,10 +22,7 @@ use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
 // Security: User must have Manage Groups & Roles permission
-if (!AuthenticationManager::getCurrentUser()->isManageGroupsEnabled()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isManageGroupsEnabled());
 
 // Was the form submitted?
 if ((isset($_GET['groupeCreationID']) || isset($_POST['Submit'])) && count($_SESSION['aPeopleCart']) > 0) {

--- a/src/CartToGroup.php
+++ b/src/CartToGroup.php
@@ -23,7 +23,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 // Security: User must have Manage Groups & Roles permission
 if (!AuthenticationManager::getCurrentUser()->isManageGroupsEnabled()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/ChurchCRM/Authentication/AuthenticationManager.php
+++ b/src/ChurchCRM/Authentication/AuthenticationManager.php
@@ -127,7 +127,7 @@ class AuthenticationManager
         }
 
         if ($result->isAuthenticated && !$result->preventRedirect) {
-            $redirectLocation = array_key_exists('location', $_SESSION) ? $_SESSION['location'] : 'Menu.php';
+            $redirectLocation = $_SESSION['location'] ?? 'v2/dashboard';
             NotificationService::updateNotifications();
             $logger->debug(
                 'Authentication Successful; redirecting to: ' . $redirectLocation

--- a/src/ChurchCRM/Authentication/AuthenticationManager.php
+++ b/src/ChurchCRM/Authentication/AuthenticationManager.php
@@ -209,4 +209,10 @@ class AuthenticationManager
         // but rather redirect users to some other password reset mechanism.
         return SystemURLs::getRootPath() . '/session/forgot-password/reset-request';
     }
+    public static function redirectHomeIfFalse(bool $hasAccess): void
+    {
+        if (!$hasAccess) {
+            RedirectUtils::redirect('v2/dashboard');
+        }
+    }
 }

--- a/src/ChurchCRM/Backup/BackupJob.php
+++ b/src/ChurchCRM/Backup/BackupJob.php
@@ -60,7 +60,7 @@ class BackupJob extends JobBase
         );
     }
 
-    public function copyToWebDAV(string $Endpoint, string $Username, string $Password)
+    public function copyToWebDAV(string $Endpoint, string $Username, string $Password): bool
     {
         LoggerUtils::getAppLogger()->info('Beginning to copy backup to: ' . $Endpoint);
 
@@ -78,7 +78,7 @@ class BackupJob extends JobBase
             curl_setopt($ch, CURLOPT_INFILESIZE, $this->BackupFile->getSize());
             LoggerUtils::getAppLogger()->debug('Beginning to send file');
             $time = new ExecutionTime();
-            $result = curl_exec($ch);
+            $result = (bool) curl_exec($ch);
             if (curl_error($ch)) {
                 $error_msg = curl_error($ch);
             }

--- a/src/ChurchCRM/Backup/JobBase.php
+++ b/src/ChurchCRM/Backup/JobBase.php
@@ -16,7 +16,7 @@ class JobBase
      */
     protected $TempFolder;
 
-    protected function createEmptyTempFolder()
+    protected function createEmptyTempFolder(): string
     {
         // both backup and restore operations require a clean temporary working folder.  Create it.
         $TempFolder = SystemURLs::getDocumentRoot() . '/tmp_attach/ChurchCRMBackups';

--- a/src/ChurchCRM/Config/Menu/Menu.php
+++ b/src/ChurchCRM/Config/Menu/Menu.php
@@ -32,7 +32,7 @@ class Menu
     private static function buildMenuItems(): array
     {
         return [
-            'Dashboard'    => new MenuItem(gettext('Dashboard'), 'Menu.php', true, 'fa-tachometer-alt'),
+            'Dashboard'    => new MenuItem(gettext('Dashboard'), 'v2/dashboard', true, 'fa-tachometer-alt'),
             'Calendar'     => self::getCalendarMenu(),
             'People'       => self::getPeopleMenu(),
             'Groups'       => self::getGroupMenu(),

--- a/src/ChurchCRM/Emails/users/BaseUserEmail.php
+++ b/src/ChurchCRM/Emails/users/BaseUserEmail.php
@@ -26,7 +26,7 @@ abstract class BaseUserEmail extends BaseEmail
 
     abstract protected function getSubSubject();
 
-    public function getTokens()
+    public function getTokens(): array
     {
         $myTokens = ['toName' => $this->user->getPerson()->getFirstName(),
             'userName'        => $this->user->getUserName(),
@@ -37,7 +37,7 @@ abstract class BaseUserEmail extends BaseEmail
         return array_merge($this->getCommonTokens(), $myTokens);
     }
 
-    protected function getFullURL()
+    protected function getFullURL(): string
     {
         return SystemURLs::getURL() . '/session/begin?username=' . $this->user->getUserName();
     }

--- a/src/ChurchCRM/Service/MailChimpService.php
+++ b/src/ChurchCRM/Service/MailChimpService.php
@@ -75,14 +75,14 @@ class MailChimpService
         return $_SESSION['MailChimpLists'];
     }
 
-    public function isEmailInMailChimp(?string $email)
+    public function isEmailInMailChimp(?string $email): array
     {
         if (empty($email)) {
-            return new Exception(gettext('No email passed in'));
+            throw new Exception(gettext('No email passed in'));
         }
 
         if (!$this->isActive()) {
-            return new Exception(gettext('Mailchimp is not active'));
+            throw new Exception(gettext('Mailchimp is not active'));
         }
 
         $lists = $this->getListsFromCache();

--- a/src/ChurchCRM/dto/Cart.php
+++ b/src/ChurchCRM/dto/Cart.php
@@ -112,7 +112,7 @@ class Cart
         return count($_SESSION['aPeopleCart']);
     }
 
-    public static function convertCartToString($aCartArray)
+    public static function convertCartToString($aCartArray): string
     {
         // Implode the array
         $sCartString = implode(',', $aCartArray);

--- a/src/ChurchCRM/utils/InputUtils.php
+++ b/src/ChurchCRM/utils/InputUtils.php
@@ -17,13 +17,24 @@ class InputUtils
         }
     }
 
-    public static function translateSpecialCharset($string)
+    public static function translateSpecialCharset($string): string
     {
         if (empty($string)) {
             return '';
         }
 
-        return (SystemConfig::getValue('sCSVExportCharset') === 'UTF-8') ? gettext($string) : iconv('UTF-8', SystemConfig::getValue('sCSVExportCharset'), gettext($string));
+        if (SystemConfig::getValue('sCSVExportCharset') === 'UTF-8') {
+            return gettext($string);
+        }
+
+        $resultString = iconv(
+            'UTF-8',
+            SystemConfig::getValue('sCSVExportCharset'),
+            gettext($string)
+        );
+        MiscUtils::throwIfFailed($resultString);
+
+        return $resultString;
     }
 
     public static function filterString($sInput): string

--- a/src/ChurchCRM/utils/RedirectUtils.php
+++ b/src/ChurchCRM/utils/RedirectUtils.php
@@ -36,6 +36,6 @@ class RedirectUtils
     public static function securityRedirect(string $missingRole): void
     {
         LoggerUtils::getAppLogger()->info('Security Redirect Request due to Role: ' . $missingRole);
-        self::Redirect('Menu.php');
+        self::Redirect('v2/dashboard');
     }
 }

--- a/src/ConvertIndividualToFamily.php
+++ b/src/ConvertIndividualToFamily.php
@@ -30,7 +30,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 // Security
 if (!AuthenticationManager::getCurrentUser()->isAdmin()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/ConvertIndividualToFamily.php
+++ b/src/ConvertIndividualToFamily.php
@@ -29,10 +29,7 @@ use ChurchCRM\model\ChurchCRM\Family;
 use ChurchCRM\Utils\RedirectUtils;
 
 // Security
-if (!AuthenticationManager::getCurrentUser()->isAdmin()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isAdmin());
 
 if ($_GET['all'] == 'true') {
     $bDoAll = true;

--- a/src/DepositSlipEditor.php
+++ b/src/DepositSlipEditor.php
@@ -41,14 +41,14 @@ if ($iDepositSlipID) {
 
     // Security: User must have finance permission or be the one who created this deposit
     if (!(AuthenticationManager::getCurrentUser()->isFinanceEnabled() || AuthenticationManager::getCurrentUser()->getId() == $thisDeposit->getEnteredby())) {
-        RedirectUtils::redirect('Menu.php');
+        RedirectUtils::redirect('v2/dashboard');
         exit;
     }
 } elseif ($iDepositSlipID == 0) {
     RedirectUtils::redirect('FindDepositSlip.php');
     exit;
 } else {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
 }
 
 //Set the page title

--- a/src/DirectoryReports.php
+++ b/src/DirectoryReports.php
@@ -22,7 +22,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 // Check for Create Directory user permission.
 if (!AuthenticationManager::getCurrentUser()->isCreateDirectoryEnabled()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 
@@ -285,7 +285,7 @@ while ($aRow = mysqli_fetch_array($rsSecurityGrp)) {
 <p align="center">
 <BR>
 <input type="submit" class="btn btn-primary" name="Submit" value="<?= gettext('Create Directory') ?>">
-<input type="button" class="btn btn-default" name="Cancel" <?= 'value="' . gettext('Cancel') . '"' ?> onclick="javascript:document.location='Menu.php';">
+<input type="button" class="btn btn-default" name="Cancel" <?= 'value="' . gettext('Cancel') . '"' ?> onclick="javascript:document.location='v2/dashboard';">
 </p>
 </form>
 </div>

--- a/src/DirectoryReports.php
+++ b/src/DirectoryReports.php
@@ -21,10 +21,7 @@ use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\Utils\RedirectUtils;
 
 // Check for Create Directory user permission.
-if (!AuthenticationManager::getCurrentUser()->isCreateDirectoryEnabled()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isCreateDirectoryEnabled());
 
 // Set the page title and include HTML header
 $sPageTitle = gettext('Directory reports');

--- a/src/DonatedItemEditor.php
+++ b/src/DonatedItemEditor.php
@@ -312,7 +312,7 @@ while ($aRow = mysqli_fetch_array($rsPeople)) {
                     <input type="submit" class="btn btn-primary" value="<?= gettext('Save and Add'); ?>" name="DonatedItemSubmitAndAdd">
                 <?php endif; ?>
                 <input type="button" class="btn btn-default" value="<?= gettext('Cancel') ?>" name="DonatedItemCancel"
-                onclick="javascript:document.location = '<?= strlen($linkBack) > 0 ? $linkBack : 'Menu.php'; ?>';">
+                onclick="javascript:document.location = '<?= strlen($linkBack) > 0 ? $linkBack : 'v2/dashboard'; ?>';">
             </div>
 
         </div>

--- a/src/DonationFundEditor.php
+++ b/src/DonationFundEditor.php
@@ -22,10 +22,7 @@ use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
 // Security: user must be administrator to use this page
-if (!AuthenticationManager::getCurrentUser()->isAdmin()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isAdmin());
 
 if (isset($_GET['Action'])) {
     $sAction = $_GET['Action'];

--- a/src/DonationFundEditor.php
+++ b/src/DonationFundEditor.php
@@ -23,7 +23,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 // Security: user must be administrator to use this page
 if (!AuthenticationManager::getCurrentUser()->isAdmin()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/EditEventTypes.php
+++ b/src/EditEventTypes.php
@@ -23,10 +23,8 @@ use ChurchCRM\Authentication\AuthenticationManager;
 use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
-if (!AuthenticationManager::getCurrentUser()->isAdmin()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isAdmin());
+
 $sPageTitle = gettext('Edit Event Types');
 require 'Include/Header.php';
 

--- a/src/EditEventTypes.php
+++ b/src/EditEventTypes.php
@@ -21,9 +21,11 @@ require 'Include/Functions.php';
 
 use ChurchCRM\Authentication\AuthenticationManager;
 use ChurchCRM\Utils\InputUtils;
+use ChurchCRM\Utils\RedirectUtils;
 
 if (!AuthenticationManager::getCurrentUser()->isAdmin()) {
-    header('Location: Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
+    exit;
 }
 $sPageTitle = gettext('Edit Event Types');
 require 'Include/Header.php';

--- a/src/EventEditor.php
+++ b/src/EventEditor.php
@@ -28,11 +28,13 @@ require 'Include/Functions.php';
 use ChurchCRM\Authentication\AuthenticationManager;
 use ChurchCRM\dto\SystemURLs;
 use ChurchCRM\Utils\InputUtils;
+use ChurchCRM\Utils\RedirectUtils;
 
 $sPageTitle = gettext('Church Event Editor');
 
 if (!AuthenticationManager::getCurrentUser()->isAddEvent()) {
-    header('Location: Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
+    exit;
 }
 
 $sAction = 'Create Event';

--- a/src/EventEditor.php
+++ b/src/EventEditor.php
@@ -32,10 +32,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 $sPageTitle = gettext('Church Event Editor');
 
-if (!AuthenticationManager::getCurrentUser()->isAddEvent()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isAddEvent());
 
 $sAction = 'Create Event';
 require 'Include/Header.php';

--- a/src/EventNames.php
+++ b/src/EventNames.php
@@ -25,7 +25,8 @@ use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
 if (!AuthenticationManager::getCurrentUser()->isAddEvent()) {
-    header('Location: Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
+    exit;
 }
 
 $sPageTitle = gettext('Edit Event Types');

--- a/src/EventNames.php
+++ b/src/EventNames.php
@@ -24,10 +24,7 @@ use ChurchCRM\dto\SystemURLs;
 use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
-if (!AuthenticationManager::getCurrentUser()->isAddEvent()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isAddEvent());
 
 $sPageTitle = gettext('Edit Event Types');
 

--- a/src/FamilyCustomFieldsEditor.php
+++ b/src/FamilyCustomFieldsEditor.php
@@ -26,7 +26,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 // Security: user must be administrator to use this page
 if (!AuthenticationManager::getCurrentUser()->isAdmin()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/FamilyCustomFieldsEditor.php
+++ b/src/FamilyCustomFieldsEditor.php
@@ -25,10 +25,7 @@ use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
 // Security: user must be administrator to use this page
-if (!AuthenticationManager::getCurrentUser()->isAdmin()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isAdmin());
 
 $sPageTitle = gettext('Custom Family Fields Editor');
 

--- a/src/FamilyCustomFieldsRowOps.php
+++ b/src/FamilyCustomFieldsRowOps.php
@@ -20,7 +20,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 // Security: user must be administrator to use this page.
 if (!AuthenticationManager::getCurrentUser()->isAdmin()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/FamilyCustomFieldsRowOps.php
+++ b/src/FamilyCustomFieldsRowOps.php
@@ -19,10 +19,7 @@ use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
 // Security: user must be administrator to use this page.
-if (!AuthenticationManager::getCurrentUser()->isAdmin()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isAdmin());
 
 // Get the Group, Property, and Action from the querystring
 $iOrderID = InputUtils::legacyFilterInput($_GET['OrderID'], 'int');

--- a/src/FamilyEditor.php
+++ b/src/FamilyEditor.php
@@ -38,17 +38,17 @@ if (array_key_exists('FamilyID', $_GET)) {
 // Clean error handling: (such as somebody typing an incorrect URL ?PersonID= manually)
 if ($iFamilyID > 0) {
     if (!(AuthenticationManager::getCurrentUser()->isEditRecordsEnabled() || (AuthenticationManager::getCurrentUser()->isEditSelfEnabled() && $iFamilyID == AuthenticationManager::getCurrentUser()->getPerson()->getFamId()))) {
-        RedirectUtils::redirect('Menu.php');
+        RedirectUtils::redirect('v2/dashboard');
         exit;
     }
 
     $sSQL = 'SELECT fam_ID FROM family_fam WHERE fam_ID = ' . $iFamilyID;
     if (mysqli_num_rows(RunQuery($sSQL)) == 0) {
-        RedirectUtils::redirect('Menu.php');
+        RedirectUtils::redirect('v2/dashboard');
         exit;
     }
 } elseif (!AuthenticationManager::getCurrentUser()->isAddRecordsEnabled()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/FinancialReports.php
+++ b/src/FinancialReports.php
@@ -19,7 +19,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 // Security
 if (!AuthenticationManager::getCurrentUser()->isFinanceEnabled()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 
@@ -69,7 +69,7 @@ if ($sReportType == '') {
     // First Pass Cancel, Next Buttons
     echo "<tr><td>&nbsp;</td>
         <td><input type=button class='btn btn-default' name=Cancel value='" . gettext('Cancel') . "'
-        onclick=\"javascript:document.location='Menu.php';\">
+        onclick=\"javascript:document.location='v2/dashboard';\">
         <input type=submit class='btn btn-primary' name=Submit1 value='" . gettext('Next') . "'>
         </td></tr>
         </table></form>";

--- a/src/FinancialReports.php
+++ b/src/FinancialReports.php
@@ -18,10 +18,7 @@ use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
 // Security
-if (!AuthenticationManager::getCurrentUser()->isFinanceEnabled()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isFinanceEnabled());
 
 $sReportType = '';
 

--- a/src/FundRaiserEditor.php
+++ b/src/FundRaiserEditor.php
@@ -152,7 +152,7 @@ require 'Include/Header.php';
             <input type="button" class="btn btn-default" value="<?= gettext('Cancel') ?>" name="FundRaiserCancel" onclick="javascript:document.location='<?php if (strlen($linkBack) > 0) {
                 echo $linkBack;
                                                                 } else {
-                                                                    echo 'Menu.php';
+                                                                    echo 'v2/dashboard';
                                                                 } ?>';">
             <?php
             if ($iFundRaiserID > 0) {

--- a/src/GroupEditor.php
+++ b/src/GroupEditor.php
@@ -24,7 +24,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 // Security: User must have Manage Groups permission
 if (!AuthenticationManager::getCurrentUser()->isManageGroupsEnabled()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/GroupEditor.php
+++ b/src/GroupEditor.php
@@ -23,10 +23,7 @@ use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
 // Security: User must have Manage Groups permission
-if (!AuthenticationManager::getCurrentUser()->isManageGroupsEnabled()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isManageGroupsEnabled());
 
 //Set the page title
 $sPageTitle = gettext('Group Editor');

--- a/src/GroupPropsEditor.php
+++ b/src/GroupPropsEditor.php
@@ -20,10 +20,7 @@ use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
 // Security: user must be allowed to edit records to use this page.
-if (!AuthenticationManager::getCurrentUser()->isEditRecordsEnabled()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isEditRecordsEnabled());
 
 $sPageTitle = gettext('Group Member Properties Editor');
 

--- a/src/GroupPropsEditor.php
+++ b/src/GroupPropsEditor.php
@@ -21,7 +21,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 // Security: user must be allowed to edit records to use this page.
 if (!AuthenticationManager::getCurrentUser()->isEditRecordsEnabled()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/GroupPropsFormEditor.php
+++ b/src/GroupPropsFormEditor.php
@@ -25,10 +25,7 @@ use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
 // Security: user must be allowed to edit records to use this page.
-if (!AuthenticationManager::getCurrentUser()->isManageGroupsEnabled()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isManageGroupsEnabled());
 
 // Get the Group from the querystring
 $iGroupID = InputUtils::legacyFilterInput($_GET['GroupID'], 'int');

--- a/src/GroupPropsFormEditor.php
+++ b/src/GroupPropsFormEditor.php
@@ -26,7 +26,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 // Security: user must be allowed to edit records to use this page.
 if (!AuthenticationManager::getCurrentUser()->isManageGroupsEnabled()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/GroupPropsFormRowOps.php
+++ b/src/GroupPropsFormRowOps.php
@@ -18,10 +18,7 @@ use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
 // Security: user must be allowed to edit records to use this page.
-if (!AuthenticationManager::getCurrentUser()->isManageGroupsEnabled()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isManageGroupsEnabled());
 
 // Get the Group, Property, and Action from the querystring
 $iGroupID = InputUtils::legacyFilterInput($_GET['GroupID'], 'int');

--- a/src/GroupPropsFormRowOps.php
+++ b/src/GroupPropsFormRowOps.php
@@ -19,7 +19,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 // Security: user must be allowed to edit records to use this page.
 if (!AuthenticationManager::getCurrentUser()->isManageGroupsEnabled()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/GroupReports.php
+++ b/src/GroupReports.php
@@ -148,7 +148,7 @@ require 'Include/Header.php';
                         <p align="center">
                             <BR>
                             <input id="CreateReportBtn" type="submit" class="btn btn-default" name="Submit" value="<?= gettext('Create Report') ?>">
-                            <input type="button" class="btn btn-default" name="Cancel" value="<?= gettext('Cancel') ?>" onclick="javascript:document.location = 'Menu.php';">
+                            <input type="button" class="btn btn-default" name="Cancel" value="<?= gettext('Cancel') ?>" onclick="javascript:document.location = 'v2/dashboard';">
                         </p>
                     </form>
 

--- a/src/Include/Header.php
+++ b/src/Include/Header.php
@@ -179,7 +179,7 @@ $MenuFirst = 1;
   <!-- Left side column. contains the sidebar -->
     <aside class="main-sidebar sidebar-dark-primary elevation-4">
     <!-- Logo -->
-      <a href="<?= SystemURLs::getRootPath() ?>/Menu.php" class="brand-link">
+      <a href="<?= SystemURLs::getRootPath() ?>/v2/dashboard" class="brand-link">
           <!-- mini logo for sidebar mini 50x50 pixels -->
           <img src="<?= SystemURLs::getRootPath() ?>/Images/CRM_50x50.png" alt="ChurchCRM Logo" class="brand-image img-circle elevation-3" style="opacity: .8">
           <!-- logo for regular state and mobile devices -->

--- a/src/LettersAndLabels.php
+++ b/src/LettersAndLabels.php
@@ -75,7 +75,7 @@ FontSizeSelect('labelfontsize');
             <div>
               <input type="submit" class="btn btn-default" name="SubmitNewsLetter" value="<?= gettext('Newsletter labels') ?>">
               <input type="submit" class="btn btn-default" name="SubmitConfirmLabels" value="<?= gettext('Confirm data labels') ?>">
-              <input type="button" class="btn btn-warning" name="Cancel" value="<?= gettext('Cancel') ?>" onclick="javascript:document.location = 'Menu.php';">
+              <input type="button" class="btn btn-warning" name="Cancel" value="<?= gettext('Cancel') ?>" onclick="javascript:document.location = 'v2/dashboard';">
             </div>
 
         </form>

--- a/src/ManageEnvelopes.php
+++ b/src/ManageEnvelopes.php
@@ -23,10 +23,7 @@ use ChurchCRM\Utils\RedirectUtils;
 $sPageTitle = gettext('Envelope Manager');
 
 // Security: User must have finance permission to use this form
-if (!AuthenticationManager::getCurrentUser()->isFinanceEnabled()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isFinanceEnabled());
 
 $envelopesToWrite = [];
 // get the array of envelopes of interest, indexed by family id

--- a/src/ManageEnvelopes.php
+++ b/src/ManageEnvelopes.php
@@ -24,7 +24,7 @@ $sPageTitle = gettext('Envelope Manager');
 
 // Security: User must have finance permission to use this form
 if (!AuthenticationManager::getCurrentUser()->isFinanceEnabled()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/MemberRoleChange.php
+++ b/src/MemberRoleChange.php
@@ -19,7 +19,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 // Security: User must have Manage Groups & Roles permission
 if (!AuthenticationManager::getCurrentUser()->isManageGroupsEnabled()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/MemberRoleChange.php
+++ b/src/MemberRoleChange.php
@@ -18,10 +18,7 @@ use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
 // Security: User must have Manage Groups & Roles permission
-if (!AuthenticationManager::getCurrentUser()->isManageGroupsEnabled()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isManageGroupsEnabled());
 
 //Set the page title
 $sPageTitle = gettext('Member Role Change');

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -1,8 +1,0 @@
-<?php
-
-//Include the function library
-require 'Include/Config.php';
-
-use ChurchCRM\Utils\RedirectUtils;
-
-RedirectUtils::redirect('v2/dashboard');

--- a/src/NoteDelete.php
+++ b/src/NoteDelete.php
@@ -21,7 +21,7 @@ use ChurchCRM\Utils\RedirectUtils;
 // Security: User must have Notes permission
 // Otherwise, re-direct them to the main menu.
 if (!AuthenticationManager::getCurrentUser()->isNotesEnabled()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/NoteDelete.php
+++ b/src/NoteDelete.php
@@ -20,10 +20,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 // Security: User must have Notes permission
 // Otherwise, re-direct them to the main menu.
-if (!AuthenticationManager::getCurrentUser()->isNotesEnabled()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isNotesEnabled());
 
 //Set the page title
 $sPageTitle = gettext('Note Delete Confirmation');

--- a/src/NoteEditor.php
+++ b/src/NoteEditor.php
@@ -22,10 +22,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 // Security: User must have Notes permission
 // Otherwise, re-direct them to the main menu.
-if (!AuthenticationManager::getCurrentUser()->isNotesEnabled()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isNotesEnabled());
 
 //Set the page title
 $sPageTitle = gettext('Note Editor');

--- a/src/NoteEditor.php
+++ b/src/NoteEditor.php
@@ -23,7 +23,7 @@ use ChurchCRM\Utils\RedirectUtils;
 // Security: User must have Notes permission
 // Otherwise, re-direct them to the main menu.
 if (!AuthenticationManager::getCurrentUser()->isNotesEnabled()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/OptionManager.php
+++ b/src/OptionManager.php
@@ -28,7 +28,7 @@ switch ($mode) {
     case 'famroles':
     case 'classes':
         if (!AuthenticationManager::getCurrentUser()->isMenuOptionsEnabled()) {
-            RedirectUtils::redirect('Menu.php');
+            RedirectUtils::redirect('v2/dashboard');
             exit;
         }
         break;
@@ -37,7 +37,7 @@ switch ($mode) {
     case 'grproles':
     case 'groupcustom':
         if (!AuthenticationManager::getCurrentUser()->isManageGroupsEnabled()) {
-            RedirectUtils::redirect('Menu.php');
+            RedirectUtils::redirect('v2/dashboard');
             exit;
         }
         break;
@@ -46,13 +46,13 @@ switch ($mode) {
     case 'famcustom':
     case 'securitygrp':
         if (!AuthenticationManager::getCurrentUser()->isAdmin()) {
-            RedirectUtils::redirect('Menu.php');
+            RedirectUtils::redirect('v2/dashboard');
             exit;
         }
         break;
 
     default:
-        RedirectUtils::redirect('Menu.php');
+        RedirectUtils::redirect('v2/dashboard');
         break;
 }
 
@@ -105,7 +105,7 @@ switch ($mode) {
 
         // Validate that this list ID is really for a group roles list. (for security)
         if (mysqli_num_rows($rsTemp) == 0) {
-            RedirectUtils::redirect('Menu.php');
+            RedirectUtils::redirect('v2/dashboard');
             break;
         }
 
@@ -126,7 +126,7 @@ switch ($mode) {
 
         // Validate that this is a valid person-custom field custom list
         if (mysqli_num_rows($rsTemp) == 0) {
-            RedirectUtils::redirect('Menu.php');
+            RedirectUtils::redirect('v2/dashboard');
             break;
         }
 
@@ -144,7 +144,7 @@ switch ($mode) {
 
         // Validate that this is a valid group-specific-property field custom list
         if (mysqli_num_rows($rsTemp) == 0) {
-            RedirectUtils::redirect('Menu.php');
+            RedirectUtils::redirect('v2/dashboard');
             break;
         }
 
@@ -162,13 +162,13 @@ switch ($mode) {
 
         // Validate that this is a valid family_custom field custom list
         if (mysqli_num_rows($rsTemp) == 0) {
-            RedirectUtils::redirect('Menu.php');
+            RedirectUtils::redirect('v2/dashboard');
             break;
         }
 
         break;
     default:
-        RedirectUtils::redirect('Menu.php');
+        RedirectUtils::redirect('v2/dashboard');
         break;
 }
 
@@ -381,7 +381,7 @@ for ($row = 1; $row <= $numRows; $row++) {
     } elseif ($mode != 'grproles') {
         ?>
         <input type="button" class="btn btn-default" value="<?= gettext('Exit') ?>" Name="Exit" onclick="javascript:document.location='<?php
-        echo 'Menu.php'; ?>';">
+        echo 'v2/dashboard'; ?>';">
         <?php
     } ?>
     </div>

--- a/src/OptionManager.php
+++ b/src/OptionManager.php
@@ -27,28 +27,19 @@ $mode = trim($_GET['mode']);
 switch ($mode) {
     case 'famroles':
     case 'classes':
-        if (!AuthenticationManager::getCurrentUser()->isMenuOptionsEnabled()) {
-            RedirectUtils::redirect('v2/dashboard');
-            exit;
-        }
+        AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isMenuOptionsEnabled());
         break;
 
     case 'grptypes':
     case 'grproles':
     case 'groupcustom':
-        if (!AuthenticationManager::getCurrentUser()->isManageGroupsEnabled()) {
-            RedirectUtils::redirect('v2/dashboard');
-            exit;
-        }
+        AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isManageGroupsEnabled());
         break;
 
     case 'custom':
     case 'famcustom':
     case 'securitygrp':
-        if (!AuthenticationManager::getCurrentUser()->isAdmin()) {
-            RedirectUtils::redirect('v2/dashboard');
-            exit;
-        }
+        AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isAdmin());
         break;
 
     default:

--- a/src/OptionManagerRowOps.php
+++ b/src/OptionManagerRowOps.php
@@ -30,7 +30,7 @@ switch ($mode) {
     case 'famroles':
     case 'classes':
         if (!AuthenticationManager::getCurrentUser()->isMenuOptionsEnabled()) {
-            RedirectUtils::redirect('Menu.php');
+            RedirectUtils::redirect('v2/dashboard');
             exit;
         }
         break;
@@ -38,7 +38,7 @@ switch ($mode) {
     case 'grptypes':
     case 'grproles':
         if (!AuthenticationManager::getCurrentUser()->isManageGroupsEnabled()) {
-            RedirectUtils::redirect('Menu.php');
+            RedirectUtils::redirect('v2/dashboard');
             exit;
         }
         break;
@@ -46,12 +46,12 @@ switch ($mode) {
     case 'custom':
     case 'famcustom':
         if (!AuthenticationManager::getCurrentUser()->isAdmin()) {
-            RedirectUtils::redirect('Menu.php');
+            RedirectUtils::redirect('v2/dashboard');
             exit;
         }
         break;
     default:
-        RedirectUtils::redirect('Menu.php');
+        RedirectUtils::redirect('v2/dashboard');
         break;
 }
 
@@ -82,7 +82,7 @@ switch ($mode) {
         $sSQL = "SELECT '' FROM group_grp WHERE grp_RoleListID = " . $listID;
         $rsTemp = RunQuery($sSQL);
         if (mysqli_num_rows($rsTemp) == 0) {
-            RedirectUtils::redirect('Menu.php');
+            RedirectUtils::redirect('v2/dashboard');
             break;
         }
 
@@ -160,7 +160,7 @@ switch ($sAction) {
 
         // If no valid action was specified, abort
     default:
-        RedirectUtils::redirect('Menu.php');
+        RedirectUtils::redirect('v2/dashboard');
         break;
 }
 

--- a/src/OptionManagerRowOps.php
+++ b/src/OptionManagerRowOps.php
@@ -29,26 +29,17 @@ $mode = trim($_GET['mode']);
 switch ($mode) {
     case 'famroles':
     case 'classes':
-        if (!AuthenticationManager::getCurrentUser()->isMenuOptionsEnabled()) {
-            RedirectUtils::redirect('v2/dashboard');
-            exit;
-        }
+        AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isMenuOptionsEnabled());
         break;
 
     case 'grptypes':
     case 'grproles':
-        if (!AuthenticationManager::getCurrentUser()->isManageGroupsEnabled()) {
-            RedirectUtils::redirect('v2/dashboard');
-            exit;
-        }
+        AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isManageGroupsEnabled());
         break;
 
     case 'custom':
     case 'famcustom':
-        if (!AuthenticationManager::getCurrentUser()->isAdmin()) {
-            RedirectUtils::redirect('v2/dashboard');
-            exit;
-        }
+        AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isAdmin());
         break;
     default:
         RedirectUtils::redirect('v2/dashboard');

--- a/src/PaddleNumEditor.php
+++ b/src/PaddleNumEditor.php
@@ -154,7 +154,7 @@ require 'Include/Header.php';
             <input type="button" class="btn btn-default" value="<?= gettext('Back') ?>" name="PaddleNumCancel" onclick="javascript:document.location='<?php if (strlen($linkBack) > 0) {
                 echo $linkBack;
                                                                 } else {
-                                                                    echo 'Menu.php';
+                                                                    echo 'v2/dashboard';
                                                                 } ?>';">
         </td>
     </tr>

--- a/src/PersonCustomFieldsEditor.php
+++ b/src/PersonCustomFieldsEditor.php
@@ -21,7 +21,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 // Security: user must be administrator to use this page
 if (!AuthenticationManager::getCurrentUser()->isAdmin()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/PersonCustomFieldsEditor.php
+++ b/src/PersonCustomFieldsEditor.php
@@ -20,10 +20,7 @@ use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
 // Security: user must be administrator to use this page
-if (!AuthenticationManager::getCurrentUser()->isAdmin()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isAdmin());
 
 $sPageTitle = gettext('Custom Person Fields Editor');
 

--- a/src/PersonCustomFieldsRowOps.php
+++ b/src/PersonCustomFieldsRowOps.php
@@ -18,10 +18,7 @@ use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
 // Security: user must be administrator to use this page.
-if (!AuthenticationManager::getCurrentUser()->isAdmin()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isAdmin());
 
 // Get the Group, Property, and Action from the querystring
 $iOrderID = InputUtils::legacyFilterInput($_GET['OrderID'], 'int');

--- a/src/PersonCustomFieldsRowOps.php
+++ b/src/PersonCustomFieldsRowOps.php
@@ -19,7 +19,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 // Security: user must be administrator to use this page.
 if (!AuthenticationManager::getCurrentUser()->isAdmin()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/PersonEditor.php
+++ b/src/PersonEditor.php
@@ -49,7 +49,7 @@ if ($iPersonID > 0) {
     $per_fam_ID = $aRow['per_fam_ID'];
 
     if (mysqli_num_rows($rsPerson) == 0) {
-        RedirectUtils::redirect('Menu.php');
+        RedirectUtils::redirect('v2/dashboard');
         exit;
     }
 
@@ -60,11 +60,11 @@ if ($iPersonID > 0) {
         (AuthenticationManager::getCurrentUser()->isEditSelfEnabled() && $per_fam_ID > 0 && $per_fam_ID == AuthenticationManager::getCurrentUser()->getPerson()->getFamId())
         )
     ) {
-        RedirectUtils::redirect('Menu.php');
+        RedirectUtils::redirect('v2/dashboard');
         exit;
     }
 } elseif (!AuthenticationManager::getCurrentUser()->isAddRecordsEnabled()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 // Get Field Security List Matrix

--- a/src/PledgeDelete.php
+++ b/src/PledgeDelete.php
@@ -25,10 +25,7 @@ $sGroupKey = InputUtils::legacyFilterInput($_GET['GroupKey'], 'string');
 
 // Security: User must have Add or Edit Records permission to use this form in those manners
 // Clean error handling: (such as somebody typing an incorrect URL ?PersonID= manually)
-if (!AuthenticationManager::getCurrentUser()->isDeleteRecordsEnabled()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isDeleteRecordsEnabled());
 
 //Is this the second pass?
 if (isset($_POST['Delete'])) {

--- a/src/PledgeDelete.php
+++ b/src/PledgeDelete.php
@@ -26,7 +26,7 @@ $sGroupKey = InputUtils::legacyFilterInput($_GET['GroupKey'], 'string');
 // Security: User must have Add or Edit Records permission to use this form in those manners
 // Clean error handling: (such as somebody typing an incorrect URL ?PersonID= manually)
 if (!AuthenticationManager::getCurrentUser()->isDeleteRecordsEnabled()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/PledgeDetails.php
+++ b/src/PledgeDetails.php
@@ -24,10 +24,7 @@ $linkBack = InputUtils::legacyFilterInput($_GET['linkBack']);
 
 // Security: User must have Finance permission to use this form.
 // Clean error handling: (such as somebody typing an incorrect URL ?PersonID= manually)
-if (!AuthenticationManager::getCurrentUser()->isFinanceEnabled()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isFinanceEnabled());
 
 //Is this the second pass?
 if (isset($_POST['Back'])) {

--- a/src/PledgeDetails.php
+++ b/src/PledgeDetails.php
@@ -25,7 +25,7 @@ $linkBack = InputUtils::legacyFilterInput($_GET['linkBack']);
 // Security: User must have Finance permission to use this form.
 // Clean error handling: (such as somebody typing an incorrect URL ?PersonID= manually)
 if (!AuthenticationManager::getCurrentUser()->isFinanceEnabled()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/PledgeEditor.php
+++ b/src/PledgeEditor.php
@@ -93,7 +93,7 @@ if ($sGroupKey) {
 
         // Security: User must have Finance permission or be the one who entered this record originally
         if (!(AuthenticationManager::getCurrentUser()->isFinanceEnabled() || AuthenticationManager::getCurrentUser()->getId() == $aRow['plg_EditedBy'])) {
-            RedirectUtils::redirect('Menu.php');
+            RedirectUtils::redirect('v2/dashboard');
             exit;
         }
     }
@@ -670,7 +670,7 @@ require 'Include/Header.php';
     } else {
         $cancelText = 'Return';
     } ?>
-    <input type="button" class="btn btn-danger" value="<?= gettext($cancelText) ?>" name="PledgeCancel" onclick="javascript:document.location='<?= $linkBack ? $linkBack : 'Menu.php' ?>';">
+    <input type="button" class="btn btn-danger" value="<?= gettext($cancelText) ?>" name="PledgeCancel" onclick="javascript:document.location='<?= $linkBack ? $linkBack : 'v2/dashboard' ?>';">
     </div>
   </div>
 </div>

--- a/src/PropertyAssign.php
+++ b/src/PropertyAssign.php
@@ -22,7 +22,7 @@ use ChurchCRM\Utils\RedirectUtils;
 // Security: User must have Manage Groups or Edit Records permissions
 // Otherwise, re-direct them to the main menu.
 if (!AuthenticationManager::getCurrentUser()->isManageGroupsEnabled() && !AuthenticationManager::getCurrentUser()->isEditRecordsEnabled()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 
@@ -78,7 +78,7 @@ if (isset($_GET['PersonID']) && AuthenticationManager::getCurrentUser()->isEditR
     $sName = $aRow['fam_Name'];
 } else {
     // Somebody tried to call the script with no options
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
 }
 
 // If no property, return to previous page

--- a/src/PropertyDelete.php
+++ b/src/PropertyDelete.php
@@ -17,10 +17,7 @@ use ChurchCRM\Authentication\AuthenticationManager;
 use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
-if (!AuthenticationManager::getCurrentUser()->isMenuOptionsEnabled()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isMenuOptionsEnabled());
 
 //Set the page title
 $sPageTitle = gettext('Property Delete Confirmation');

--- a/src/PropertyDelete.php
+++ b/src/PropertyDelete.php
@@ -18,7 +18,7 @@ use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
 if (!AuthenticationManager::getCurrentUser()->isMenuOptionsEnabled()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/PropertyEditor.php
+++ b/src/PropertyEditor.php
@@ -19,10 +19,7 @@ use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
 // Security: User must have property and classification editing permission
-if (!AuthenticationManager::getCurrentUser()->isMenuOptionsEnabled()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isMenuOptionsEnabled());
 
 $sClassError = '';
 $sNameError = '';

--- a/src/PropertyEditor.php
+++ b/src/PropertyEditor.php
@@ -20,7 +20,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 // Security: User must have property and classification editing permission
 if (!AuthenticationManager::getCurrentUser()->isMenuOptionsEnabled()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 
@@ -51,7 +51,7 @@ switch ($sType) {
         break;
 
     default:
-        RedirectUtils::redirect('Menu.php');
+        RedirectUtils::redirect('v2/dashboard');
         exit;
         break;
 }

--- a/src/PropertyList.php
+++ b/src/PropertyList.php
@@ -35,7 +35,7 @@ switch ($sType) {
         break;
 
     default:
-        RedirectUtils::redirect('Menu.php');
+        RedirectUtils::redirect('v2/dashboard');
         exit;
         break;
 }

--- a/src/PropertyTypeDelete.php
+++ b/src/PropertyTypeDelete.php
@@ -19,7 +19,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 // Security: User must have property and classification editing permission
 if (!AuthenticationManager::getCurrentUser()->isMenuOptionsEnabled()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/PropertyTypeDelete.php
+++ b/src/PropertyTypeDelete.php
@@ -18,10 +18,7 @@ use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
 // Security: User must have property and classification editing permission
-if (!AuthenticationManager::getCurrentUser()->isMenuOptionsEnabled()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isMenuOptionsEnabled());
 
 //Set the page title
 $sPageTitle = gettext('Property Type Delete Confirmation');

--- a/src/PropertyTypeEditor.php
+++ b/src/PropertyTypeEditor.php
@@ -18,10 +18,7 @@ use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
 // Security: User must have property and classification editing permission
-if (!AuthenticationManager::getCurrentUser()->isMenuOptionsEnabled()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isMenuOptionsEnabled());
 
 //Set the page title
 $sPageTitle = gettext('Property Type Editor');

--- a/src/PropertyTypeEditor.php
+++ b/src/PropertyTypeEditor.php
@@ -19,7 +19,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 // Security: User must have property and classification editing permission
 if (!AuthenticationManager::getCurrentUser()->isMenuOptionsEnabled()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/PropertyUnassign.php
+++ b/src/PropertyUnassign.php
@@ -20,7 +20,7 @@ use ChurchCRM\Utils\RedirectUtils;
 // Security: User must have Manage Groups or Edit Records permissions
 // Otherwise, re-direct them to the main menu.
 if (!AuthenticationManager::getCurrentUser()->isManageGroupsEnabled() && !AuthenticationManager::getCurrentUser()->isEditRecordsEnabled()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 
@@ -68,7 +68,7 @@ if (isset($_GET['PersonID']) && AuthenticationManager::getCurrentUser()->isEditR
     $sName = $aRow['fam_Name'];
 } else {
     // Somebody tried to call the script with no options
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/QuerySQL.php
+++ b/src/QuerySQL.php
@@ -23,7 +23,7 @@ $sPageTitle = gettext('Free-Text Query');
 // Security: User must be an Admin to access this page.  It allows unrestricted database access!
 // Otherwise, re-direct them to the main menu.
 if (!AuthenticationManager::getCurrentUser()->isAdmin()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/QuerySQL.php
+++ b/src/QuerySQL.php
@@ -22,10 +22,7 @@ $sPageTitle = gettext('Free-Text Query');
 
 // Security: User must be an Admin to access this page.  It allows unrestricted database access!
 // Otherwise, re-direct them to the main menu.
-if (!AuthenticationManager::getCurrentUser()->isAdmin()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isAdmin());
 
 if (isset($_POST['SQL'])) {
     //Assign the value locally

--- a/src/QueryView.php
+++ b/src/QueryView.php
@@ -28,7 +28,7 @@ $iQueryID = InputUtils::legacyFilterInput($_GET['QueryID'], 'int');
 $aFinanceQueries = explode(',', SystemConfig::getValue('aFinanceQueries'));
 
 if (!AuthenticationManager::getCurrentUser()->isFinanceEnabled() && in_array($iQueryID, $aFinanceQueries)) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/ReminderReport.php
+++ b/src/ReminderReport.php
@@ -19,7 +19,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 // If CSVAdminOnly option is enabled and user is not admin, redirect to the menu.
 if (!AuthenticationManager::getCurrentUser()->isAdmin() && SystemConfig::getValue('bCSVAdminOnly')) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 
@@ -51,7 +51,7 @@ if (isset($_POST['Submit'])) {
             <div class="col-sm-offset-2 col-sm-8">
                 <button type="submit" class="btn btn-primary" name="Submit"><?= gettext('Create Report') ?></button>
                 <button type="button" class="btn btn-default" name="Cancel"
-                        onclick="javascript:document.location='Menu.php';"><?= gettext('Cancel') ?></button>
+                        onclick="javascript:document.location='v2/dashboard';"><?= gettext('Cancel') ?></button>
             </div>
         </div>
 

--- a/src/Reports/AdvancedDeposit.php
+++ b/src/Reports/AdvancedDeposit.php
@@ -20,7 +20,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 // Security
 if (!AuthenticationManager::getCurrentUser()->isFinanceEnabled()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 
@@ -80,7 +80,7 @@ if (!$output) {
 
 // If CSVAdminOnly option is enabled and user is not admin, redirect to the menu.
 if (!AuthenticationManager::getCurrentUser()->isAdmin() && SystemConfig::getValue('bCSVAdminOnly') && $output != 'pdf') {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/Reports/AdvancedDeposit.php
+++ b/src/Reports/AdvancedDeposit.php
@@ -19,10 +19,7 @@ use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
 // Security
-if (!AuthenticationManager::getCurrentUser()->isFinanceEnabled()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isFinanceEnabled());
 
 // Filter values
 $sort = InputUtils::legacyFilterInput($_POST['sort']);

--- a/src/Reports/DirectoryReport.php
+++ b/src/Reports/DirectoryReport.php
@@ -23,7 +23,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 // Check for Create Directory user permission.
 if (!AuthenticationManager::getCurrentUser()->isCreateDirectoryEnabled()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/Reports/DirectoryReport.php
+++ b/src/Reports/DirectoryReport.php
@@ -22,10 +22,7 @@ use ChurchCRM\Utils\MiscUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
 // Check for Create Directory user permission.
-if (!AuthenticationManager::getCurrentUser()->isCreateDirectoryEnabled()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isCreateDirectoryEnabled());
 
 // Get and filter the classifications selected
 $aClasses = [];

--- a/src/Reports/EnvelopeReport.php
+++ b/src/Reports/EnvelopeReport.php
@@ -18,7 +18,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 // If CSVAdminOnly option is enabled and user is not admin, redirect to the menu.
 if (!AuthenticationManager::getCurrentUser()->isAdmin() && SystemConfig::getValue('bCSVAdminOnly')) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/Reports/FamilyPledgeSummary.php
+++ b/src/Reports/FamilyPledgeSummary.php
@@ -20,10 +20,7 @@ use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
 // Security
-if (!AuthenticationManager::getCurrentUser()->isFinanceEnabled()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isFinanceEnabled());
 
 if (!empty($_POST['classList'])) {
     $classList = $_POST['classList'];

--- a/src/Reports/FamilyPledgeSummary.php
+++ b/src/Reports/FamilyPledgeSummary.php
@@ -21,7 +21,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 // Security
 if (!AuthenticationManager::getCurrentUser()->isFinanceEnabled()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 
@@ -74,7 +74,7 @@ if (array_key_exists('only_owe', $_POST)) {
 
 // If CSVAdminOnly option is enabled and user is not admin, redirect to the menu.
 if (!AuthenticationManager::getCurrentUser()->isAdmin() && SystemConfig::getValue('bCSVAdminOnly')) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/Reports/PledgeSummary.php
+++ b/src/Reports/PledgeSummary.php
@@ -19,10 +19,7 @@ use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
 // Security
-if (!AuthenticationManager::getCurrentUser()->isFinanceEnabled()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isFinanceEnabled());
 
 // Filter Values
 $output = InputUtils::legacyFilterInput($_POST['output']);

--- a/src/Reports/PledgeSummary.php
+++ b/src/Reports/PledgeSummary.php
@@ -20,7 +20,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 // Security
 if (!AuthenticationManager::getCurrentUser()->isFinanceEnabled()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 
@@ -34,7 +34,7 @@ $_SESSION['idefaultFY'] = $iFYID; // Remember the chosen FYID
 
 // If CSVAdminOnly option is enabled and user is not admin, redirect to the menu.
 if (!AuthenticationManager::getCurrentUser()->isAdmin() && SystemConfig::getValue('bCSVAdminOnly') && $output != 'pdf') {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/Reports/PrintDeposit.php
+++ b/src/Reports/PrintDeposit.php
@@ -25,7 +25,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 //Security
 if (!AuthenticationManager::getCurrentUser()->isFinanceEnabled()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 
@@ -54,7 +54,7 @@ if (!$iDepositSlipID && array_key_exists('iCurrentDeposit', $_SESSION)) {
 // If CSVAdminOnly option is enabled and user is not admin, redirect to the menu.
 // If no DepositSlipId, redirect to the menu
 if ((!AuthenticationManager::getCurrentUser()->isAdmin() && $bCSVAdminOnly && $output != 'pdf') || !$iDepositSlipID) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/Reports/PrintDeposit.php
+++ b/src/Reports/PrintDeposit.php
@@ -24,10 +24,7 @@ use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
 //Security
-if (!AuthenticationManager::getCurrentUser()->isFinanceEnabled()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isFinanceEnabled());
 
 $iBankSlip = 0;
 if (array_key_exists('BankSlip', $_GET)) {

--- a/src/Reports/ReminderReport.php
+++ b/src/Reports/ReminderReport.php
@@ -20,7 +20,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 // Security
 if (!AuthenticationManager::getCurrentUser()->isFinanceEnabled()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 
@@ -36,7 +36,7 @@ $only_owe = InputUtils::legacyFilterInput($_POST['only_owe']);
 
 // If CSVAdminOnly option is enabled and user is not admin, redirect to the menu.
 if (!AuthenticationManager::getCurrentUser()->isAdmin() && SystemConfig::getValue('bCSVAdminOnly')) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/Reports/ReminderReport.php
+++ b/src/Reports/ReminderReport.php
@@ -19,10 +19,7 @@ use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
 // Security
-if (!AuthenticationManager::getCurrentUser()->isFinanceEnabled()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isFinanceEnabled());
 
 //Get the Fiscal Year ID out of the querystring
 $iFYID = InputUtils::legacyFilterInput($_POST['FYID'], 'int');

--- a/src/Reports/TaxReport.php
+++ b/src/Reports/TaxReport.php
@@ -20,7 +20,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 // Security
 if (!AuthenticationManager::getCurrentUser()->isFinanceEnabled()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 
@@ -36,7 +36,7 @@ $iMinimum = InputUtils::legacyFilterInput($_POST['minimum'], 'int');
 
 // If CSVAdminOnly option is enabled and user is not admin, redirect to the menu.
 if (!AuthenticationManager::getCurrentUser()->isAdmin() && SystemConfig::getValue('bCSVAdminOnly') && $output != 'pdf') {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/Reports/TaxReport.php
+++ b/src/Reports/TaxReport.php
@@ -19,10 +19,7 @@ use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
 // Security
-if (!AuthenticationManager::getCurrentUser()->isFinanceEnabled()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isFinanceEnabled());
 
 // Filter values
 $letterhead = InputUtils::legacyFilterInput($_POST['letterhead']);

--- a/src/Reports/ZeroGivers.php
+++ b/src/Reports/ZeroGivers.php
@@ -21,7 +21,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 // Security
 if (!AuthenticationManager::getCurrentUser()->isFinanceEnabled()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 
@@ -35,7 +35,7 @@ $remittance = InputUtils::legacyFilterInput($_POST['remittance']);
 
 // If CSVAdminOnly option is enabled and user is not admin, redirect to the menu.
 if (!AuthenticationManager::getCurrentUser()->isAdmin() && SystemConfig::getValue('bCSVAdminOnly') && $output != 'pdf') {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/Reports/ZeroGivers.php
+++ b/src/Reports/ZeroGivers.php
@@ -20,10 +20,7 @@ use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
 // Security
-if (!AuthenticationManager::getCurrentUser()->isFinanceEnabled()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isFinanceEnabled());
 
 // Filter values
 $output = InputUtils::legacyFilterInput($_POST['output']);

--- a/src/RestoreDatabase.php
+++ b/src/RestoreDatabase.php
@@ -21,10 +21,7 @@ use ChurchCRM\dto\SystemURLs;
 use ChurchCRM\Utils\RedirectUtils;
 
 // Security: User must have Manage Groups permission
-if (!AuthenticationManager::getCurrentUser()->isAdmin()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isAdmin());
 
 //Set the page title
 $sPageTitle = gettext('Restore Database');

--- a/src/RestoreDatabase.php
+++ b/src/RestoreDatabase.php
@@ -22,7 +22,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 // Security: User must have Manage Groups permission
 if (!AuthenticationManager::getCurrentUser()->isAdmin()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/SelectDelete.php
+++ b/src/SelectDelete.php
@@ -30,7 +30,7 @@ use ChurchCRM\Utils\RedirectUtils;
 // Security: User must have Delete records permission
 // Otherwise, re-direct them to the main menu.
 if (!AuthenticationManager::getCurrentUser()->isDeleteRecordsEnabled()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/SelectDelete.php
+++ b/src/SelectDelete.php
@@ -29,10 +29,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 // Security: User must have Delete records permission
 // Otherwise, re-direct them to the main menu.
-if (!AuthenticationManager::getCurrentUser()->isDeleteRecordsEnabled()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isDeleteRecordsEnabled());
 
 // default values to make the newer versions of php happy
 $iFamilyID = 0;

--- a/src/SettingsUser.php
+++ b/src/SettingsUser.php
@@ -22,10 +22,7 @@ use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
 // Security
-if (!AuthenticationManager::getCurrentUser()->isAdmin()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isAdmin());
 
 // Save Settings
 if (isset($_POST['save'])) {

--- a/src/SettingsUser.php
+++ b/src/SettingsUser.php
@@ -23,7 +23,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 // Security
 if (!AuthenticationManager::getCurrentUser()->isAdmin()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 
@@ -158,7 +158,7 @@ while (list($ucfg_per_id, $ucfg_id, $ucfg_name, $ucfg_value, $ucfg_type, $ucfg_t
 <tr>
     <td colspan='3' class='text-center'>
         <input type=submit class='btn btn-primary' name=save value="<?=  gettext('Save Settings') ?> ">
-        <input type=submit class=btn name=cancel value="<?= gettext('Cancel') ?>" onclick="javascript:document.location = 'Menu.php';">
+        <input type=submit class=btn name=cancel value="<?= gettext('Cancel') ?>" onclick="javascript:document.location = 'v2/dashboard';">
     </td>
 </tr>
 </table>

--- a/src/SystemDBUpdate.php
+++ b/src/SystemDBUpdate.php
@@ -13,7 +13,7 @@ $bSuppressSessionTests = true; // DO NOT MOVE
 require 'Include/Functions.php';
 
 if (Bootstrapper::isDBCurrent()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 
@@ -23,7 +23,7 @@ if (isset($_GET['upgrade']) && InputUtils::filterString($_GET['upgrade']) === "t
         $logger->info("Beginning database upgrade");
         UpgradeService::upgradeDatabaseVersion();
         $logger->info("Complete database upgrade; redirecting to Main menu");
-        RedirectUtils::redirect('Menu.php');
+        RedirectUtils::redirect('v2/dashboard');
         exit;
     } catch (\Exception $ex) {
         $errorMessage = $ex->getMessage();

--- a/src/SystemSettings.php
+++ b/src/SystemSettings.php
@@ -24,7 +24,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 // Security
 if (!AuthenticationManager::getCurrentUser()->isAdmin()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/SystemSettings.php
+++ b/src/SystemSettings.php
@@ -23,10 +23,7 @@ use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
 // Security
-if (!AuthenticationManager::getCurrentUser()->isAdmin()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isAdmin());
 
 // Set the page title and include HTML header
 $sPageTitle = gettext('System Settings');

--- a/src/TaxReport.php
+++ b/src/TaxReport.php
@@ -20,7 +20,7 @@ use ChurchCRM\Utils\RedirectUtils;
 
 // If CSVAdminOnly option is enabled and user is not admin, redirect to the menu.
 if (!AuthenticationManager::getCurrentUser()->isAdmin() && SystemConfig::getValue('bCSVAdminOnly')) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 
@@ -51,7 +51,7 @@ if (isset($_POST['Submit'])) {
             <div class="col-sm-offset-2 col-sm-8">
                 <button type="submit" class="btn btn-primary" name="Submit"><?= gettext('Create Report') ?></button>
                 <button type="button" class="btn btn-default" name="Cancel"
-                        onclick="javascript:document.location='Menu.php';"><?= gettext('Cancel') ?></button>
+                        onclick="javascript:document.location='v2/dashboard';"><?= gettext('Cancel') ?></button>
             </div>
         </div>
 

--- a/src/TaxReport.php
+++ b/src/TaxReport.php
@@ -19,10 +19,7 @@ use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
 // If CSVAdminOnly option is enabled and user is not admin, redirect to the menu.
-if (!AuthenticationManager::getCurrentUser()->isAdmin() && SystemConfig::getValue('bCSVAdminOnly')) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isAdmin() && SystemConfig::getValue('bCSVAdminOnly'));
 
 // Set the page title and include HTML header
 $sPageTitle = gettext('Tax Report');

--- a/src/UserEditor.php
+++ b/src/UserEditor.php
@@ -36,7 +36,7 @@ use Propel\Runtime\ActiveQuery\Criteria;
 // Security: User must be an Admin to access this page.
 // Otherwise re-direct to the main menu.
 if (!AuthenticationManager::getCurrentUser()->isAdmin()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/UserEditor.php
+++ b/src/UserEditor.php
@@ -35,10 +35,7 @@ use Propel\Runtime\ActiveQuery\Criteria;
 
 // Security: User must be an Admin to access this page.
 // Otherwise re-direct to the main menu.
-if (!AuthenticationManager::getCurrentUser()->isAdmin()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isAdmin());
 
 $iPersonID = -1;
 $vNewUser = false;

--- a/src/VolunteerOpportunityEditor.php
+++ b/src/VolunteerOpportunityEditor.php
@@ -21,7 +21,7 @@ use ChurchCRM\Utils\RedirectUtils;
 // Future ... $bManageVol
 
 if (!AuthenticationManager::getCurrentUser()->isAdmin()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 
@@ -60,7 +60,7 @@ if (($sAction == 'delete') && $iOpp > 0) {
     // Security: User must have Delete records permission
     // Otherwise, redirect to the main menu
     if (!AuthenticationManager::getCurrentUser()->isDeleteRecordsEnabled()) {
-        RedirectUtils::redirect('Menu.php');
+        RedirectUtils::redirect('v2/dashboard');
         exit;
     }
 
@@ -121,7 +121,7 @@ if (($sAction == 'ConfDelete') && $iOpp > 0) {
     // Security: User must have Delete records permission
     // Otherwise, redirect to the main menu
     if (!AuthenticationManager::getCurrentUser()->isDeleteRecordsEnabled()) {
-        RedirectUtils::redirect('Menu.php');
+        RedirectUtils::redirect('v2/dashboard');
         exit;
     }
 
@@ -408,7 +408,7 @@ for ($row = 1; $row <= $numRows; $row++) {
 <td width="40%" align="center" valign="bottom">
 <input type="submit" class="btn btn-primary" value="<?= gettext('Save Changes') ?>" Name="SaveChanges">
 &nbsp;
-<input type="button" class="btn btn-default" value="<?= gettext('Exit') ?>" Name="Exit" onclick="javascript:document.location='Menu.php'">
+<input type="button" class="btn btn-default" value="<?= gettext('Exit') ?>" Name="Exit" onclick="javascript:document.location='v2/dashboard'">
 </td>
 <td width="30%"></td>
 </tr>

--- a/src/VolunteerOpportunityEditor.php
+++ b/src/VolunteerOpportunityEditor.php
@@ -19,11 +19,7 @@ use ChurchCRM\Utils\RedirectUtils;
 // Security: User must have proper permission
 // For now ... require $bAdmin
 // Future ... $bManageVol
-
-if (!AuthenticationManager::getCurrentUser()->isAdmin()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isAdmin());
 
 // top down design....
 // title line
@@ -59,10 +55,7 @@ if (($sAction == 'delete') && $iOpp > 0) {
 
     // Security: User must have Delete records permission
     // Otherwise, redirect to the main menu
-    if (!AuthenticationManager::getCurrentUser()->isDeleteRecordsEnabled()) {
-        RedirectUtils::redirect('v2/dashboard');
-        exit;
-    }
+    AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isDeleteRecordsEnabled());
 
     $sSQL = "SELECT * FROM `volunteeropportunity_vol` WHERE `vol_ID` = '" . $iOpp . "'";
     $rsOpps = RunQuery($sSQL);
@@ -120,10 +113,7 @@ if (($sAction == 'delete') && $iOpp > 0) {
 if (($sAction == 'ConfDelete') && $iOpp > 0) {
     // Security: User must have Delete records permission
     // Otherwise, redirect to the main menu
-    if (!AuthenticationManager::getCurrentUser()->isDeleteRecordsEnabled()) {
-        RedirectUtils::redirect('v2/dashboard');
-        exit;
-    }
+    AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isDeleteRecordsEnabled());
 
     // get the order value for the record being deleted
     $sSQL = "SELECT vol_Order from volunteeropportunity_vol WHERE vol_ID='$iOpp'";

--- a/src/composer.lock
+++ b/src/composer.lock
@@ -5170,16 +5170,16 @@
     "packages-dev": [
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.56",
+            "version": "1.10.57",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "27816a01aea996191ee14d010f325434c0ee76fa"
+                "reference": "1627b1d03446904aaa77593f370c5201d2ecc34e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/27816a01aea996191ee14d010f325434c0ee76fa",
-                "reference": "27816a01aea996191ee14d010f325434c0ee76fa",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/1627b1d03446904aaa77593f370c5201d2ecc34e",
+                "reference": "1627b1d03446904aaa77593f370c5201d2ecc34e",
                 "shasum": ""
             },
             "require": {
@@ -5228,25 +5228,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-15T10:43:00+00:00"
+            "time": "2024-01-24T11:51:34+00:00"
         },
         {
             "name": "rector/rector",
-            "version": "0.19.1",
+            "version": "0.19.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "2bba0dd55ba92c23f1253d9e60d0242a896d1025"
+                "reference": "de3b3bb159abd704b144aa86fb244f7f1f4ac947"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/2bba0dd55ba92c23f1253d9e60d0242a896d1025",
-                "reference": "2bba0dd55ba92c23f1253d9e60d0242a896d1025",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/de3b3bb159abd704b144aa86fb244f7f1f4ac947",
+                "reference": "de3b3bb159abd704b144aa86fb244f7f1f4ac947",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2|^8.0",
-                "phpstan/phpstan": "^1.10.52"
+                "phpstan/phpstan": "^1.10.56"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -5276,7 +5276,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/0.19.1"
+                "source": "https://github.com/rectorphp/rector/tree/0.19.8"
             },
             "funding": [
                 {
@@ -5284,7 +5284,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-01-15T18:02:43+00:00"
+            "time": "2024-02-05T10:59:13+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",

--- a/src/eGive.php
+++ b/src/eGive.php
@@ -16,10 +16,7 @@ use ChurchCRM\Authentication\AuthenticationManager;
 use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
-if (!AuthenticationManager::getCurrentUser()->isFinanceEnabled()) {
-    RedirectUtils::redirect('v2/dashboard');
-    exit;
-}
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isFinanceEnabled());
 
 $now = time();
 $dDate = date('Y-m-d', $now);

--- a/src/eGive.php
+++ b/src/eGive.php
@@ -17,7 +17,7 @@ use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
 if (!AuthenticationManager::getCurrentUser()->isFinanceEnabled()) {
-    RedirectUtils::redirect('Menu.php');
+    RedirectUtils::redirect('v2/dashboard');
     exit;
 }
 

--- a/src/index.php
+++ b/src/index.php
@@ -41,8 +41,8 @@ if (!empty($_GET['location'])) {
 AuthenticationManager::ensureAuthentication();
 
 if (strtolower($shortName) === 'index.php' || strtolower($fileName) === 'index.php') {
-    // Index.php -> Menu.php
-    header('Location: ' . SystemURLs::getRootPath() . '/Menu.php');
+    // Index.php -> v2/dashboard
+    header('Location: ' . SystemURLs::getRootPath() . '/v2/dashboard');
     exit;
 } elseif (file_exists($shortName)) {
     // Try actual path

--- a/src/sundayschool/SundaySchoolReports.php
+++ b/src/sundayschool/SundaySchoolReports.php
@@ -286,7 +286,7 @@ $dNoSchool8 = change_date_for_place_holder($dNoSchool6);
           </td>
           <td width="35%">
             <div class="col-rd-12">
-                <input type="button" style="align=right" class="btn btn-default" name="Cancel" value="<?= gettext('Cancel') ?>" onclick="javascript:document.location = 'Menu.php';">
+                <input type="button" style="align=right" class="btn btn-default" name="Cancel" value="<?= gettext('Cancel') ?>" onclick="javascript:document.location = 'v2/dashboard';">
             </div>
           </td>
         </tr>


### PR DESCRIPTION
# Description & Issue number it closes 

Back in version 4.2.3, there was an effort to remove the old `Menu.php` landing page and replace it with a new `v2/dashboard`. Since this was new and the previous developer wanted to ensure a clean migration, they added gutted the old Menu page and made it a redirect.

Now that an ample amount of time has passed since this change, it should be safe to remove the old `Menu.php` and exclusively rely on `v2/dashboard`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
