### PR TITLE
Upgrade GitHub Actions workflows to Node.js v22

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['20.x']
+        node-version: ['22.x']
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/locale-poeditor-download.yml
+++ b/.github/workflows/locale-poeditor-download.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['20.x']
+        node-version: ['22.x']
     
     steps:
     - name: Checkout repository

--- a/.github/workflows/locale-update.yml
+++ b/.github/workflows/locale-update.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
       
       - name: Install dependencies

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
       
       - name: Install dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -1129,9 +1129,9 @@
             }
         },
         "node_modules/@messageformat/runtime": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@messageformat/runtime/-/runtime-3.0.1.tgz",
-            "integrity": "sha512-6RU5ol2lDtO8bD9Yxe6CZkl0DArdv0qkuoZC+ZwowU+cdRlVE1157wjCmlA5Rsf1Xc/brACnsZa5PZpEDfTFFg==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@messageformat/runtime/-/runtime-3.0.2.tgz",
+            "integrity": "sha512-dkIPDCjXcfhSHgNE1/qV6TeczQZR59Yx0xXeafVKgK3QVWoxc38ljwpksUpnzCGvN151KUbCJTDZVmahtf1YZw==",
             "license": "MIT",
             "dependencies": {
                 "make-plural": "^7.0.0"
@@ -4081,15 +4081,6 @@
             "dependencies": {
                 "datatables.net": "1.13.11",
                 "jquery": "1.8 - 4"
-            }
-        },
-        "node_modules/datatables.net-bs4/node_modules/datatables.net": {
-            "version": "1.13.8",
-            "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.13.8.tgz",
-            "integrity": "sha512-2pDamr+GUwPTby2OgriVB9dR9ftFKD2AQyiuCXzZIiG4d9KkKFQ7gqPfNmG7uj9Tc5kDf+rGj86do4LAb/V71g==",
-            "license": "MIT",
-            "dependencies": {
-                "jquery": ">=1.7"
             }
         },
         "node_modules/datatables.net-buttons": {


### PR DESCRIPTION
## What Changed
<!-- Short summary - what and why (not how) -->
## 🚀 Upgrade to Node.js v22

This PR upgrades all GitHub Actions workflows from Node.js v20 to v22.

### Changes
- **build-test-package.yml**: Updated matrix node-version from \`20.x\` → \`22.x\`
- **start-release.yml**: Updated node-version from \`'20'\` → \`'22'\`
- **locale-poeditor-download.yml**: Updated matrix node-version from \`20.x\` → \`22.x\`
- **locale-update.yml**: Updated node-version from \`'20'\` → \`'22'\`
- **package-lock.json**: Updated \`@messageformat/runtime\` from 3.0.1 → 3.0.2 (security fix)

### Why This Change?

Eliminates engine compatibility warnings:
- ✅ Cypress 15.5.0 requires Node \`^20.1.0 || ^22.0.0 || >=24.0.0\`
- ✅ i18next-parser 9.3.0 requires Node \`^18.0.0 || ^20.0.0 || ^22.0.0\`

### Testing
All workflows will run with Node.js v22 in CI/CD when this PR is merged.

### Related Issues
Fixes npm install warnings about unsupported Node.js engine versions.

## Type
<!-- Check one -->
- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
<!-- How to verify this works -->

## Screenshots
<!-- Only for UI changes - drag & drop images here -->

## Security Check
<!-- Only check if applicable -->
- [ ] Introduces new input validation
- [ ] Modifies authentication/authorization
- [ ] Affects data privacy/GDPR

### Code Quality
- [ ] Database: Propel ORM only, no raw SQL
- [ ] No deprecated attributes (align, valign, nowrap, border, cellpadding, cellspacing, bgcolor)
- [ ] Bootstrap CSS classes used
- [ ] All CSS bundled via webpack

## Pre-Merge
- [ ] Tested locally
- [ ] No new warnings
- [ ] Build passes
- [ ] Backward compatible (or migration documented)