### PR TITLE
Make Person List Columns Configurable

### DIFF
--- a/src/ChurchCRM/dto/ListColumn.php
+++ b/src/ChurchCRM/dto/ListColumn.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace ChurchCRM\dto;
+
+class ListColumn
+{
+    public string $name;
+    public string $displayFunction;
+    public string $emptyOrUnassigned;
+    public string $visible;
+
+    public function __construct(string $name, string $displayFunction, string $emptyOrUnassigned, string $visible)
+    {
+        $this->name = $name;
+        $this->displayFunction = $displayFunction;
+        $this->emptyOrUnassigned = $emptyOrUnassigned;
+        $this->visible = $visible;
+    }
+}

--- a/src/ChurchCRM/dto/SystemConfig.php
+++ b/src/ChurchCRM/dto/SystemConfig.php
@@ -91,6 +91,28 @@ class SystemConfig
         ];
     }
 
+    public static function getPersonListColumns(): array
+    {
+        return [
+            'Id'                => new ListColumn('Id', 'getId', 'false', 'false'),
+            'Family Name'       => new ListColumn('Family Name', 'getFamilyName', 'false', 'false'),
+            'Name'              => new ListColumn('Name', 'getFullName', 'false', 'false'),
+            'Last Name'         => new ListColumn('Last Name', 'getLastName', 'false', 'true'),
+            'First Name'        => new ListColumn('First Name', 'getFirstName', 'false', 'true'),
+            'Birth Date'        => new ListColumn('Birth Date', 'getFormattedBirthDate', 'false', 'false'),
+            'Address'           => new ListColumn('Address', 'getAddress', 'false', 'false'),
+            'Home Phone'        => new ListColumn('Home Phone', 'getHomePhone', 'false', 'true'),
+            'Cell Phone'        => new ListColumn('Cell Phone', 'getCellPhone', 'false', 'true'),
+            'Email'             => new ListColumn('Email', 'getEmail', 'false', 'true'),
+            'Gender'            => new ListColumn('Gender', 'getGenderName', 'true', 'true'),
+            'Classification'    => new ListColumn('Classification', 'getClassificationName', 'true', 'true'),
+            'Role'              => new ListColumn('Role', 'getFamilyRoleName', 'true', 'true'),
+            'Properties'        => new ListColumn('Properties', 'getPropertiesString', 'true', 'false'),
+            'Custom'            => new ListColumn('Custom', 'getCustomFields', 'true', 'false'),
+            'Group'             => new ListColumn('Group', 'getGroups', 'true', 'false'),
+        ];
+    }
+
     private static function buildConfigs(): array
     {
         return [
@@ -279,6 +301,7 @@ class SystemConfig
             'sGoogleMapsRenderKey'                 => new ConfigItem(2072, 'sGoogleMapsRenderKey', 'text', '', gettext('Google Maps API Key used for rendering maps in browser'), 'https://developers.google.com/maps/documentation/javascript/get-api-key'),
             'sInactiveClassification'              => new ConfigItem(2073, 'sInactiveClassification', 'text', '', gettext('Comma separated list of classifications that should appear as inactive')),
             'sDefaultZip'                          => new ConfigItem(2074, 'sDefaultZip', 'text', '', gettext('Default Zip')),
+            'sPersonListColumns'                   => new ConfigItem(2075, 'sPersonListColumns', 'json', json_encode(SystemConfig::getPersonListColumns()), gettext('Person List Columns')),
         ];
     }
 
@@ -288,7 +311,7 @@ class SystemConfig
             gettext('Church Information') => ['sChurchName', 'sChurchAddress', 'sChurchCity', 'sChurchState', 'sChurchZip', 'sChurchCountry', 'sChurchPhone', 'sChurchEmail', 'sHomeAreaCode', 'sTimeZone', 'iChurchLatitude', 'iChurchLongitude', 'sChurchWebSite', 'sChurchFB', 'sChurchTwitter'],
             gettext('User Setup')         => ['iMinPasswordLength', 'iMinPasswordChange', 'iMaxFailedLogins', 'iSessionTimeout', 'aDisallowedPasswords', 'bEnableLostPassword', 'bEnable2FA', 'bRequire2FA', 's2FAApplicationName', 'bSendUserDeletedEmail'],
             gettext('Email Setup')        => ['sSMTPHost', 'bSMTPAuth', 'sSMTPUser', 'sSMTPPass', 'iSMTPTimeout', 'sToEmailAddress', 'bPHPMailerAutoTLS', 'sPHPMailerSMTPSecure'],
