### PR TITLE
Add clearing of Lat/Long to verify null values are functional

### DIFF
--- a/cypress/e2e/ui/people/standard.family.spec.js
+++ b/cypress/e2e/ui/people/standard.family.spec.js
@@ -55,6 +55,9 @@ context("Standard Family", () => {
         cy.get('input[name="Address1"').type("4222 Clinton Way");
         cy.get('input[name="City"]').clear().type("Los Angelas");
         cy.get('select[name="State"]').select("CA", { force: true });
+        // Add clearing of Lat/Long to verify these can be null, instead of default 0
+        cy.get('input[name="Latitude"]').clear();
+        cy.get('input[name="Longitude"]').clear();
         cy.get('input[name="FirstName1"]').type("Mike");
         cy.get('input[name="FirstName2"]').type("Carol");
         cy.get('input[name="FirstName3"]').type("Alice");


### PR DESCRIPTION
# Description & Issue number it closes 
This should close Issue #6833 . The primary fix for that issue was actually done in pull request #6834, but this adds a specific test for the possibility of Latitude, or Longitude being null, which was a problem before.

## Screenshots (if appropriate)
N/A

## How to test the changes?
Should be tested as a result of the standard.family.spec.js test.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
-[x] Adds a test for previous fix

# How Has This Been Tested?

Ran cypress test for standard.family.spec.js

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

