### PR TITLE
fix `location` redirect query parameter on login page

### DIFF
--- a/src/ChurchCRM/Authentication/AuthenticationManager.php
+++ b/src/ChurchCRM/Authentication/AuthenticationManager.php
@@ -127,7 +127,11 @@ class AuthenticationManager
         }
 
         if ($result->isAuthenticated && !$result->preventRedirect) {
-            $redirectLocation = $_SESSION['location'] ?? 'v2/dashboard';
+            $redirectLocation = null;
+            if ($AuthenticationRequest instanceof LocalUsernamePasswordRequest) {
+                $redirectLocation = $AuthenticationRequest->redirectPath;
+            }
+            $redirectLocation = $redirectLocation ?? $_SESSION['location'] ?? 'v2/dashboard';
             NotificationService::updateNotifications();
             $logger->debug(
                 'Authentication Successful; redirecting to: ' . $redirectLocation
@@ -171,11 +175,12 @@ class AuthenticationManager
                     'Session not authenticated.  Redirecting to login page'
                 );
 
-                $queryParams = http_build_query([
-                    'location' => $_SERVER['REQUEST_URI'],
-                ]);
+                $redirectPath = $_GET['location'] ?? $_SESSION['location'] ?? null;
                 $loginUrl = self::getSessionBeginURL();
-                if (!str_contains(self::getSessionBeginURL(), $_SERVER['REQUEST_URI'])) {
+                if (!empty($redirectPath)) {
+                    $queryParams = http_build_query([
+                        'location' => $redirectPath,
+                    ]);
                     $loginUrl .= '?' . $queryParams;
                 }
                 RedirectUtils::redirect($loginUrl);
@@ -183,6 +188,13 @@ class AuthenticationManager
                 LoggerUtils::getAuthLogger()->debug(
                     'Session authenticated, but redirect requested by authentication provider.'
                 );
+                $redirectPath = $_GET['location'] ?? $_SESSION['location'] ?? null;
+                if (!empty($redirectPath)) {
+                    $queryParams = http_build_query([
+                        'location' => $redirectPath,
+                    ]);
+                    $result->nextStepURL .= '?' . $queryParams;
+                }
                 RedirectUtils::redirect($result->nextStepURL);
             }
             LoggerUtils::getAuthLogger()->debug('Session valid');
@@ -195,16 +207,21 @@ class AuthenticationManager
         }
     }
 
-    public static function getSessionBeginURL(): string
+    public static function getSessionBeginURL(?string $redirectPath = null): string
     {
-        return SystemURLs::getRootPath() . '/session/begin';
+        $url = SystemURLs::getRootPath() . '/session/begin';
+        if (!empty($redirectPath)) {
+            $url .= '?location=' . urlencode($redirectPath);
+        }
+
+        return $url;
     }
 
     public static function getForgotPasswordURL(): string
     {
         // this assumes we're using local authentication
         // TODO: when we implement other authentication providers (SAML/etc)
-        // this URL will need to be configuable by the system administrator
+        // this URL will need to be configurable by the system administrator
         // since they likely will not want users attempting to reset ChurchCRM passwords
         // but rather redirect users to some other password reset mechanism.
         return SystemURLs::getRootPath() . '/session/forgot-password/reset-request';

--- a/src/ChurchCRM/Authentication/AuthenticationManager.php
+++ b/src/ChurchCRM/Authentication/AuthenticationManager.php
@@ -131,7 +131,7 @@ class AuthenticationManager
             if ($AuthenticationRequest instanceof LocalUsernamePasswordRequest) {
                 $redirectLocation = $AuthenticationRequest->redirectPath;
             }
-            $redirectLocation = $redirectLocation ?? $_SESSION['location'] ?? 'v2/dashboard';
+            $redirectLocation ??= $_SESSION['location'] ?? 'v2/dashboard';
             NotificationService::updateNotifications();
             $logger->debug(
                 'Authentication Successful; redirecting to: ' . $redirectLocation

--- a/src/ChurchCRM/Authentication/AuthenticationResult.php
+++ b/src/ChurchCRM/Authentication/AuthenticationResult.php
@@ -4,8 +4,8 @@ namespace ChurchCRM\Authentication;
 
 class AuthenticationResult
 {
-    public $isAuthenticated;
-    public $nextStepURL;
-    public $message;
-    public $preventRedirect;
+    public bool $isAuthenticated = false;
+    public ?string $nextStepURL = null;
+    public string $message;
+    public bool $preventRedirect = false;
 }

--- a/src/ChurchCRM/Authentication/Requests/APITokenAuthenticationRequest.php
+++ b/src/ChurchCRM/Authentication/Requests/APITokenAuthenticationRequest.php
@@ -4,9 +4,10 @@ namespace ChurchCRM\Authentication\Requests;
 
 class APITokenAuthenticationRequest extends AuthenticationRequest
 {
-    public function __construct($APIToken)
+    public string $APIToken;
+
+    public function __construct(string $APIToken)
     {
         $this->APIToken = $APIToken;
     }
-    public $APIToken;
 }

--- a/src/ChurchCRM/Authentication/Requests/LocalTwoFactorTokenRequest.php
+++ b/src/ChurchCRM/Authentication/Requests/LocalTwoFactorTokenRequest.php
@@ -4,9 +4,9 @@ namespace ChurchCRM\Authentication\Requests;
 
 class LocalTwoFactorTokenRequest extends AuthenticationRequest
 {
-    public $TwoFACode;
+    public string $TwoFACode;
 
-    public function __construct($TwoFACode)
+    public function __construct(string $TwoFACode)
     {
         $this->TwoFACode = $TwoFACode;
     }

--- a/src/ChurchCRM/Authentication/Requests/LocalUsernamePasswordRequest.php
+++ b/src/ChurchCRM/Authentication/Requests/LocalUsernamePasswordRequest.php
@@ -4,12 +4,14 @@ namespace ChurchCRM\Authentication\Requests;
 
 class LocalUsernamePasswordRequest extends AuthenticationRequest
 {
-    public $username;
-    public $password;
+    public string $username;
+    public string $password;
+    public ?string $redirectPath = null;
 
-    public function __construct($username, $password)
+    public function __construct(string $username, string $password, ?string $redirectPath = null)
     {
         $this->username = $username;
         $this->password = $password;
+        $this->redirectPath = $redirectPath;
     }
 }


### PR DESCRIPTION
# Description & Issue number it closes 
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->

noticed the location query parameter wasn't being respected on login so I fixed it here.

## How to test the changes?

1. visit /session/begin?location=/v2/people
2. login
3. observe how the application automatically brings you to `/v2/people`
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
