### PR TITLE
Fix API Authentication Bypass

### DIFF
--- a/cypress/e2e/api/private/private.auth.spec.js
+++ b/cypress/e2e/api/private/private.auth.spec.js
@@ -1,0 +1,26 @@
+/// <reference types="cypress" />
+
+context("API Private wihouth Auth", () => {
+    it("Basic Rejcet", () => {
+        cy.request({
+            method: "GET",
+            url: "/api/persons/latest",
+            failOnStatusCode: false
+        }).then((resp) => {
+            const result = JSON.parse(JSON.stringify(resp.body));
+            expect(resp.status).to.eq(401);
+        });
+    });
+
+    it("Basic Rejcet, public bypass", () => {
+        cy.request({
+            method: "GET",
+            url: "/api/persons/latest?bypass=api/public",
+            failOnStatusCode: false
+        }).then((resp) => {
+            const result = JSON.parse(JSON.stringify(resp.body));
+            expect(resp.status).to.eq(401);
+        });
+    });
+
+});

--- a/src/ChurchCRM/Slim/Middleware/AuthMiddleware.php
+++ b/src/ChurchCRM/Slim/Middleware/AuthMiddleware.php
@@ -12,7 +12,7 @@ class AuthMiddleware
 {
     public function __invoke(Request $request, RequestHandler $handler): Response
     {
-        if (!str_contains($request->getUri()->getPath(), 'api/public')) {
+        if (!str_starts_with($request->getUri()->getPath(), '/api/public')) {
             $apiKey = $request->getHeader('x-api-key');
             if (!empty($apiKey)) {
                 $authenticationResult = AuthenticationManager::authenticate(new APITokenAuthenticationRequest($apiKey[0]));

--- a/src/ChurchCRM/Slim/Middleware/AuthMiddleware.php
+++ b/src/ChurchCRM/Slim/Middleware/AuthMiddleware.php
@@ -12,7 +12,7 @@ class AuthMiddleware
 {
     public function __invoke(Request $request, RequestHandler $handler): Response
     {
-        if (!str_contains($request->getUri(), 'api/public')) {
+        if (!str_contains($request->getUri()->getPath(), 'api/public')) {
             $apiKey = $request->getHeader('x-api-key');
             if (!empty($apiKey)) {
                 $authenticationResult = AuthenticationManager::authenticate(new APITokenAuthenticationRequest($apiKey[0]));


### PR DESCRIPTION
# Description & Issue number it closes 
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->
- Fix API Authentication Bypass in apis where a query param alows security check bypass. 
- https://github.com/ChurchCRM/CRM/security/advisories/GHSA-v3p2-mx78-pxhc#event-489177

## Screenshots (if appropriate)
<!-- Before and after --> 
http://localhost/api/persons/latest?bypass=api/public was returning the full API Payload  and now it returns 401. 

## How to test the changes?

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

