### PR TITLE
better application version check (hopefully remove usage of composer.json in prod)

### DIFF
--- a/src/ChurchCRM/Service/SystemService.php
+++ b/src/ChurchCRM/Service/SystemService.php
@@ -8,6 +8,7 @@ use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\dto\SystemURLs;
 use ChurchCRM\Utils\ChurchCRMReleaseManager;
 use ChurchCRM\Utils\LoggerUtils;
+use Composer\InstalledVersions;
 use PDO;
 use Propel\Runtime\Propel;
 
@@ -15,13 +16,21 @@ require SystemURLs::getDocumentRoot() . '/vendor/ifsnop/mysqldump-php/src/Ifsnop
 
 class SystemService
 {
+    private const COMPOSER_NAME = 'churchcrm/crm';
+
     public static function getInstalledVersion()
     {
+        $version = InstalledVersions::getPrettyVersion(self::COMPOSER_NAME);
+        if ($version) {
+            return $version;
+        }
+
+        // TODO: remove deprecated version check in a future release
+        LoggerUtils::getAppLogger()->info('could not determine version from composer autoloader, falling back to legacy composer.json parsing');
         $composerFile = file_get_contents(SystemURLs::getDocumentRoot() . '/composer.json');
         $composerJson = json_decode($composerFile, true, 512, JSON_THROW_ON_ERROR);
-        $version = $composerJson['version'];
 
-        return $version;
+        return $composerJson['version'];
     }
 
     public static function getCopyrightDate()


### PR DESCRIPTION
# Description & Issue number it closes 
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->

Reimplement application version check to use generated version provided by composer autoloader.  If this succeeds without any issues, we can remove the legacy mechanism of version checking and stop deploying `composer.json` in builds.  This would allow for the application to be more secure since we won't be actively exposing all of the libraries used (for a bad actor to iterate through and find vulnerabilities)