### PR TITLE
Improve prerequisite checks to test actual functionality

### DIFF
--- a/src/ChurchCRM/Service/AppIntegrityService.php
+++ b/src/ChurchCRM/Service/AppIntegrityService.php
@@ -196,7 +196,17 @@ class AppIntegrityService
             new Prerequisite('PHP EXIF', fn (): bool => function_exists('exif_imagetype')),
             new Prerequisite('PHP iconv', fn (): bool => function_exists('iconv')),
             new Prerequisite('Mod Rewrite or Equivalent', fn (): bool => AppIntegrityService::hasModRewrite()),
-            new Prerequisite('GD Library for image manipulation', fn (): bool => function_exists('imagecreatetruecolor') && function_exists('gd_info')),
+            new Prerequisite(
+                'GD Library for image manipulation',
+                fn (): bool =>
+                    function_exists('imagecreatetruecolor') &&
+                    function_exists('gd_info') &&
+                    function_exists('imagecolorallocate') &&
+                    function_exists('imagefilledrectangle') &&
+                    function_exists('imageftbbox') &&
+                    function_exists('imagefttext') &&
+                    function_exists('imagepng')
+            ),
             new Prerequisite('FreeType Library', fn (): bool => function_exists('imagefttext')),
             new Prerequisite('FileInfo Extension for image manipulation', fn (): bool => function_exists('finfo_open') || function_exists('mime_content_type')),
             new Prerequisite('cURL', fn (): bool => function_exists('curl_init')),


### PR DESCRIPTION
## What Changed

Replace extension_loaded() checks with more specific function_exists() and class_exists() checks that test the actual functionality required by the application. This approach is more precise and works with polyfills.


- PHP 8.2+: Use PHP_VERSION_ID constant for efficiency
- Multibyte Encoding: Test mb_strlen() instead of mbstring extension
- PHP Phar: Test PharData class (used for backup/restore)
- PHP Session: Test session_start() function
- PHP XML: Test SimpleXMLElement class (Slim requirement)
- PHP EXIF: Test exif_imagetype() function (used in Photo.php)
- PHP iconv: Test iconv() function
- GD Library: Test imagecreatetruecolor() function
- FileInfo: Test finfo_open() or mime_content_type() functions
- cURL: Test curl_init() instead of curl_version()
- locale gettext: Simplify to only test gettext() function
- PHP BCMath: Test bcadd() function
- PHP Sodium: Test sodium_crypto_secretbox() function
- PHP ZipArchive: Test ZipArchive class (used for upgrades)

Benefits:
- More precise - tests actual needed functionality
- Polyfill-friendly - works if functionality comes from userland
- Better error messages - users know exactly what's missing
- Consistent pattern across all checks



## Type
<!-- Check one -->
- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
<!-- How to verify this works -->

## Screenshots
<!-- Only for UI changes - drag & drop images here -->

## Security Check
<!-- Only check if applicable -->
- [ ] Introduces new input validation
- [ ] Modifies authentication/authorization
- [ ] Affects data privacy/GDPR

### Code Quality
- [ ] Database: Propel ORM only, no raw SQL
- [ ] No deprecated attributes (align, valign, nowrap, border, cellpadding, cellspacing, bgcolor)
- [ ] Bootstrap CSS classes used
- [ ] All CSS bundled via webpack

## Pre-Merge
- [ ] Tested locally
- [ ] No new warnings
- [ ] Build passes
- [ ] Backward compatible (or migration documented)