### PR TITLE
Fix Directory Report page size selector

### DIFF
--- a/src/Reports/DirectoryReport.php
+++ b/src/Reports/DirectoryReport.php
@@ -80,19 +80,19 @@ $sChurchPhone = InputUtils::legacyFilterInput($_POST['sChurchPhone']);
 $bDirUseTitlePage = isset($_POST['bDirUseTitlePage']);
 
 $bNumberofColumns = InputUtils::legacyFilterInput($_POST['NumCols'] ?? '1', 'int');
-$bPageSize = InputUtils::legacyFilterInput($_POST['PageSize'] ?? 'letter', 'int');
+$sPageSize = InputUtils::legacyFilterInput($_POST['PageSize']);
 $bFontSz = InputUtils::legacyFilterInput($_POST['FSize'] ?? '8', 'int');
 $bLineSp = $bFontSz / 3;
 
-if ($bPageSize != 'letter' && $bPageSize != 'a4') {
-    $bPageSize = 'legal';
+if ($sPageSize != 'letter' && $sPageSize != 'a4') {
+    $sPageSize = 'legal';
 }
 
-//echo "ncols={$bNumberofColumns}  page size={$bPageSize}";
+//echo "ncols={$bNumberofColumns}  page size={$sPageSize}";
 
 // Instantiate the directory class and build the report.
 //echo "font sz = {$bFontSz} and line sp={$bLineSp}";
-$pdf = new PdfDirectory($bNumberofColumns, $bPageSize, $bFontSz, $bLineSp);
+$pdf = new PdfDirectory($bNumberofColumns, $sPageSize, $bFontSz, $bLineSp);
 
 // Get the list of custom person fields
 $sSQL = 'SELECT person_custom_master.* FROM person_custom_master ORDER BY custom_Order';


### PR DESCRIPTION
# Description & Issue number it closes 
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->

Fixes #6980

This line somehow always results in a zero value:

https://github.com/ChurchCRM/CRM/blob/351183aac36c9809708bb3d7f960c8c212520350/src/Reports/DirectoryReport.php#L83

And so this always defaults to 'legal':

https://github.com/ChurchCRM/CRM/blob/351183aac36c9809708bb3d7f960c8c212520350/src/Reports/DirectoryReport.php#L87-L89

## Screenshots (if appropriate)
<!-- Before and after --> 

None.

## How to test the changes?

Go through the steps listed in the bug report above. Result is always 'legal' page size for PDF.

Apply the changes, and generate new PDFs choosing each one of the 3 page size options. Check the PDF metadata (I used `pdfinfo`):

Letter:

`Page size:       612 x 792 pts (letter)`

Legal:

`Page size:       612 x 1008 pts`

A4:

`Page size:       595.28 x 841.89 pts (A4)`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Go through the steps listed in the bug report above. Result is always 'legal' page size for PDF.

Apply the changes, and generate new PDFs choosing each one of the 3 page size options. Check the PDF metadata (I used `pdfinfo`):

Letter:

`Page size:       612 x 792 pts (letter)`

Legal:

`Page size:       612 x 1008 pts`

A4:

`Page size:       595.28 x 841.89 pts (A4)`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

