### PR TITLE
Use iPersonNameStyle in GroupView

### DIFF
--- a/src/ChurchCRM/model/ChurchCRM/Person.php
+++ b/src/ChurchCRM/model/ChurchCRM/Person.php
@@ -687,6 +687,7 @@ class Person extends BasePerson implements PhotoInterface
     {
         $array = parent::toArray();
         $array['Address'] = $this->getAddress();
+        $array['FullName'] = $this->getFullName();
 
         return $array;
     }

--- a/src/skin/js/GroupView.js
+++ b/src/skin/js/GroupView.js
@@ -247,9 +247,7 @@ function initDataTable() {
                         '"><a target="_top" href="PersonView.php?PersonID=' +
                         full.PersonId +
                         '">' +
-                        full.Person.FirstName +
-                        " " +
-                        full.Person.LastName +
+                        full.Person.FullName +
                         "</a>"
                     );
                 },


### PR DESCRIPTION
# Description & Issue number it closes 
Name style in group view doesn't match with iPersonNameStyle.

## Screenshots (if appropriate)
### Change System Setting of iPersonNameStyle
<img width="978" alt="Screenshot 2024-09-13 at 10 08 04 PM" src="https://github.com/user-attachments/assets/d7d1b3ba-cd56-42f9-aefc-8feafd3fcfc8">

### Before
<img width="486" alt="Screenshot 2024-09-13 at 4 05 03 PM" src="https://github.com/user-attachments/assets/fc2c61e6-bb40-4aeb-b351-bb5e3fe8d1ad">

### After
<img width="495" alt="Screenshot 2024-09-13 at 10 07 15 PM" src="https://github.com/user-attachments/assets/7f38354f-bec4-4a6c-9f6c-c1e82fb66d54">

## How to test the changes?
See the above screenshots

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Docker

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

