### PR TITLE
prevent deprecation warning in InputUtils

### DIFF
--- a/src/ChurchCRM/utils/InputUtils.php
+++ b/src/ChurchCRM/utils/InputUtils.php
@@ -55,11 +55,23 @@ class InputUtils
 
     public static function filterInt($sInput): int
     {
+        // added this to prevent deprecation warning:
+        //   PHP Deprecated:  trim(): Passing null to parameter #1 ($string) of type string is deprecated
+        if ($sInput === null) {
+            return 0;
+        }
+
         return (int) intval(trim($sInput));
     }
 
     public static function filterFloat($sInput): float
     {
+        // added this to prevent deprecation warning:
+        //   PHP Deprecated:  trim(): Passing null to parameter #1 ($string) of type string is deprecated
+        if ($sInput === null) {
+            return 0;
+        }
+
         return (float) floatval(trim($sInput));
     }
 


### PR DESCRIPTION
# Description & Issue number it closes 
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->

Noticed that this is a possible code path if a code path was not developed correctly:
```
PHP Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated
```

Added this to avoid this potential log-spam.
