### PR TITLE
Fix logoff url

### DIFF
--- a/src/RestoreDatabase.php
+++ b/src/RestoreDatabase.php
@@ -72,7 +72,7 @@ require_once 'Include/Header.php';
         }
         $("#restorestatus").css("color", "green");
         $("#restorestatus").html("<?= gettext('Restore Complete')?>");
-        $("#restoreNextStep").html('<a href="Logoff.php" class="btn btn-primary"><?= gettext('Login to restored Database')?></a>');
+        $("#restoreNextStep").html('<a href="/session/end" class="btn btn-primary"><?= gettext('Login to restored Database')?></a>');
       }).fail(function () {
       $("#restorestatus").css("color", "red");
       $("#restorestatus").html("<?= gettext('Restore Error.')?>");

--- a/src/UpgradeCRM.php
+++ b/src/UpgradeCRM.php
@@ -160,7 +160,7 @@ Header_body_scripts();
       <div class="timeline-item" >
         <h3 class="timeline-header"><?= gettext('Step 4: Login') ?></h3>
         <div class="timeline-body" id="finalPhase" <?= $expertMode ? '' : 'style="display: none"' ?>>
-          <a href="Logoff.php" class="btn btn-primary"><?= gettext('Login to Upgraded System') ?> </a>
+          <a href="/session/end" class="btn btn-primary"><?= gettext('Login to Upgraded System') ?> </a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
# Description & Issue number it closes 
changes two old references of `Logoff.php`  to `/session/end` instead  (from RestoreDatabase.php and UpgradeCRM.php)

## How to test the changes?
Run a database restore and click the link after successful restore, you should now be correctly signed off

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested the link after doing a restore

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

