### PR TITLE
UI: Modernize icon usage across the UI to be fully compatible with Font Awesome 6

### DIFF
--- a/src/CSVExport.php
+++ b/src/CSVExport.php
@@ -243,7 +243,7 @@ require_once 'Include/Header.php';
               <div class="card-header with-border">
                 <h3 class="card-title"><?= gettext('Records to export') ?>:</h3>
                 <div class="card-tools pull-right">
-                  <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fa fa-plus"></i>
+                  <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fa-solid fa-plus"></i>
                   </button>
                 </div>
               </div>
@@ -264,7 +264,7 @@ require_once 'Include/Header.php';
               <div class="card-header with-border">
                 <h3 class="card-title"><?= gettext('Classification') ?>:</h3>
                 <div class="card-tools pull-right">
-                  <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fa fa-plus"></i>
+                  <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fa-solid fa-plus"></i>
                   </button>
                 </div>
               </div>
@@ -289,7 +289,7 @@ require_once 'Include/Header.php';
               <div class="card-header with-border">
                 <h3 class="card-title"><?= gettext('Family Role') ?>:</h3>
                 <div class="card-tools pull-right">
-                  <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fa fa-plus"></i>
+                  <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fa-solid fa-plus"></i>
                   </button>
                 </div>
               </div>
@@ -314,7 +314,7 @@ require_once 'Include/Header.php';
               <div class="card-header with-border">
                 <h3 class="card-title"><?= gettext('Gender') ?>:</h3>
                 <div class="card-tools pull-right">
-                  <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fa fa-plus"></i>
+                  <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fa-solid fa-plus"></i>
                   </button>
                 </div>
               </div>
@@ -334,7 +334,7 @@ require_once 'Include/Header.php';
               <div class="card-header with-border">
                 <h3 class="card-title"><?= gettext('Group Membership') ?>:</h3>
                 <div class="card-tools pull-right">
-                  <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fa fa-plus"></i>
+                  <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fa-solid fa-plus"></i>
                   </button>
                 </div>
               </div>
@@ -358,7 +358,7 @@ require_once 'Include/Header.php';
               <div class="card-header with-border">
                 <h3 class="card-title"><?= gettext('Membership Date') ?>:</h3>
                 <div class="card-tools pull-right">
-                  <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fa fa-plus"></i>
+                  <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fa-solid fa-plus"></i>
                   </button>
                 </div>
               </div>
@@ -375,7 +375,7 @@ require_once 'Include/Header.php';
               <div class="card-header with-border">
                 <h3 class="card-title"><?= gettext('Birthday Date') ?>:</h3>
                 <div class="card-tools pull-right">
-                  <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fa fa-plus"></i>
+                  <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fa-solid fa-plus"></i>
                   </button>
                 </div>
               </div>
@@ -392,7 +392,7 @@ require_once 'Include/Header.php';
               <div class="card-header with-border">
                 <h3 class="card-title"><?= gettext('Anniversary Date:') ?></h3>
                 <div class="card-tools pull-right">
-                  <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fa fa-plus"></i>
+                  <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fa-solid fa-plus"></i>
                   </button>
                 </div>
               </div>
@@ -409,7 +409,7 @@ require_once 'Include/Header.php';
               <div class="card-header with-border">
                 <h3 class="card-title"><?= gettext('Date Entered:') ?></h3>
                 <div class="card-tools pull-right">
-                  <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fa fa-plus"></i>
+                  <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fa-solid fa-plus"></i>
                   </button>
                 </div>
               </div>

