### PR TITLE
Configurable Person's Initial Format

### DIFF
--- a/cypress/e2e/api/private/admin/private.admin.person.initial.style.setting.spec.js
+++ b/cypress/e2e/api/private/admin/private.admin.person.initial.style.setting.spec.js
@@ -1,0 +1,64 @@
+/// <reference types="cypress" />
+
+context("API Private Admin Person Initial Setting", () => {
+    it("Delete Person Image / Generate Initial Image", () => {
+        cy.makePrivateAdminAPICall(
+            "DELETE",
+            "/api/person/2/photo",
+            null,
+            200,
+        );
+
+        cy.request({
+            method: "GET",
+            url: "/api/person/2/photo",
+            headers: {
+                "content-type": "application/json",
+                "x-api-key": Cypress.env("admin.api.key"),
+            },
+        }).then((resp) => {
+            expect(resp.status).to.eq(200);
+        });
+    });
+
+    it("Change Person Initial Style / Delete Person Image / Generate Initial Image", () => {
+        let json = { value: "1" };
+        cy.makePrivateAdminAPICall(
+            "POST",
+            "/api/system/config/iPersonInitialStyle",
+            json,
+            200,
+        );
+
+        cy.request({
+            method: "GET",
+            url: "/api/system/config/iPersonInitialStyle",
+            headers: {
+                "content-type": "application/json",
+                "x-api-key": Cypress.env("admin.api.key"),
+            },
+        }).then((resp) => {
+            expect(resp.status).to.eq(200);
+            const result = JSON.parse(JSON.stringify(resp.body));
+            expect(result.value).to.eq(json.value);
+        });
+
+        cy.makePrivateAdminAPICall(
+            "DELETE",
+            "/api/person/2/photo",
+            null,
+            200,
+        );
+
+        cy.request({
+            method: "GET",
+            url: "/api/person/2/photo",
+            headers: {
+                "content-type": "application/json",
+                "x-api-key": Cypress.env("admin.api.key"),
+            },
+        }).then((resp) => {
+            expect(resp.status).to.eq(200);
+        });
+    });
+});

