### PR TITLE
Addressed Docker Warning

### DIFF
--- a/docker/docker-compose.dev-php8-apache.yaml
+++ b/docker/docker-compose.dev-php8-apache.yaml
@@ -2,7 +2,6 @@
 # from this file by first filling in your password and db info in the .env
 # file and then running "docker compose -f docker-compose.develop.yaml build", and
 # "docker compose -f docker-compose.develop.yaml up" in your terminal.
-version: "3.8"
 services:
   database:
     image: mariadb

--- a/docker/docker-compose.test-php8-apache.gh-actions.yaml
+++ b/docker/docker-compose.test-php8-apache.gh-actions.yaml
@@ -1,7 +1,6 @@
 # This is the test docker-compose.yml override file for Github Actions -
 # it is not intended to be used on it's own but instead layered into the
 # normal test docker compose so it can be ran in CI.
-version: "3.6"
 services:
   webserver:
     user: 1001:121

--- a/docker/docker-compose.test-php8-apache.yaml
+++ b/docker/docker-compose.test-php8-apache.yaml
@@ -2,7 +2,6 @@
 # from this file by first filling in your password and db info in the .env
 # file and then running "docker compose -f docker-compose.develop.yaml build", and
 # "docker compose -f docker-compose.develop.yaml up" in your terminal.
-version: "3.6"
 services:
   database:
     image: mariadb


### PR DESCRIPTION
running `npm run docker-test-start` showed the following warning 
```
WARN[0000] /Users/gdawoud/Development/ChurchCRM/CRM/docker/docker-compose.test-php8-apache.yaml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
```