-            gettext('People Setup')       => ['sDirClassifications', 'sDirRoleHead', 'sDirRoleSpouse', 'sDirRoleChild', 'sDefaultCity', 'sDefaultState', 'sDefaultZip', 'sDefaultCountry', 'bShowFamilyData', 'bHidePersonAddress', 'bHideFriendDate', 'bHideFamilyNewsletter', 'bHideWeddingDate', 'bHideLatLon', 'bForceUppercaseZip', 'bEnableSelfRegistration', 'bAllowEmptyLastName', 'iPersonNameStyle', 'iPersonInitialStyle', 'iProfilePictureListSize', 'sNewPersonNotificationRecipientIDs', 'IncludeDataInNewPersonNotifications', 'sGreeterCustomMsg1', 'sGreeterCustomMsg2', 'sInactiveClassification'],
+            gettext('People Setup')       => ['sDirClassifications', 'sDirRoleHead', 'sDirRoleSpouse', 'sDirRoleChild', 'sDefaultCity', 'sDefaultState', 'sDefaultZip', 'sDefaultCountry', 'bShowFamilyData', 'bHidePersonAddress', 'bHideFriendDate', 'bHideFamilyNewsletter', 'bHideWeddingDate', 'bHideLatLon', 'bForceUppercaseZip', 'bEnableSelfRegistration', 'bAllowEmptyLastName', 'iPersonNameStyle', 'iPersonInitialStyle', 'iProfilePictureListSize', 'sNewPersonNotificationRecipientIDs', 'IncludeDataInNewPersonNotifications', 'sGreeterCustomMsg1', 'sGreeterCustomMsg2', 'sInactiveClassification', 'sPersonListColumns'],
             gettext('Enabled Features')   => ['bEnabledFinance', 'bEnabledSundaySchool', 'bEnabledEvents', 'bEnabledCalendar', 'bEnabledFundraiser', 'bEnabledEmail', 'bEnabledMenuLinks'],
             gettext('Map Settings')       => ['sGeoCoderProvider', 'sGoogleMapsGeocodeKey', 'sGoogleMapsRenderKey', 'sBingMapKey', 'sGMapIcons', 'iMapZoom'],
             gettext('Report Settings')    => ['sQBDTSettings', 'leftX', 'incrementY', 'sTaxReport1', 'sTaxReport2', 'sTaxReport3', 'sTaxSigner', 'sReminder1', 'sReminderSigner', 'sReminderNoPledge', 'sReminderNoPayments', 'sConfirm1', 'sConfirm2', 'sConfirm3', 'sConfirm4', 'sConfirm5', 'sConfirm6', 'sDear', 'sConfirmSincerely', 'sConfirmSigner', 'sPledgeSummary1', 'sPledgeSummary2', 'sDirectoryDisclaimer1', 'sDirectoryDisclaimer2', 'bDirLetterHead', 'sZeroGivers', 'sZeroGivers2', 'sZeroGivers3', 'iPDFOutputType'],


### PR DESCRIPTION
# Description & Issue number it closes 
https://github.com/ChurchCRM/CRM/issues/7021
I will make similar change for family list later.

## Screenshots (if appropriate)
### Before
<img width="1421" alt="Screenshot 2024-09-15 at 11 10 11 PM" src="https://github.com/user-attachments/assets/441f0f44-eca1-4cad-a885-6e540f10f163">

### Config Change
Hide `Home Phone` and `Cell Phone`.
<img width="1313" alt="Screenshot 2024-09-15 at 11 11 18 PM" src="https://github.com/user-attachments/assets/ea014948-f5b1-492e-84e9-281d0728452d">

### After
<img width="1421" alt="Screenshot 2024-09-15 at 11 23 49 PM" src="https://github.com/user-attachments/assets/c8456322-c154-4452-bc48-8017ed775f07">

## How to test the changes?
See the above screenshots

Click View Active People after changing `Admin/ Edit General Settings / People Setup / sPersonListColumns`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Docker

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