--- a/src/Checkin.php
+++ b/src/Checkin.php
@@ -66,7 +66,7 @@ if ($EventID > 0) {
                         <label class="col-md-2 control-label"><?= gettext('Select Event'); ?></label>
                         <div class="col-md-10 inputGroupContainer">
                             <div class="input-group">
-                                <span class="input-group-addon"><i class="fa fa-calendar-check fa-2xl"> </i> </span> &nbsp;
+                                <span class="input-group-addon"><i class="fa-solid fa-calendar-check fa-2xl"> </i> </span> &nbsp;
                                 <select id="EventID" name="EventID" class="form-control" onchange="this.form.submit()">
                                     <option value="<?= $EventID; ?>"
                                             disabled <?= ($EventID == 0) ? " Selected='selected'" : "" ?> ><?= gettext('Select event') ?></option>
@@ -118,7 +118,7 @@ if (!$CheckoutOrDelete &&  $EventID > 0) {
                             <label for="child" class="col-sm-2 control-label"><?= gettext("Person's Name") ?></label>
                             <div class="col-sm-5 inputGroupContainer">
                                 <div class="input-group">
-                                    <span class="input-group-addon"><i class="fa fa-child fa-2xl"></i></span> &nbsp;
+                                    <span class="input-group-addon"><i class="fa-solid fa-child fa-2xl"></i></span> &nbsp;
                                     <input type="text" class="form-control" id="child"
                                            placeholder="<?= gettext("Person's Name"); ?>" required tabindex=1>
                                 </div>
@@ -133,7 +133,7 @@ if (!$CheckoutOrDelete &&  $EventID > 0) {
                                    class="col-sm-2 control-label"><?= gettext('Adult Name (Optional)') ?></label>
                             <div class="col-sm-5 inputGroupContainer">
                                 <div class="input-group">
-                                    <span class="input-group-addon"><i class="fa fa-user fa-2xl"></i></span> &nbsp;
+                                    <span class="input-group-addon"><i class="fa-solid fa-user fa-2xl"></i></span> &nbsp;
                                     <input type="text" class="form-control" id="adult"
                                            placeholder="<?= gettext('Checked in By (Optional)'); ?>" tabindex=2>
                                 </div>
@@ -244,7 +244,7 @@ if (
                                     <div class="form-group">
                                         <label><?= gettext('Adult Checking Out Person') ?>:</label>
                                         <div class="input-group">
-                                            <span class="input-group-addon"><i class="fa fa-user"></i></span>
+                                            <span class="input-group-addon"><i class="fa-solid fa-user"></i></span>
                                             <input type="text" id="adultout" name="adult" class="form-control"
                                                placeholder="<?= gettext('Adult Name (Optional)') ?>">
                                             </div>
@@ -350,7 +350,7 @@ if (isset($_POST['EventID'])) {
                                     <?php
                                 } else {
                                     ?>
-                                    <i class="fa fa-check-circle"></i>
+                                    <i class="fa-solid fa-check-circle"></i>
                                     <?php
                                 } ?>
                             </form>

--- a/src/ChurchCRM/view/MenuRenderer.php
+++ b/src/ChurchCRM/view/MenuRenderer.php
@@ -48,7 +48,7 @@ class MenuRenderer
                     <span><?= htmlspecialchars($menuItem->getName()) ?></span>
                     <span class="right">
                         <?php self::renderMenuCounters($menuItem) ?>
-                        <i class="fas fa-angle-left"></i>
+                        <i class="fa-solid fa-angle-left"></i>
                     </span>
                 </p>
             </a>

--- a/src/DonationFundEditor.php
+++ b/src/DonationFundEditor.php
@@ -108,7 +108,7 @@ if ( answer )
 <form method="post" action="DonationFundEditor.php" name="FundsEditor">
 
 <div class="alert alert-warning">
-        <i class="fa fa-ban"></i>
+        <i class="fa-solid fa-ban"></i>
         <?= gettext("Warning: Field changes will be lost if you do not 'Save Changes' before using a delete or 'add new' button!") ?>
 
 </div>

--- a/src/FamilyCustomFieldsEditor.php
+++ b/src/FamilyCustomFieldsEditor.php
@@ -267,7 +267,7 @@ function confirmDeleteField( Field ) {
 }
 </script>
 <div class="alert alert-warning">
-        <i class="fa fa-ban"></i>
+        <i class="fa-solid fa-ban"></i>
         <?= gettext("Warning: Arrow and delete buttons take effect immediately.  Field name changes will be lost if you do not 'Save Changes' before using an up, down, delete or 'add new' button!") ?>
 </div>
 <form method="post" action="FamilyCustomFieldsEditor.php" name="FamilyCustomFieldsEditor">
@@ -351,10 +351,10 @@ if ($numRows == 0) {
             <td class="TextColumn" width="5%" class="text-nowrap">
                 <?php
                 if ($row > 1) {
-                    echo "<a href=\"FamilyCustomFieldsRowOps.php?OrderID=$row&Field=" . $aFieldFields[$row] . '&Action=up"><i class="fa fa-arrow-up"></i></a>';
+                    echo "<a href=\"FamilyCustomFieldsRowOps.php?OrderID=$row&Field=" . $aFieldFields[$row] . '&Action=up"><i class="fa-solid fa-arrow-up"></i></a>';
                 }
                 if ($row < $numRows) {
-                    echo "<a href=\"FamilyCustomFieldsRowOps.php?OrderID=$row&Field=" . $aFieldFields[$row] . '&Action=down"><i class="fa fa-arrow-down"></i></a>';
+                    echo "<a href=\"FamilyCustomFieldsRowOps.php?OrderID=$row&Field=" . $aFieldFields[$row] . '&Action=down"><i class="fa-solid fa-arrow-down"></i></a>';
                 } ?>
             </td>
 

--- a/src/FamilyEditor.php
+++ b/src/FamilyEditor.php
@@ -651,7 +651,7 @@ require_once 'Include/Header.php';
                     <label><?= gettext('Home Phone') ?>:</label>
                     <div class="input-group">
                         <div class="input-group-addon">
-                            <i class="fa fa-phone"></i>
+                            <i class="fa-solid fa-phone"></i>
                         </div>
                         <input type="text" Name="HomePhone" value="<?= htmlentities(stripslashes($sHomePhone)) ?>" size="30" maxlength="30" class="form-control" data-inputmask='"mask": "<?= SystemConfig::getValue('sPhoneFormat') ?>"' data-mask>
                         <input type="checkbox" name="NoFormat_HomePhone" value="1" <?php if ($bNoFormat_HomePhone) {
@@ -663,7 +663,7 @@ require_once 'Include/Header.php';
                     <label><?= gettext('Work Phone') ?>:</label>
                     <div class="input-group">
                         <div class="input-group-addon">
-                            <i class="fa fa-phone"></i>
+                            <i class="fa-solid fa-phone"></i>
                         </div>
                         <input type="text" name="WorkPhone" value="<?= htmlentities(stripslashes($sWorkPhone)) ?>" size="30" maxlength="30" class="form-control" data-inputmask='"mask": "<?= SystemConfig::getValue('sPhoneFormatWithExt') ?>"' data-mask />
                         <input type="checkbox" name="NoFormat_WorkPhone" value="1" <?= $bNoFormat_WorkPhone ? ' checked' : '' ?>><?= gettext('Do not auto-format') ?>
@@ -673,7 +673,7 @@ require_once 'Include/Header.php';
                     <label><?= gettext('Mobile Phone') ?>:</label>
                     <div class="input-group">
                         <div class="input-group-addon">
-                            <i class="fa fa-phone"></i>
+                            <i class="fa-solid fa-phone"></i>
                         </div>
                         <input type="text" name="CellPhone" value="<?= htmlentities(stripslashes($sCellPhone)) ?>" size="30" maxlength="30" class="form-control" data-inputmask='"mask": "<?= SystemConfig::getValue('sPhoneFormatCell') ?>"' data-mask>
                         <input type="checkbox" name="NoFormat_CellPhone" value="1" <?= $bNoFormat_CellPhone ? ' checked' : '' ?>><?= gettext('Do not auto-format') ?>
@@ -685,7 +685,7 @@ require_once 'Include/Header.php';
                     <label><?= gettext('Email') ?>:</label>
                     <div class="input-group">
                         <div class="input-group-addon">
-                            <i class="fa fa-envelope"></i>
+                            <i class="fa-solid fa-envelope"></i>
                         </div>
                         <input type="text" Name="Email" class="form-control" value="<?= htmlentities(stripslashes($sEmail)) ?>" size="30" maxlength="100"><span class="text-danger"><?php echo '<BR>' . $sEmailError ?></span>
                     </div>

--- a/src/FindDepositSlip.php
+++ b/src/FindDepositSlip.php
@@ -67,9 +67,9 @@ require_once 'Include/Header.php';
       <button type="button" id="deleteSelectedRows" class="btn btn-danger"
               disabled> <?= gettext('Delete Selected Rows') ?> </button>
       <button type="button" id="exportSelectedRows" class="btn btn-success exportButton" data-exportType="ofx"
-              disabled><i class="fa fa-download"></i> <?= gettext('Export Selected Rows (OFX)') ?></button>
+              disabled><i class="fa-solid fa-download"></i> <?= gettext('Export Selected Rows (OFX)') ?></button>
       <button type="button" id="exportSelectedRowsCSV" class="btn btn-success exportButton" data-exportType="csv"
-              disabled><i class="fa fa-download"></i> <?= gettext('Export Selected Rows (CSV)') ?></button>
+              disabled><i class="fa-solid fa-download"></i> <?= gettext('Export Selected Rows (CSV)') ?></button>
       <button type="button" id="generateDepositSlip" class="btn btn-success exportButton" data-exportType="pdf"
               disabled> <?= gettext('Generate Deposit Slip for Selected Rows (PDF)') ?></button>
     </div>

--- a/src/GeoPage.php
+++ b/src/GeoPage.php
@@ -262,7 +262,7 @@ $families = FamilyQuery::create()
             <div class="card-header with-border">
                 <h3 class="card-title"><?= gettext('Make Data File') ?></h3>
                 <div class="card-tools pull-right">
-                    <button class="btn btn-tool" data-card-widget="collapse"><i class="fa fa-plus"></i></button>
+                    <button class="btn btn-tool" data-card-widget="collapse"><i class="fa-solid fa-plus"></i></button>
                 </div><!-- /.card-tools -->
             </div><!-- /.box-header -->
             <div class="card-body">

--- a/src/GroupEditor.php
+++ b/src/GroupEditor.php
@@ -165,7 +165,7 @@ require_once 'Include/Header.php';
   </div>
   <div class="card-body">
     <div class="alert alert-info alert-dismissable">
-      <i class="fa fa-info"></i>
+      <i class="fa-solid fa-info"></i>
       <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>
       <strong></strong><?= gettext('Group role name changes are saved as soon as the box loses focus')?>
     </div>

--- a/src/GroupPropsFormEditor.php
+++ b/src/GroupPropsFormEditor.php
@@ -293,10 +293,10 @@ require_once 'Include/Header.php'; ?>
                             <td class="TextColumn" width="5%" class="text-nowrap">
                                 <?php
                                 if ($row != 1) {
-                                    echo "<a href=\"GroupPropsFormRowOps.php?GroupID=$iGroupID&PropID=$row&Field=" . $aFieldFields[$row] . '&Action=up"><i class="fa fa-arrow-up"></i></a>';
+                                    echo "<a href=\"GroupPropsFormRowOps.php?GroupID=$iGroupID&PropID=$row&Field=" . $aFieldFields[$row] . '&Action=up"><i class="fa-solid fa-arrow-up"></i></a>';
                                 }
                                 if ($row < $numRows) {
-                                    echo "<a href=\"GroupPropsFormRowOps.php?GroupID=$iGroupID&PropID=$row&Field=" . $aFieldFields[$row] . '&Action=down"><i class="fa fa-arrow-down"></i></a>';
+                                    echo "<a href=\"GroupPropsFormRowOps.php?GroupID=$iGroupID&PropID=$row&Field=" . $aFieldFields[$row] . '&Action=down"><i class="fa-solid fa-arrow-down"></i></a>';
                                 } ?>
 
                                 <?= "<a href=\"GroupPropsFormRowOps.php?GroupID=$iGroupID&PropID=$row&Field=$aFieldFields[$row]&Action=delete\"><i class='fa fa-times' ></i></a>"; ?>

--- a/src/GroupView.php
+++ b/src/GroupView.php
@@ -62,17 +62,17 @@ require_once 'Include/Header.php';
 
         <?php
         if (AuthenticationManager::getCurrentUser()->isManageGroupsEnabled()) {
-            echo '<a class="btn btn-app" href="GroupEditor.php?GroupID=' . $thisGroup->getId() . '"><i class="fas fa-pen"></i>' . gettext('Edit this Group') . '</a>';
-            echo '<button class="btn btn-app"  id="deleteGroupButton"><i class="fa fa-trash"></i>' . gettext('Delete this Group') . '</button>'; ?>
+            echo '<a class="btn btn-app" href="GroupEditor.php?GroupID=' . $thisGroup->getId() . '"><i class="fa-solid fa-pen"></i>' . gettext('Edit this Group') . '</a>';
+            echo '<button class="btn btn-app"  id="deleteGroupButton"><i class="fa-solid fa-trash"></i>' . gettext('Delete this Group') . '</button>'; ?>
 
             <?php
             if ($thisGroup->getHasSpecialProps()) {
-                echo '<a class="btn btn-app" href="GroupPropsFormEditor.php?GroupID=' . $thisGroup->getId() . '"><i class="fa fa-list-alt"></i>' . gettext('Edit Group-Specific Properties Form') . '</a>';
+                echo '<a class="btn btn-app" href="GroupPropsFormEditor.php?GroupID=' . $thisGroup->getId() . '"><i class="fa-solid fa-list-alt"></i>' . gettext('Edit Group-Specific Properties Form') . '</a>';
             }
         } ?>
 
-        <a class="btn btn-app" id="AddGroupMembersToCart" data-groupid="<?= $thisGroup->getId() ?>"><i class="fa fa-users"></i><?= gettext('Add Group Members to Cart') ?></a>
-        <a class="btn btn-app" href="MapUsingGoogle.php?GroupID=<?= $thisGroup->getId() ?>"><i class="fa fa-map-marker"></i><?= gettext('Map this group') ?></a>
+        <a class="btn btn-app" id="AddGroupMembersToCart" data-groupid="<?= $thisGroup->getId() ?>"><i class="fa-solid fa-users"></i><?= gettext('Add Group Members to Cart') ?></a>
+        <a class="btn btn-app" href="MapUsingGoogle.php?GroupID=<?= $thisGroup->getId() ?>"><i class="fa-solid fa-map-marker"></i><?= gettext('Map this group') ?></a>
 
         <?php
 
@@ -117,7 +117,7 @@ require_once 'Include/Header.php';
                 // Display link
                 ?>
                 <div class="btn-group">
-                    <a class="btn btn-app" href="mailto:<?= mb_substr($sEmailLink, 0, -3) ?>"><i class="fa fa-paper-plane"></i><?= gettext('Email Group') ?></a>
+                    <a class="btn btn-app" href="mailto:<?= mb_substr($sEmailLink, 0, -3) ?>"><i class="fa-solid fa-paper-plane"></i><?= gettext('Email Group') ?></a>
                     <button type="button" class="btn btn-app dropdown-toggle" data-toggle="dropdown">
                         <span class="caret"></span>
                         <span class="sr-only">Toggle Dropdown</span>
@@ -171,7 +171,7 @@ require_once 'Include/Header.php';
         if ($sPhoneLink) {
             if (AuthenticationManager::getCurrentUser()->isEmailEnabled()) { // Does user have permission to email groups
                 // Display link
-                echo '<a class="btn btn-app" href="javascript:void(0)" onclick="allPhonesCommaD()"><i class="fa fa-mobile-phone"></i>' . gettext('Text Group') . '</a>';
+                echo '<a class="btn btn-app" href="javascript:void(0)" onclick="allPhonesCommaD()"><i class="fa-solid fa-mobile-phone"></i>' . gettext('Text Group') . '</a>';
                 echo '<script nonce="' . SystemURLs::getCSPNonce() . '">function allPhonesCommaD() {prompt("' . gettext("Press CTRL + C to copy all group members\' phone numbers") . '", "' . mb_substr($sPhoneLink, 0, -2) . '")};</script>';
             }
         }

--- a/src/Include/Footer.php
+++ b/src/Include/Footer.php
@@ -31,7 +31,7 @@ $isAdmin = AuthenticationManager::getCurrentUser()->isAdmin();
                     <!-- Task item -->
                     <div class="mb-1">
                         <a target="blank" href="<?= $task['link'] ?>">
-                            <i class="menu-icon fa fa-fw <?= $task['admin'] ? 'fa-lock' : 'fa-info' ?>"></i> <?= $task['title'] ?>
+                            <i class="menu-icon fa-solid fa-fw <?= $task['admin'] ? 'fa-lock' : 'fa-info' ?>"></i> <?= $task['title'] ?>
                         </a>
                     </div>
                     <!-- end task item -->

--- a/src/Include/Functions.php
+++ b/src/Include/Functions.php
@@ -723,7 +723,7 @@ function formCustomField($type, string $fieldname, $data, ?string $special, bool
             // code rajouté par Philippe Logel
             echo '<div class="input-group">' .
             '<div class="input-group-addon">' .
-            '<i class="fa fa-calendar"></i>' .
+            '<i class="fa-solid fa-calendar"></i>' .
             '</div>' .
             '<input class="form-control date-picker" type="text" id="' . $fieldname . '" Name="' . $fieldname . '" value="' . change_date_for_place_holder($data) . '" placeholder="' . SystemConfig::getValue("sDatePickerPlaceHolder") . '"> ' .
             '</div>';
@@ -834,7 +834,7 @@ function formCustomField($type, string $fieldname, $data, ?string $special, bool
 
             echo '<div class="input-group">';
             echo '<div class="input-group-addon">';
-            echo '<i class="fa fa-phone"></i>';
+            echo '<i class="fa-solid fa-phone"></i>';
             echo '</div>';
             echo '<input class="form-control"  type="text" Name="' . $fieldname . '" maxlength="30" size="30" value="' . htmlentities(stripslashes($data), ENT_NOQUOTES, 'UTF-8') . '" data-inputmask=\'"mask": "' . SystemConfig::getValue('sPhoneFormat') . '"\' data-mask>';
             echo '<br><input type="checkbox" name="' . $fieldname . 'noformat" value="1"';

--- a/src/Include/Header-function.php
+++ b/src/Include/Header-function.php
@@ -28,7 +28,7 @@ function Header_modals(): void
                     <div class="modal-body">
                         <div class="alert alert-info alert-dismissible">
                             <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>
-                            <h5><i class="icon fas fa-info"></i>Alert!</h5>
+                            <h5><i class="icon fa-solid fa-info"></i>Alert!</h5>
                             <?= gettext('When you click "Submit to GitHub" you will be directed to GitHub issues page with your system info prefilled.') ?> <?= gettext('No personally identifiable information will be submitted unless you purposefully include it.') ?>
                         </div>
                     </div>

--- a/src/Include/Header.php
+++ b/src/Include/Header.php
@@ -43,7 +43,7 @@ $MenuFirst = 1;
         <!-- Left navbar links -->
         <ul class="navbar-nav">
             <li class="nav-item">
-                <a class="nav-link" data-widget="pushmenu" href="#" role="button"><i class="fas fa-bars"></i></a>
+                <a class="nav-link" data-widget="pushmenu" href="#" role="button"><i class="fa-solid fa-bars"></i></a>
             </li>
             <li class="nav-item d-none d-sm-inline-block">
                 <a href="<?= SystemURLs::getRootPath()?>/" class="nav-link">Home</a>
@@ -57,7 +57,7 @@ $MenuFirst = 1;
             <!-- Support Dropdown Menu -->
             <li class="nav-item dropdown d-none" id="systemUpdateMenuItem">
                 <a class="nav-link" data-toggle="dropdown" href="#" aria-expanded="true" id="upgradeMenu" title="<?= gettext('New Release') ?>">
-                    <i class="fas fa-download"></i>
+                    <i class="fa-solid fa-download"></i>
                 </a>
                 <div class="dropdown-menu dropdown-menu-lg dropdown-menu-right" style="left: inherit; right: 0px;">
                     <?php if (AuthenticationManager::getCurrentUser()->isAdmin()) { ?>
@@ -79,12 +79,12 @@ $MenuFirst = 1;
                 </a>
                 <div class="dropdown-menu dropdown-menu-lg dropdown-menu-right" style="left: inherit; right: 0px;">
                     <a href="https://poeditor.com/join/project?hash=RABdnDSqAt" class="dropdown-item">
-                        <i class="fas fa-people-carry"></i> <?= gettext("Help translate this project")?>
+                        <i class="fa-solid fa-people-carry"></i> <?= gettext("Help translate this project")?>
                     </a>
                     <?php if (AuthenticationManager::getCurrentUser()->isAdmin()) { ?>
                     <div class="dropdown-divider"></div>
                     <a href="<?= SystemURLs::getRootPath() ?>/v2/user/<?= AuthenticationManager::getCurrentUser()->getPersonId() ?>" class="dropdown-item">
-                        <i class="fas fa-user-edit"></i> <span id="translationInfo"></span>
+                        <i class="fa-solid fa-user-edit"></i> <span id="translationInfo"></span>
                     </a>
                     <?php } ?>
                 </div>
@@ -93,7 +93,7 @@ $MenuFirst = 1;
             <!-- Cart Functions: style can be found in dropdown.less -->
             <li class="nav-item dropdown show">
                 <a class="nav-link" data-toggle="dropdown" href="#" aria-expanded="true">
-                    <i class="fas fa-shopping-cart"></i>
+                    <i class="fa-solid fa-shopping-cart"></i>
                     <span class="badge badge-info navbar-badge"><?= Cart::countPeople() ?></span>
                 </a>
                 <div class="dropdown-menu dropdown-menu-lg dropdown-menu-right" style="left: inherit; right: 0px;">
@@ -104,18 +104,18 @@ $MenuFirst = 1;
             <!-- Support Dropdown Menu -->
             <li class="nav-item dropdown show">
                 <a class="nav-link" data-toggle="dropdown" href="#" aria-expanded="true" id="supportMenu">
-                    <i class="fas fa-headset"></i>
+                    <i class="fa-solid fa-headset"></i>
                 </a>
                 <div class="dropdown-menu dropdown-menu-lg dropdown-menu-right" style="left: inherit; right: 0px;">
                     <a href="<?= SystemURLs::getSupportURL() ?>" target="help" class="dropdown-item" title="<?= gettext('Help & Manual') ?>">
-                        <i class="fas fa-book-reader"></i> <?= gettext('Help & Manual') ?>
+                        <i class="fa-solid fa-book-reader"></i> <?= gettext('Help & Manual') ?>
                     </a>
                     <div class="dropdown-divider"></div>
                     <a href="#" id="reportIssue" class="dropdown-item" data-toggle="modal" data-target="#IssueReportModal"  title="<?= gettext('Report an issue') ?>">
-                        <i class="fas fa-bug"></i> <?= gettext('Report an issue') ?>
+                        <i class="fa-solid fa-bug"></i> <?= gettext('Report an issue') ?>
                     </a>
                     <a href="https://gitter.im/ChurchCRM/CRM" target="_blank" class="dropdown-item" title="<?= gettext('Developer Chat') ?>">
-                        <i class="far fa-comment-dots"></i> <?= gettext('Developer Chat') ?>
+                        <i class="fa-regular fa-comment-dots"></i> <?= gettext('Developer Chat') ?>
                     </a>
                     <div class="dropdown-divider"></div>
                     <a href="https://github.com/ChurchCRM/CRM/wiki/Contributing" target="_blank" class="dropdown-item" title="<?= gettext('Contributing') ?>">
@@ -131,7 +131,7 @@ $MenuFirst = 1;
             ?>
             <li class="nav-item">
                 <a class="nav-link" data-widget="control-sidebar" data-slide="true" href="#" role="button">
-                    <i class="far fa-bell"></i>
+                    <i class="fa-regular fa-bell"></i>
                     <span class="badge badge-warning navbar-badge"><?= $taskSize ?></span>
                 </a>
             </li>
@@ -139,30 +139,30 @@ $MenuFirst = 1;
             <!-- Support Dropdown Menu -->
             <li class="nav-item dropdown show">
                 <a class="nav-link" data-toggle="dropdown" href="#" aria-expanded="true">
-                    <i class="fas fa-user"></i> <?= AuthenticationManager::getCurrentUser()->getName() ?>
+                    <i class="fa-solid fa-user"></i> <?= AuthenticationManager::getCurrentUser()->getName() ?>
                 </a>
                 <div class="dropdown-menu dropdown-menu-lg dropdown-menu-right" style="left: inherit; right: 0px;">
                     <a href="<?= SystemURLs::getRootPath()?>/PersonView.php?PersonID=<?= AuthenticationManager::getCurrentUser()->getPersonId() ?>" class="dropdown-item">
-                      <i class="fa fa-home"></i> <?= gettext("Profile") ?></a>
+                      <i class="fa-solid fa-home"></i> <?= gettext("Profile") ?></a>
                   <a href="<?= SystemURLs::getRootPath() ?>/v2/user/current/changepassword" class="dropdown-item">
-                      <i class="fa fa-key"></i> <?= gettext('Change Password') ?></a>
+                      <i class="fa-solid fa-key"></i> <?= gettext('Change Password') ?></a>
                   <a href="<?= SystemURLs::getRootPath() ?>/v2/user/<?= AuthenticationManager::getCurrentUser()->getPersonId() ?>" class="dropdown-item">
-                      <i class="fas fa-cogs"></i> <?= gettext('Change Settings') ?></a>
+                      <i class="fa-solid fa-cogs"></i> <?= gettext('Change Settings') ?></a>
                   <?php if (LocalAuthentication::getIsTwoFactorAuthSupported()) { ?>
                       <div class="dropdown-divider"></div>
                       <a href="<?= SystemURLs::getRootPath() ?>/v2/user/current/enroll2fa" class="dropdown-item">
-                          <i class="fa fa-gear"></i> <?= gettext("Manage 2 Factor Authentication") ?></a>
+                          <i class="fa-solid fa-gear"></i> <?= gettext("Manage 2 Factor Authentication") ?></a>
                   <?php } ?>
                      <div class="dropdown-divider"></div>
                     <a href="<?= SystemURLs::getRootPath() ?>/session/end" class="dropdown-item">
-                      <i class="fas fa-sign-out-alt"></i> <?= gettext('Sign out') ?></a>
+                      <i class="fa-solid fa-sign-out-alt"></i> <?= gettext('Sign out') ?></a>
 
                 </div>
             </li>
 
             <li class="nav-item">
                 <a class="nav-link" data-widget="fullscreen" href="#" role="button">
-                    <i class="fas fa-expand-arrows-alt"></i>
+                    <i class="fa-solid fa-expand-arrows-alt"></i>
                 </a>
             </li>
         </span>

--- a/src/ManageEnvelopes.php
+++ b/src/ManageEnvelopes.php
@@ -105,7 +105,7 @@ if (isset($_POST['PrintReport'])) {
 ?>
 
 <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#updateEnvelopesModal"><?= gettext('Update Family Records') ?></button>
-<button type="submit" class="btn btn-default" name="PrintReport"><i class="fa fa-print"></i></button>
+<button type="submit" class="btn btn-default" name="PrintReport"><i class="fa-solid fa-print"></i></button>
 
 <br><br>
 

--- a/src/MapUsingGoogle.php
+++ b/src/MapUsingGoogle.php
@@ -19,7 +19,7 @@ $iGroupID = InputUtils::legacyFilterInput($_GET['GroupID'], 'int');
 ?>
 
 <div class="callout callout-info">
-    <a href="<?= SystemURLs::getRootPath() ?>/UpdateAllLatLon.php" class="btn btn-default"><i class="fa fa-map-marker"></i> </a>
+    <a href="<?= SystemURLs::getRootPath() ?>/UpdateAllLatLon.php" class="btn btn-default"><i class="fa-solid fa-map-marker"></i> </a>
     <?= gettext('Missing Families? Update Family Latitude or Longitude now.') ?>
 </div>
 

--- a/src/OptionManager.php
+++ b/src/OptionManager.php
@@ -326,13 +326,13 @@ for ($row = 1; $row <= $numRows; $row++) {
 
             <?php
             if ($row != 1) {
-                echo "<a href=\"OptionManagerRowOps.php?mode=$mode&Order=$aSeqs[$row]&ListID=$listID&ID=" . $aIDs[$row] . '&Action=up"><i class="fa fa-arrow-up"></i></a>';
+                echo "<a href=\"OptionManagerRowOps.php?mode=$mode&Order=$aSeqs[$row]&ListID=$listID&ID=" . $aIDs[$row] . '&Action=up"><i class="fa-solid fa-arrow-up"></i></a>';
             }
             if ($row < $numRows) {
-                echo "<a href=\"OptionManagerRowOps.php?mode=$mode&Order=$aSeqs[$row]&ListID=$listID&ID=" . $aIDs[$row] . '&Action=down"><i class="fa fa-arrow-down"></i></a>';
+                echo "<a href=\"OptionManagerRowOps.php?mode=$mode&Order=$aSeqs[$row]&ListID=$listID&ID=" . $aIDs[$row] . '&Action=down"><i class="fa-solid fa-arrow-down"></i></a>';
             }
             if ($numRows > 0) {
-                echo "<a href=\"OptionManagerRowOps.php?mode=$mode&Order=$aSeqs[$row]&ListID=$listID&ID=" . $aIDs[$row] . '&Action=delete"><i class="fa fa-times"></i></a>';
+                echo "<a href=\"OptionManagerRowOps.php?mode=$mode&Order=$aSeqs[$row]&ListID=$listID&ID=" . $aIDs[$row] . '&Action=delete"><i class="fa-solid fa-times"></i></a>';
             } ?>
 
         </td>

--- a/src/PeopleDashboard.php
+++ b/src/PeopleDashboard.php
@@ -63,14 +63,14 @@ if (SystemConfig::getBooleanValue("bEnableSelfRegistration")) {
         <h3 class="card-title"><?= gettext('People Functions') ?></h3>
     </div>
     <div class="card-body">
-        <a href="<?= SystemURLs::getRootPath() ?>/v2/people" class="btn btn-app"><i class="fa fa-user"></i><?= gettext('All People') ?></a>
-        <a href="<?= SystemURLs::getRootPath() ?>/v2/people/verify" class="btn btn-app"><i class="fas fa-clipboard-check"></i><?= gettext('Verify People') ?></a>
-        <div class="btn btn-app"><span class="badge <?= $selfRegColor ?>"><?= $selfRegText ?></span><i class="fa fa-user-plus"></i><?= gettext('Self Register') ?></div>
-        <a href="<?= SystemURLs::getRootPath() ?>/v2/family" class="btn btn-app"><i class="fa fa-people-roof"></i><?= gettext('All Families') ?></a>
+        <a href="<?= SystemURLs::getRootPath() ?>/v2/people" class="btn btn-app"><i class="fa-solid fa-user"></i><?= gettext('All People') ?></a>
+        <a href="<?= SystemURLs::getRootPath() ?>/v2/people/verify" class="btn btn-app"><i class="fa-solid fa-clipboard-check"></i><?= gettext('Verify People') ?></a>
+        <div class="btn btn-app"><span class="badge <?= $selfRegColor ?>"><?= $selfRegText ?></span><i class="fa-solid fa-user-plus"></i><?= gettext('Self Register') ?></div>
+        <a href="<?= SystemURLs::getRootPath() ?>/v2/family" class="btn btn-app"><i class="fa-solid fa-people-roof"></i><?= gettext('All Families') ?></a>
         <br />
-        <a href="MapUsingGoogle.php?GroupID=-1" class="btn btn-app"><i class="fa fa-map"></i><?= gettext('Family Map') ?></a>
-        <a href="GeoPage.php" class="btn btn-app"><i class="fa fa-globe"></i><?= gettext('Family Geographic') ?></a>
-        <a href="UpdateAllLatLon.php" class="btn btn-app"><i class="fa fa-map-pin"></i><?= gettext('Update All Family Coordinates') ?></a>
+        <a href="MapUsingGoogle.php?GroupID=-1" class="btn btn-app"><i class="fa-solid fa-map"></i><?= gettext('Family Map') ?></a>
+        <a href="GeoPage.php" class="btn btn-app"><i class="fa-solid fa-globe"></i><?= gettext('Family Geographic') ?></a>
+        <a href="UpdateAllLatLon.php" class="btn btn-app"><i class="fa-solid fa-map-pin"></i><?= gettext('Update All Family Coordinates') ?></a>
         <br />
 
         <?php
@@ -84,7 +84,7 @@ if (SystemConfig::getBooleanValue("bEnableSelfRegistration")) {
                 // Display link
                 ?>
                 <div class="btn-group">
-                    <a class="btn btn-app" href="mailto:<?= mb_substr($sEmailLink, 0, -3) ?>"><i class="fas fa-mail-bulk"></i></i><?= gettext('Email All') ?></a>
+                    <a class="btn btn-app" href="mailto:<?= mb_substr($sEmailLink, 0, -3) ?>"><i class="fa-solid fa-mail-bulk"></i></i><?= gettext('Email All') ?></a>
                     <button type="button" class="btn btn-app dropdown-toggle" data-toggle="dropdown">
                         <span class="caret"></span>
                         <span class="sr-only">Toggle Dropdown</span>
@@ -94,7 +94,7 @@ if (SystemConfig::getBooleanValue("bEnableSelfRegistration")) {
                     </ul>
                 </div>
                 <div class="btn-group">
-                    <a class="btn btn-app" href="mailto:?bcc=<?= mb_substr($sEmailLink, 0, -3) ?>"><i class="fas fa-mail-bulk"></i><?= gettext('Email All (BCC)') ?></a>
+                    <a class="btn btn-app" href="mailto:?bcc=<?= mb_substr($sEmailLink, 0, -3) ?>"><i class="fa-solid fa-mail-bulk"></i><?= gettext('Email All (BCC)') ?></a>
                     <button type="button" class="btn btn-app dropdown-toggle" data-toggle="dropdown">
                         <span class="caret"></span>
                         <span class="sr-only">Toggle Dropdown</span>
@@ -124,10 +124,10 @@ if (SystemConfig::getBooleanValue("bEnableSelfRegistration")) {
                 </p>
             </div>
             <div class="icon">
-                <i class="fa fa-people-roof"></i>
+                <i class="fa-solid fa-people-roof"></i>
             </div>
             <a href="<?= SystemURLs::getRootPath() ?>/v2/family" class="small-box-footer">
-                <?= gettext('See all Families') ?> <i class="fa fa-arrow-circle-right"></i>
+                <?= gettext('See all Families') ?> <i class="fa-solid fa-arrow-circle-right"></i>
             </a>
         </div>
     </div>
@@ -145,10 +145,10 @@ if (SystemConfig::getBooleanValue("bEnableSelfRegistration")) {
                 </p>
             </div>
             <div class="icon">
-                <i class="fa fa-user"></i>
+                <i class="fa-solid fa-user"></i>
             </div>
             <a href="<?= SystemURLs::getRootPath() ?>/v2/people" class="small-box-footer">
-                <?= gettext('See All People') ?> <i class="fa fa-arrow-circle-right"></i>
+                <?= gettext('See All People') ?> <i class="fa-solid fa-arrow-circle-right"></i>
             </a>
         </div>
     </div>
@@ -168,10 +168,10 @@ if (SystemConfig::getBooleanValue("bEnableSelfRegistration")) {
                     </p>
                 </div>
                 <div class="icon">
-                    <i class="fa fa-children"></i>
+                    <i class="fa-solid fa-children"></i>
                 </div>
                 <a href="<?= SystemURLs::getRootPath() ?>/sundayschool/SundaySchoolDashboard.php" class="small-box-footer">
-                    <?= gettext('More info') ?> <i class="fa fa-arrow-circle-right"></i>
+                    <?= gettext('More info') ?> <i class="fa-solid fa-arrow-circle-right"></i>
                 </a>
             </div>
         </div>
@@ -191,10 +191,10 @@ if (SystemConfig::getBooleanValue("bEnableSelfRegistration")) {
                 </p>
             </div>
             <div class="icon">
-                <i class="fa fa-users"></i>
+                <i class="fa-solid fa-users"></i>
             </div>
             <a href="<?= SystemURLs::getRootPath() ?>/GroupList.php" class="small-box-footer">
-                <?= gettext('More info') ?> <i class="fa fa-arrow-circle-right"></i>
+                <?= gettext('More info') ?> <i class="fa-solid fa-arrow-circle-right"></i>
             </a>
         </div>
     </div>
@@ -205,10 +205,10 @@ if (SystemConfig::getBooleanValue("bEnableSelfRegistration")) {
     <div class="col-lg-6">
         <div class="card card-info">
             <div class="card-header with-border">
-                <h3 class="card-title"><i class="fa fa-file-lines"></i> <?= gettext('Reports') ?></h3>
+                <h3 class="card-title"><i class="fa-solid fa-file-lines"></i> <?= gettext('Reports') ?></h3>
                 <div class="card-tools pull-right">
-                    <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fa fa-minus"></i></button>
-                    <button type="button" class="btn btn-tool" data-card-widget="remove"><i class="fa fa-times"></i></button>
+                    <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fa-solid fa-minus"></i></button>
+                    <button type="button" class="btn btn-tool" data-card-widget="remove"><i class="fa-solid fa-times"></i></button>
                 </div>
             </div>
             <div class="card-body">
@@ -235,10 +235,10 @@ if (SystemConfig::getBooleanValue("bEnableSelfRegistration")) {
     <div class="col-lg-6">
         <div class="card card-primary">
             <div class="card-header with-border">
-                <h3 class="card-title"><i class="fa fa-chart-bar"></i> <?= gettext('People Classification') ?></h3>
+                <h3 class="card-title"><i class="fa-solid fa-chart-bar"></i> <?= gettext('People Classification') ?></h3>
                 <div class="card-tools pull-right">
-                    <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fa fa-minus"></i></button>
-                    <button type="button" class="btn btn-tool" data-card-widget="remove"><i class="fa fa-times"></i></button>
+                    <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fa-solid fa-minus"></i></button>
+                    <button type="button" class="btn btn-tool" data-card-widget="remove"><i class="fa-solid fa-times"></i></button>
                 </div>
             </div>
             <div class="card-body no-padding">
@@ -271,10 +271,10 @@ if (SystemConfig::getBooleanValue("bEnableSelfRegistration")) {
     <div class="col-lg-6">
         <div class="card card-primary">
             <div class="card-header with-border">
-                <h3 class="card-title"> <i class="fa fa-people-group"></i> <?= gettext('Family Roles') ?></h3>
+                <h3 class="card-title"> <i class="fa-solid fa-people-group"></i> <?= gettext('Family Roles') ?></h3>
                 <div class="card-tools pull-right">
-                    <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fa fa-minus"></i></button>
-                    <button type="button" class="btn btn-tool" data-card-widget="remove"><i class="fa fa-times"></i></button>
+                    <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fa-solid fa-minus"></i></button>
+                    <button type="button" class="btn btn-tool" data-card-widget="remove"><i class="fa-solid fa-times"></i></button>
                 </div>
             </div>
             <div class="card-body no-padding">
@@ -315,7 +315,7 @@ if (SystemConfig::getBooleanValue("bEnableSelfRegistration")) {
     <div class="col-lg-6">
         <div class="card card-info">
             <div class="card-header">
-                <h3 class="card-title"><i class="fa fa-id-card-clip"></i> <?= gettext('Gender Demographics') ?></h3>
+                <h3 class="card-title"><i class="fa-solid fa-id-card-clip"></i> <?= gettext('Gender Demographics') ?></h3>
             </div>
             <!-- /.box-header -->
             <div class="card-body" style="height: 300px">
@@ -324,7 +324,7 @@ if (SystemConfig::getBooleanValue("bEnableSelfRegistration")) {
         </div>
         <div class="card card-info">
             <div class="card-header">
-                <h3 class="card-title"><i class="fa fa-birthday-cake"></i> <?= gettext('Age Histogram') ?></h3>
+                <h3 class="card-title"><i class="fa-solid fa-birthday-cake"></i> <?= gettext('Age Histogram') ?></h3>
             </div>
             <!-- /.box-header -->
             <div class="card-body" style="height: 400px">

--- a/src/PersonCustomFieldsEditor.php
+++ b/src/PersonCustomFieldsEditor.php
@@ -259,7 +259,7 @@ require_once 'Include/Header.php'; ?>
     </script>
 
     <div class="alert alert-warning">
-        <i class="fa fa-ban"></i>
+        <i class="fa-solid fa-ban"></i>
         <?= gettext("Warning: Arrow and delete buttons take effect immediately.  Field name changes will be lost if you do not 'Save Changes' before using an up, down, delete or 'add new' button!") ?>
     </div>
     <form method="post" action="PersonCustomFieldsEditor.php" name="PersonCustomFieldsEditor">
@@ -349,10 +349,10 @@ require_once 'Include/Header.php'; ?>
                             <td class="TextColumn" width="5%" class="text-nowrap">
                                 <?php
                                 if ($row != 1) {
-                                    echo "<a href=\"PersonCustomFieldsRowOps.php?OrderID=$row&Field=" . $aFieldFields[$row] . '&Action=up"><i class="fa fa-arrow-up"></i></a>';
+                                    echo "<a href=\"PersonCustomFieldsRowOps.php?OrderID=$row&Field=" . $aFieldFields[$row] . '&Action=up"><i class="fa-solid fa-arrow-up"></i></a>';
                                 }
                                 if ($row < $numRows) {
-                                    echo "<a href=\"PersonCustomFieldsRowOps.php?OrderID=$row&Field=" . $aFieldFields[$row] . '&Action=down"><i class="fa fa-arrow-down"></i></a>';
+                                    echo "<a href=\"PersonCustomFieldsRowOps.php?OrderID=$row&Field=" . $aFieldFields[$row] . '&Action=down"><i class="fa-solid fa-arrow-down"></i></a>';
                                 } ?>
 
                             </td>

--- a/src/PersonEditor.php
+++ b/src/PersonEditor.php
@@ -601,7 +601,7 @@ require_once 'Include/Header.php';
 ?>
 <form method="post" action="PersonEditor.php?PersonID=<?= $iPersonID ?>" name="PersonEditor">
     <div class="alert alert-info alert-dismissable">
-        <i class="fa fa-info"></i>
+        <i class="fa-solid fa-info"></i>
         <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
         <strong><span
                 class="text-danger"><?= gettext('Red text') ?></span></strong> <?php echo gettext('indicates items inherited from the associated family record.'); ?>
@@ -609,7 +609,7 @@ require_once 'Include/Header.php';
     <?php if ($bErrorFlag) {
         ?>
         <div class="alert alert-danger alert-dismissable">
-            <i class="fa fa-ban"></i>
+            <i class="fa-solid fa-ban"></i>
             <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
             <?= gettext('Invalid fields or selections. Changes not saved! Please correct and try again!') ?>
         </div>
@@ -967,7 +967,7 @@ require_once 'Include/Header.php';
                     </label>
                     <div class="input-group">
                         <div class="input-group-addon">
-                            <i class="fa fa-phone"></i>
+                            <i class="fa-solid fa-phone"></i>
                         </div>
                         <input type="text" name="HomePhone"
                                value="<?= htmlentities(stripslashes($sHomePhone), ENT_NOQUOTES, 'UTF-8') ?>" size="30"
@@ -991,7 +991,7 @@ require_once 'Include/Header.php';
                     </label>
                     <div class="input-group">
                         <div class="input-group-addon">
-                            <i class="fa fa-phone"></i>
+                            <i class="fa-solid fa-phone"></i>
                         </div>
                         <input type="text" name="WorkPhone"
                                value="<?= htmlentities(stripslashes($sWorkPhone), ENT_NOQUOTES, 'UTF-8') ?>" size="30"
@@ -1017,7 +1017,7 @@ require_once 'Include/Header.php';
                     </label>
                     <div class="input-group">
                         <div class="input-group-addon">
-                            <i class="fa fa-phone"></i>
+                            <i class="fa-solid fa-phone"></i>
                         </div>
                         <input type="text" name="CellPhone"
                                value="<?= htmlentities(stripslashes($sCellPhone), ENT_NOQUOTES, 'UTF-8') ?>" size="30"
@@ -1044,7 +1044,7 @@ require_once 'Include/Header.php';
                     </label>
                     <div class="input-group">
                         <div class="input-group-addon">
-                            <i class="fa fa-envelope"></i>
+                            <i class="fa-solid fa-envelope"></i>
                         </div>
                         <input type="text" name="Email" id="Email"
                                value="<?= htmlentities(stripslashes($sEmail), ENT_NOQUOTES, 'UTF-8') ?>" size="30"
@@ -1058,7 +1058,7 @@ require_once 'Include/Header.php';
                     <label for="WorkEmail"><?= gettext('Work / Other Email') ?>:</label>
                     <div class="input-group">
                         <div class="input-group-addon">
-                            <i class="fa fa-envelope"></i>
+                            <i class="fa-solid fa-envelope"></i>
                         </div>
                         <input type="text" name="WorkEmail"
                                value="<?= htmlentities(stripslashes($sWorkEmail), ENT_NOQUOTES, 'UTF-8') ?>" size="30"
@@ -1152,7 +1152,7 @@ require_once 'Include/Header.php';
                     <label><?= gettext('Membership Date') ?>:</label>
                     <div class="input-group">
                         <div class="input-group-addon">
-                            <i class="fa fa-calendar"></i>
+                            <i class="fa-solid fa-calendar"></i>
                         </div>
                         <!-- Philippe Logel -->
                         <input type="text" name="MembershipDate" class="form-control date-picker"
@@ -1169,7 +1169,7 @@ require_once 'Include/Header.php';
                         <label><?= gettext('Friend Date') ?>:</label>
                         <div class="input-group">
                             <div class="input-group-addon">
-                                <i class="fa fa-calendar"></i>
+                                <i class="fa-solid fa-calendar"></i>
                             </div>
                             <input type="text" name="FriendDate" class="form-control date-picker"
                                    value="<?= change_date_for_place_holder($dFriendDate) ?>" maxlength="10" id="sel2"

--- a/src/PersonView.php
+++ b/src/PersonView.php
@@ -201,13 +201,13 @@ $bOkToEdit = (
                         <?php if ($bOkToEdit) : ?>
                             <div class="buttons">
                                 <a id="view-larger-image-btn" class="hide" title="<?= gettext("View Photo") ?>">
-                                    <i class="fa fa-search-plus"></i>
+                                    <i class="fa-solid fa-search-plus"></i>
                                 </a>&nbsp;
                                 <a class="" data-toggle="modal" data-target="#upload-image" title="<?= gettext("Upload Photo") ?>">
-                                    <i class="fa fa-camera"></i>
+                                    <i class="fa-solid fa-camera"></i>
                                 </a>&nbsp;
                                 <a data-toggle="modal" data-target="#confirm-delete-image" title="<?= gettext("Delete Photo") ?>">
-                                    <i class="fa fa-trash-can"></i>
+                                    <i class="fa-solid fa-trash-can"></i>
                                 </a>
                             </div>
 
@@ -230,7 +230,7 @@ $bOkToEdit = (
                     <li class="list-group-item">
                         <b><?= gettext('Family Role') ?></b> <a class="float-right"><?= empty($sFamRole) ? gettext('Undefined') : gettext($sFamRole); ?></a>
                         <a id="edit-role-btn" data-person_id="<?= $person->getId() ?>" data-family_role="<?= $person->getFamilyRoleName() ?>" data-family_role_id="<?= $person->getFmrId() ?>" class="btn btn-xs">
-                            <i class="fas fa-pen"></i>
+                            <i class="fa-solid fa-pen"></i>
                         </a>
                     </li>
                     <li class="list-group-item">
@@ -260,13 +260,13 @@ $bOkToEdit = (
             <!-- /.box-header -->
             <div class="card-body">
                 <ul class="fa-ul">
-                    <li><i class="fa-li fa fa-people-roof"></i><?php echo gettext('Family:'); ?> <span>
+                    <li><i class="fa-li fa-solid fa-people-roof"></i><?php echo gettext('Family:'); ?> <span>
                             <?php
                             if ($fam_ID != '') {
                                 ?>
                                 <a href="<?= SystemURLs::getRootPath() ?>/v2/family/<?= $fam_ID ?>"><?= $fam_Name ?> </a>
                                 <a href="<?= SystemURLs::getRootPath() ?>/FamilyEditor.php?FamilyID=<?= $fam_ID ?>" class="table-link">
-                                    <i class="fas fa-pen"></i>
+                                    <i class="fa-solid fa-pen"></i>
                                 </a>
                                 <?php
                             } else {
@@ -275,7 +275,7 @@ $bOkToEdit = (
                         </span></li>
                     <?php if (!empty($formattedMailingAddress)) {
                         ?>
-                        <li><i class="fa-li fa fa-home"></i><?php echo gettext('Address'); ?>: <span>
+                        <li><i class="fa-li fa-solid fa-home"></i><?php echo gettext('Address'); ?>: <span>
                                 <a href="https://maps.google.com/?q=<?= $plaintextMailingAddress ?>" target="_blank">
                                     <?= $formattedMailingAddress ?>
                                 </a>
@@ -285,7 +285,7 @@ $bOkToEdit = (
                     if ($dBirthDate) {
                         ?>
                         <li>
-                            <i class="fa-li fa fa-calendar"></i><?= gettext('Birth Date') ?>: <?= $dBirthDate ?>
+                            <i class="fa-li fa-solid fa-calendar"></i><?= gettext('Birth Date') ?>: <?= $dBirthDate ?>
                             <?php if (!$person->hideAge()) {
                                 ?>
                                 (<span></span><?= $person->getAge() ?>)
@@ -295,32 +295,32 @@ $bOkToEdit = (
                         <?php
                     }
                     if (!SystemConfig::getValue('bHideFriendDate') && $per_FriendDate != '') { /* Friend Date can be hidden - General Settings */ ?>
-                        <li><i class="fa-li fa fa-tasks"></i><?= gettext('Friend Date') ?>: <span><?= FormatDate($per_FriendDate, false) ?></span></li>
+                        <li><i class="fa-li fa-solid fa-tasks"></i><?= gettext('Friend Date') ?>: <span><?= FormatDate($per_FriendDate, false) ?></span></li>
                         <?php
                     }
                     if ($sCellPhone) {
                         ?>
-                        <li><i class="fa-li fa fa-mobile-phone"></i><?= gettext('Mobile Phone') ?>: <span><a href="tel:<?= $sCellPhoneUnformatted ?>"><?= $sCellPhone ?></a></span></li>
+                        <li><i class="fa-li fa-solid fa-mobile-phone"></i><?= gettext('Mobile Phone') ?>: <span><a href="tel:<?= $sCellPhoneUnformatted ?>"><?= $sCellPhone ?></a></span></li>
                         <?php
                     }
                     if ($sHomePhone) {
                         ?>
-                        <li><i class="fa-li fa fa-phone"></i><?= gettext('Home Phone') ?>: <span><a href="tel:<?= $sHomePhoneUnformatted ?>"><?= $sHomePhone ?></a></span></li>
+                        <li><i class="fa-li fa-solid fa-phone"></i><?= gettext('Home Phone') ?>: <span><a href="tel:<?= $sHomePhoneUnformatted ?>"><?= $sHomePhone ?></a></span></li>
                         <?php
                     }
                     if ($sEmail != '') {
                         ?>
-                        <li><i class="fa-li fa fa-envelope"></i><?= gettext('Email') ?>: <span><a href="mailto:<?= $sUnformattedEmail ?>"><?= $sEmail ?></a></span></li>
+                        <li><i class="fa-li fa-solid fa-envelope"></i><?= gettext('Email') ?>: <span><a href="mailto:<?= $sUnformattedEmail ?>"><?= $sEmail ?></a></span></li>
                         <?php
                     }
                     if ($sWorkPhone) {
                         ?>
-                        <li><i class="fa-li fa fa-phone"></i><?= gettext('Work Phone') ?>: <span><a href="tel:<?= $sWorkPhoneUnformatted ?>"><?= $sWorkPhone ?></a></span></li>
+                        <li><i class="fa-li fa-solid fa-phone"></i><?= gettext('Work Phone') ?>: <span><a href="tel:<?= $sWorkPhoneUnformatted ?>"><?= $sWorkPhone ?></a></span></li>
                         <?php
                     } ?>
                     <?php if ($per_WorkEmail != '') {
                         ?>
-                        <li><i class="fa-li fa fa-envelope"></i><?= gettext('Work/Other Email') ?>: <span><a href="mailto:<?= $per_WorkEmail ?>"><?= $per_WorkEmail ?></a></span></li>
+                        <li><i class="fa-li fa-solid fa-envelope"></i><?= gettext('Work/Other Email') ?>: <span><a href="mailto:<?= $per_WorkEmail ?>"><?= $per_WorkEmail ?></a></span></li>
                         <?php
                     }
 
@@ -371,29 +371,29 @@ $bOkToEdit = (
             </div>
         </div>
         <div class="alert alert-info alert-dismissable">
-            <i class="fa fa-fw fa-tree"></i> <?php echo gettext('indicates items inherited from the associated family record.'); ?>
+            <i class="fa-solid fa-fw fa-tree"></i> <?php echo gettext('indicates items inherited from the associated family record.'); ?>
         </div>
     </div>
     <div class="col-lg-9 col-md-9 col-sm-9">
         <div class="row">
-            <a class="btn btn-app" id="printPerson" href="<?= SystemURLs::getRootPath() ?>/PrintView.php?PersonID=<?= $iPersonID ?>"><i class="fa fa-print"></i> <?= gettext("Printable Page") ?></a>
-            <a class="btn btn-app AddToPeopleCart" id="AddPersonToCart" data-cartpersonid="<?= $iPersonID ?>"><i class="fa fa-cart-plus"></i><span class="cartActionDescription"><?= gettext("Add to Cart") ?></span></a>
+            <a class="btn btn-app" id="printPerson" href="<?= SystemURLs::getRootPath() ?>/PrintView.php?PersonID=<?= $iPersonID ?>"><i class="fa-solid fa-print"></i> <?= gettext("Printable Page") ?></a>
+            <a class="btn btn-app AddToPeopleCart" id="AddPersonToCart" data-cartpersonid="<?= $iPersonID ?>"><i class="fa-solid fa-cart-plus"></i><span class="cartActionDescription"><?= gettext("Add to Cart") ?></span></a>
             <?php if (AuthenticationManager::getCurrentUser()->isNotesEnabled()) {
                 ?>
-                <a class="btn btn-app" id="editWhyCame" href="<?= SystemURLs::getRootPath() ?>/WhyCameEditor.php?PersonID=<?= $iPersonID ?>"><i class="fa fa-question-circle"></i> <?= gettext("Edit \"Why Came\" Notes") ?></a>
-                <a class="btn btn-app" id="addNote" href="<?= SystemURLs::getRootPath() ?>/NoteEditor.php?PersonID=<?= $iPersonID ?>"><i class="fa fa-sticky-note"></i> <?= gettext("Add a Note") ?></a>
+                <a class="btn btn-app" id="editWhyCame" href="<?= SystemURLs::getRootPath() ?>/WhyCameEditor.php?PersonID=<?= $iPersonID ?>"><i class="fa-solid fa-question-circle"></i> <?= gettext("Edit \"Why Came\" Notes") ?></a>
+                <a class="btn btn-app" id="addNote" href="<?= SystemURLs::getRootPath() ?>/NoteEditor.php?PersonID=<?= $iPersonID ?>"><i class="fa-solid fa-sticky-note"></i> <?= gettext("Add a Note") ?></a>
                 <?php
             }
             if (AuthenticationManager::getCurrentUser()->isManageGroupsEnabled()) {
                 ?>
-                <a class="btn btn-app" id="addGroup"><i class="fa fa-users"></i> <?= gettext("Assign New Group") ?></a>
+                <a class="btn btn-app" id="addGroup"><i class="fa-solid fa-users"></i> <?= gettext("Assign New Group") ?></a>
                 <?php
             } ?>
-            <a class="btn btn-app" role="button" href="<?= SystemURLs::getRootPath() ?>/v2/people"><i class="fa fa-list"></i> <?= gettext("List Members") ?></span></a>
+            <a class="btn btn-app" role="button" href="<?= SystemURLs::getRootPath() ?>/v2/people"><i class="fa-solid fa-list"></i> <?= gettext("List Members") ?></span></a>
             <?php
             if (AuthenticationManager::getCurrentUser()->isDeleteRecordsEnabled()) {
                 ?>
-                <a id="deletePersonBtn" class="btn btn-app bg-maroon delete-person" data-person_name="<?= $person->getFullName() ?>" data-person_id="<?= $iPersonID ?>"><i class="fa fa-trash-can"></i> <?= gettext("Delete this Record") ?></a>
+                <a id="deletePersonBtn" class="btn btn-app bg-maroon delete-person" data-person_name="<?= $person->getFullName() ?>" data-person_id="<?= $iPersonID ?>"><i class="fa-solid fa-trash-can"></i> <?= gettext("Delete this Record") ?></a>
                 <?php
             }
             ?>
@@ -402,19 +402,19 @@ $bOkToEdit = (
             if (AuthenticationManager::getCurrentUser()->isAdmin()) {
                 if (!$person->isUser()) {
                     ?>
-                    <a class="btn btn-app" href="<?= SystemURLs::getRootPath() ?>/UserEditor.php?NewPersonID=<?= $iPersonID ?>"><i class="fa fa-person-chalkboard"></i> <?= gettext('Make User') ?></a>
+                    <a class="btn btn-app" href="<?= SystemURLs::getRootPath() ?>/UserEditor.php?NewPersonID=<?= $iPersonID ?>"><i class="fa-solid fa-person-chalkboard"></i> <?= gettext('Make User') ?></a>
                     <?php
                 } else {
                     ?>
-                    <a class="btn btn-app" href="<?= SystemURLs::getRootPath() ?>/UserEditor.php?PersonID=<?= $iPersonID ?>"><i class="fa fa-user-secret"></i> <?= gettext('Edit User') ?></a>
-                    <a class="btn btn-app" href="<?= SystemURLs::getRootPath() ?>/v2/user/<?= $iPersonID ?>"><i class="fa fa-eye"></i> <?= gettext('View User') ?></a>
-                    <a class="btn btn-app" href="<?= SystemURLs::getRootPath() ?>/v2/user/<?= $iPersonID ?>/changePassword"><i class="fa fa-key"></i> <?= gettext("Change Password") ?></a>
+                    <a class="btn btn-app" href="<?= SystemURLs::getRootPath() ?>/UserEditor.php?PersonID=<?= $iPersonID ?>"><i class="fa-solid fa-user-secret"></i> <?= gettext('Edit User') ?></a>
+                    <a class="btn btn-app" href="<?= SystemURLs::getRootPath() ?>/v2/user/<?= $iPersonID ?>"><i class="fa-solid fa-eye"></i> <?= gettext('View User') ?></a>
+                    <a class="btn btn-app" href="<?= SystemURLs::getRootPath() ?>/v2/user/<?= $iPersonID ?>/changePassword"><i class="fa-solid fa-key"></i> <?= gettext("Change Password") ?></a>
                     <?php
                 }
             } elseif ($person->isUser() && $person->getId() == AuthenticationManager::getCurrentUser()->getId()) {
                 ?>
-                <a class="btn btn-app" href="<?= SystemURLs::getRootPath() ?>/v2/user/<?= $iPersonID ?>"><i class="fa fa-eye"></i> <?= gettext('View User') ?></a>
-                <a class="btn btn-app" href="<?= SystemURLs::getRootPath() ?>/v2/user/current/changepassword"><i class="fa fa-key"></i> <?= gettext("Change Password") ?></a>
+                <a class="btn btn-app" href="<?= SystemURLs::getRootPath() ?>/v2/user/<?= $iPersonID ?>"><i class="fa-solid fa-eye"></i> <?= gettext('View User') ?></a>
+                <a class="btn btn-app" href="<?= SystemURLs::getRootPath() ?>/v2/user/current/changepassword"><i class="fa-solid fa-key"></i> <?= gettext("Change Password") ?></a>
                 <?php
             } ?>
         </div>
@@ -470,15 +470,15 @@ $bOkToEdit = (
                                             </td>
                                             <td style="width: 20%;">
                                                 <a class="AddToPeopleCart" data-cartpersonid="<?= $tmpPersonId ?>">
-                                                    <i class="fa fa-cart-plus "></i>
+                                                    <i class="fa-solid fa-cart-plus "></i>
                                                 </a>
                                                 <?php if ($bOkToEdit) {
                                                     ?>
                                                     <a href="<?= SystemURLs::getRootPath() ?>/PersonEditor.php?PersonID=<?= $tmpPersonId ?>">
-                                                        <i class="fas fa-pen "></i>
+                                                        <i class="fa-solid fa-pen "></i>
                                                     </a>
                                                     <a class="delete-person" data-person_name="<?= $familyMember->getFullName() ?>" data-person_id="<?= $familyMember->getId() ?>" data-view="family">
-                                                        <i class="fa fa-trash-can btn-danger"></i>
+                                                        <i class="fa-solid fa-trash-can btn-danger"></i>
                                                     </a>
                                                     <?php
                                                 } ?>
@@ -516,18 +516,18 @@ $bOkToEdit = (
                                                 ?>
                                                 <?php if (isset($item["editLink"])) {
                                                     ?>
-                                                    <a href="<?= $item["editLink"] ?>"><button type="button" class="btn btn-xs btn-primary"><i class="fa fa-pen"></i></button></a>
+                                                    <a href="<?= $item["editLink"] ?>"><button type="button" class="btn btn-xs btn-primary"><i class="fa-solid fa-pen"></i></button></a>
                                                     <?php
                                                 }
                                                 if (isset($item["deleteLink"])) {
                                                     ?>
-                                                    <a href="<?= $item["deleteLink"] ?>"><button type="button" class="btn btn-xs btn-danger"><i class="fa fa-trash"></i></button></a>
+                                                    <a href="<?= $item["deleteLink"] ?>"><button type="button" class="btn btn-xs btn-danger"><i class="fa-solid fa-trash"></i></button></a>
                                                     <?php
                                                 } ?>
                                                 &nbsp;
                                                 <?php
                                             } ?>
-                                            <i class="fa fa-clock"></i> <?= $item['datetime'] ?></span>
+                                            <i class="fa-solid fa-clock"></i> <?= $item['datetime'] ?></span>
 
                                         <?php if ($item['slim']) {
                                             ?>
@@ -572,7 +572,7 @@ $bOkToEdit = (
                                     ?>
                                     <br>
                                     <div class="alert alert-warning">
-                                        <i class="fa fa-question-circle fa-fw fa-lg"></i> <span><?= gettext('No group assignments.') ?></span>
+                                        <i class="fa-solid fa-question-circle fa-fw fa-lg"></i> <span><?= gettext('No group assignments.') ?></span>
                                     </div>
                                     <?php
                                 } else {
@@ -622,7 +622,7 @@ $bOkToEdit = (
                                                     <code>
                                                         <?php if (AuthenticationManager::getCurrentUser()->isManageGroupsEnabled()) {
                                                             ?>
-                                                            <a href="<?= SystemURLs::getRootPath() ?>/GroupView.php?GroupID=<?= $grp_ID ?>" class="btn btn-default" role="button"><i class="fa fa-list"></i></a>
+                                                            <a href="<?= SystemURLs::getRootPath() ?>/GroupView.php?GroupID=<?= $grp_ID ?>" class="btn btn-default" role="button"><i class="fa-solid fa-list"></i></a>
                                                             <div class="btn-group">
                                                                 <button type="button" class="btn btn-default"><?= gettext('Action') ?></button>
                                                                 <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
@@ -639,7 +639,7 @@ $bOkToEdit = (
                                                                 </ul>
                                                             </div>
                                                             <div class="btn-group">
-                                                                <button data-groupid="<?= $grp_ID ?>" data-groupname="<?= $grp_Name ?>" type="button" class="btn btn-danger groupRemove" data-toggle="dropdown"><i class="fa fa-trash-can"></i></button>
+                                                                <button data-groupid="<?= $grp_ID ?>" data-groupname="<?= $grp_Name ?>" type="button" class="btn btn-danger groupRemove" data-toggle="dropdown"><i class="fa-solid fa-trash-can"></i></button>
                                                             </div>
                                                             <?php
                                                         } ?>
@@ -667,7 +667,7 @@ $bOkToEdit = (
                                 <?php if (mysqli_num_rows($rsAssignedProperties) === 0) : ?>
                                     <br>
                                     <div class="alert alert-warning">
-                                        <i class="fa fa-question-circle fa-fw fa-lg"></i> <span><?= gettext('No property assignments.') ?></span>
+                                        <i class="fa-solid fa-question-circle fa-fw fa-lg"></i> <span><?= gettext('No property assignments.') ?></span>
                                     </div>
                                 <?php else : ?>
                                     <table class="table table-condensed dt-responsive" id="assigned-properties-table" width="100%">
@@ -695,7 +695,7 @@ $bOkToEdit = (
                                                     <?php if ($bOkToEdit) { ?>
                                                         <td>
                                                             <a class="btn remove-property-btn" data-property_id="<?= $pro_ID ?>">
-                                                                <i class="fa fa-trash"></i>
+                                                                <i class="fa-solid fa-trash"></i>
                                                             </a>
                                                         </td>
                                                     <?php } ?>
@@ -772,7 +772,7 @@ $bOkToEdit = (
                                     ?>
                                     <br>
                                     <div class="alert alert-warning">
-                                        <i class="fa fa-question-circle fa-fw fa-lg"></i> <span><?= gettext('No volunteer opportunity assignments.') ?></span>
+                                        <i class="fa-solid fa-question-circle fa-fw fa-lg"></i> <span><?= gettext('No volunteer opportunity assignments.') ?></span>
                                     </div>
                                     <?php
                                 } else {

--- a/src/QueryView.php
+++ b/src/QueryView.php
@@ -219,8 +219,8 @@ function DoQuery()
                 <td>
                     <a class="AddToPeopleCart"  data-cartpersonid="<?= $aRow[$iCount] ?>">
                         <span class="fa-stack">
-                        <i class="fa fa-square fa-stack-2x"></i>
-                        <i class="fa fa-cart-plus fa-stack-1x fa-inverse"></i>
+                        <i class="fa-solid fa-square fa-stack-2x"></i>
+                        <i class="fa-solid fa-cart-plus fa-stack-1x fa-inverse"></i>
                         </span>
                     </a>
                 </td>

--- a/src/RestoreDatabase.php
+++ b/src/RestoreDatabase.php
@@ -65,7 +65,7 @@ require_once 'Include/Header.php';
       .done(function (data) {
         if (data.Messages.length > 0) {
           $.each(data.Messages, function (index, value) {
-            var inhtml = '<h4><i class="icon fa fa-ban"></i> Alert!</h4>' + value;
+            var inhtml = '<h4><i class="icon fa-solid fa-ban"></i> Alert!</h4>' + value;
             $("<div>").addClass("alert alert-danger").html(inhtml).appendTo("#restoreMessages");
           });
         }

--- a/src/SystemDBUpdate.php
+++ b/src/SystemDBUpdate.php
@@ -40,7 +40,7 @@ require_once 'Include/HeaderNotLoggedIn.php'; ?>
 
     <div class="error-content">
         <div class="row">
-            <h3><i class="fa fa-triangle-exclamation text-yellow"></i> <?= gettext('Upgrade Required') ?></h3>
+            <h3><i class="fa-solid fa-triangle-exclamation text-yellow"></i> <?= gettext('Upgrade Required') ?></h3>
             <p>
                 <?= gettext("Current DB Version" . ": " . VersionUtils::getDBVersion()) ?> <br/>
                 <?= gettext("Current Software Version" . ": " . VersionUtils::getInstalledVersion()) ?> <br/>
@@ -54,7 +54,7 @@ require_once 'Include/HeaderNotLoggedIn.php'; ?>
                 <form id="dbUpgradeForm">
                     <input type="hidden" name="upgrade" value="true"/>
                     <button type="submit" class="btn btn-primary btn-block btn-flat" id="upgradeDatabase"><i
-                            class="fa fa-database"></i> <?= gettext('Upgrade database') ?></button>
+                            class="fa-solid fa-database"></i> <?= gettext('Upgrade database') ?></button>
                 </form>
         </div>
         <?php
@@ -62,7 +62,7 @@ require_once 'Include/HeaderNotLoggedIn.php'; ?>
         ?>
         <div class="main-box-body clearfix" id="globalMessage">
             <div class="callout callout-danger fade in" id="globalMessageCallOut">
-                <i class="fa fa-triangle-exclamation fa-fw fa-lg"></i> <?= $errorMessage ?>
+                <i class="fa-solid fa-triangle-exclamation fa-fw fa-lg"></i> <?= $errorMessage ?>
             </div>
         </div>
         <?php

--- a/src/SystemSettings.php
+++ b/src/SystemSettings.php
@@ -213,12 +213,12 @@ require_once 'Include/Header.php';
                   <td>
                     <?php if (!empty($setting->getTooltip())) {
                         ?>
-                      <a class="setting-tip" data-tip="<?= $setting->getTooltip() ?>"><i class="fa fa-fw fa-question-circle"></i></a>
+                      <a class="setting-tip" data-tip="<?= $setting->getTooltip() ?>"><i class="fa-solid fa-fw fa-question-circle"></i></a>
                         <?php
                     }
                     if (!empty($setting->getUrl())) {
                         ?>
-                      <a href="<?= $setting->getUrl() ?>" target="_blank"><i class="fa fa-fw fa-link"></i></a>
+                      <a href="<?= $setting->getUrl() ?>" target="_blank"><i class="fa-solid fa-fw fa-link"></i></a>
                         <?php
                     } ?>
                     <?= $display_default ?>

--- a/src/UpgradeCRM.php
+++ b/src/UpgradeCRM.php
@@ -38,7 +38,7 @@ Header_body_scripts();
     if (count($preUpgradeTasks) > 0) {
         ?>
     <div>
-      <i class="fa fa-bomb bg-red"></i>
+      <i class="fa-solid fa-bomb bg-red"></i>
       <div class="timeline-item" >
         <h3 class="timeline-header"><?= gettext('Warning: Pre-Upgrade Tasks Detected') ?> <span id="status1"></span></h3>
         <div class="timeline-body" id="preUpgradeCheckWarning">
@@ -68,7 +68,7 @@ Header_body_scripts();
     if (AppIntegrityService::getIntegrityCheckStatus() === gettext("Failed")) {
         ?>
     <div>
-      <i class="fa fa-bomb bg-red"></i>
+      <i class="fa-solid fa-bomb bg-red"></i>
       <div class="timeline-item" >
         <h3 class="timeline-header"><?= gettext('Warning: Signature mismatch') ?> <span id="status1"></span></h3>
         <div class="timeline-body" id="integrityCheckWarning" <?= count($preUpgradeTasks) > 0 ? 'style="display:none"' : '' ?>>
@@ -115,7 +115,7 @@ Header_body_scripts();
     }
     ?>
     <div>
-      <i class="fa fa-database bg-blue"></i>
+      <i class="fa-solid fa-database bg-blue"></i>
       <div class="timeline-item" >
         <h3 class="timeline-header"><?= gettext('Step 1: Backup Database') ?> <span id="status1"></span></h3>
         <div class="timeline-body" id="backupPhase" <?= (AppIntegrityService::getIntegrityCheckStatus() === gettext("Failed") || count($preUpgradeTasks) > 0) ? 'style="display:none"' : '' ?>>
@@ -128,7 +128,7 @@ Header_body_scripts();
       </div>
     </div>
     <div>
-      <i class="fa fa-cloud-download bg-blue"></i>
+      <i class="fa-solid fa-cloud-download bg-blue"></i>
       <div class="timeline-item" >
         <h3 class="timeline-header"><?= gettext('Step 2: Fetch Update Package on Server') ?> <span id="status2"></span></h3>
         <div class="timeline-body" id="fetchPhase" <?= $expertMode ? '' : 'style="display: none"' ?>>
@@ -138,7 +138,7 @@ Header_body_scripts();
       </div>
     </div>
     <div>
-      <i class="fa fa-cogs bg-blue"></i>
+      <i class="fa-solid fa-cogs bg-blue"></i>
       <div class="timeline-item" >
         <h3 class="timeline-header"><?= gettext('Step 3: Apply Update Package on Server') ?> <span id="status3"></span></h3>
         <div class="timeline-body" id="updatePhase" <?= $expertMode ? '' : 'style="display: none"' ?>>
@@ -156,7 +156,7 @@ Header_body_scripts();
       </div>
     </div>
     <div>
-      <i class="fa fa-right-to-bracket bg-blue"></i>
+      <i class="fa-solid fa-right-to-bracket bg-blue"></i>
       <div class="timeline-item" >
         <h3 class="timeline-header"><?= gettext('Step 4: Login') ?></h3>
         <div class="timeline-body" id="finalPhase" <?= $expertMode ? '' : 'style="display: none"' ?>>
@@ -186,7 +186,7 @@ Header_body_scripts();
   });
 
  $("#doBackup").click(function(){
-   $("#status1").html('<i class="fa fa-circle-notch fa-spin"></i>');
+   $("#status1").html('<i class="fa-solid fa-circle-notch fa-spin"></i>');
    window.CRM.APIRequest({
       method : 'POST',
       path : 'database/backup',
@@ -199,11 +199,11 @@ Header_body_scripts();
       $("#backupstatus").css("color","green");
       $("#backupstatus").html("<?= gettext('Backup Complete, Ready for Download.') ?>");
       $("#resultFiles").html(downloadButton);
-      $("#status1").html('<i class="fa fa-check" style="color:orange"></i>');
+      $("#status1").html('<i class="fa-solid fa-check" style="color:orange"></i>');
       $("#downloadbutton").click(function(){
         $("#fetchPhase").show("slow");
         $("#backupPhase").slideUp();
-        $("#status1").html('<i class="fa fa-check text-success"></i>');
+        $("#status1").html('<i class="fa-solid fa-check text-success"></i>');
       });
     }).fail(function()  {
       $("#backupstatus").css("color","red");
@@ -213,12 +213,12 @@ Header_body_scripts();
  });
 
  $("#fetchUpdate").click(function(){
-    $("#status2").html('<i class="fa fa-circle-notch fa-spin"></i>');
+    $("#status2").html('<i class="fa-solid fa-circle-notch fa-spin"></i>');
     window.CRM.APIRequest({
       type : 'GET',
       path  : 'systemupgrade/downloadlatestrelease',
     }).done(function(data){
-      $("#status2").html('<i class="fa fa-check text-success"></i>');
+      $("#status2").html('<i class="fa-solid fa-check text-success"></i>');
       window.CRM.updateFile=data;
       $("#updateFileName").text(data.fileName);
       $("#updateFullPath").text(data.fullPath);
@@ -231,7 +231,7 @@ Header_body_scripts();
  });
 
  $("#applyUpdate").click(function(){
-   $("#status3").html('<i class="fa fa-circle-notch fa-spin"></i>');
+   $("#status3").html('<i class="fa-solid fa-circle-notch fa-spin"></i>');
    $("#updatePhase").slideUp();
    window.CRM.APIRequest({
       method : 'POST',
@@ -241,7 +241,7 @@ Header_body_scripts();
         sha1: window.CRM.updateFile.sha1
       })
     }).done(function(data){
-      $("#status3").html('<i class="fa fa-check text-success"></i>');
+      $("#status3").html('<i class="fa-solid fa-check text-success"></i>');
       $("#finalPhase").show("slow");
     });
  });

--- a/src/UserList.php
+++ b/src/UserList.php
@@ -23,15 +23,15 @@ require_once 'Include/Header.php';
 <!-- Default box -->
 <div class="card">
     <div class="card-header">
-        <a href="UserEditor.php" class="btn btn-app"><i class="fa fa-user-plus"></i><?= gettext('New User') ?></a>
-        <a href="SettingsUser.php" class="btn btn-app"><i class="fa fa-wrench"></i><?= gettext('User Settings') ?></a>
+        <a href="UserEditor.php" class="btn btn-app"><i class="fa-solid fa-user-plus"></i><?= gettext('New User') ?></a>
+        <a href="SettingsUser.php" class="btn btn-app"><i class="fa-solid fa-wrench"></i><?= gettext('User Settings') ?></a>
     </div>
 </div>
 <div class="card collapsed-card">
     <div class="card-header">
         <b class="card-title"><?= _("Global User Settings")?></b>
             <div class="card-tools pull-right">
-                <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fa fa-plus"></i></button>
+                <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fa-solid fa-plus"></i></button>
             </div>
         </b>
     </div>
@@ -49,7 +49,7 @@ require_once 'Include/Header.php';
                         <tr>
                             <?php $config = SystemConfig::getConfigItem("iSessionTimeout"); ?>
                             <td width="350px"><b><?= _("Session Timeout")?></b>:
-                                <a class="setting-tip" data-tip="<?= $config->getTooltip() ?>"><i class="fa fa-fw fa-question-circle"></i></a>
+                                <a class="setting-tip" data-tip="<?= $config->getTooltip() ?>"><i class="fa-solid fa-fw fa-question-circle"></i></a>
                             </td>
                             <td>
                                 <input disabled type="text" class="system-setting form-control" data-setting="<?= $config->getName()?>" data-default-value="<?= $config->getDefault()?>" value="<?= $config->getValue()?>">
@@ -59,7 +59,7 @@ require_once 'Include/Header.php';
                             <?php $config = SystemConfig::getConfigItem("iMaxFailedLogins"); ?>
                             <td width="350px">
                                 <b><?= _("Max Failed Login")?></b>:
-                                <a class="setting-tip" data-tip="<?= $config->getTooltip() ?>"><i class="fa fa-fw fa-question-circle"></i></a>
+                                <a class="setting-tip" data-tip="<?= $config->getTooltip() ?>"><i class="fa-solid fa-fw fa-question-circle"></i></a>
                             </td>
                             <td>
                                 <input disabled type="text" class="system-setting form-control" data-setting="<?= $config->getName()?>" data-default-value="<?= $config->getDefault()?>" value="<?= $config->getValue()?>">
@@ -68,7 +68,7 @@ require_once 'Include/Header.php';
                         <tr>
                             <?php $config = SystemConfig::getConfigItem("bEnableLostPassword"); ?>
                             <td width="350px"><b><?= _("Enable Password Reset")?></b>:
-                                <a class="setting-tip" data-tip="<?= $config->getTooltip() ?>"><i class="fa fa-fw fa-question-circle"></i></a>
+                                <a class="setting-tip" data-tip="<?= $config->getTooltip() ?>"><i class="fa-solid fa-fw fa-question-circle"></i></a>
                             </td>
                             <td>
                                 <input disabled type="checkbox" class="system-setting " data-setting="<?= $config->getName()?>" data-default-value="<?= $config->getDefault()?>" <?= $config->getBooleanValue() ? "checked" : "" ?>>
@@ -77,7 +77,7 @@ require_once 'Include/Header.php';
                         <tr>
                             <?php $config = SystemConfig::getConfigItem("bSendUserDeletedEmail"); ?>
                             <td width="350px"><b><?= _("Send email to Deleted Users")?></b>:
-                                <a class="setting-tip" data-tip="<?= $config->getTooltip() ?>"><i class="fa fa-fw fa-question-circle"></i></a>
+                                <a class="setting-tip" data-tip="<?= $config->getTooltip() ?>"><i class="fa-solid fa-fw fa-question-circle"></i></a>
                             </td>
                             <td>
                                 <input disabled type="checkbox" class="system-setting " data-setting="<?= $config->getName()?>" data-default-value="<?= $config->getDefault()?>" <?= $config->getBooleanValue() ? "checked" : "" ?>>
@@ -91,7 +91,7 @@ require_once 'Include/Header.php';
                         <tr>
                         <?php $config = SystemConfig::getConfigItem("iMinPasswordLength"); ?>
                             <td width="350px"><b><?= _("Min Password Length")?></b>:
-                                <a class="setting-tip" data-tip="<?= $config->getTooltip() ?>"><i class="fa fa-fw fa-question-circle"></i></a>
+                                <a class="setting-tip" data-tip="<?= $config->getTooltip() ?>"><i class="fa-solid fa-fw fa-question-circle"></i></a>
                             </td>
                             <td>
                                 <input disabled type="text" class="system-setting form-control" data-setting="<?= $config->getName()?>" data-default-value="<?= $config->getDefault()?>" value="<?= $config->getValue()?>">
@@ -101,7 +101,7 @@ require_once 'Include/Header.php';
                         <?php $config = SystemConfig::getConfigItem("iMinPasswordChange"); ?>
                         <td>
                             <b><?= _("Min Password Characters Delta")?></b>:
-                            <a class="setting-tip" data-tip="<?= $config->getTooltip() ?>"><i class="fa fa-fw fa-question-circle"></i></a>
+                            <a class="setting-tip" data-tip="<?= $config->getTooltip() ?>"><i class="fa-solid fa-fw fa-question-circle"></i></a>
                         </td>
                         <td>
                             <input disabled type="text" class="system-setting form-control" data-setting="<?= $config->getName()?>" data-default-value="<?= $config->getDefault()?>" value="<?= $config->getValue()?>">
@@ -111,7 +111,7 @@ require_once 'Include/Header.php';
                         <?php $config = SystemConfig::getConfigItem("aDisallowedPasswords"); ?>
                         <td>
                             <b><?= _("Disallowed Passwords")?></b>:
-                            <a class="setting-tip" data-tip="<?= $config->getTooltip() ?>"><i class="fa fa-fw fa-question-circle"></i></a>
+                            <a class="setting-tip" data-tip="<?= $config->getTooltip() ?>"><i class="fa-solid fa-fw fa-question-circle"></i></a>
                         </td>
                         <td>
                             <input disabled type="text" class="system-setting form-control" data-setting="<?= $config->getName()?>" data-default-value="<?= $config->getDefault()?>" value="<?= $config->getValue()?>" width="300px">
@@ -127,7 +127,7 @@ require_once 'Include/Header.php';
                         <?php $config = SystemConfig::getConfigItem("bEnable2FA"); ?>
                         <td width="350px">
                             <b><?= _("Enable 2FA")?></b>:
-                            <a class="setting-tip" data-tip="<?= $config->getTooltip() ?>"><i class="fa fa-fw fa-question-circle"></i></a>
+                            <a class="setting-tip" data-tip="<?= $config->getTooltip() ?>"><i class="fa-solid fa-fw fa-question-circle"></i></a>
                         </td>
                         <td>
                             <input disabled type="checkbox" class="system-setting " data-setting="<?= $config->getName()?>" data-default-value="<?= $config->getDefault()?>" <?= $config->getBooleanValue() ? "checked" : "" ?>
@@ -137,7 +137,7 @@ require_once 'Include/Header.php';
                         <?php $config = SystemConfig::getConfigItem("bRequire2FA"); ?>
                         <td>
                             <b><?= _("Require 2FA")?></b>:
-                            <a class="setting-tip" data-tip="<?= $config->getTooltip() ?>"><i class="fa fa-fw fa-question-circle"></i></a>
+                            <a class="setting-tip" data-tip="<?= $config->getTooltip() ?>"><i class="fa-solid fa-fw fa-question-circle"></i></a>
                         </td>
                         <td>
                             <input disabled type="checkbox" class="system-setting " data-setting="<?= $config->getName()?>" data-default-value="<?= $config->getDefault()?>" <?= $config->getBooleanValue() ? "checked" : "" ?>
@@ -147,7 +147,7 @@ require_once 'Include/Header.php';
                         <?php $config = SystemConfig::getConfigItem("s2FAApplicationName"); ?>
                         <td>
                             <b><?= _("2FA Application Name")?></b>:
-                            <a class="setting-tip" data-tip="<?= $config->getTooltip() ?>"><i class="fa fa-fw fa-question-circle"></i></a>
+                            <a class="setting-tip" data-tip="<?= $config->getTooltip() ?>"><i class="fa-solid fa-fw fa-question-circle"></i></a>
                         </td>
                         <td>
                             <input disabled type="text" class="system-setting form-control" data-setting="<?= $config->getName()?>" data-default-value="<?= $config->getDefault()?>" value="<?= $config->getValue()?>">
@@ -169,7 +169,7 @@ require_once 'Include/Header.php';
     <div class="card-header">
         <b class="card-title"><?= _("User Listing")?></b>
         <div class="card-tools pull-right">
-            <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fa fa-minus"></i></button>
+            <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fa-solid fa-minus"></i></button>
         </div>
         </h3>
     </div>
@@ -192,14 +192,14 @@ require_once 'Include/Header.php';
                 <tr>
                     <td>
                         <a href="UserEditor.php?PersonID=<?= $user->getId() ?>">
-                            <i class="fas fa-pen" aria-hidden="true"></i>
+                            <i class="fa-solid fa-pen" aria-hidden="true"></i>
                         </a>&nbsp;&nbsp;
                         <a href="v2/user/<?= $user->getId() ?>">
-                            <i class="fa fa-eye" aria-hidden="true"></i>
+                            <i class="fa-solid fa-eye" aria-hidden="true"></i>
                         </a>&nbsp;&nbsp;
                         <?php if ($user->getId() != AuthenticationManager::getCurrentUser()->getId()) { ?>
                             <a href="#" onclick="deleteUser(<?= $user->getId() ?>, '<?= $user->getPerson()->getFullName() ?>')">
-                                <i class="fa fa-trash-can" aria-hidden="true"></i>
+                                <i class="fa-solid fa-trash-can" aria-hidden="true"></i>
                             </a>
                         <?php } ?>
                     </td>
@@ -216,17 +216,17 @@ require_once 'Include/Header.php';
                         }
                         if ($user->getFailedLogins() > 0) { ?>
                                 <a onclick="restUserLoginCount(<?= $user->getId() ?>, '<?= $user->getPerson()->getFullName() ?>')">
-                                    <i class="fa fa-eraser" aria-hidden="true"></i>
+                                    <i class="fa-solid fa-eraser" aria-hidden="true"></i>
                                 </a>
                         <?php } ?>
                     </td>
                     <td>
-                        <a href="v2/user/<?= $user->getId() ?>/changePassword"><i class="fa fa-wrench"></i></a
+                        <a href="v2/user/<?= $user->getId() ?>/changePassword"><i class="fa-solid fa-wrench"></i></a
                         >&nbsp;&nbsp;
                         <?php if ($user->getId() != AuthenticationManager::getCurrentUser()->getId() && !empty($user->getEmail())) {
                             ?>
                             <a href="#" onclick="resetUserPassword(<?= $user->getId() ?>, '<?= $user->getPerson()->getFullName() ?>')">
-                                <i class="fa fa-paper-plane"></i></a>
+                                <i class="fa-solid fa-paper-plane"></i></a>
                             <?php
                         } ?>
                     </td>

--- a/src/external/templates/404.php
+++ b/src/external/templates/404.php
@@ -12,7 +12,7 @@ require(SystemURLs::getDocumentRoot() . "/Include/HeaderNotLoggedIn.php");
   <div class="error-page">
     <h2 class="headline text-yellow">404</h2>
     <div class="error-content">
-      <h3><i class="fa fa-triangle-exclamation text-yellow"></i><?= gettext("Oops! Page not found.") ?></h3>
+      <h3><i class="fa-solid fa-triangle-exclamation text-yellow"></i><?= gettext("Oops! Page not found.") ?></h3>
       <p/>
       <h4><?= $message ?></h4>
     </div>

--- a/src/external/templates/registration/family-register.php
+++ b/src/external/templates/registration/family-register.php
@@ -35,11 +35,11 @@ if (!empty($sHeader)) {
             <h2><?= gettext("Family Info") ?></h2>
             <section>
                 <div class="form-group has-feedback">
-                    <span class="fa fa-user form-control-feedback"></span>
+                    <span class="fa-solid fa-user form-control-feedback"></span>
                     <input id="familyName" name="familyName" type="text" class="form-control" placeholder="<?= gettext('Family Name') ?>" required>
                 </div>
                 <div class="form-group has-feedback">
-                    <span class="fa fa-envelope form-control-feedback"></span>
+                    <span class="fa-solid fa-envelope form-control-feedback"></span>
                     <input id="familyAddress1" name="familyAddress1" class="form-control" placeholder="<?= gettext('Address') ?>" required>
                 </div>
                 <div class="form-group has-feedback">
@@ -68,7 +68,7 @@ if (!empty($sHeader)) {
                 </div>
                 <div class="form-group has-feedback">
                     <input id="familyHomePhone" name="familyHomePhone" class="form-control" placeholder="<?= gettext('Home Phone') ?>"  data-inputmask='"mask": "<?= SystemConfig::getValue('sPhoneFormat') ?>"' data-mask>
-                    <span class="fa fa-phone form-control-feedback"></span>
+                    <span class="fa-solid fa-phone form-control-feedback"></span>
                 </div>
                 <div class="form-group has-feedback">
                     <label><?= gettext('How many people are in your family') ?></label>
@@ -138,7 +138,7 @@ if (!empty($sHeader)) {
                             <div class="form-group has-feedback">
                                 <div class="input-group">
                                     <div class="input-group-addon">
-                                        <i class="fa fa-envelope"></i>
+                                        <i class="fa-solid fa-envelope"></i>
                                     </div>
                                     <input id="memberEmail-<?= $x ?>" class="form-control" maxlength="50" placeholder="<?= gettext('Email') ?>" type="email">
                                 </div>
@@ -148,7 +148,7 @@ if (!empty($sHeader)) {
                                     <div class="col-lg-4">
                                         <div class="input-group">
                                             <div class="input-group-addon">
-                                                <i class="fa fa-phone"></i>
+                                                <i class="fa-solid fa-phone"></i>
                                             </div>
                                             <select id="memberPhoneType-<?= $x ?>" class="form-control">
                                                 <option value="mobile"><?= gettext('Mobile') ?></option>
@@ -170,7 +170,7 @@ if (!empty($sHeader)) {
                                     <div class="col-lg-6">
                                         <div class="input-group">
                                             <div class="input-group-addon">
-                                                <i class="fa fa-birthday-cake"></i>
+                                                <i class="fa-solid fa-birthday-cake"></i>
                                             </div>
                                             <input type="text" class="form-control inputDatePicker" id="memberBirthday-<?= $x ?>">
                                         </div>

--- a/src/external/templates/verify/enter-info.php
+++ b/src/external/templates/verify/enter-info.php
@@ -19,19 +19,19 @@ require(SystemURLs::getDocumentRoot() . "/Include/HeaderNotLoggedIn.php");
             <form action="<?= SystemURLs::getRootPath() ?>/external/verify/" method="post">
                 <div class="form-group has-feedback">
                     <input name="firstName" type="text" class="form-control" placeholder="<?= gettext("First Name") ?>" required>
-                    <span class="fa fa-user form-control-feedback"></span>
+                    <span class="fa-solid fa-user form-control-feedback"></span>
                 </div>
                 <div class="form-group has-feedback">
                     <input name="lastName" type="text" class="form-control" placeholder="<?= gettext("Last Name") ?>" required>
-                    <span class="fa fa-user form-control-feedback"></span>
+                    <span class="fa-solid fa-user form-control-feedback"></span>
                 </div>
                 <div class="form-group has-feedback">
                     <input name="zip" type="text" class="form-control" placeholder="<?= gettext("Zip") ?>" required>
-                    <span class="fa fa-user form-control-feedback"></span>
+                    <span class="fa-solid fa-user form-control-feedback"></span>
                 </div>
                 <div class="form-group has-feedback">
                     <input name="email" type="text" class="form-control" placeholder="<?= gettext("Email") ?>" required>
-                    <span class="fa fa-user form-control-feedback"></span>
+                    <span class="fa-solid fa-user form-control-feedback"></span>
                 </div>
                 <div class="row">
                     <div class="col-xs-12 text-center">

--- a/src/external/templates/verify/verify-family-info.php
+++ b/src/external/templates/verify/verify-family-info.php
@@ -14,7 +14,7 @@ $doShowMap = !(empty($family->getLatitude()) && empty($family->getLongitude()));
 ?>
   <div class="row">
     <div id="right-buttons" class="btn-group" role="group">
-      <button type="button" id="verify" class="btn btn-sm" data-toggle="modal" data-target="#confirm-Verify"><div class="btn-txt"><?=gettext("Confirm")?></div><i class="fa fa-check fa-5x"></i>  </button>
+      <button type="button" id="verify" class="btn btn-sm" data-toggle="modal" data-target="#confirm-Verify"><div class="btn-txt"><?=gettext("Confirm")?></div><i class="fa-solid fa-check fa-5x"></i>  </button>
     </div>
   </div>
   <div class="card card-info" id="verifyBox">
@@ -22,21 +22,21 @@ $doShowMap = !(empty($family->getLatitude()) && empty($family->getLongitude()));
       <img class="img-circle center-block pull-right img-responsive initials-image" width="200" height="200" src="data:image/png;base64,<?= base64_encode($family->getPhoto()->getThumbnailBytes()) ?>" >
       <h2><?= $family->getName() ?></h2>
       <div class="text-muted font-bold m-b-xs">
-        <i class="fa fa-fw fa-map-marker" title="<?= gettext("Home Address")?>"></i><?= $family->getAddress() ?><br/>
+        <i class="fa-solid fa-fw fa-map-marker" title="<?= gettext("Home Address")?>"></i><?= $family->getAddress() ?><br/>
           <?php if (!empty($family->getHomePhone())) { ?>
-          <i class="fa fa-fw fa-phone" title="<?= gettext("Home Phone")?>"> </i>(H) <?= $family->getHomePhone() ?><br/>
+          <i class="fa-solid fa-fw fa-phone" title="<?= gettext("Home Phone")?>"> </i>(H) <?= $family->getHomePhone() ?><br/>
           <?php }  if (!empty($family->getEmail())) { ?>
-          <i class="fa fa-fw fa-envelope" title="<?= gettext("Family Email") ?>"></i><?= $family->getEmail() ?><br/>
+          <i class="fa-solid fa-fw fa-envelope" title="<?= gettext("Family Email") ?>"></i><?= $family->getEmail() ?><br/>
               <?php
           }
           if ($family->getWeddingDate() !== null) {
                 ?>
-            <i class="fa fa-fw fa-heart" title="<?= gettext("Wedding Date")?>"></i><?= $family->getWeddingDate()->format(SystemConfig::getValue("sDateFormatLong")) ?><br/>
+            <i class="fa-solid fa-fw fa-heart" title="<?= gettext("Wedding Date")?>"></i><?= $family->getWeddingDate()->format(SystemConfig::getValue("sDateFormatLong")) ?><br/>
               <?php
           }
             ?>
 
-        <i class="fa fa-fw fa-newspaper" title="<?= gettext("Send Newsletter")?>"></i><?= $family->getSendNewsletter() ?><br/>
+        <i class="fa-solid fa-fw fa-newspaper" title="<?= gettext("Send Newsletter")?>"></i><?= $family->getSendNewsletter() ?><br/>
       </div>
     </div>
     <div class="border-right border-left">
@@ -48,7 +48,7 @@ $doShowMap = !(empty($family->getLatitude()) && empty($family->getLongitude()));
     </div>
     <div class="card card-solid">
       <div class="card-header">
-        <i class="fa fa-users"></i>
+        <i class="fa-solid fa-users"></i>
         <h3 class="card-title"><?= gettext("Family Member(s)")?></h3>
       </div>
       <div class="row row-flex row-flex-wrap">
@@ -61,23 +61,23 @@ $doShowMap = !(empty($family->getLatitude()) && empty($family->getLongitude()));
                 <h3 class="profile-username text-center"><?= $person->getTitle() ?> <?= $person->getFullName() ?></h3>
 
                 <p class="text-muted text-center"><i
-                    class="fa fa-fw fa-<?= ($person->isMale() ? "male" : "female") ?>"></i> <?= $person->getFamilyRoleName() ?>
+                    class="fa-solid fa-fw fa-<?= ($person->isMale() ? "male" : "female") ?>"></i> <?= $person->getFamilyRoleName() ?>
                 </p>
 
                 <ul class="list-group list-group-unbordered">
                   <li class="list-group-item">
                       <?php if (!empty($person->getHomePhone())) { ?>
-                    <i class="fa fa-fw fa-phone" title="<?= gettext("Home Phone")?>"></i>(H) <?= $person->getHomePhone() ?><br/>
+                    <i class="fa-solid fa-fw fa-phone" title="<?= gettext("Home Phone")?>"></i>(H) <?= $person->getHomePhone() ?><br/>
                       <?php }  if (!empty($person->getWorkPhone())) { ?>
-                    <i class="fa fa-fw fa-briefcase" title="<?= gettext("Work Phone")?>"></i>(W) <?= $person->getWorkPhone() ?><br/>
+                    <i class="fa-solid fa-fw fa-briefcase" title="<?= gettext("Work Phone")?>"></i>(W) <?= $person->getWorkPhone() ?><br/>
                       <?php }  if (!empty($person->getCellPhone())) { ?>
-                    <i class="fa fa-fw fa-mobile" title="<?= gettext("Mobile Phone")?>"></i>(M) <?= $person->getCellPhone() ?><br/>
+                    <i class="fa-solid fa-fw fa-mobile" title="<?= gettext("Mobile Phone")?>"></i>(M) <?= $person->getCellPhone() ?><br/>
                       <?php }  if (!empty($person->getEmail())) { ?>
-                    <i class="fa fa-fw fa-envelope" title="<?= gettext("Email")?>"></i>(H) <?= $person->getEmail() ?><br/>
+                    <i class="fa-solid fa-fw fa-envelope" title="<?= gettext("Email")?>"></i>(H) <?= $person->getEmail() ?><br/>
                       <?php }  if (!empty($person->getWorkEmail())) { ?>
-                    <i class="fa fa-fw fa-envelope" title="<?= gettext("Work Email")?>"></i>(W) <?= $person->getWorkEmail() ?><br/>
+                    <i class="fa-solid fa-fw fa-envelope" title="<?= gettext("Work Email")?>"></i>(W) <?= $person->getWorkEmail() ?><br/>
                       <?php }  ?>
-                    <i class="fa fa-fw fa-cake-candles" title="<?= gettext("Birthday")?>"></i> <?= $person->getFormattedBirthDate() ?><br/>
+                    <i class="fa-solid fa-fw fa-cake-candles" title="<?= gettext("Birthday")?>"></i> <?= $person->getFormattedBirthDate() ?><br/>
                   </li>
                   <li class="list-group-item">
                     <b>Classification:</b> <?= Classification::getName($person->getClsId()) ?>

--- a/src/kiosk/templates/404.php
+++ b/src/kiosk/templates/404.php
@@ -12,7 +12,7 @@ require(SystemURLs::getDocumentRoot() . "/Include/HeaderNotLoggedIn.php");
   <div class="error-page">
     <h2 class="headline text-yellow">404</h2>
     <div class="error-content">
-      <h3><i class="fa fa-triangle-exclamation text-yellow"></i><?= gettext("Oops! Page not found.") ?></h3>
+      <h3><i class="fa-solid fa-triangle-exclamation text-yellow"></i><?= gettext("Oops! Page not found.") ?></h3>
       <p/>
       <h4><?= $message ?></h4>
     </div>

--- a/src/kiosk/templates/kioskDevices/sunday-school-class-view.php
+++ b/src/kiosk/templates/kioskDevices/sunday-school-class-view.php
@@ -24,7 +24,7 @@ require(SystemURLs::getDocumentRoot() . "/Include/HeaderNotLoggedIn.php");
     </div>
   </div>
   <div class="container" id="classMemberContainer"></div>
-  <!-- TODO: Add a quick-entry screen for new people <a id="newStudent"><i class="fa fa-plus-circle" aria-hidden="true"></i></a>-->
+  <!-- TODO: Add a quick-entry screen for new people <a id="newStudent"><i class="fa-solid fa-plus-circle" aria-hidden="true"></i></a>-->
 </div>
 
 <script src="<?= SystemURLs::getRootPath() ?>/skin/js/KioskJSOM.js"></script>

--- a/src/session/templates/begin-session.php
+++ b/src/session/templates/begin-session.php
@@ -39,7 +39,7 @@ require SystemURLs::getDocumentRoot() . '/Include/HeaderNotLoggedIn.php';
                         <input type="text" id="UserBox" name="User"  class="form-control" placeholder="<?= gettext('Email/Username') ?>" value="<?= $prefilledUserName ?>" required autofocus>
                         <div class="input-group-append">
                             <div class="input-group-text">
-                                <span class="fas fa-envelope"></span>
+                                <span class="fa-solid fa-envelope"></span>
                             </div>
                         </div>
                     </div>

--- a/src/session/templates/error.php
+++ b/src/session/templates/error.php
@@ -12,7 +12,7 @@ require(SystemURLs::getDocumentRoot() . "/Include/HeaderNotLoggedIn.php");
   <div class="error-page">
     <h2 class="headline text-yellow">404</h2>
     <div class="error-content">
-      <h3><i class="fa fa-triangle-exclamation text-yellow"></i><?= gettext("Authentication Issue") ?></h3>
+      <h3><i class="fa-solid fa-triangle-exclamation text-yellow"></i><?= gettext("Authentication Issue") ?></h3>
       <p/>
       <h4><?= $message ?></h4>
     </div>

--- a/src/session/templates/password/enter-username.php
+++ b/src/session/templates/password/enter-username.php
@@ -29,7 +29,7 @@ require(SystemURLs::getDocumentRoot() . "/Include/HeaderNotLoggedIn.php");
                 <input id="username" type="text" class="form-control" placeholder="<?= gettext('Login Name') ?>" required autofocus>
                 <div class="input-group-append">
                     <div class="input-group-text">
-                        <span class="fas fa-user form-control-feedback"></span>
+                        <span class="fa-solid fa-user form-control-feedback"></span>
                     </div>
                 </div>
             </div>
@@ -51,7 +51,7 @@ require(SystemURLs::getDocumentRoot() . "/Include/HeaderNotLoggedIn.php");
         $("#resetPassword").click(function (e) {
             var userName = $("#username").val();
             if (userName) {
-                $("#resetStatusText").html(i18next.t('Requesting Password Reset')+'<i class="fa fa-circle-notch fa-spin"></i>');
+                $("#resetStatusText").html(i18next.t('Requesting Password Reset')+'<i class="fa-solid fa-circle-notch fa-spin"></i>');
                 $.ajax({
                     method: "POST",
                     url: "<?= $PasswordResetXHREndpoint ?>",

--- a/src/session/templates/two-factor.php
+++ b/src/session/templates/two-factor.php
@@ -27,7 +27,7 @@ require SystemURLs::getDocumentRoot() . '/Include/HeaderNotLoggedIn.php';
                 <!-- /.col -->
                 <div class="col-xs-5">
                     <button type="submit" class="btn btn-primary btn-block btn-flat"><i
-                                class="fa fa-right-to-bracket"></i> <?= gettext('Login') ?></button>
+                                class="fa-solid fa-right-to-bracket"></i> <?= gettext('Login') ?></button>
                 </div>
             </div>
         </form>

--- a/src/setup/templates/setup-error.php
+++ b/src/setup/templates/setup-error.php
@@ -16,7 +16,7 @@ require_once '../Include/HeaderNotLoggedIn.php';
   <div class="error-page">
     <h2 class="headline text-yellow">500</h2>
     <div class="error-content">
-      <h3><i class="fa fa-triangle-exclamation text-yellow"></i> PHP <?= substr(phpversion(), 0, 3)   ?> not a supported </h3>
+      <h3><i class="fa-solid fa-triangle-exclamation text-yellow"></i> PHP <?= substr(phpversion(), 0, 3)   ?> not a supported </h3>
       <p/>
       <h4>See <a target="php" href="https://php.net/supported-versions.php" > supported versions</a></h4>
     </div>

--- a/src/skin/js/CRMJSOM.js
+++ b/src/skin/js/CRMJSOM.js
@@ -188,38 +188,38 @@ window.CRM.cart = {
                           <a  class="dropdown-item" href="' +
                     window.CRM.root +
                     '/v2/cart">\
-                              <i class="fa fa-shopping-cart text-green"></i> ' +
+                              <i class="fa-solid fa-shopping-cart text-green"></i> ' +
                     i18next.t("View Cart") +
                     '\
                           </a>\
                           <a  class="dropdown-item emptyCart" >\
-                              <i class="fa fa-trash text-danger"></i> ' +
+                              <i class="fa-solid fa-trash text-danger"></i> ' +
                     i18next.t("Empty Cart") +
                     ' \
                           </a>\
                            <a id="emptyCartToGroup" class="dropdown-item" >\
-                              <i class="fa fa-object-ungroup text-info"></i> ' +
+                              <i class="fa-solid fa-object-ungroup text-info"></i> ' +
                     i18next.t("Empty Cart to Group") +
                     '\
                           </a>\
                           <a href="' +
                     window.CRM.root +
                     '/CartToFamily.php"  class="dropdown-item">\
-                              <i class="fa fa fa-users text-info"></i> ' +
+                              <i class="fa-solid fa-users text-info"></i> ' +
                     i18next.t("Empty Cart to Family") +
                     '\
                           </a>\
                           <a href="' +
                     window.CRM.root +
                     '/CartToEvent.php" class="dropdown-item">\
-                              <i class="fas fa-clipboard-list text-info"></i> ' +
+                              <i class="fa-solid fa-clipboard-list text-info"></i> ' +
                     i18next.t("Empty Cart to Event") +
                     '\
                           </a>\
                           <a href="' +
                     window.CRM.root +
                     '/MapUsingGoogle.php?GroupID=0" class="dropdown-item">\
-                              <i class="fa fa-map-marker text-info"></i> ' +
+                              <i class="fa-solid fa-map-marker text-info"></i> ' +
                     i18next.t("Map Cart") +
                     "\
                           </a>\

--- a/src/skin/js/Calendar.js
+++ b/src/skin/js/Calendar.js
@@ -2,10 +2,10 @@ window.moveEventModal = {
     getButtons: function () {
         return {
             cancel: {
-                label: '<i class="fa fa-times"></i> ' + i18next.t("Cancel"),
+                label: '<i class="fa-solid fa-times"></i> ' + i18next.t("Cancel"),
             },
             confirm: {
-                label: '<i class="fa fa-check"></i> ' + i18next.t("Confirm"),
+                label: '<i class="fa-solid fa-check"></i> ' + i18next.t("Confirm"),
             },
         };
     },
@@ -133,13 +133,13 @@ window.calendarPropertiesModal = {
             calendar.AccessToken +
             '"/>' +
             (window.CRM.calendarJSArgs.isModifiable
-                ? '<a id="NewAccessToken" class="btn btn-warning"><i class="fa fa-repeat"></i>' +
+                ? '<a id="NewAccessToken" class="btn btn-warning"><i class="fa-solid fa-repeat"></i>' +
                   i18next.t("New Access Token") +
                   "</a>"
                 : "") +
             (window.CRM.calendarJSArgs.isModifiable &&
             calendar.AccessToken != null
-                ? '<a id="DeleteAccessToken" class="btn btn-danger"><i class="fa fa-trash-can"></i>' +
+                ? '<a id="DeleteAccessToken" class="btn btn-danger"><i class="fa-solid fa-trash-can"></i>' +
                   i18next.t("Delete Access Token") +
                   "</a>"
                 : "") +
@@ -693,7 +693,7 @@ function initializeNewCalendarButton() {
     if (window.CRM.calendarJSArgs.isModifiable) {
         var newCalendarButton =
             '<div class="strike">' +
-            '<span id="newCalendarButton"><i class="fa fa-plus-circle"></i></span>' +
+            '<span id="newCalendarButton"><i class="fa-solid fa-plus-circle"></i></span>' +
             "</div>";
 
         $("#userCalendars").after(newCalendarButton);

--- a/src/skin/js/DepositSlipEditor.js
+++ b/src/skin/js/DepositSlipEditor.js
@@ -139,12 +139,12 @@ function initDepositSlipEditor() {
             // This row is already open - close it
             row.child.hide();
             tr.removeClass("shown");
-            $(this).html('<i class="fa fa-plus-circle"></i>');
+            $(this).html('<i class="fa-solid fa-plus-circle"></i>');
         } else {
             // Open this row
             row.child(format(row.data())).show();
             tr.addClass("shown");
-            $(this).html('<i class="fa fa-minus-circle"></i>');
+            $(this).html('<i class="fa-solid fa-minus-circle"></i>');
         }
     });
 

--- a/src/skin/js/FamilyView.js
+++ b/src/skin/js/FamilyView.js
@@ -56,10 +56,10 @@ $(function () {
                     selectedFamilyProperties.push(propId);
 
                     let editIcon = allowEdit
-                        ? `<a href="${window.CRM.root}/PropertyAssign.php?FamilyID=${window.CRM.currentFamily}&PropertyID=${propId}"><button type="button" class="btn btn-xs btn-primary"><i class="fa fa-pen"></i></button></a>`
+                        ? `<a href="${window.CRM.root}/PropertyAssign.php?FamilyID=${window.CRM.currentFamily}&PropertyID=${propId}"><button type="button" class="btn btn-xs btn-primary"><i class="fa-solid fa-pen"></i></button></a>`
                         : "";
                     let deleteIcon = allowDelete
-                        ? `<div class="btn btn-xs btn-danger delete-property" data-property-id="${propId}" data-property-name="${propName}"><i class="fa fa-trash"></i></div>`
+                        ? `<div class="btn btn-xs btn-danger delete-property" data-property-id="${propId}" data-property-name="${propName}"><i class="fa-solid fa-trash"></i></div>`
                         : "";
 
                     $("#family-property-table").append(
@@ -138,7 +138,7 @@ $(function () {
                         row.GroupKey +
                         "&amp;linkBack=v2/family/" +
                         window.CRM.currentFamily +
-                        '"><i class="fas fa-pen bg-info"></i></a>'
+                        '"><i class="fa-solid fa-pen bg-info"></i></a>'
                     );
                 },
                 searchable: false,
@@ -156,7 +156,7 @@ $(function () {
                         row.GroupKey +
                         "&amp;linkBack=v2/family/" +
                         window.CRM.currentFamily +
-                        '"><i class="fa fa-trash bg-red"></i></a>'
+                        '"><i class="fa-solid fa-trash bg-red"></i></a>'
                     );
                 },
                 searchable: false,

--- a/src/skin/js/FindDepositSlip.js
+++ b/src/skin/js/FindDepositSlip.js
@@ -9,19 +9,19 @@ document.addEventListener("DOMContentLoaded", function () {
         );
         $("#exportSelectedRows").prop("disabled", !selectedRows);
         $("#exportSelectedRows").html(
-            '<i class="fa fa-download"></i> Export (' +
+            '<i class="fa-solid fa-download"></i> Export (' +
                 selectedRows +
                 ") Selected Rows (OFX)",
         );
         $("#exportSelectedRowsCSV").prop("disabled", !selectedRows);
         $("#exportSelectedRowsCSV").html(
-            '<i class="fa fa-download"></i> Export (' +
+            '<i class="fa-solid fa-download"></i> Export (' +
                 selectedRows +
                 ") Selected Rows (CSV)",
         );
         $("#generateDepositSlip").prop("disabled", !selectedRows);
         $("#generateDepositSlip").html(
-            '<i class="fa fa-download"></i> Generate Deposit Split for Selected (' +
+            '<i class="fa-solid fa-download"></i> Generate Deposit Split for Selected (' +
                 selectedRows +
                 ") Rows (PDF)",
         );
@@ -141,7 +141,7 @@ document.addEventListener("DOMContentLoaded", function () {
                         return (
                             "<a href='DepositSlipEditor.php?DepositSlipID=" +
                             full.Id +
-                            '\'><i class="fa fa-search-plus"></i></a>' +
+                            '\'><i class="fa-solid fa-search-plus"></i></a>' +
                             full.Id
                         );
                     } else {

--- a/src/skin/js/GroupEditor.js
+++ b/src/skin/js/GroupEditor.js
@@ -225,7 +225,7 @@ $("document").ready(function () {
                 render: function (data, type, full, meta) {
                     if (full.lst_OptionID == defaultRoleID) {
                         return (
-                            '<strong><i class="fa fa-check"></i>' +
+                            '<strong><i class="fa-solid fa-check"></i>' +
                             i18next.t("Default") +
                             "</strong>"
                         );
@@ -252,14 +252,14 @@ $("document").ready(function () {
                             sequenceCell +=
                                 '<button type="button" id="roleUp-' +
                                 full.lst_OptionID +
-                                '" class="btn rollOrder"> <i class="fa fa-arrow-up"></i></button>&nbsp;';
+                                '" class="btn rollOrder"> <i class="fa-solid fa-arrow-up"></i></button>&nbsp;';
                         }
                         sequenceCell += data;
                         if (data != roleCount) {
                             sequenceCell +=
                                 '&nbsp;<button type="button" id="roleDown-' +
                                 full.lst_OptionID +
-                                '" class="btn rollOrder"> <i class="fa fa-arrow-down"></i></button>';
+                                '" class="btn rollOrder"> <i class="fa-solid fa-arrow-down"></i></button>';
                         }
                         return sequenceCell;
                     } else {

--- a/src/skin/js/GroupView.js
+++ b/src/skin/js/GroupView.js
@@ -266,7 +266,7 @@ function initDataTable() {
                         i18next.t(thisRole?.OptionName) +
                         '<button class="changeMembership" data-personid=' +
                         full.PersonId +
-                        '><i class="fas fa-pen"></i></button>'
+                        '><i class="fa-solid fa-pen"></i></button>'
                     );
                 },
             },

--- a/src/skin/js/MainDashboard.js
+++ b/src/skin/js/MainDashboard.js
@@ -18,7 +18,7 @@ $(document).ready(function () {
                     window.CRM.root +
                     "/FamilyEditor.php?FamilyID=" +
                     row.FamilyId +
-                    '"><button class="btn btn-default"><i class="fas fa-pen"></i></button></a>'
+                    '"><button class="btn btn-default"><i class="fa-solid fa-pen"></i></button></a>'
                 );
             },
             searchable: false,
@@ -153,12 +153,12 @@ $(document).ready(function () {
                     window.CRM.root +
                     "/PersonView.php?PersonID=" +
                     row.PersonId +
-                    '"><button class="btn btn-default"><i class="fa fa-search-plus"></i></button></a> ' +
+                    '"><button class="btn btn-default"><i class="fa-solid fa-search-plus"></i></button></a> ' +
                     '<a href="' +
                     window.CRM.root +
                     "/PersonView.php?PersonID=" +
                     row.PersonId +
-                    '"><button class="btn btn-default"><i class="fas fa-pen"></i></button></a>'
+                    '"><button class="btn btn-default"><i class="fa-solid fa-pen"></i></button></a>'
                 );
             },
             searchable: false,

--- a/src/skin/js/MemberView.js
+++ b/src/skin/js/MemberView.js
@@ -26,10 +26,10 @@ $(".delete-person").click(function (event) {
             thisLink.data("person_name"),
         buttons: {
             cancel: {
-                label: '<i class="fa fa-times"></i> ' + i18next.t("Cancel"),
+                label: '<i class="fa-solid fa-times"></i> ' + i18next.t("Cancel"),
             },
             confirm: {
-                label: '<i class="fa fa-trash"></i> ' + i18next.t("Delete"),
+                label: '<i class="fa-solid fa-trash"></i> ' + i18next.t("Delete"),
                 className: "btn-danger",
             },
         },

--- a/src/skin/js/setup.js
+++ b/src/skin/js/setup.js
@@ -60,7 +60,7 @@ window.CRM.renderPrerequisite = function (prerequisite) {
     } else if (prerequisite.Satisfied === "pending") {
         td = {
             class: "text-orange",
-            html: '<i class="fa fa-spinner fa-spin"></i>',
+            html: '<i class="fa-solid fa-spinner fa-spin"></i>',
         };
     } else if (prerequisite.Satisfied === false) {
         td = {

--- a/src/sundayschool/SundaySchoolClassView.php
+++ b/src/sundayschool/SundaySchoolClassView.php
@@ -98,7 +98,7 @@ require_once '../Include/Header.php';
         ?>
       <div class="btn-group">
         <a class="btn btn-app" href="mailto:<?= mb_substr($sEmailLink, 0, -3) ?>"><i
-            class="fa fa-paper-plane"></i><?= gettext('Email') ?></a>
+            class="fa-solid fa-paper-plane"></i><?= gettext('Email') ?></a>
         <button type="button" class="btn btn-app dropdown-toggle" data-toggle="dropdown">
           <span class="caret"></span>
           <span class="sr-only"><?= gettext('Toggle Dropdown') ?></span>
@@ -122,11 +122,11 @@ require_once '../Include/Header.php';
         <?php
     }
     ?>
-    <!-- <a class="btn btn-success" data-toggle="modal" data-target="#compose-modal"><i class="fas fa-pen"></i> Compose Message</a>  This doesn't really work right now...-->
+    <!-- <a class="btn btn-success" data-toggle="modal" data-target="#compose-modal"><i class="fa-solid fa-pen"></i> Compose Message</a>  This doesn't really work right now...-->
     <a class="btn btn-app" href="../GroupView.php?GroupID=<?= $iGroupId ?>"><i
-        class="fa fa-user-plus"></i><?= gettext('Add Students') ?> </a>
+        class="fa-solid fa-user-plus"></i><?= gettext('Add Students') ?> </a>
 
-    <a class="btn btn-app" href="../GroupEditor.php?GroupID=<?= $iGroupId?>"><i class="fas fa-pen"></i><?= gettext("Edit this Class") ?></a>
+    <a class="btn btn-app" href="../GroupEditor.php?GroupID=<?= $iGroupId?>"><i class="fa-solid fa-pen"></i><?= gettext("Edit this Class") ?></a>
   </div>
 </div>
 
@@ -146,9 +146,9 @@ require_once '../Include/Header.php';
             <img src="<?= SystemURLs::getRootPath(); ?>/api/person/<?= $teacher['per_ID'] ?>/thumbnail"
                   alt="User Image" class="user-image initials-image" width="85" height="85" />
             <a href="mailto:<?= $teacher['per_Email'] ?>" type="button" class="btn btn-primary btn-sm btn-block"><i
-                class="fa fa-envelope"></i> <?= gettext('Send Message') ?></a>
+                class="fa-solid fa-envelope"></i> <?= gettext('Send Message') ?></a>
             <a href="../PersonView.php?PersonID=<?= $teacher['per_ID'] ?>" type="button"
-               class="btn btn-primary btn-info btn-block"><i class="fa fa-q"></i><?= gettext('View Profile') ?></a>
+               class="btn btn-primary btn-info btn-block"><i class="fa-solid fa-q"></i><?= gettext('View Profile') ?></a>
           </div>
         </div>
       </div>
@@ -162,7 +162,7 @@ require_once '../Include/Header.php';
     <h3 class="card-title"><?= gettext('Quick Status') ?></h3>
 
     <div class="card-tools pull-right">
-      <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fa fa-plus"></i></button>
+      <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fa-solid fa-plus"></i></button>
     </div>
   </div>
   <!-- /.box-header -->
@@ -173,7 +173,7 @@ require_once '../Include/Header.php';
         <div class="card-header">
           <h3 class="card-title"><?= gettext('Birthdays by Month') ?></h3>
             <div class="card-tools">
-                <i class="fa fa-chart-bar"></i>
+                <i class="fa-solid fa-chart-bar"></i>
             </div>
         </div>
         <div class="card-body">
@@ -191,7 +191,7 @@ require_once '../Include/Header.php';
         <div class="card-header">
           <h3 class="card-title"><?= gettext('Gender') ?></h3>
             <div class="card-tools">
-                <i class="fa fa-chart-bar"></i>
+                <i class="fa-solid fa-chart-bar"></i>
             </div>
         </div>
         <div class="card-body">
@@ -210,7 +210,7 @@ require_once '../Include/Header.php';
   </div>
   <!-- /.box-header -->
   <div class="card-body table-responsive">
-    <h4 class="birthday-filter d-none"><?= gettext('Showing students with birthdays in') ?><span class="month"></span> <i style="cursor:pointer;" class="icon fa fa-close text-danger"></i></h4>
+    <h4 class="birthday-filter d-none"><?= gettext('Showing students with birthdays in') ?><span class="month"></span> <i style="cursor:pointer;" class="icon fa-solid fa-close text-danger"></i></h4>
     <table id="sundayschool" class="table table-striped table-bordered data-table" cellspacing="0" width="100%">
       <thead>
       <tr>
@@ -291,7 +291,7 @@ function implodeUnique($array, $withQuotes): string
     <div class="modal-content large">
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-        <h4 class="modal-title"><i class="fa fa-envelope"></i><?= gettext('Compose New Message') ?></h4>
+        <h4 class="modal-title"><i class="fa-solid fa-envelope"></i><?= gettext('Compose New Message') ?></h4>
       </div>
       <form action="SendEmail.php" method="post">
         <div class="modal-body">
@@ -316,7 +316,7 @@ function implodeUnique($array, $withQuotes): string
           </div>
           <div class="form-group">
             <div class="btn btn-success btn-file">
-              <i class="fa fa-paperclip"></i><?= gettext('Attachment') ?>
+              <i class="fa-solid fa-paperclip"></i><?= gettext('Attachment') ?>
               <input type="file" name="attachment"/>
             </div>
             <p class="help-block"><?= gettext('Max. 32MB') ?></p>
@@ -326,10 +326,10 @@ function implodeUnique($array, $withQuotes): string
         <div class="modal-footer clearfix">
 
           <button type="button" class="btn btn-danger" data-dismiss="modal"><i
-              class="fa fa-times"></i><?= gettext('Discard') ?></button>
+              class="fa-solid fa-times"></i><?= gettext('Discard') ?></button>
 
           <button type="submit" class="btn btn-primary pull-left"><i
-              class="fa fa-envelope"></i><?= gettext('Send Message') ?></button>
+              class="fa-solid fa-envelope"></i><?= gettext('Send Message') ?></button>
         </div>
       </form>
     </div>

--- a/src/sundayschool/SundaySchoolDashboard.php
+++ b/src/sundayschool/SundaySchoolDashboard.php
@@ -49,15 +49,15 @@ require_once '../Include/Header.php';
     <?php if (AuthenticationManager::getCurrentUser()->isManageGroupsEnabled()) {
         ?>
       <button class="btn btn-app" data-toggle="modal" data-target="#add-class"><i
-          class="fa fa-plus-square"></i><?= gettext('Add New Class') ?></button>
+          class="fa-solid fa-plus-square"></i><?= gettext('Add New Class') ?></button>
         <?php
     } ?>
     <a href="SundaySchoolReports.php" class="btn btn-app"
        title="<?= gettext('Generate class lists and attendance sheets'); ?>"><i
-        class="fa fa-file-pdf"></i><?= gettext('Reports'); ?></a>
+        class="fa-solid fa-file-pdf"></i><?= gettext('Reports'); ?></a>
     <a href="SundaySchoolClassListExport.php" class="btn btn-app"
        title="<?= gettext('Export All Classes, Kids, and Parent to CSV file'); ?>"><i
-        class="fa fa-file-csv"></i><?= gettext('Export to CSV') ?></a><br/>
+        class="fa-solid fa-file-csv"></i><?= gettext('Export to CSV') ?></a><br/>
   </div>
 </div>
 <!-- Small boxes (Stat box) -->
@@ -88,7 +88,7 @@ require_once '../Include/Header.php';
   </div>
   <div class="col-md-3 col-sm-6 col-xs-12">
     <div class="info-box">
-      <span class="info-box-icon bg-orange"><i class="fa fa-children"></i></span>
+      <span class="info-box-icon bg-orange"><i class="fa-solid fa-children"></i></span>
       <div class="info-box-content">
         <span class="info-box-text"><?= gettext('Students') ?></span>
         <span class="info-box-number"> <?= $kids ?></span>
@@ -99,7 +99,7 @@ require_once '../Include/Header.php';
   </div>
   <div class="col-md-3 col-sm-6 col-xs-12">
     <div class="info-box">
-      <span class="info-box-icon bg-gray"><i class="fa fa-people-roof"></i></span>
+      <span class="info-box-icon bg-gray"><i class="fa-solid fa-people-roof"></i></span>
 
       <div class="info-box-content">
         <span class="info-box-text"><?= gettext('Families') ?></span>
@@ -111,7 +111,7 @@ require_once '../Include/Header.php';
   </div>
   <div class="col-md-3 col-sm-6 col-xs-12">
     <div class="info-box">
-      <span class="info-box-icon bg-blue"><i class="fa fa-child"></i></span>
+      <span class="info-box-icon bg-blue"><i class="fa-solid fa-child"></i></span>
 
       <div class="info-box-content">
         <span class="info-box-text"><?= gettext('Boys') ?></span>
@@ -123,7 +123,7 @@ require_once '../Include/Header.php';
   </div>
   <div class="col-md-3 col-sm-6 col-xs-12">
     <div class="info-box">
-      <span class="info-box-icon bg-fuchsia"><i class="fa fa-child-dress"></i></span>
+      <span class="info-box-icon bg-fuchsia"><i class="fa-solid fa-child-dress"></i></span>
 
       <div class="info-box-content">
         <span class="info-box-text"><?= gettext('Girls') ?></span>
@@ -139,9 +139,9 @@ require_once '../Include/Header.php';
   <div class="card-header">
     <h3 class="card-title"><?= gettext('Sunday School Classes') ?></h3>
       <div class="card-tools pull-right">
-          <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fa fa-minus"></i>
+          <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fa-solid fa-minus"></i>
           </button>
-          <button type="button" class="btn btn-tool" data-card-widget="remove"><i class="fa fa-times"></i>
+          <button type="button" class="btn btn-tool" data-card-widget="remove"><i class="fa-solid fa-times"></i>
           </button>
       </div>
   </div>
@@ -161,10 +161,10 @@ require_once '../Include/Header.php';
         <tr>
           <td style="width:80px">
             <a href='SundaySchoolClassView.php?groupId=<?= $class['id'] ?>'>
-              <i class="fa fa-search-plus"></i>
+              <i class="fa-solid fa-search-plus"></i>
             </a>
             <a href='<?= SystemURLs::getRootPath() ?>/GroupEditor.php?GroupID=<?= $class['id'] ?>'>
-              <i class="fa fas fa-pen"></i>
+              <i class="fa-solid fa-pen"></i>
             </a>
           </td>
           <td><?= $class['name'] ?></td>
@@ -182,9 +182,9 @@ require_once '../Include/Header.php';
   <div class="card-header">
     <h3 class="card-title"><?= gettext('Students not in a Sunday School Class') ?></h3>
       <div class="card-tools pull-right">
-          <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fa fa-minus"></i>
+          <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fa-solid fa-minus"></i>
           </button>
-          <button type="button" class="btn btn-tool" data-card-widget="remove"><i class="fa fa-times"></i>
+          <button type="button" class="btn btn-tool" data-card-widget="remove"><i class="fa-solid fa-times"></i>
           </button>
       </div>
   </div>
@@ -223,7 +223,7 @@ require_once '../Include/Header.php';
 <tr>
 <td>
   <a href="../PersonView.php?PersonID={$kidId}">
-    <i class="fa fa-search-plus"></i>
+    <i class="fa-solid fa-search-plus"></i>
   </a>
 </td>
 <td>$firstName</td>

--- a/src/v2/templates/admin/logs.php
+++ b/src/v2/templates/admin/logs.php
@@ -26,12 +26,12 @@ include SystemURLs::getDocumentRoot() . '/Include/Header.php';
                         </select>
                     </div>
                     <button type="button" class="btn btn-primary" id="saveLogLevel">
-                        <i class="fa fa-save"></i> <?= gettext('Save Log Level') ?>
+                        <i class="fa-solid fa-save"></i> <?= gettext('Save Log Level') ?>
                     </button>
                     <span id="logLevelStatus" class="ml-3"></span>
                 </form>
                 <p class="text-muted mt-2 mb-0">
-                    <small><i class="fa fa-info-circle"></i> <?= gettext('Lower numbers log more details. Higher numbers log only severe issues. Changes apply to new log entries immediately.') ?></small>
+                    <small><i class="fa-solid fa-info-circle"></i> <?= gettext('Lower numbers log more details. Higher numbers log only severe issues. Changes apply to new log entries immediately.') ?></small>
                 </p>
             </div>
         </div>
@@ -46,14 +46,14 @@ include SystemURLs::getDocumentRoot() . '/Include/Header.php';
                 <p class="text-muted"><?= gettext('View application logs. Click on a log file to view its contents.') ?></p>
                 <?php if (!empty($logFiles)): ?>
                 <button class="btn btn-danger float-right" id="deleteAllLogs">
-                    <i class="fa fa-trash"></i> <?= gettext('Delete All Logs') ?>
+                    <i class="fa-solid fa-trash"></i> <?= gettext('Delete All Logs') ?>
                 </button>
                 <?php endif; ?>
             </div>
             <div class="card-body">
                 <?php if (empty($logFiles)): ?>
                     <div class="alert alert-info">
-                        <i class="fa fa-info-circle"></i> <?= gettext('No log files found.') ?>
+                        <i class="fa-solid fa-info-circle"></i> <?= gettext('No log files found.') ?>
                     </div>
                 <?php else: ?>
                     <div class="table-responsive">
@@ -73,16 +73,16 @@ include SystemURLs::getDocumentRoot() . '/Include/Header.php';
                                             <button class="btn btn-sm btn-primary view-log" 
                                                     data-file="<?= htmlspecialchars($logFile['name']) ?>"
                                                     title="<?= gettext('View') ?>">
-                                                <i class="fa fa-eye"></i>
+                                                <i class="fa-solid fa-eye"></i>
                                             </button>
                                             <button class="btn btn-sm btn-danger delete-log" 
                                                     data-file="<?= htmlspecialchars($logFile['name']) ?>"
                                                     title="<?= gettext('Delete') ?>">
-                                                <i class="fa fa-trash"></i>
+                                                <i class="fa-solid fa-trash"></i>
                                             </button>
                                         </td>
                                         <td>
-                                            <i class="fa fa-file-alt"></i> 
+                                            <i class="fa-solid fa-file-alt"></i> 
                                             <strong><?= htmlspecialchars($logFile['name']) ?></strong>
                                         </td>
                                         <td><?= number_format($logFile['size'] / 1024, 2) ?> KB</td>
@@ -131,7 +131,7 @@ include SystemURLs::getDocumentRoot() . '/Include/Header.php';
                 </div>
                 <pre id="logContent" style="max-height: 500px; overflow-y: auto; background-color: #f4f4f4; padding: 10px; border: 1px solid #ddd; border-radius: 4px; font-size: 12px;"><code></code></pre>
                 <div id="logLoading" class="d-none text-center p-3">
-                    <i class="fa fa-spinner fa-spin fa-3x"></i>
+                    <i class="fa-solid fa-spinner fa-spin fa-3x"></i>
                     <p><?= gettext('Loading log file...') ?></p>
                 </div>
             </div>
@@ -320,14 +320,14 @@ include SystemURLs::getDocumentRoot() . '/Include/Header.php';
             contentType: 'application/json',
             data: JSON.stringify({ value: logLevel }),
             success: function(data) {
-                $('#logLevelStatus').html('<span class="text-success"><i class="fa fa-check"></i> ' + i18next.t('Saved - Log level updated immediately') + '</span>');
+                $('#logLevelStatus').html('<span class="text-success"><i class="fa-solid fa-check"></i> ' + i18next.t('Saved - Log level updated immediately') + '</span>');
                 setTimeout(function() {
                     $('#logLevelStatus').html('');
                 }, 3000);
             },
             error: function(xhr, status, error) {
                 console.error('Error:', error);
-                $('#logLevelStatus').html('<span class="text-danger"><i class="fa fa-times"></i> ' + i18next.t('Error') + '</span>');
+                $('#logLevelStatus').html('<span class="text-danger"><i class="fa-solid fa-times"></i> ' + i18next.t('Error') + '</span>');
             }
         });
     }

--- a/src/v2/templates/admin/menus.php
+++ b/src/v2/templates/admin/menus.php
@@ -61,7 +61,7 @@ include SystemURLs::getDocumentRoot() . '/Include/Header.php';
                     title: i18next.t('Delete'),
                     data: 'Id',
                     render: function (data, type, row) {
-                        return '<a class="btn btn-default" onclick="deleteMenu(' + row.Id + ')"><i class="fa fa-trash bg-red"></i></a>';
+                        return '<a class="btn btn-default" onclick="deleteMenu(' + row.Id + ')"><i class="fa-solid fa-trash bg-red"></i></a>';
                     },
                     searchable: false
                 },

--- a/src/v2/templates/cart/cartfunctions.php
+++ b/src/v2/templates/cart/cartfunctions.php
@@ -9,31 +9,31 @@ use ChurchCRM\dto\SystemURLs;
     <h3 class="card-title">Cart Functions</h3>
   </div>
   <div class="card-body">
-    <a href="#" id="emptyCart" class="btn btn-app emptyCart"><i class="fa fa-trash"></i><?= gettext('Empty Cart') ?></a>
+    <a href="#" id="emptyCart" class="btn btn-app emptyCart"><i class="fa-solid fa-trash"></i><?= gettext('Empty Cart') ?></a>
     <?php if (AuthenticationManager::getCurrentUser()->isManageGroupsEnabled()) {
         ?>
-      <a id="emptyCartToGroup" class="btn btn-app"><i class="fa fa-users"></i><?= gettext('Empty Cart to Group') ?></a>
+      <a id="emptyCartToGroup" class="btn btn-app"><i class="fa-solid fa-users"></i><?= gettext('Empty Cart to Group') ?></a>
         <?php
     }
     if (AuthenticationManager::getCurrentUser()->isAddRecordsEnabled()) {
         ?>
       <a href="<?= SystemURLs::getRootPath() . "/CartToFamily.php"?>" class="btn btn-app"><i
-          class="fa fa-people-roof"></i><?= gettext('Empty Cart to Family') ?></a>
+          class="fa-solid fa-people-roof"></i><?= gettext('Empty Cart to Family') ?></a>
     <?php }
     ?>
     <a href="<?= SystemURLs::getRootPath() . "/CartToEvent.php"?>" class="btn btn-app"><i
-        class="fa fa-ticket-alt"></i><?= gettext('Empty Cart to Event') ?></a>
+        class="fa-solid fa-ticket-alt"></i><?= gettext('Empty Cart to Event') ?></a>
 
     <?php if (AuthenticationManager::getCurrentUser()->isCSVExport()) {
         ?>
       <a href="<?= SystemURLs::getRootPath() . "/CSVExport.php?Source=cart" ?>" class="btn btn-app"><i
-          class="fa fa-file-csv"></i><?= gettext('CSV Export') ?></a>
+          class="fa-solid fa-file-csv"></i><?= gettext('CSV Export') ?></a>
     <?php }
     ?>
     <a href="<?= SystemURLs::getRootPath() . "/MapUsingGoogle.php?GroupID=0"?>" class="btn btn-app"><i
-        class="fa fa-map-marker"></i><?= gettext('Map Cart') ?></a>
+        class="fa-solid fa-map-marker"></i><?= gettext('Map Cart') ?></a>
     <a href="<?= SystemURLs::getRootPath() . "/Reports/NameTags.php?labeltype=74536&labelfont=times&labelfontsize=36"?>" class="btn btn-app"><i
-        class="fa fa-file-pdf"></i><?= gettext('Name Tags') ?></a>
+        class="fa-solid fa-file-pdf"></i><?= gettext('Name Tags') ?></a>
       <?php
 
         if (AuthenticationManager::getCurrentUser()->isEmailEnabled()) { // Does user have permission to email groups
@@ -42,13 +42,13 @@ use ChurchCRM\dto\SystemURLs;
             echo "<a href='mailto:?bcc=" . $sEmailLink . "' class='btn btn-app'><i class='fa-regular fa-paper-plane'></i>" . gettext('Email (BCC)') . '</a>';
 
             // Display link
-            echo '<a href="javascript:void(0)" onclick="allPhonesCommaD()" class="btn btn-app"><i class="fa fa-mobile-phone"></i>' . gettext("Text Cart");
+            echo '<a href="javascript:void(0)" onclick="allPhonesCommaD()" class="btn btn-app"><i class="fa-solid fa-mobile-phone"></i>' . gettext("Text Cart");
             echo '<script nonce="' . SystemURLs::getCSPNonce() . '">function allPhonesCommaD() {prompt("Press CTRL + C to copy all group members\' phone numbers", "' . $sPhoneLink . '")};</script>';
         }
 
         ?>
       <a href="<?= SystemURLs::getRootPath() . "/DirectoryReports.php?cartdir=Cart+Directory"?>" class="btn btn-app"><i
-          class="fa fa-book"></i><?= gettext('Create Directory From Cart') ?></a>
+          class="fa-solid fa-book"></i><?= gettext('Create Directory From Cart') ?></a>
 
       <script nonce="<?= SystemURLs::getCSPNonce() ?>" ><!--
                   function codename() {

--- a/src/v2/templates/common/not-found-view.php
+++ b/src/v2/templates/common/not-found-view.php
@@ -10,7 +10,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
     <h2 class="headline text-yellow">404</h2>
 
     <div class="error-content">
-        <h3><i class="fa fa-triangle-exclamation text-yellow"></i> <?= gettext("Oops!") . " " . strtoupper($memberType) . " " . $id . " " . gettext("Not Found") ?></h3>
+        <h3><i class="fa-solid fa-triangle-exclamation text-yellow"></i> <?= gettext("Oops!") . " " . strtoupper($memberType) . " " . $id . " " . gettext("Not Found") ?></h3>
 
         <p>
             <?= gettext("We could not find the person(s) you were looking for.") ?>

--- a/src/v2/templates/email/dashboard.php
+++ b/src/v2/templates/email/dashboard.php
@@ -11,11 +11,11 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
         <h3 class="card-title"><?= gettext('Email Functions') ?></h3>
     </div>
     <div class="card-body">
-        <a href="<?= SystemURLs::getRootPath()?>/email/MemberEmailExport.php" class="btn btn-app"><i class="fa fa-table"></i><?= gettext('Email Export') ?></a>
-        <a href="<?= SystemURLs::getRootPath()?>/v2/email/duplicate" class="btn btn-app"><i class="fa fa-exclamation-triangle"></i><?= gettext('Find Duplicate Emails') ?></a>
-        <a href="<?= SystemURLs::getRootPath()?>/v2/email/missing" class="btn btn-app"><i class="fa fa-bell-slash"></i><?= gettext('Families Without Emails') ?></a>
+        <a href="<?= SystemURLs::getRootPath()?>/email/MemberEmailExport.php" class="btn btn-app"><i class="fa-solid fa-table"></i><?= gettext('Email Export') ?></a>
+        <a href="<?= SystemURLs::getRootPath()?>/v2/email/duplicate" class="btn btn-app"><i class="fa-solid fa-exclamation-triangle"></i><?= gettext('Find Duplicate Emails') ?></a>
+        <a href="<?= SystemURLs::getRootPath()?>/v2/email/missing" class="btn btn-app"><i class="fa-solid fa-bell-slash"></i><?= gettext('Families Without Emails') ?></a>
         <?php if (AuthenticationManager::getCurrentUser()->isAdmin()) { ?>
-        <a href="<?= SystemURLs::getRootPath()?>/v2/email/debug" class="btn btn-app"><i class="fa fa-stethoscope"></i><?= gettext('Debug') ?></a>
+        <a href="<?= SystemURLs::getRootPath()?>/v2/email/debug" class="btn btn-app"><i class="fa-solid fa-stethoscope"></i><?= gettext('Debug') ?></a>
         <?php } ?>
     </div>
 </div>
@@ -77,7 +77,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
         <div class="col-lg-12 col-md-7 col-sm-3">
             <div class="card card-body">
                 <div class="alert alert-warning">
-                    <h4><i class="fa fa-ban"></i> <?= gettext('MailChimp is not configured') ?></h4>
+                    <h4><i class="fa-solid fa-ban"></i> <?= gettext('MailChimp is not configured') ?></h4>
                     <?= gettext('Please update the MailChimp API key in:') ?> <a
                         href="<?= SystemURLs::getRootPath() ?>/SystemSettings.php#Integration"><?= gettext('Integration') ?></a>
                 </div>

--- a/src/v2/templates/people/family-list.php
+++ b/src/v2/templates/people/family-list.php
@@ -11,7 +11,7 @@ include SystemURLs::getDocumentRoot() . '/Include/Header.php';
 
 <div class="pull-right">
     <a class="btn btn-success" role="button" href="<?= SystemURLs::getRootPath() ?>/FamilyEditor.php">
-        <span class="fa fa-plus" aria-hidden="true"></span><?= gettext('Add Family') ?>
+        <span class="fa-solid fa-plus" aria-hidden="true"></span><?= gettext('Add Family') ?>
     </a>
 </div>
 <p><br /><br /></p>
@@ -38,10 +38,10 @@ include SystemURLs::getDocumentRoot() . '/Include/Header.php';
                     ?>
                     <tr>
                         <td><a href='<?= SystemURLs::getRootPath() ?>/v2/family/<?= $family->getId() ?>'>
-                                <i class="fa fa-search-plus"></i>
+                                <i class="fa-solid fa-search-plus"></i>
                             </a>
                             <a href='<?= SystemURLs::getRootPath() ?>/FamilyEditor.php?FamilyID=<?= $family->getId() ?>'>
-                                <i class="fas fa-pen"></i>
+                                <i class="fa-solid fa-pen"></i>
                             </a>
                         </td>
 

--- a/src/v2/templates/people/family-view.php
+++ b/src/v2/templates/people/family-view.php
@@ -39,7 +39,7 @@ if (array_key_exists('idefaultFY', $_SESSION)) {
                     <div class="card-header">
                         <h3 class="card-title"><?= $family->getName() ?> [<?= $family->getId() ?>]</h3>
                         <div class="card-tools pull-right">
-                            <button type="button" class="btn btn-box-tool edit-family"><i class="fa fa-pen"></i>
+                            <button type="button" class="btn btn-box-tool edit-family"><i class="fa-solid fa-pen"></i>
                             </button>
                         </div>
                     </div>
@@ -50,17 +50,17 @@ if (array_key_exists('idefaultFY', $_SESSION)) {
                             <div class="after">
                                 <div class="buttons">
                                     <a id="view-larger-image-btn" href="#" title="<?= gettext("View Photo") ?>">
-                                        <i class="fa fa-search-plus"></i>
+                                        <i class="fa-solid fa-search-plus"></i>
                                     </a>
                                     <?php if (AuthenticationManager::getCurrentUser()->isEditRecordsEnabled()) : ?>
                                         &nbsp;
                                         <a href="#" data-toggle="modal" data-target="#upload-image"
                                            title="<?= gettext("Upload Photo") ?>">
-                                            <i class="fa fa-camera"></i>
+                                            <i class="fa-solid fa-camera"></i>
                                         </a>&nbsp;
                                         <a href="#" data-toggle="modal" data-target="#confirm-delete-image"
                                            title="<?= gettext("Delete Photo") ?>">
-                                            <i class="fa fa-trash-can"></i>
+                                            <i class="fa-solid fa-trash-can"></i>
                                         </a>
                                     <?php endif; ?>
                                 </div>
@@ -75,21 +75,21 @@ if (array_key_exists('idefaultFY', $_SESSION)) {
                         <br/>
                         <div class="text-center">
                             <a class="btn btn-app" id="lastFamily"><i
-                                        class="fa fa-hand-point-left"></i><?= gettext('Previous Family') ?></a>
+                                        class="fa-solid fa-hand-point-left"></i><?= gettext('Previous Family') ?></a>
 
                             <a class="btn btn-app btn-danger" role="button" href="<?= SystemURLs::getRootPath()?>/v2/family"><i
-                                        class="fa fa-list-ul"></i><?= gettext('Family List') ?></a>
+                                        class="fa-solid fa-list-ul"></i><?= gettext('Family List') ?></a>
 
                             <a class="btn btn-app" role="button" id="nextFamily" ><i
-                                        class="fa fa-hand-point-right"></i><?= gettext('Next Family') ?> </a>
+                                        class="fa-solid fa-hand-point-right"></i><?= gettext('Next Family') ?> </a>
                         </div>
                         <hr/>
                         <div class="text-center">
                         <a class="btn btn-sm btn-app" href="#" data-toggle="modal" data-target="#confirm-verify"><i
-                                class="fa fa-check-square"></i> <?= gettext("Verify Info") ?></a>
+                                class="fa-solid fa-check-square"></i> <?= gettext("Verify Info") ?></a>
                         <a class="btn btn-app bg-olive"
                            href="<?= SystemURLs::getRootPath() ?>/PersonEditor.php?FamilyID=<?=$family->getId()?>"><i
-                                class="fa fa-plus-square"></i> <?= gettext('Add New Member') ?></a>
+                                class="fa-solid fa-plus-square"></i> <?= gettext('Add New Member') ?></a>
 
                         <?php if (AuthenticationManager::getCurrentUser()->isEditRecordsEnabled()) { ?>
                             <button class="btn btn-app bg-orange" id="activateDeactivate">
@@ -100,22 +100,22 @@ if (array_key_exists('idefaultFY', $_SESSION)) {
                             ?>
                             <a id="deleteFamilyBtn" class="btn btn-app bg-maroon"
                                href="<?= SystemURLs::getRootPath() ?>/SelectDelete.php?FamilyID=<?=$family->getId()?>"><i
-                                        class="fa fa-trash-can"></i><?= gettext('Delete this Family') ?></a>
+                                        class="fa-solid fa-trash-can"></i><?= gettext('Delete this Family') ?></a>
                             <?php
                         }
                         if (AuthenticationManager::getCurrentUser()->isNotesEnabled()) {
                             ?>
                             <a class="btn btn-app"
                                href="<?= SystemURLs::getRootPath() ?>/NoteEditor.php?FamilyID=<?= $family->getId()?>"><i
-                                    class="fa fa-sticky-note"></i><?= gettext("Add a Note") ?></a>
+                                    class="fa-solid fa-sticky-note"></i><?= gettext("Add a Note") ?></a>
                             <?php
                         } ?>
                         <a class="btn btn-app" id="AddFamilyToCart" data-familyid="<?= $family->getId() ?>"> <i
-                                class="fa fa-cart-plus"></i> <?= gettext("Add All Family Members to Cart") ?></a>
+                                class="fa-solid fa-cart-plus"></i> <?= gettext("Add All Family Members to Cart") ?></a>
                         <?php if (AuthenticationManager::getCurrentUser()->isFinanceEnabled()) { ?>
                             <a class="btn btn-app"
                                href="<?= SystemURLs::getRootPath()?>/PledgeEditor.php?FamilyID=<?= $family->getId() ?>&amp;linkBack=v2/family/<?= $family->getId() ?>&PledgeOrPayment=Pledge">
-                                <i class="fa fa-hand-holding-dollar"></i><?= gettext("Add a new pledge") ?></a>
+                                <i class="fa-solid fa-hand-holding-dollar"></i><?= gettext("Add a new pledge") ?></a>
                             <a class="btn btn-app"
                                href="<?= SystemURLs::getRootPath()?>/PledgeEditor.php?FamilyID=<?= $family->getId() ?>&amp;linkBack=v2/family/<?= $family->getId() ?>&PledgeOrPayment=Payment">
                                 <i class="fa-solid fa-money-bill-transfer"></i><?= gettext("Add a new payment") ?></a>
@@ -129,10 +129,10 @@ if (array_key_exists('idefaultFY', $_SESSION)) {
             <div class="col-lg-12">
                 <div class="card card-primary">
                     <div class="card-header">
-                        <h3 class="card-title"> <i class="fa fa-thumbtack"></i> <?= gettext("Metadata") ?></h3>
+                        <h3 class="card-title"> <i class="fa-solid fa-thumbtack"></i> <?= gettext("Metadata") ?></h3>
                         <div class="card-tools pull-right">
                             <button type="button" class="btn btn-box-tool edit-family"><i
-                                    class="fa fa-pen"></i>
+                                    class="fa-solid fa-pen"></i>
                             </button>
                         </div>
                     </div>
@@ -141,48 +141,48 @@ if (array_key_exists('idefaultFY', $_SESSION)) {
 
                             <?php
                             if (!SystemConfig::getBooleanValue("bHideFamilyNewsletter")) { /* Newsletter can be hidden - General Settings */ ?>
-                                <li><i class="fa-li fa fa-newspaper"></i><?= gettext("Send Newsletter") ?>:
+                                <li><i class="fa-li fa-solid fa-newspaper"></i><?= gettext("Send Newsletter") ?>:
                                     <span style="color:<?= ($family->isSendNewsletter() ? "green" : "red") ?>"><i
-                                            class="fa fa-<?= ($family->isSendNewsletter() ? "check" : "times") ?>"></i></span>
+                                            class="fa-solid fa-<?= ($family->isSendNewsletter() ? "check" : "times") ?>"></i></span>
                                 </li>
                                 <?php
                             }
                             if (!SystemConfig::getBooleanValue("bHideWeddingDate") && !empty($family->getWeddingdate())) { /* Wedding Date can be hidden - General Settings */ ?>
-                                <li><i class="fa-li fa fa-magic"></i><?= gettext("Wedding Date") ?>:
+                                <li><i class="fa-li fa-solid fa-magic"></i><?= gettext("Wedding Date") ?>:
                                     <span><?= $family->getWeddingDate()->format(SystemConfig::getValue("sDateFormatLong")) ?></span></li>
                                 <?php
                             }
                             if (SystemConfig::getValue("bUseDonationEnvelopes")) {
                                 ?>
-                                <li><i class="fa-li fa fa-phone"></i><?= gettext("Envelope Number") ?>
+                                <li><i class="fa-li fa-solid fa-phone"></i><?= gettext("Envelope Number") ?>
                                     <span><?= $family->getEnvelope() ?></span>
                                 </li>
                                 <?php
                             }
                             if (!empty($family->getHomePhone())) {
                                 ?>
-                                <li><i class="fa-li fa fa-phone"></i><?= gettext("Home Phone") ?>: <span><a
+                                <li><i class="fa-li fa-solid fa-phone"></i><?= gettext("Home Phone") ?>: <span><a
                                             href="tel:<?= $family->getHomePhone() ?>"><?= $family->getHomePhone() ?></a></span>
                                 </li>
                                 <?php
                             }
                             if ($family->getWorkPhone() !== "") {
                                 ?>
-                                <li><i class="fa-li fa fa-building"></i><?= gettext("Work Phone") ?>: <span><a
+                                <li><i class="fa-li fa-solid fa-building"></i><?= gettext("Work Phone") ?>: <span><a
                                             href="tel:<?= $family->getWorkPhone() ?>"><?= $family->getWorkPhone() ?></a></span>
                                 </li>
                                 <?php
                             }
                             if ($family->getCellPhone() !== "") {
                                 ?>
-                                <li><i class="fa-li fa fa-mobile"></i><?= gettext("Mobile Phone") ?>: <span><a
+                                <li><i class="fa-li fa-solid fa-mobile"></i><?= gettext("Mobile Phone") ?>: <span><a
                                             href="tel:<?= $family->getCellPhone() ?>"><?= $family->getCellPhone() ?></a></span>
                                 </li>
                                 <?php
                             }
                             if ($family->getEmail() !== "") {
                                 ?>
-                                <li><i class="fa-li fa fa-envelope"></i><?= gettext("Email") ?>:<a
+                                <li><i class="fa-li fa-solid fa-envelope"></i><?= gettext("Email") ?>:<a
                                         href="mailto:<?= $family->getEmail() ?>">
                                         <span><?= $family->getEmail() ?></span></a></li>
                                 <?php if ($mailchimp->isActive()) { ?>
@@ -209,10 +209,10 @@ if (array_key_exists('idefaultFY', $_SESSION)) {
             <div class="col-lg-12">
                 <div class="card">
                     <div class="card-header">
-                        <h3 class="card-title"> <i class="fa fa-people-roof"></i> <?= gettext("Family Members") ?></h3>
+                        <h3 class="card-title"> <i class="fa-solid fa-people-roof"></i> <?= gettext("Family Members") ?></h3>
                         <div class="card-tools pull-right">
                             <button type="button" class="btn btn-tool" data-card-widget="collapse"><i
-                                    class="fa fa-minus"></i>
+                                    class="fa-solid fa-minus"></i>
                             </button>
 
                         </div>
@@ -228,16 +228,16 @@ if (array_key_exists('idefaultFY', $_SESSION)) {
                                             <h3 class="profile-username text-center"><?= $person->getTitle() ?> <?= $person->getFullName() ?></h3>
                                         </a>
                                         <p class="text-muted text-center"><i
-                                                class="fa fa-fw fa-<?= ($person->isMale() ? "male" : "female") ?>"></i> <?= $person->getFamilyRoleName() ?>
+                                                class="fa-solid fa-fw fa-<?= ($person->isMale() ? "male" : "female") ?>"></i> <?= $person->getFamilyRoleName() ?>
                                         </p>
 
                                         <p class="text-center">
                                             <a class="AddToPeopleCart" data-cartpersonid="<?= $person->getId() ?>">
-                                                <button type="button" class="btn btn-xs btn-primary"><i class="fa fa-cart-plus"></i></button>
+                                                <button type="button" class="btn btn-xs btn-primary"><i class="fa-solid fa-cart-plus"></i></button>
                                             </a>
 
                                             <a href="<?= SystemURLs::getRootPath()?>/PersonEditor.php?PersonID=<?= $person->getID()?>" class="table-link">
-                                                <button type="button" class="btn btn-xs btn-primary"><i class="fas fa-pen"></i></button>
+                                                <button type="button" class="btn btn-xs btn-primary"><i class="fa-solid fa-pen"></i></button>
                                             </a>
                                             <a class="delete-person" data-person_name="<?= $person->getFullName() ?>"
                                                data-person_id="<?= $person->getId() ?>" data-view="family">
@@ -252,33 +252,33 @@ if (array_key_exists('idefaultFY', $_SESSION)) {
                                         <ul class="list-group list-group-unbordered">
                                             <li class="list-group-item">
                                                 <?php if (!empty($person->getHomePhone())) { ?>
-                                                    <i class="fa fa-fw fa-phone"
+                                                    <i class="fa-solid fa-fw fa-phone"
                                                        title="<?= gettext("Home Phone") ?>"></i>(H) <?= $person->getHomePhone() ?>
                                                     <br/>
                                                 <?php }
                                                 if (!empty($person->getWorkPhone())) { ?>
-                                                    <i class="fa fa-fw fa-briefcase"
+                                                    <i class="fa-solid fa-fw fa-briefcase"
                                                        title="<?= gettext("Work Phone") ?>"></i>(W) <?= $person->getWorkPhone() ?>
                                                     <br/>
                                                 <?php }
                                                 if (!empty($person->getCellPhone())) { ?>
-                                                    <i class="fa fa-fw fa-mobile"
+                                                    <i class="fa-solid fa-fw fa-mobile"
                                                        title="<?= gettext("Mobile Phone") ?>"></i>(M) <?= $person->getCellPhone() ?>
                                                     <br/>
                                                 <?php }
                                                 if (!empty($person->getEmail())) { ?>
-                                                    <i class="fa fa-fw fa-envelope"
+                                                    <i class="fa-solid fa-fw fa-envelope"
                                                        title="<?= gettext("Email") ?>"></i>(H) <?= $person->getEmail() ?>
                                                     <br/>
                                                 <?php }
                                                 if (!empty($person->getWorkEmail())) { ?>
-                                                    <i class="fa fa-fw fa-inbox"
+                                                    <i class="fa-solid fa-fw fa-inbox"
                                                        title="<?= gettext("Work Email") ?>"></i>(W) <?= $person->getWorkEmail() ?>
                                                     <br/>
                                                 <?php }
                                                 $formattedBirthday = $person->getFormattedBirthDate();
                                                 if ($formattedBirthday) {?>
-                                                <i class="fa fa-fw fa-birthday-cake"
+                                                <i class="fa-solid fa-fw fa-birthday-cake"
                                                    title="<?= gettext("Birthday") ?>"></i>
                                                     <?= $formattedBirthday ?>  <?= $person->getAge() ?? sprintf('(%s)', gettext('not found')) ?>
                                                 </i>
@@ -300,16 +300,16 @@ if (array_key_exists('idefaultFY', $_SESSION)) {
     <div class="col-lg-6">
         <div class="card">
             <div class="card-header">
-                <h3 class="card-title"><i class="fa fa-hashtag"></i> <?= gettext("Properties") ?></h3>
+                <h3 class="card-title"><i class="fa-solid fa-hashtag"></i> <?= gettext("Properties") ?></h3>
                 <div class="card-tools pull-right">
                     <?php if (AuthenticationManager::getCurrentUser()->isEditRecordsEnabled()) { ?>
                     <button id="add-family-property" type="button" class="btn btn-box-tool" style="display: block;">
-                        <i class="fa fa-plus-circle text-blue"></i>
+                        <i class="fa-solid fa-plus-circle text-blue"></i>
                     </button>
                     <?php } ?>
 
                     <button type="button" class="btn btn-tool" data-card-widget="collapse">
-                        <i class="fa fa-minus"></i>
+                        <i class="fa-solid fa-minus"></i>
                     </button>
                 </div>
             </div>
@@ -317,12 +317,12 @@ if (array_key_exists('idefaultFY', $_SESSION)) {
 
                 <div id="family-property-loading" class="col-xs-12 text-center">
                     <i class="btn btn-default btn-lrg ajax">
-                        <i class="fa fa-spin fa-spinner"></i>&nbsp; <?= gettext("Loading") ?>
+                        <i class="fa-solid fa-spin fa-spinner"></i>&nbsp; <?= gettext("Loading") ?>
                     </i>
                 </div>
 
                 <div id="family-property-no-data" class="alert alert-warning" style="display: block;">
-                    <i class="fa fa-question-circle fa-fw fa-lg"></i>
+                    <i class="fa-solid fa-question-circle fa-fw fa-lg"></i>
                     <span><?= gettext("No property assignments.") ?></span>
                 </div>
 
@@ -343,11 +343,11 @@ if (array_key_exists('idefaultFY', $_SESSION)) {
             <div class="col-lg-12">
                 <div class="card">
                     <div class="card-header">
-                        <h3 class="card-title"><i class="fa fa-map"></i> <?= gettext("Address") ?></h3>
+                        <h3 class="card-title"><i class="fa-solid fa-map"></i> <?= gettext("Address") ?></h3>
                         <div class="card-tools pull-right">
-                            <button type="button" class="btn btn-box-tool edit-family"><i class="fa fa-pen"></i>
+                            <button type="button" class="btn btn-box-tool edit-family"><i class="fa-solid fa-pen"></i>
                             </button>
-                            <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fa fa-minus"></i>
+                            <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fa-solid fa-minus"></i>
                             </button>
                         </div>
                     </div>
@@ -382,9 +382,9 @@ if (array_key_exists('idefaultFY', $_SESSION)) {
         <!-- Maps End -->
         <div class="card">
             <div class="card-header">
-                <h3 class="card-title"><i class="fa fa-history"></i> <?= gettext("Timeline") ?></h3>
+                <h3 class="card-title"><i class="fa-solid fa-history"></i> <?= gettext("Timeline") ?></h3>
                 <div class="card-tools pull-right">
-                    <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fa fa-minus"></i>
+                    <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fa-solid fa-minus"></i>
                     </button>
                 </div>
             </div>
@@ -408,15 +408,15 @@ if (array_key_exists('idefaultFY', $_SESSION)) {
                                     <?php if (AuthenticationManager::getCurrentUser()->isNotesEnabled() && (isset($item["editLink"]) || isset($item["deleteLink"]))) {
                                         ?>
                                         <?php if (isset($item["editLink"])) { ?>
-                                            <a href="<?= $item["editLink"] ?>"><button type="button" class="btn btn-xs btn-primary"><i class="fa fa-pen"></i></button></a>
+                                            <a href="<?= $item["editLink"] ?>"><button type="button" class="btn btn-xs btn-primary"><i class="fa-solid fa-pen"></i></button></a>
                                         <?php }
                                         if (isset($item["deleteLink"])) { ?>
-                                            <a href="<?= $item["deleteLink"] ?>"><button type="button" class="btn btn-xs btn-danger"><i class="fa fa-trash"></i></button></a>
+                                            <a href="<?= $item["deleteLink"] ?>"><button type="button" class="btn btn-xs btn-danger"><i class="fa-solid fa-trash"></i></button></a>
                                         <?php } ?>
                                         &nbsp;
                                         <?php
                                     } ?>
-                                <i class="fa fa-clock"></i> <?= $item['datetime'] ?></span>
+                                <i class="fa-solid fa-clock"></i> <?= $item['datetime'] ?></span>
                                 <?php if ($item['slim']) { ?>
                                     <h4 class="timeline-header">
                                         <?= $item['text'] ?> <?= gettext($item['header']) ?>
@@ -458,7 +458,7 @@ if (array_key_exists('idefaultFY', $_SESSION)) {
             <div class="col-lg-12">
             <div class="card">
                 <div class="card-header">
-                    <h3 class="card-title"><i class="fa fa-circle-dollar-to-slot"></i> <?= gettext("Pledges and Payments") ?></h3>
+                    <h3 class="card-title"><i class="fa-solid fa-circle-dollar-to-slot"></i> <?= gettext("Pledges and Payments") ?></h3>
                     <div class="card-tools pull-right">
                         <input type="checkbox" id="ShowPledges" <?= AuthenticationManager::getCurrentUser()->isShowPledges() ? "checked" : "" ?>> <?= gettext("Show Pledges") ?>
                         <input type="checkbox" id="ShowPayments" <?= AuthenticationManager::getCurrentUser()->isShowPayments() ? "checked" : "" ?>> <?= gettext("Show Payments") ?>
@@ -558,16 +558,16 @@ if (array_key_exists('idefaultFY', $_SESSION)) {
                     ?>
                     <button type="button" id="onlineVerify"
                             class="btn btn-warning warning"><i
-                            class="fa fa-envelope"></i> <?= gettext("Online Verification") ?>
+                            class="fa-solid fa-envelope"></i> <?= gettext("Online Verification") ?>
                     </button>
                     <?php
                 } ?>
                 <button type="button" id="verifyURL"
-                        class="btn btn-default"><i class="fa fa-link"></i> <?= gettext("URL") ?></button>
+                        class="btn btn-default"><i class="fa-solid fa-link"></i> <?= gettext("URL") ?></button>
                 <button type="button" id="verifyDownloadPDF"
-                        class="btn btn-info"><i class="fa fa-download"></i> <?= gettext("PDF") ?></button>
+                        class="btn btn-info"><i class="fa-solid fa-download"></i> <?= gettext("PDF") ?></button>
                 <button type="button" id="verifyNow"
-                        class="btn btn-success"><i class="fa fa-check"></i> <?= gettext("Verified In Person") ?>
+                        class="btn btn-success"><i class="fa-solid fa-check"></i> <?= gettext("Verified In Person") ?>
                 </button>
             </div>
         </div>

--- a/src/v2/templates/people/people-verify-view.php
+++ b/src/v2/templates/people/people-verify-view.php
@@ -11,7 +11,7 @@ include SystemURLs::getDocumentRoot() . '/Include/Header.php';
         <h3 class="card-title"><?= gettext('Functions') ?></h3>
     </div>
     <div class="card-body">
-        <a href="<?= SystemURLs::getRootPath()?>/Reports/ConfirmReport.php" class="btn btn-app"><i class="fa fa-file-pdf"></i><?= gettext('Download family letters') ?></a>
+        <a href="<?= SystemURLs::getRootPath()?>/Reports/ConfirmReport.php" class="btn btn-app"><i class="fa-solid fa-file-pdf"></i><?= gettext('Download family letters') ?></a>
         <div class="btn btn-app" id="verifyEmail"><i class="fa  fa-envelope"></i><?= gettext('Send family email') ?></div>
     </div>
 </div>

--- a/src/v2/templates/people/person-list.php
+++ b/src/v2/templates/people/person-list.php
@@ -115,7 +115,7 @@ foreach ($ListItem as $element) {
             </div>
 
             <div class= "col-lg-6">
-                <a class="btn btn-success" role="button" href="<?= SystemURLs::getRootPath()?>/PersonEditor.php"><span class="fa fa-plus" aria-hidden="true"></span><?= gettext('Add Person') ?></a>
+                <a class="btn btn-success" role="button" href="<?= SystemURLs::getRootPath()?>/PersonEditor.php"><span class="fa-solid fa-plus" aria-hidden="true"></span><?= gettext('Add Person') ?></a>
                 <a id="AddAllToCart" class="btn btn-primary" ><?= gettext('Add All to Cart') ?></a>
                 <!-- <input name="IntersectCart" type="submit" class="btn btn-warning" value="< ?= gettext('Intersect with Cart') ?>">&nbsp; -->
                 <a id="RemoveAllFromCart" class="btn btn-danger" ><?= gettext('Remove All from Cart') ?></a>
@@ -137,23 +137,23 @@ foreach ($ListItem as $element) {
             <tr>
               <td>
                     <a href='<?= SystemURLs::getRootPath()?>/PersonView.php?PersonID=<?= $person->getId() ?>'>
-                        <i class="fa fa-search-plus"></i>
+                        <i class="fa-solid fa-search-plus"></i>
                     </a>
                     <a href='<?= SystemURLs::getRootPath()?>/PersonEditor.php?PersonID=<?= $person->getId() ?>'>
-                            <i class="fas fa-pen"></i>
+                            <i class="fa-solid fa-pen"></i>
                     </a>
 
                     <?php if (!isset($_SESSION['aPeopleCart']) || !in_array($per_ID, $_SESSION['aPeopleCart'], false)) {
                         ?>
                             <a class="AddToPeopleCart" data-cartpersonid="<?= $person->getId() ?>">
-                                <i class="fa fa-cart-plus"></i>
+                                <i class="fa-solid fa-cart-plus"></i>
                             </a>
                         </td>
                         <?php
                     } else {
                         ?>
                         <a class="RemoveFromPeopleCart" data-cartpersonid="<?= $person->getId() ?>">
-                                    <i class="fa fa-remove"></i>
+                                    <i class="fa-solid fa-remove"></i>
                             </a>
                             <?php
                     }

--- a/src/v2/templates/root/dashboard.php
+++ b/src/v2/templates/root/dashboard.php
@@ -19,10 +19,10 @@ include SystemURLs::getDocumentRoot() . '/Include/Header.php';
                 </p>
             </div>
             <div class="icon">
-                <i class="fa fa-user-friends"></i>
+                <i class="fa-solid fa-user-friends"></i>
             </div>
             <a href="<?= SystemURLs::getRootPath() ?>/v2/family" class="small-box-footer">
-                <?= gettext('See all Families') ?> <i class="fa fa-arrow-circle-right"></i>
+                <?= gettext('See all Families') ?> <i class="fa-solid fa-arrow-circle-right"></i>
             </a>
         </div>
     </div><!-- ./col -->
@@ -38,10 +38,10 @@ include SystemURLs::getDocumentRoot() . '/Include/Header.php';
                 </p>
             </div>
             <div class="icon">
-                <i class="fa fa-user"></i>
+                <i class="fa-solid fa-user"></i>
             </div>
             <a href="<?= SystemURLs::getRootPath() ?>/v2/people" class="small-box-footer">
-                <?= gettext('See All People') ?> <i class="fa fa-arrow-circle-right"></i>
+                <?= gettext('See All People') ?> <i class="fa-solid fa-arrow-circle-right"></i>
             </a>
         </div>
     </div><!-- ./col -->
@@ -57,10 +57,10 @@ include SystemURLs::getDocumentRoot() . '/Include/Header.php';
                 </p>
             </div>
             <div class="icon">
-                <i class="fa fa-users"></i>
+                <i class="fa-solid fa-users"></i>
             </div>
             <a href="<?= SystemURLs::getRootPath() ?>/GroupList.php" class="small-box-footer">
-                <?= gettext('More info') ?>  <i class="fa fa-arrow-circle-right"></i>
+                <?= gettext('More info') ?>  <i class="fa-solid fa-arrow-circle-right"></i>
             </a>
         </div>
     </div><!-- ./col -->
@@ -78,10 +78,10 @@ include SystemURLs::getDocumentRoot() . '/Include/Header.php';
                     </p>
                 </div>
                 <div class="icon">
-                    <i class="fa fa-child"></i>
+                    <i class="fa-solid fa-child"></i>
                 </div>
                 <a href="<?= SystemURLs::getRootPath() ?>/sundayschool/SundaySchoolDashboard.php" class="small-box-footer">
-                    <?= gettext('More info') ?> <i class="fa fa-arrow-circle-right"></i>
+                    <?= gettext('More info') ?> <i class="fa-solid fa-arrow-circle-right"></i>
                 </a>
             </div>
         </div><!-- ./col -->
@@ -101,10 +101,10 @@ include SystemURLs::getDocumentRoot() . '/Include/Header.php';
                 </p>
             </div>
             <div class="icon">
-                <i class="far fa-calendar-check"></i>
+                <i class="fa-regular fa-calendar-check"></i>
             </div>
             <a href="<?= SystemURLs::getRootPath() ?>/ListEvents.php" class="small-box-footer">
-                <?= gettext('More info') ?>  <i class="fa fa-arrow-circle-right"></i>
+                <?= gettext('More info') ?>  <i class="fa-solid fa-arrow-circle-right"></i>
             </a>
         </div>
     </div><!-- ./col -->
@@ -132,7 +132,7 @@ if ($depositEnabled) { // If the user has Finance permissions, then let's displa
     ?>
     <div class="card card-info"  id="depositChartRow">
         <div class="card-header">
-            <h3 class="card-title"><i class="fa fa-circle-dollar-to-slot"></i> <?= gettext('Deposit Tracking') ?></h3>
+            <h3 class="card-title"><i class="fa-solid fa-circle-dollar-to-slot"></i> <?= gettext('Deposit Tracking') ?></h3>
             <div class="card-tools pull-right">
                 <div id="deposit-graph" class="chart-legend"></div>
             </div>

--- a/src/v2/templates/user/unsupported-2fa.php
+++ b/src/v2/templates/user/unsupported-2fa.php
@@ -10,7 +10,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
     <div class="card-body">
 
     <div class="card-body">
-        <h3><i class="fa fa-triangle-exclamation text-yellow"></i> <?= gettext("Unable To Begin Two Factor Authentication Enrollment") ?></h3>
+        <h3><i class="fa-solid fa-triangle-exclamation text-yellow"></i> <?= gettext("Unable To Begin Two Factor Authentication Enrollment") ?></h3>
 
         <p><?= gettext("Two factor authentication requires ChurchCRM administrators to configure a few parameters") . ":" ?></p>
         <ul>

--- a/src/v2/templates/user/user.php
+++ b/src/v2/templates/user/user.php
@@ -12,7 +12,7 @@ include SystemURLs::getDocumentRoot() . '/Include/Header.php';
             <div class="card-header">
                 <div class="card-title"><?= _("Login Info") ?></div>
                 <div class="card-tools">
-                    <a id="editSettings" href="<?= SystemURLs::getRootPath() ?>/SettingsIndividual.php" class="btn btn-primary float-end"><i class="fas fa-user-pen"></i> <?= _("Edit") ?> </a>
+                    <a id="editSettings" href="<?= SystemURLs::getRootPath() ?>/SettingsIndividual.php" class="btn btn-primary float-end"><i class="fa-solid fa-user-pen"></i> <?= _("Edit") ?> </a>
                 </div>
             </div>
             <div class="card-body">
@@ -29,7 +29,7 @@ include SystemURLs::getDocumentRoot() . '/Include/Header.php';
                 </form>
                 <br/>
                 <p/>
-                <a id="regenApiKey" class="btn btn-warning"><i class="fa fa-repeat"></i> <?= _("Regen API Key")?> </a>
+                <a id="regenApiKey" class="btn btn-warning"><i class="fa-solid fa-repeat"></i> <?= _("Regen API Key")?> </a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## What Changed
<!-- Short summary - what and why (not how) -->

:

Replace deprecated icon names with their FA6 equivalents
Update all icon class prefixes to the FA6 scheme
What changed

Deprecated icons
fa-male → fa-person
fa-female → fa-person-dress
fa-refresh → fa-spinner
fa-chain → fa-link
fa-warning → fa-triangle-exclamation
fa-circle-o-notch → fa-circle-notch
fa-sign-in → fa-right-to-bracket
Class prefix migration
fa fa-* → fa-solid fa-*
fas fa-* → fa-solid fa-*
far fa-* → fa-regular fa-*
Cleanups
Removed the last “fa fa-solid …” double-prefix cases

## Type
<!-- Check one -->
- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
<!-- How to verify this works -->

## Screenshots
<!-- Only for UI changes - drag & drop images here -->

## Security Check
<!-- Only check if applicable -->
- [ ] Introduces new input validation
- [ ] Modifies authentication/authorization
- [ ] Affects data privacy/GDPR

### Code Quality
- [ ] Database: Propel ORM only, no raw SQL
- [ ] No deprecated attributes (align, valign, nowrap, border, cellpadding, cellspacing, bgcolor)
- [ ] Bootstrap CSS classes used
- [ ] All CSS bundled via webpack

## Pre-Merge
- [ ] Tested locally
- [ ] No new warnings
- [ ] Build passes
- [ ] Backward compatible (or migration documented)