### PR TITLE
Bug fix: Fix DataTable pageLength value

### DIFF
--- a/src/Include/Header-function.php
+++ b/src/Include/Header-function.php
@@ -75,7 +75,7 @@ function Header_body_scripts(): void
             iDashboardServiceIntervalTime:"<?= SystemConfig::getValue('iDashboardServiceIntervalTime') ?>",
             plugin: {
                 dataTable : {
-                    "pageLength": "<?= $tableSize  ?>",
+                    "pageLength": <?= $tableSize ?>,
                     "lengthMenu": [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]],
                     "language": {
                         "url": "<?= SystemURLs::getRootPath() ?>/locale/datatables/<?= $localeInfo->getDataTables() ?>.json"


### PR DESCRIPTION
# Description & Issue number it closes 

## Screenshots (if appropriate)

#### Info at the bottom of the table has leading zero(010).
`Showing 1 to 010 of 41 entries`

<img width="1412" alt="Screenshot 2024-09-27 at 3 29 07 PM" src="https://github.com/user-attachments/assets/c887e28e-79f1-483d-a61a-c544d68686b6">

#### Second page displays more than expected
<img width="1406" alt="Screenshot 2024-09-27 at 3 29 32 PM" src="https://github.com/user-attachments/assets/52de340f-2edb-4ce1-8c77-c35028126412">

#### Same issue in the other tables too
`Showing 1 to 010 of 213 entries`

<img width="1412" alt="Screenshot 2024-09-27 at 3 30 15 PM" src="https://github.com/user-attachments/assets/2865e07c-b376-488d-9790-e60ac827981d">

#### Second page displays `Showing 11 to 213 of 213 entries`
<img width="1398" alt="Screenshot 2024-09-27 at 3 30 29 PM" src="https://github.com/user-attachments/assets/cacffaa2-d362-489d-972b-e9fb8a314617">

### After fix
#### Info at the bottom of the table has no leading zero.
`Showing 1 to 10 of 41 entries`
<img width="1410" alt="Screenshot 2024-09-27 at 3 31 54 PM" src="https://github.com/user-attachments/assets/4c6ad0f2-40e3-4090-89c5-e65fdb9d4706">

#### Second page displays 10 elements
<img width="1412" alt="Screenshot 2024-09-27 at 3 38 35 PM" src="https://github.com/user-attachments/assets/a215fd68-3c52-4d11-a904-d8d6d51870df">


## How to test the changes?

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Docker

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

