### PR TITLE
Fix "More info" button on People Dashboard

### DIFF
--- a/src/PeopleDashboard.php
+++ b/src/PeopleDashboard.php
@@ -221,7 +221,7 @@ if (SystemConfig::getBooleanValue("bEnableSelfRegistration")) {
       <div class="icon">
         <i class="fa fa-users"></i>
       </div>
-      <a href="<?= SystemURLs::getRootPath() ?>/grouplist" class="small-box-footer">
+      <a href="<?= SystemURLs::getRootPath() ?>/GroupList.php" class="small-box-footer">
         <?= gettext('More info') ?> <i class="fa fa-arrow-circle-right"></i>
       </a>
     </div>


### PR DESCRIPTION
# Description & Issue number it closes 
"More Info" button on People Dashboard is not clickable.

## Screenshots (if appropriate)

## How to test the changes?

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested it on my site

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

