### PR TITLE
Potential fix for code scanning alert no. 142: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/locale-poeditor-download.yml
+++ b/.github/workflows/locale-poeditor-download.yml
@@ -1,4 +1,6 @@
 name: Locale POEditor Download and Audit 
+permissions:
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ChurchCRM/CRM/security/code-scanning/142](https://github.com/ChurchCRM/CRM/security/code-scanning/142)

To fix this problem, add a `permissions` block to the workflow YAML file, ideally at the root level but optionally at the job level. This will explicitly set the permissions that the `GITHUB_TOKEN` receives, adhering to the principle of least privilege. Review the workflow steps: repository checkout, creation of pull requests, and possible branch and commit operations require `contents: write`. If writing pull requests or issues, add those scopes as needed (e.g. `pull-requests: write`). The safest and most developer-friendly approach is to add a root-level `permissions` block near the top of the workflow, just below the `name:` key, setting only the required permissions. For this workflow, set `contents: write`, and (optionally) `pull-requests: write` if needed, though the core pull request creation is done via an action using repo contents. Edit the top lines of `.github/workflows/locale-poeditor-download.yml` accordingly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
