### PR TITLE
Fix: Birthday calendar API now filters by start and end parameters

### DIFF
--- a/src/ChurchCRM/SystemCalendars/BirthdaysCalendar.php
+++ b/src/ChurchCRM/SystemCalendars/BirthdaysCalendar.php
@@ -39,13 +39,13 @@ class BirthdaysCalendar implements SystemCalendar
         return gettext('Birthdays');
     }
 
-    public function getEvents(string $start, string $end): ObjectCollection
+    public function getEvents(?string $start = null, ?string $end = null): ObjectCollection
     {
         $people = PersonQuery::create()
             ->filterByBirthDay('', Criteria::NOT_EQUAL)
             ->find();
 
-        return $this->peopleCollectionToEvents($people);
+        return $this->peopleCollectionToEvents($people, $start, $end);
     }
 
     public function getEventById(int $Id): ObjectCollection
@@ -58,24 +58,60 @@ class BirthdaysCalendar implements SystemCalendar
         return $this->peopleCollectionToEvents($people);
     }
 
-    private function peopleCollectionToEvents(ObjectCollection $People): ObjectCollection
+    private function peopleCollectionToEvents(ObjectCollection $People, ?string $start = null, ?string $end = null): ObjectCollection
     {
         $events = new ObjectCollection();
         $events->setModel(Event::class);
+
+        $startDate = $start ? new \DateTimeImmutable($start) : new \DateTimeImmutable(date('Y') . '-01-01');
+        $endDate = $end ? new \DateTimeImmutable($end) : new \DateTimeImmutable((date('Y') + 1) . '-12-31');
+
+        $maxYears = 2;
+        if ($startDate->diff($endDate)->y > $maxYears) {
+            throw new \Exception("Date range too large. Maximum allowed is {$maxYears} years.");
+        }
+
+        $years = [];
+        for ($year = (int)$startDate->format('Y'); $year <= (int)$endDate->format('Y'); $year++) {
+            $years[] = $year;
+        }
+
         foreach ($People as $person) {
-            for ($year = (int) date('Y'); $year <= (int) date('Y') + 1; $year++) {
+            $birthMonth = (int)$person->getBirthMonth();
+            $birthDay = (int)$person->getBirthDay();
+
+            foreach ($years as $year) {
+                $eventDateStr = sprintf('%04d-%02d-%02d', $year, $birthMonth, $birthDay);
+                $eventDateObj = \DateTimeImmutable::createFromFormat('Y-m-d', $eventDateStr);
+                if (!$eventDateObj) {
+                    continue;
+                }
+                $eventDateStr = sprintf('%04d-%02d-%02d', $year, $birthMonth, $birthDay);
+                if (!$this->isDateInRange($eventDateObj, $startDate, $endDate)) {
+                    continue;
+                }
+
                 $birthday = new Event();
                 $birthday->setId($person->getId());
                 $birthday->setEditable(false);
-                $eventDate = $year . '-' . $person->getBirthMonth() . '-' . $person->getBirthDay();
-                $birthday->setStart($eventDate);
-                $age = $person->getAge($eventDate);
+                $birthday->setStart($eventDateStr);
+                $age = $person->getAge($eventDateStr);
                 $birthday->setTitle($person->getFullName() . ($age ? ' (' . $age . ')' : ''));
                 $birthday->setURL($person->getViewURI());
+
                 $events->push($birthday);
             }
         }
 
         return $events;
+    }
+
+    private function isDateInRange(\DateTimeImmutable $date, \DateTimeImmutable $startDate, \DateTimeImmutable $endDate): bool
+    {
+        // Convert all to Y-m-d strings, so time and timezone are ignored
+        $d = $date->format('Y-m-d');
+        $s = $startDate->format('Y-m-d');
+        $e = $endDate->format('Y-m-d');
+        return ($d >= $s && $d <= $e);
     }
 }


### PR DESCRIPTION
They were previously ignored, even though the front-end sends values for them.

# Description & Issue number it closes 
This PR fixes the birthday calendar API to honor the `start` and `end` parameters. Previously, these parameters were ignored, and the endpoint would always return birthdays for the current and next year, regardless of input. This closes #7334.

## How to test the changes?

1. Navigate to `/v2/calendar` in the web application.
2. Select a specific date range and observe that only birthdays within that range are displayed.
3. Use the browser's network debugger to inspect the GET request to `/api/systemcalendars/0/fullcalendar` and confirm that the returned events are filtered according to the `start` and `end` parameters.
4. Optionally, make a direct API request with custom `start` and `end` dates and verify the filtered results.

Alternatively, test directly with curl (replace dates and URL as needed):
   ```bash
   curl "http://localhost/api/systemcalendars/0/fullcalendar?start=2025-06-01T00:00:00-05:00&end=2025-07-13T00:00:00-05:00" -H "x-api-key: <your_token>"
   ```
Verify that only birthdays within the specified range are returned.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Manually tested in the browser by selecting various date ranges on the calendar and verifying that only birthdays within the range are returned.
- Verified that API requests with custom `start` and `end` parameters now return correctly filtered data.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules