### PR TITLE
Only display error details if we are in debug more

### DIFF
--- a/src/ChurchCRM/utils/LoggerUtils.php
+++ b/src/ChurchCRM/utils/LoggerUtils.php
@@ -32,6 +32,11 @@ class LoggerUtils
         return intval(SystemConfig::getValue('sLogLevel'));
     }
 
+    public static function isDebugLogLevel(): bool
+    {
+        return SystemConfig::getValue('sLogLevel') == Logger::DEBUG;
+    }
+
     public static function buildLogFilePath(string $type): string
     {
         return SystemURLs::getDocumentRoot() . '/logs/' . date('Y-m-d') . '-' . $type . '.log';

--- a/src/Include/slim/error-handler.php
+++ b/src/Include/slim/error-handler.php
@@ -7,7 +7,7 @@ ini_set('display_errors', true);
 ini_set('log_errors', true);
 ini_set('error_log', LoggerUtils::buildLogFilePath('slim'));
 
-$errorMiddleware = $app->addErrorMiddleware(true, true, true, LoggerUtils::getSlimMVCLogger());
+$errorMiddleware = $app->addErrorMiddleware(LoggerUtils::isDebugLogLevel(), true,true, LoggerUtils::getSlimMVCLogger());
 // Get the default error handler and register my custom error renderer.
 $errorHandler = $errorMiddleware->getDefaultErrorHandler();
 


### PR DESCRIPTION
# Description & Issue number it closes 
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->

Only display error details for SLIM if the application is in debug level 
closes #7240 

## How to test the changes?

Before - 

```
Content-Type: text/html;charset=UTF-8

<!doctype html><html lang="en">    <head>        <meta charset="utf-8">        <meta name="viewport" content="width=device-width, initial-scale=1">        <title>Slim Application Error</title>        <style>            body{margin:0;padding:30px;font:12px/1.5 Helvetica,Arial,Verdana,sans-serif}            h1{margin:0;font-size:48px;font-weight:normal;line-height:48px}            strong{display:inline-block;width:65px}        </style>    </head>    <body>        <h1>Slim Application Error</h1>        <div><p>The application could not run because of the following error:</p><h2>Details</h2><div><strong>Type:</strong> TypeError</div><div><strong>Code:</strong> 0</div><div><strong>Message:</strong> Slim\Exception\HttpSpecializedException::__construct(): Argument #1 ($request) must be of type Psr\Http\Message\ServerRequestInterface, string given, called in /var/www/html/session/routes/password-reset.php on line 80</div><div><strong>File:</strong> /var/www/html/vendor/slim/slim/Slim/Exception/HttpSpecializedException.php</div><div><strong>Line:</strong> 23</div><h2>Trace</h2><pre>#0 /var/www/html/session/routes/password-reset.php(80): Slim\Exception\HttpSpecializedException-&gt;__construct()
#1 /var/www/html/vendor/slim/slim/Slim/Handlers/Strategies/RequestResponse.php(38): userPasswordReset()
#2 /var/www/html/vendor/slim/slim/Slim/Routing/Route.php(363): Slim\Handlers\Strategies\RequestResponse-&gt;__invoke()
#3 /var/www/html/vendor/slim/slim/Slim/MiddlewareDispatcher.php(73): Slim\Routing\Route-&gt;handle()
#4 /var/www/html/vendor/slim/slim/Slim/MiddlewareDispatcher.php(73): Slim\MiddlewareDispatcher-&gt;handle()
#5 /var/www/html/vendor/slim/slim/Slim/Routing/Route.php(321): Slim\MiddlewareDispatcher-&gt;handle()
#6 /var/www/html/vendor/slim/slim/Slim/Routing/RouteRunner.php(74): Slim\Routing\Route-&gt;run()
#7 /var/www/html/vendor/slim/slim/Slim/Middleware/ErrorMiddleware.php(77): Slim\Routing\RouteRunner-&gt;handle()
#8 /var/www/html/vendor/slim/slim/Slim/MiddlewareDispatcher.php(129): Slim\Middleware\ErrorMiddleware-&gt;process()
#9 /var/www/html/vendor/slim/slim/Slim/Middleware/RoutingMiddleware.php(45): Psr\Http\Server\RequestHandlerInterface@anonymous-&gt;handle()
#10 /var/www/html/vendor/slim/slim/Slim/MiddlewareDispatcher.php(129): Slim\Middleware\RoutingMiddleware-&gt;process()
#11 /var/www/html/ChurchCRM/Slim/Middleware/VersionMiddleware.php(14): Psr\Http\Server\RequestHandlerInterface@anonymous-&gt;handle()
#12 /var/www/html/vendor/slim/slim/Slim/MiddlewareDispatcher.php(280): ChurchCRM\Slim\Middleware\VersionMiddleware-&gt;__invoke()
#13 /var/www/html/vendor/slim/slim/Slim/MiddlewareDispatcher.php(73): Psr\Http\Server\RequestHandlerInterface@anonymous-&gt;handle()
#14 /var/www/html/vendor/slim/slim/Slim/App.php(209): Slim\MiddlewareDispatcher-&gt;handle()
#15 /var/www/html/vendor/slim/slim/Slim/App.php(193): Slim\App-&gt;handle()
#16 /var/www/html/session/index.php(90): Slim\App-&gt;run()
#17 {main}</pre></div>        <a href="#" onclick="window.history.go(-1)">Go Back</a>    </body></html>%                                      
```

**After** 
```
 CRM % curl --path-as-is -i -s -k -X $'POST' \
    -H $'Host: localhost' -H $'User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36' -H $'Accept: */*' -H $'Accept-Language: en-US,en;q=0.5' -H $'Accept-Encoding: gzip, deflate, br' -H $'Content-Type: application/x-www-form-urlencoded; charset=UTF-8' -H $'X-Requested-With: XMLHttpRequest' -H $'Content-Length: 23' -H $'Origin: http://localhost' -H $'Connection: keep-alive' -H $'Referer: http://localhost/session/forgot-password/reset-request' -H $'sec-ch-ua-platform: \"Windows\"' -H $'sec-ch-ua: \"Google Chrome\";v=\"117\", \"Chromium\";v=\"117\", \"Not=A?Brand\";v=\"24\"' -H $'sec-ch-ua-mobile: ?0' -H $'Priority: u=0' \
    -b $'CRM-<redacted>=<redacted>' \
    --data-binary $'{\"userName\":\"fakeUser\"}' \
    $'http://localhost/session/forgot-password/reset-request'
HTTP/1.1 500 Internal Server Error
Date: Mon, 03 Feb 2025 00:56:20 GMT
Server: Apache/2.4.62 (Debian)
X-Powered-By: PHP/8.4.2
Set-Cookie: CRM-40d1b2d83998fabacb726e5bc3d22129=5ef343dac86e3f4708ea2cba8168ae05; path=/
CRM_VERSION: 5.14.0
Content-Length: 672
Connection: close
Content-Type: text/html;charset=UTF-8

<!doctype html><html lang="en">    <head>        <meta charset="utf-8">        <meta name="viewport" content="width=device-width, initial-scale=1">        <title>Slim Application Error</title>        <style>            body{margin:0;padding:30px;font:12px/1.5 Helvetica,Arial,Verdana,sans-serif}            h1{margin:0;font-size:48px;font-weight:normal;line-height:48px}            strong{display:inline-block;width:65px}        </style>    </head>    <body>        <h1>Slim Application Error</h1>        <div><p>A website error has occurred. Sorry for the temporary inconvenience.</p></div>        <a href="#" onclick="window.history.go(-1)">Go Back</a>    </body></html>%           
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

