### PR TITLE
Make Family List Columns Configurable

### DIFF
--- a/src/ChurchCRM/dto/SystemConfig.php
+++ b/src/ChurchCRM/dto/SystemConfig.php
@@ -113,6 +113,19 @@ class SystemConfig
         ];
     }
 
+    public static function getFamilyListColumns(): array
+    {
+        return [
+            'Name'              => new ListColumn('Name', 'getName', 'false', 'true'),
+            'Address'           => new ListColumn('Address', 'getAddress', 'false', 'true'),
+            'Home Phone'        => new ListColumn('Home Phone', 'getHomePhone', 'false', 'true'),
+            'Cell Phone'        => new ListColumn('Cell Phone', 'getCellPhone', 'false', 'true'),
+            'Email'             => new ListColumn('Email', 'getEmail', 'false', 'true'),
+            'Created'           => new ListColumn('Created', 'getDateEntered', 'false', 'true'),
+            'Edited'            => new ListColumn('Edited', 'getDateLastEdited', 'false', 'true'),
+        ];
+    }
+
     private static function buildConfigs(): array
     {
         return [
@@ -302,6 +315,7 @@ class SystemConfig
             'sInactiveClassification'              => new ConfigItem(2073, 'sInactiveClassification', 'text', '', gettext('Comma separated list of classifications that should appear as inactive')),
             'sDefaultZip'                          => new ConfigItem(2074, 'sDefaultZip', 'text', '', gettext('Default Zip')),
             'sPersonListColumns'                   => new ConfigItem(2075, 'sPersonListColumns', 'json', json_encode(SystemConfig::getPersonListColumns()), gettext('Person List Columns')),
+            'sFamilyListColumns'                   => new ConfigItem(2076, 'sFamilyListColumns', 'json', json_encode(SystemConfig::getFamilyListColumns()), gettext('Family List Columns')),
         ];
     }
 
@@ -311,7 +325,7 @@ class SystemConfig
             gettext('Church Information') => ['sChurchName', 'sChurchAddress', 'sChurchCity', 'sChurchState', 'sChurchZip', 'sChurchCountry', 'sChurchPhone', 'sChurchEmail', 'sHomeAreaCode', 'sTimeZone', 'iChurchLatitude', 'iChurchLongitude', 'sChurchWebSite', 'sChurchFB', 'sChurchTwitter'],
             gettext('User Setup')         => ['iMinPasswordLength', 'iMinPasswordChange', 'iMaxFailedLogins', 'iSessionTimeout', 'aDisallowedPasswords', 'bEnableLostPassword', 'bEnable2FA', 'bRequire2FA', 's2FAApplicationName', 'bSendUserDeletedEmail'],
             gettext('Email Setup')        => ['sSMTPHost', 'bSMTPAuth', 'sSMTPUser', 'sSMTPPass', 'iSMTPTimeout', 'sToEmailAddress', 'bPHPMailerAutoTLS', 'sPHPMailerSMTPSecure'],
-            gettext('People Setup')       => ['sDirClassifications', 'sDirRoleHead', 'sDirRoleSpouse', 'sDirRoleChild', 'sDefaultCity', 'sDefaultState', 'sDefaultZip', 'sDefaultCountry', 'bShowFamilyData', 'bHidePersonAddress', 'bHideFriendDate', 'bHideFamilyNewsletter', 'bHideWeddingDate', 'bHideLatLon', 'bForceUppercaseZip', 'bEnableSelfRegistration', 'bAllowEmptyLastName', 'iPersonNameStyle', 'iPersonInitialStyle', 'iProfilePictureListSize', 'sNewPersonNotificationRecipientIDs', 'IncludeDataInNewPersonNotifications', 'sGreeterCustomMsg1', 'sGreeterCustomMsg2', 'sInactiveClassification', 'sPersonListColumns'],
+            gettext('People Setup')       => ['sDirClassifications', 'sDirRoleHead', 'sDirRoleSpouse', 'sDirRoleChild', 'sDefaultCity', 'sDefaultState', 'sDefaultZip', 'sDefaultCountry', 'bShowFamilyData', 'bHidePersonAddress', 'bHideFriendDate', 'bHideFamilyNewsletter', 'bHideWeddingDate', 'bHideLatLon', 'bForceUppercaseZip', 'bEnableSelfRegistration', 'bAllowEmptyLastName', 'iPersonNameStyle', 'iPersonInitialStyle', 'iProfilePictureListSize', 'sNewPersonNotificationRecipientIDs', 'IncludeDataInNewPersonNotifications', 'sGreeterCustomMsg1', 'sGreeterCustomMsg2', 'sInactiveClassification', 'sPersonListColumns', 'sFamilyListColumns'],
             gettext('Enabled Features')   => ['bEnabledFinance', 'bEnabledSundaySchool', 'bEnabledEvents', 'bEnabledCalendar', 'bEnabledFundraiser', 'bEnabledEmail', 'bEnabledMenuLinks'],
             gettext('Map Settings')       => ['sGeoCoderProvider', 'sGoogleMapsGeocodeKey', 'sGoogleMapsRenderKey', 'sBingMapKey', 'sGMapIcons', 'iMapZoom'],
             gettext('Report Settings')    => ['sQBDTSettings', 'leftX', 'incrementY', 'sTaxReport1', 'sTaxReport2', 'sTaxReport3', 'sTaxSigner', 'sReminder1', 'sReminderSigner', 'sReminderNoPledge', 'sReminderNoPayments', 'sConfirm1', 'sConfirm2', 'sConfirm3', 'sConfirm4', 'sConfirm5', 'sConfirm6', 'sDear', 'sConfirmSincerely', 'sConfirmSigner', 'sPledgeSummary1', 'sPledgeSummary2', 'sDirectoryDisclaimer1', 'sDirectoryDisclaimer2', 'bDirLetterHead', 'sZeroGivers', 'sZeroGivers2', 'sZeroGivers3', 'iPDFOutputType'],

