### PR TITLE
Potential fix for code scanning alert no. 126: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,3 +1,7 @@
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 name: 'Close stale issues and PRs'
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/ChurchCRM/CRM/security/code-scanning/126](https://github.com/ChurchCRM/CRM/security/code-scanning/126)

To fix the issue, we need to explicitly define the `permissions` block in the workflow. Since the job involves operations on issues and pull requests (e.g., adding comments, closing stale items), the required permissions are `issues: write` and `pull-requests: write`. The `contents: read` permission is also necessary for accessing repository contents. These permissions should be added at the workflow level to apply globally to all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