--- a/src/ChurchCRM/dto/Photo.php
+++ b/src/ChurchCRM/dto/Photo.php
@@ -304,10 +304,7 @@ class Photo
     {
         $retstr = '';
         if ($this->photoType == 'Person') {
-            $fullNameArr = PersonQuery::create()->select(['FirstName', 'LastName'])->findOneById($this->id);
-            foreach ($fullNameArr as $name) {
-                $retstr .= mb_strtoupper(mb_substr($name, 0, 1));
-            }
+            $retstr = PersonQuery::create()->findOneById($this->id)->getInitial(SystemConfig::getValue('iPersonInitialStyle'));
         } elseif ($this->photoType == 'Family') {
             $fullNameArr = FamilyQuery::create()->findOneById($this->id)->getName();
             $retstr .= mb_strtoupper(mb_substr($fullNameArr, 0, 1));

--- a/src/ChurchCRM/dto/SystemConfig.php
+++ b/src/ChurchCRM/dto/SystemConfig.php
@@ -81,6 +81,16 @@ class SystemConfig
         return ['Choices' => $roles];
     }
 
+    public static function getInitialStyleChoices(): array
+    {
+        return [
+            'Choices' => [
+                gettext('One character from FirstName and one character from LastName') . ':0',
+                gettext('Two characters from FirstName') . ':1',
+            ],
+        ];
+    }
+
     private static function buildConfigs(): array
     {
         return [
@@ -198,6 +208,7 @@ class SystemConfig
             'sDepositSlipType'                     => new ConfigItem(2001, 'sDepositSlipType', 'choice', 'QBDT', gettext('Deposit ticket type.  QBDT - Quickbooks'), '', '{"Choices":["QBDT"]}'),
             'bAllowEmptyLastName'                  => new ConfigItem(2010, 'bAllowEmptyLastName', 'boolean', '0', gettext('Set true to allow empty lastname in Person Editor.  Set false to validate last name and inherit from family when left empty.')),
             'iPersonNameStyle'                     => new ConfigItem(2020, 'iPersonNameStyle', 'choice', '4', '', '', json_encode(SystemConfig::getNameChoices(), JSON_THROW_ON_ERROR)),
+            'iPersonInitialStyle'                  => new ConfigItem(20201, 'iPersonInitialStyle', 'choice', '0', '', '', json_encode(SystemConfig::getInitialStyleChoices(), JSON_THROW_ON_ERROR)),
             'bDisplayBillCounts'                   => new ConfigItem(2002, 'bDisplayBillCounts', 'boolean', '1', gettext('Display bill counts on deposit slip')),
             'sCloudURL'                            => new ConfigItem(2003, 'sCloudURL', 'text', 'http://demo.churchcrm.io/', gettext('ChurchCRM Cloud Access URL')),
             'sNexmoAPIKey'                         => new ConfigItem(2012, 'sNexmoAPIKey', 'text', '', gettext('Nexmo SMS API Key')),
@@ -277,7 +288,7 @@ class SystemConfig
             gettext('Church Information') => ['sChurchName', 'sChurchAddress', 'sChurchCity', 'sChurchState', 'sChurchZip', 'sChurchCountry', 'sChurchPhone', 'sChurchEmail', 'sHomeAreaCode', 'sTimeZone', 'iChurchLatitude', 'iChurchLongitude', 'sChurchWebSite', 'sChurchFB', 'sChurchTwitter'],
             gettext('User Setup')         => ['iMinPasswordLength', 'iMinPasswordChange', 'iMaxFailedLogins', 'iSessionTimeout', 'aDisallowedPasswords', 'bEnableLostPassword', 'bEnable2FA', 'bRequire2FA', 's2FAApplicationName', 'bSendUserDeletedEmail'],
             gettext('Email Setup')        => ['sSMTPHost', 'bSMTPAuth', 'sSMTPUser', 'sSMTPPass', 'iSMTPTimeout', 'sToEmailAddress', 'bPHPMailerAutoTLS', 'sPHPMailerSMTPSecure'],
-            gettext('People Setup')       => ['sDirClassifications', 'sDirRoleHead', 'sDirRoleSpouse', 'sDirRoleChild', 'sDefaultCity', 'sDefaultState', 'sDefaultZip', 'sDefaultCountry', 'bShowFamilyData', 'bHidePersonAddress', 'bHideFriendDate', 'bHideFamilyNewsletter', 'bHideWeddingDate', 'bHideLatLon', 'bForceUppercaseZip', 'bEnableSelfRegistration', 'bAllowEmptyLastName', 'iPersonNameStyle', 'iProfilePictureListSize', 'sNewPersonNotificationRecipientIDs', 'IncludeDataInNewPersonNotifications', 'sGreeterCustomMsg1', 'sGreeterCustomMsg2', 'sInactiveClassification'],
+            gettext('People Setup')       => ['sDirClassifications', 'sDirRoleHead', 'sDirRoleSpouse', 'sDirRoleChild', 'sDefaultCity', 'sDefaultState', 'sDefaultZip', 'sDefaultCountry', 'bShowFamilyData', 'bHidePersonAddress', 'bHideFriendDate', 'bHideFamilyNewsletter', 'bHideWeddingDate', 'bHideLatLon', 'bForceUppercaseZip', 'bEnableSelfRegistration', 'bAllowEmptyLastName', 'iPersonNameStyle', 'iPersonInitialStyle', 'iProfilePictureListSize', 'sNewPersonNotificationRecipientIDs', 'IncludeDataInNewPersonNotifications', 'sGreeterCustomMsg1', 'sGreeterCustomMsg2', 'sInactiveClassification'],
             gettext('Enabled Features')   => ['bEnabledFinance', 'bEnabledSundaySchool', 'bEnabledEvents', 'bEnabledCalendar', 'bEnabledFundraiser', 'bEnabledEmail', 'bEnabledMenuLinks'],
             gettext('Map Settings')       => ['sGeoCoderProvider', 'sGoogleMapsGeocodeKey', 'sGoogleMapsRenderKey', 'sBingMapKey', 'sGMapIcons', 'iMapZoom'],
             gettext('Report Settings')    => ['sQBDTSettings', 'leftX', 'incrementY', 'sTaxReport1', 'sTaxReport2', 'sTaxReport3', 'sTaxSigner', 'sReminder1', 'sReminderSigner', 'sReminderNoPledge', 'sReminderNoPayments', 'sConfirm1', 'sConfirm2', 'sConfirm3', 'sConfirm4', 'sConfirm5', 'sConfirm6', 'sDear', 'sConfirmSincerely', 'sConfirmSigner', 'sPledgeSummary1', 'sPledgeSummary2', 'sDirectoryDisclaimer1', 'sDirectoryDisclaimer2', 'bDirLetterHead', 'sZeroGivers', 'sZeroGivers2', 'sZeroGivers3', 'iPDFOutputType'],

--- a/src/ChurchCRM/model/ChurchCRM/Person.php
+++ b/src/ChurchCRM/model/ChurchCRM/Person.php
@@ -707,4 +707,25 @@ class Person extends BasePerson implements PhotoInterface
 
         return parent::getEmail();
     }
+
+    /**
+     * Returns a string of a person's full name initial, formatted as specified by $Style
+     * $Style = 0  :  "One character from FirstName and one character from LastName"
+     * $Style = 1  :  "Two characters from FirstName"
+     */
+    public function getInitial(int $Style): string
+    {
+        $initialString = '';
+        switch ($Style) {
+            case 0:
+                $initialString .= mb_strtoupper(mb_substr($this->getFirstName(), 0, 1));
+                $initialString .= mb_strtoupper(mb_substr($this->getLastName(), 0, 1));
+                break;
+            case 1:
+                $fullNameArr = $this->getFirstName();
+                $initialString .= mb_strtoupper(mb_substr($fullNameArr, 0, 2));
+        }
+
+        return $initialString;
+    }
 }


### PR DESCRIPTION
# Description & Issue number it closes 
Person's Initial format should be configurable.

## Screenshots (if appropriate)
Before
<img width="311" alt="Screenshot 2024-09-10 at 5 11 01 PM" src="https://github.com/user-attachments/assets/69bfcef7-382e-4677-8359-b7c37f7db32d">

After
<img width="303" alt="Screenshot 2024-09-10 at 5 11 24 PM" src="https://github.com/user-attachments/assets/9ac3e35c-5713-44cd-9cfd-0b4204e396a0">

## How to test the changes?
Change Config
<img width="730" alt="Screenshot 2024-09-10 at 5 10 26 PM" src="https://github.com/user-attachments/assets/353c8cf2-660f-4e88-8d1a-99c898c036ce">

Delete Photo
<img width="736" alt="Screenshot 2024-09-10 at 5 11 15 PM" src="https://github.com/user-attachments/assets/cc12eb75-49a2-4710-b567-6d0fc6e23f91">

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Docker

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

