### PR TITLE
initialize $sRowClass so AlternateRowStyle works

### DIFF
--- a/src/QuerySQL.php
+++ b/src/QuerySQL.php
@@ -74,7 +74,7 @@ function ExportQueryResults(string $sSQL, &$rsQueryResults)
 
         $sCSVstring .= "\n";
 
-        //Loop through the recordsert
+        //Loop through the recordset
         while ($aRow = mysqli_fetch_array($rsQueryResults)) {
             //Loop through the fields and write each one
             for ($iCount = 0; $iCount < mysqli_num_fields($rsQueryResults); $iCount++) {
@@ -132,7 +132,7 @@ function RunFreeQuery(string $sSQL, &$rsQueryResults)
 
         echo '</tr>';
 
-        //Loop through the recordsert
+        //Loop through the recordset
         while ($aRow = mysqli_fetch_array($rsQueryResults)) {
             $sRowClass = AlternateRowStyle($sRowClass);
 
@@ -146,7 +146,7 @@ function RunFreeQuery(string $sSQL, &$rsQueryResults)
                     $aHiddenFormField[] = $aRow[$iCount];
                 } else {  //...otherwise just render the field
                     //Write the actual value of this row
-                    echo '<td align="center">' . $aRow[$iCount] . '</td>';
+                    echo '<td align="center">' . htmlspecialchars($aRow[$iCount]) . '</td>';
                 }
             }
             echo '</tr>';

--- a/src/QueryView.php
+++ b/src/QueryView.php
@@ -203,6 +203,7 @@ function DoQuery()
     <?php
     $aAddToCartIDs = [];
 
+    $sRowClass = 'RowColorA';
     while ($aRow = mysqli_fetch_array($rsQueryResults)) {
         // Alternate the background color of the row
         $sRowClass = AlternateRowStyle($sRowClass);
@@ -229,7 +230,7 @@ function DoQuery()
             } else {
                 // ...otherwise just render the field
                 // Write the actual value of this row
-                echo '<td>' . $aRow[$iCount] . '</td>';
+                echo '<td>' . htmlspecialchars($aRow[$iCount]) . '</td>';
             }
         }
 


### PR DESCRIPTION
# Description & Issue number it closes 
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->

initialize `$sRowClass` so `AlternateRowStyle` works

from Gitter:

>In Data/Reports -> Query Menu, if you run for example a Birthdays query, which should return a person, the results are not shown and the page seems unfinished (also menus on the left or icons on the right top do not expand if you click on them if this happens). This does not happen when you run a query which do not return any result.
You can check this issue by running the Demo session, add some person with a birth date, and then try the Birthdays query which should return that person.
There is actually and error in log file for this issue: `Uncaught TypeError: AlternateRowStyle(): Argument #1 ($sCurrentStyle) must be of type string, null given`
I have not tried all the queries on the Query Menu page, but it seems other queries do the same.
