### PR TITLE
[custom field] mb_substr($fieldInfo->name, 1) string must be cast to int to do arithmetic

### DIFF
--- a/src/FamilyCustomFieldsEditor.php
+++ b/src/FamilyCustomFieldsEditor.php
@@ -136,7 +136,7 @@ if (isset($_POST['SaveChanges'])) {
                 // doesn't allow numeric-only field (table column) names.
                 $fields = mysqli_query($cnInfoCentral, 'SELECT * FROM family_custom');
                 $fieldInfo = mysqli_fetch_field_direct($fields, $last);
-                $newFieldNum = mb_substr($fieldInfo->name, 1) + 1;
+                $newFieldNum = (int) mb_substr($fieldInfo->name, 1) + 1;
 
                 // If we're inserting a new custom-list type field,
                 // create a new list and get its ID

--- a/src/PersonCustomFieldsEditor.php
+++ b/src/PersonCustomFieldsEditor.php
@@ -127,7 +127,7 @@ require 'Include/Header.php'; ?>
                     // The "c#" naming scheme is necessary because MySQL 3.23 doesn't allow numeric-only field (table column) names.
                     $fields = mysqli_query($cnInfoCentral, 'SELECT * FROM person_custom');
                     $fieldInfo = mysqli_fetch_field_direct($fields, $last);
-                    $newFieldNum = mb_substr($fieldInfo->name, 1) + 1;
+                    $newFieldNum = (int) mb_substr($fieldInfo->name, 1) + 1;
 
                     // If we're inserting a new custom-list type field, create a new list and get its ID
                     if ($newFieldType == 12) {


### PR DESCRIPTION
# Description & Issue number it closes 
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->

Reported in [Gitter Matrix chat](https://matrix.to/#/!xSsEgXcTcVSgRZMDNu:gitter.im/$slQiy0jAl3YE0q-oWj29pH-m1oWedsu_qTLK6yDccl8?via=gitter.im&via=matrix.org&via=llamarific.social)

>[18-Jan-2024 02:36:47 America/New_York] PHP Fatal error: Uncaught TypeError: Unsupported operand types: string + int in /home/AccountName/subdomain/FamilyCustomFieldsEditor.php:138
>Stack trace:
>#0 {main}
>thrown in /home/AccountName/subdomain/FamilyCustomFieldsEditor.php on line 138

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
