### PR TITLE
fix - removed second header from event attendance page

### DIFF
--- a/src/EventAttendance.php
+++ b/src/EventAttendance.php
@@ -139,7 +139,6 @@ for ($row = 1; $row <= $events->count(); $row++) {
     $aEventTitle[$row] = htmlentities(stripslashes($event->getTitle()), ENT_NOQUOTES, 'UTF-8');
     $aEventStartDateTime[$row] = $event->getStart(\DateTimeInterface::ATOM);
 }
-require 'Include/Header.php';
 
 // Construct the form
 ?>


### PR DESCRIPTION
Removed second ``require Header.php`` from ``EventAttendance.php``.

Checked locally, second sidebar disappear.

![20241013_14h16m05s_grim](https://github.com/user-attachments/assets/2b92287a-fa7d-4fa7-9d37-8fb00f348403)
