### PR TITLE
Potential fix for code scanning alert no. 139: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -22,6 +22,8 @@ on:
 
 jobs:
   test-n-package:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/ChurchCRM/CRM/security/code-scanning/139](https://github.com/ChurchCRM/CRM/security/code-scanning/139)

To fix the problem, set the `permissions` key explicitly so that the `GITHUB_TOKEN` used by steps in the workflow has only the access required. For this workflow:

- Most steps (such as checkout or artifact upload) require at most `contents: read`.
- The step creating a GitHub Release (`softprops/action-gh-release`) requires `contents: write` permission.
- You can set general permissions at the workflow root (`contents: read` by default), and override to `contents: write` for the `Create Draft Release` step if needed.
- However, since that release step is within the same job as the rest, and may require the broader permission for the job, it's safest to set job-level permissions of `contents: write`, or, for greater security, root-level `contents: read` and job-level `contents: write`.

**Recommended edit:**  
Add a `permissions:` block with `contents: write` at the job level (line 25), or, optionally, at the workflow root with only `contents: read` for all jobs and override as needed.

**Required steps:**  
- Insert a `permissions: contents: write` block just above `runs-on:` at job-level (line 25).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
