### PR TITLE
Bug fix: Fix DataTable options of GroupView

### DIFF
--- a/src/skin/js/GroupView.js
+++ b/src/skin/js/GroupView.js
@@ -314,7 +314,7 @@ function initDataTable() {
             $(row).addClass("groupRow");
         },
     };
-    $.extend(DataTableOpts, window.CRM.plugin.DataTable);
+    $.extend(DataTableOpts, window.CRM.plugin.dataTable);
     window.CRM.DataTableAPI = $("#membersTable").DataTable(DataTableOpts);
 
     $("#isGroupActive").change(function () {


### PR DESCRIPTION
# Description & Issue number it closes 

There was a typo.

## Screenshots (if appropriate)
### Change `Page Length` Setting to 25
<img width="1532" alt="Screenshot 2024-09-27 at 7 20 36 PM" src="https://github.com/user-attachments/assets/51213655-1340-44e0-b93b-82341aa65ebc">

### Group View displays 10 entries
<img width="1513" alt="Screenshot 2024-09-27 at 7 21 17 PM" src="https://github.com/user-attachments/assets/d50210ba-390c-405b-b71c-39f5d3fa7ff8">

### After fix, it displays correct entries
<img width="1520" alt="Screenshot 2024-09-27 at 7 21 32 PM" src="https://github.com/user-attachments/assets/bffe92f8-9e27-4a22-8468-3414d13663c3">

## How to test the changes?

See the above screenshots

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Docker

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

