### PR TITLE
fix php deprecation notice in Countries

### DIFF
--- a/src/ChurchCRM/data/Countries.php
+++ b/src/ChurchCRM/data/Countries.php
@@ -277,7 +277,7 @@ class Countries
     {
         self::initializeCountries();
 
-        return array_map(['static', 'getSingleName'], self::$countries);
+        return array_map([__CLASS__, 'getSingleName'], self::$countries);
     }
 
     public static function getAll(): array
@@ -303,7 +303,7 @@ class Countries
         self::initializeCountries();
         $result = array_filter(self::$countries, fn ($e): bool => $e->getCountryName() === $CountryName);
         if (count($result) === 1) {
-            // Note that array_values() is needed because array_filter does not return  continuous array
+            // Note that array_values() is needed because array_filter does not return a continuous array
             return array_values($result)[0];
         }
 


### PR DESCRIPTION
This resolves the issue shown below:
```
PHP Deprecated:  Use of "static" in callables is deprecated in develop/ChurchCRM/src/ChurchCRM/data/Countries.php on line 280

Deprecated: Use of "static" in callables is deprecated in develop/ChurchCRM/src/ChurchCRM/data/Countries.php on line 280
```

# Description & Issue number it closes 
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->

## Screenshots (if appropriate)
<!-- Before and after --> 

## How to test the changes?

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

