### PR TITLE
Bug: Family Editor reset Classification of Family Members

### DIFF
--- a/src/FamilyEditor.php
+++ b/src/FamilyEditor.php
@@ -367,7 +367,7 @@ if (isset($_POST['FamilySubmit']) || isset($_POST['FamilySubmitAndAdd'])) {
                         ->setFmrId($aRoles[$iCount])
                         ->setBirthMonth($aBirthMonths[$iCount])
                         ->setBirthDay($aBirthDays[$iCount])
-                        ->setClsId($aClassification);
+                        ->setClsId($aClassification[$iCount]);
                     if ($aUpdateBirthYear[$iCount] & 1) {
                         $person->setBirthYear($aBirthYears[$iCount]);
                     }


### PR DESCRIPTION
# Description & Issue number it closes 

https://github.com/ChurchCRM/CRM/issues/7119

## How to test the changes?

Make sure classifications are correct after saving.
<img width="1863" alt="Screenshot 2024-08-26 at 7 39 40 PM" src="https://github.com/user-attachments/assets/466d7113-4093-43c8-ab2e-5e360082c96c">

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Docker

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