--- a/src/v2/templates/people/family-list.php
+++ b/src/v2/templates/people/family-list.php
@@ -21,13 +21,14 @@ include SystemURLs::getDocumentRoot() . '/Include/Header.php';
             <thead>
                 <tr>
                     <th><?= gettext('Actions') ?></th>
-                    <th><?= gettext('Name') ?></th>
-                    <th><?= gettext('Address') ?></th>
-                    <th><?= gettext('Home Phone') ?></th>
-                    <th><?= gettext('Cell Phone') ?></th>
-                    <th><?= gettext('Email') ?></th>
-                    <th><?= gettext('Created') ?></th>
-                    <th><?= gettext('Edited') ?></th>
+                    <?php
+                    $columns = json_decode(SystemConfig::getValue('sFamilyListColumns'), null, 512, JSON_THROW_ON_ERROR);
+                    foreach ($columns as $column) {
+                        if ($column->visible === 'true') {
+                            echo '<th>' . gettext($column->name) . '</th>';
+                        }
+                    }
+                    ?>
                 </tr>
             </thead>
             <tbody>
@@ -43,17 +44,19 @@ include SystemURLs::getDocumentRoot() . '/Include/Header.php';
                                 <i class="fas fa-pen"></i>
                             </a>
                         </td>
-                        <td><?= $family->getName() ?></td>
-                        <td> <?= $family->getAddress() ?></td>
-                        <td><?= $family->getHomePhone() ?></td>
-                        <td><?= $family->getCellPhone() ?></td>
-                        <td><?= $family->getEmail() ?></td>
-                        <td><?= date_format($family->getDateEntered(), SystemConfig::getValue('sDateFormatLong')) ?></td>
-                        <td>
-                            <?php if ($family->getDateLastEdited()) {
-                                echo date_format($family->getDateLastEdited(), SystemConfig::getValue('sDateFormatLong'));
-                            } ?>
-                        </td>
+
+                        <?php
+                        foreach ($columns as $column) {
+                            if ($column->visible === 'true') {
+                                if (str_starts_with($column->displayFunction, 'getDate')) {
+                                    $columnData = [$family, $column->displayFunction](SystemConfig::getValue('sDateFormatLong'));
+                                } else {
+                                    $columnData = [$family, $column->displayFunction]();
+                                }
+                                echo '<td>' . $columnData . '</td>';
+                            }
+                        }
+                        ?>
                     </tr>
                 <?php } ?>
             </tbody>


### PR DESCRIPTION
# Description & Issue number it closes 
https://github.com/ChurchCRM/CRM/issues/7021

## Screenshots (if appropriate)
### Before
<img width="1447" alt="Screenshot 2024-09-17 at 9 30 05 AM" src="https://github.com/user-attachments/assets/f98fcae1-6821-474a-9a95-920a0e2528c2">

### Config Change
Hide `Cell Phone` and `Email`
<img width="929" alt="Screenshot 2024-09-17 at 10 00 22 AM" src="https://github.com/user-attachments/assets/3e334eb9-ecf1-42dd-9c95-9006f40bfce3">

### After
<img width="1600" alt="Screenshot 2024-09-17 at 10 00 43 AM" src="https://github.com/user-attachments/assets/e94a466c-4813-456d-af92-cc7ba9db1bb2">

## How to test the changes?
See the above screenshots

Click View Active Families after changing Admin/ Edit General Settings / People Setup / sFamilyListColumns

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

