### PR TITLE
Bug: Age is not correct in Birthday Calendar. #6990

### DIFF
--- a/src/ChurchCRM/SystemCalendars/BirthdaysCalendar.php
+++ b/src/ChurchCRM/SystemCalendars/BirthdaysCalendar.php
@@ -67,8 +67,9 @@ class BirthdaysCalendar implements SystemCalendar
                 $birthday = new Event();
                 $birthday->setId($person->getId());
                 $birthday->setEditable(false);
-                $birthday->setStart($year . '-' . $person->getBirthMonth() . '-' . $person->getBirthDay());
-                $age = $person->getAge($birthday->getStart());
+                $eventDate = $year . '-' . $person->getBirthMonth() . '-' . $person->getBirthDay();
+                $birthday->setStart($eventDate);
+                $age = $person->getAge($eventDate);
                 $birthday->setTitle($person->getFullName() . ($age ? ' (' . $age . ')' : ''));
                 $birthday->setURL($person->getViewURI());
                 $events->push($birthday);

--- a/src/ChurchCRM/model/ChurchCRM/Person.php
+++ b/src/ChurchCRM/model/ChurchCRM/Person.php
@@ -640,7 +640,7 @@ class Person extends BasePerson implements PhotoInterface
         parent::postSave($con);
     }
 
-    public function getAge(?\DateTimeInterface $now = null): ?string
+    public function getAge(?string $date = null): ?string
     {
         if ($this->getBirthYear() === null) {
             return null;
@@ -651,9 +651,7 @@ class Person extends BasePerson implements PhotoInterface
         if (!$birthDate instanceof \DateTimeImmutable || $this->hideAge()) {
             return false;
         }
-        if (!$now instanceof \DateTimeInterface) {
-            $now = new \DateTimeImmutable('today');
-        }
+        $now = $date == null ? new \DateTimeImmutable('today') : \DateTimeImmutable::createFromFormat('Y-m-d', $date);
         $age = date_diff($now, $birthDate);
 
         if ($age->y < 1) {


### PR DESCRIPTION
# Description & Issue number it closes 
Bug: Age is not correct in Birthday Calendar. #6990

Use same date function used in Person::getBirthDate() to create calendar date 

## Screenshots (if appropriate)
Before
<img width="1221" alt="Screenshot 2024-05-04 at 10 52 59 PM" src="https://github.com/ChurchCRM/CRM/assets/40956907/247fd92f-3dbe-4d7a-9738-b62f7384e0c3">

After
<img width="1223" alt="Screenshot 2024-05-04 at 10 38 04 PM" src="https://github.com/ChurchCRM/CRM/assets/40956907/7dff1b0b-6bf6-4163-b884-b02d3b6b2252">


## How to test the changes?
http://localhost/v2/calendar

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
From local host with
```
npm run build
num run package
npm run docker-test-start
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

