### PR TITLE
add more null checks when determining age of person

### DIFF
--- a/src/ChurchCRM/model/ChurchCRM/Person.php
+++ b/src/ChurchCRM/model/ChurchCRM/Person.php
@@ -635,8 +635,12 @@ class Person extends BasePerson implements PhotoInterface
         parent::postSave($con);
     }
 
-    public function getAge(?\DateTimeInterface $now = null): string
+    public function getAge(?\DateTimeInterface $now = null): ?string
     {
+        if ($this->getBirthYear() === null) {
+            return null;
+        }
+
         $birthDate = $this->getBirthDate();
 
         if (!$birthDate instanceof \DateTimeImmutable || $this->hideAge()) {

--- a/src/v2/templates/people/family-view.php
+++ b/src/v2/templates/people/family-view.php
@@ -287,7 +287,7 @@ if (array_key_exists('idefaultFY', $_SESSION)) {
                                                 if ($formattedBirthday) {?>
                                                 <i class="fa fa-fw fa-birthday-cake"
                                                    title="<?= gettext("Birthday") ?>"></i>
-                                                    <?= $formattedBirthday ?>  <?= $person->getAge()?>
+                                                    <?= $formattedBirthday ?>  <?= $person->getAge() ?? sprintf('(%s)', gettext('not found')) ?>
                                                 </i>
                                                 <?php } ?>
                                             </li>


### PR DESCRIPTION
# Description & Issue number it closes 
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->

Issue reported from Github.  Now that users can be submitted without birth year, a null check must be performed when age is being determined.

Closes #6847

## Screenshots (if appropriate)
<!-- Before and after --> 

## How to test the changes?

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

