### PR TITLE
Add additional method to check for mod_rewrite

### DIFF
--- a/src/ChurchCRM/Service/AppIntegrityService.php
+++ b/src/ChurchCRM/Service/AppIntegrityService.php
@@ -202,7 +202,7 @@ class AppIntegrityService
         //   This header comes from index.php (which is the target of .htaccess for invalid URLs)
 
         $check = false;
-        $logger = LoggerUtils::getAppLogger();
+        $logger = LoggerUtils::getAppLogger('DEBUG');
 
         if (isset($_SERVER['HTTP_MOD_REWRITE'])) {
             $logger->debug("Webserver configuration has set mod_rewrite variable: {$_SERVER['HTTP_MOD_REWRITE']}");
@@ -213,6 +213,12 @@ class AppIntegrityService
                 $check = in_array('mod_rewrite', apache_get_modules());
             }
             $logger->debug("Apache mod_rewrite check status: $check");
+            if (empty($check)) {
+                if (!empty(shell_exec('/usr/sbin/apachectl -M | grep rewrite'))) {
+                    $logger->debug('Found rewrite module enabled using apachectl');
+                    $check = true;
+                }
+            }
         } else {
             $logger->debug('PHP is not running through Apache');
         }

--- a/src/ChurchCRM/Service/AppIntegrityService.php
+++ b/src/ChurchCRM/Service/AppIntegrityService.php
@@ -202,20 +202,20 @@ class AppIntegrityService
         //   This header comes from index.php (which is the target of .htaccess for invalid URLs)
 
         $check = false;
-        $logger = LoggerUtils::getAppLogger('DEBUG');
+        $logger = LoggerUtils::getAppLogger();
 
         if (isset($_SERVER['HTTP_MOD_REWRITE'])) {
-            $logger->debug("Webserver configuration has set mod_rewrite variable: {$_SERVER['HTTP_MOD_REWRITE']}");
+            $logger->info("Webserver configuration has set mod_rewrite variable: {$_SERVER['HTTP_MOD_REWRITE']}");
             $check = strtolower($_SERVER['HTTP_MOD_REWRITE']) === 'on';
         } elseif (stristr($_SERVER['SERVER_SOFTWARE'], 'apache') !== false) {
-            $logger->debug('PHP is running through Apache; looking for mod_rewrite');
+            $logger->info('PHP is running through Apache; looking for mod_rewrite');
             if (function_exists('apache_get_modules')) {
                 $check = in_array('mod_rewrite', apache_get_modules());
             }
-            $logger->debug("Apache mod_rewrite check status: $check");
+            $logger->info("Apache mod_rewrite check status: $check");
             if (empty($check)) {
                 if (!empty(shell_exec('/usr/sbin/apachectl -M | grep rewrite'))) {
-                    $logger->debug('Found rewrite module enabled using apachectl');
+                    $logger->info('Found rewrite module enabled using apachectl');
                     $check = true;
                 }
             }


### PR DESCRIPTION
# Description & Issue number it closes 
This closes #6910 by adding an additional method to check if apache is able to process rewrite rules.

## Screenshots (if appropriate)
N/A

## How to test the changes?
This could be checked if a demo could be spun up on Softaculous from this change... and then checking the Admin/Debug page to verify that it reports mod_rewrite is detected.

Alternatively, if you are running a setup where php is not loaded as a module, but is enabled via CGI (which prevents apache_get_modules() from working via PHP) -- then you can verify the rewrite module is properly detected in this case similarly with the Admin/Debug page, or in the initial ChurchCRM setup, if you have a blank database.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This has been tested on a RockyLinux v8 install, using php via the php-fpm service.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

