### PR TITLE
sanitize the CurrentFundraiser provided from query params, use ORM to get fundraiser data

### DIFF
--- a/src/Reports/FRBidSheets.php
+++ b/src/Reports/FRBidSheets.php
@@ -14,51 +14,42 @@ require '../Include/Config.php';
 require '../Include/Functions.php';
 
 use ChurchCRM\dto\SystemConfig;
+use ChurchCRM\model\ChurchCRM\FundRaiserQuery;
+use ChurchCRM\Utils\InputUtils;
 
-$iCurrentFundraiser = $_GET['CurrentFundraiser'];
+if (!isset($_GET['CurrentFundraiser'])) {
+    throw new \InvalidArgumentException('Missing required CurrentFundraiser parameter');
+}
+$iCurrentFundraiser = (int) InputUtils::legacyFilterInput($_GET['CurrentFundraiser'], 'int');
 
 class PdfFRBidSheetsReport extends ChurchInfoReport
 {
-    // Constructor
     public function __construct()
     {
         parent::__construct('P', 'mm', $this->paperFormat);
+
         $this->SetFont('Times', '', 10);
         $this->SetMargins(15, 25);
 
         $this->SetAutoPageBreak(true, 25);
     }
-
-    public function addPage($orientation = '', $format = '', $rotation = 0): void
-    {
-        global $fr_title, $fr_description;
-
-        parent::addPage($orientation, $format, $rotation);
-
-        //      $this->SetFont("Times",'B',16);
-//      $this->Write (8, $fr_title."\n");
-        //      $curY += 8;
-        //      $this->Write (8, $fr_description."\n\n");
-        //      $curY += 8;
-        //      $this->SetFont("Times",'',10);
-    }
 }
 
 // Get the information about this fundraiser
-$sSQL = 'SELECT * FROM fundraiser_fr WHERE fr_ID=' . $iCurrentFundraiser;
-$rsFR = RunQuery($sSQL);
-$thisFR = mysqli_fetch_array($rsFR);
-extract($thisFR);
+$fundraiser = FundRaiserQuery::create()->findOneById($iCurrentFundraiser);
+if ($fundraiser === null) {
+    throw new \InvalidArgumentException('No results found for provided CurrentFundraiser parameter');
+}
 
 // Get all the donated items
 $sSQL = 'SELECT * FROM donateditem_di LEFT JOIN person_per on per_ID=di_donor_ID ' .
-        ' WHERE di_FR_ID=' . $iCurrentFundraiser .
+        ' WHERE di_FR_ID=' . $fundraiser->getId() .
         ' ORDER BY SUBSTR(di_item,1,1),cast(SUBSTR(di_item,2) as unsigned integer),SUBSTR(di_item,4)';
 
 $rsItems = RunQuery($sSQL);
 
 $pdf = new PdfFRBidSheetsReport();
-$pdf->SetTitle($fr_title);
+$pdf->SetTitle($fundraiser->getTitle());
 
 // Loop through items
 while ($oneItem = mysqli_fetch_array($rsItems)) {


### PR DESCRIPTION
# Description & Issue number it closes 
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->

- Validate the CurrentFundraiser parameter in FRBidSheets, FRCatalog, and FRCertificates, throwing an exception when it's missing or invalid.
- Replace direct SQL queries with object-oriented FundRaiserQuery for cleaner code.
- Update constructors to work with FundRaiser objects, improving encapsulation.
- Streamline variable handling by removing global variable extraction.

Closes #6856 
