### PR TITLE
PHP Cleanup: implode

### DIFF
--- a/src/ChurchCRM/model/ChurchCRM/User.php
+++ b/src/ChurchCRM/model/ChurchCRM/User.php
@@ -159,7 +159,7 @@ class User extends BaseUser
             $pass[] = $alphabet[$n];
         }
 
-        return implode($pass); //turn the array into a string
+        return implode('', $pass); //turn the array into a string
     }
 
     public static function randomApiKey(): string

--- a/src/ChurchCRM/utils/MiscUtils.php
+++ b/src/ChurchCRM/utils/MiscUtils.php
@@ -26,7 +26,7 @@ class MiscUtils
             $apiKey[] = $alphabet[$n];
         }
 
-        return implode($apiKey); //turn the array into a string
+        return implode('', $apiKey); //turn the array into a string
     }
 
     public static function randomWord(int $length = 6): string


### PR DESCRIPTION


## What Changed
<!-- Short summary - what and why (not how) -->

- Replace implode(\$array) with implode('', \$array) in User.php
- Replace implode(\$apiKey) with implode('', \$apiKey) in MiscUtils.php

## Type
<!-- Check one -->
- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
<!-- How to verify this works -->

## Screenshots
<!-- Only for UI changes - drag & drop images here -->

## Security Check
<!-- Only check if applicable -->
- [ ] Introduces new input validation
- [ ] Modifies authentication/authorization
- [ ] Affects data privacy/GDPR

### Code Quality
- [ ] Database: Propel ORM only, no raw SQL
- [ ] No deprecated attributes (align, valign, nowrap, border, cellpadding, cellspacing, bgcolor)
- [ ] Bootstrap CSS classes used
- [ ] All CSS bundled via webpack

## Pre-Merge
- [ ] Tested locally
- [ ] No new warnings
- [ ] Build passes
- [ ] Backward compatible (or migration documented)