### PR TITLE
UI Package Cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
                 "fullcalendar": "^6.1.19",
                 "i18n": "^0.15.2",
                 "i18next": "^24.2.3",
-                "icheck-bootstrap": "^3.0.1",
                 "inputmask": "^5.0.9",
                 "jquery": "^3.7.1",
                 "jquery-photo-uploader": "^1.0.13",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
         "fullcalendar": "^6.1.19",
         "i18n": "^0.15.2",
         "i18next": "^24.2.3",
-        "icheck-bootstrap": "^3.0.1",
         "inputmask": "^5.0.9",
         "jquery": "^3.7.1",
         "jquery-photo-uploader": "^1.0.13",

--- a/src/session/templates/begin-session.php
+++ b/src/session/templates/begin-session.php
@@ -48,9 +48,9 @@ require SystemURLs::getDocumentRoot() . '/Include/HeaderNotLoggedIn.php';
                     </div>
                     <div class="row">
                         <div class="col-8">
-                            <div class="icheck-primary">
-                                <input type="checkbox" id="remember">
-                                <label for="remember">
+                            <div class="custom-control custom-checkbox">
+                                <input type="checkbox" class="custom-control-input" id="remember">
+                                <label class="custom-control-label" for="remember">
                                     Remember Me
                                 </label>
                             </div>


### PR DESCRIPTION
## What Changed
<!-- Short summary - what and why (not how) -->

Fixes #
- removed pace-js - Unused 
- removed icheck-bootstrap  - The "Remember Me" checkbox will now use Bootstrap 4's native styling

## Type
<!-- Check one -->
- [ ] 🐛 Bug fix
- [ ] ✨ Feature
- [x] ♻️ Refactor
- [x] 🏗️ Build/Infrastructure
- [ ] 🔒 Security


## Security Check
<!-- Only check if applicable -->
- [ ] Introduces new input validation
- [ ] Modifies authentication/authorization
- [ ] Affects data privacy/GDPR

## Pre-Merge
- [x] Tested locally
- [ ] No new warnings
- [x] Build passes
- [ ] Backward compatible (or migration documented)

