### PR TITLE
Move CSP report endpoint to public API for pre-login access

### DIFF
--- a/cypress/e2e/api/public/public.csp-report.spec.js
+++ b/cypress/e2e/api/public/public.csp-report.spec.js
@@ -1,0 +1,59 @@
+/// <reference types="cypress" />
+
+describe("API Public CSP Report", () => {
+    it("should accept CSP violation report with 204 status", () => {
+        const cspReport = {
+            "csp-report": {
+                "document-uri": "http://example.com/page.html",
+                "referrer": "",
+                "violated-directive": "script-src 'self'",
+                "effective-directive": "script-src",
+                "original-policy": "default-src 'self'; script-src 'self'",
+                "disposition": "report",
+                "blocked-uri": "http://evil.example.com/malicious.js",
+                "line-number": 1,
+                "column-number": 1,
+                "source-file": "http://example.com/page.html",
+                "status-code": 200,
+                "script-sample": ""
+            }
+        };
+
+        cy.request({
+            method: "POST",
+            url: "/api/public/csp-report",
+            body: cspReport
+        }).then((resp) => {
+            expect(resp.status).to.eq(204);
+            // 204 responses have no body content
+        });
+    });
+
+    it("should accept CSP report with minimal data", () => {
+        const minimalReport = {
+            "csp-report": {
+                "violated-directive": "img-src 'self'",
+                "blocked-uri": "http://untrusted.com/image.png"
+            }
+        };
+
+        cy.request({
+            method: "POST",
+            url: "/api/public/csp-report",
+            body: minimalReport
+        }).then((resp) => {
+            expect(resp.status).to.eq(204);
+        });
+    });
+
+    it("should handle empty report object", () => {
+        cy.request({
+            method: "POST",
+            url: "/api/public/csp-report",
+            body: {},
+            failOnStatusCode: false
+        }).then((resp) => {
+            expect(resp.status).to.eq(204);
+        });
+    });
+});

--- a/src/Include/Header-Security.php
+++ b/src/Include/Header-Security.php
@@ -8,6 +8,7 @@
  * - Content-Security-Policy (CSP): Helps protect against XSS attacks
  *   By default, CSP is in report-only mode. Enable enforcement via
  *   System Settings > bEnforceCSP configuration option.
+ *   CSP violations are reported to /api/public/csp-report (public endpoint).
  *
  * - Strict-Transport-Security (HSTS): Enforces HTTPS connections
  *   Enable via System Settings > bHSTSEnable configuration option.
@@ -31,7 +32,7 @@ $csp = [
     "base-uri 'self'",
     "form-action 'self'",
     "frame-ancestors 'self'",
-    'report-uri ' . SystemURLs::getRootPath() . '/api/system/background/csp-report',
+    'report-uri ' . SystemURLs::getRootPath() . '/api/public/csp-report',
 ];
 if (SystemConfig::getBooleanValue('bHSTSEnable')) {
     header('Strict-Transport-Security: max-age=31536000; includeSubDomains');

--- a/src/api/routes/public/public.php
+++ b/src/api/routes/public/public.php
@@ -1,15 +1,26 @@
 <?php
 
 use ChurchCRM\Slim\SlimUtils;
+use ChurchCRM\Utils\LoggerUtils;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Routing\RouteCollectorProxy;
 
 $app->group('/public', function (RouteCollectorProxy $group): void {
     $group->get('/echo', 'getEcho');
+    $group->post('/csp-report', 'logCSPReportAPI');
 });
 
 function getEcho(Request $request, Response $response): Response
 {
     return SlimUtils::renderJSON($response, ['message' => 'echo']);
+}
+
+function logCSPReportAPI(Request $request, Response $response, array $args): Response
+{
+    $input = json_decode($request->getBody(), null, 512, JSON_THROW_ON_ERROR);
+    $log = json_encode($input, JSON_PRETTY_PRINT);
+    LoggerUtils::getCSPLogger()->warning($log);
+
+    return $response->withStatus(204);
 }

--- a/src/api/routes/system/system.php
+++ b/src/api/routes/system/system.php
@@ -4,24 +4,13 @@ use ChurchCRM\dto\Notification\UiNotification;
 use ChurchCRM\Service\NotificationService;
 use ChurchCRM\Service\TaskService;
 use ChurchCRM\Slim\SlimUtils;
-use ChurchCRM\Utils\LoggerUtils;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Routing\RouteCollectorProxy;
 
 $app->group('/system', function (RouteCollectorProxy $group): void {
     $group->get('/notification', 'getUiNotificationAPI');
-    $group->post('/background/csp-report', 'logCSPReportAPI');
 });
-
-function logCSPReportAPI(Request $request, Response $response, array $args): Response
-{
-    $input = json_decode($request->getBody(), null, 512, JSON_THROW_ON_ERROR);
-    $log = json_encode($input, JSON_PRETTY_PRINT);
-    LoggerUtils::getCSPLogger()->debug($log);
-
-    return SlimUtils::renderSuccessJSON($response);
-}
 
 function getUiNotificationAPI(Request $request, Response $response, array $args): Response
 {


### PR DESCRIPTION
## What Changed
<!-- Short summary - what and why (not how) -->

Move CSP report endpoint to public API for pre-login access

## Type
<!-- Check one -->
- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
<!-- How to verify this works -->

## Screenshots
<!-- Only for UI changes - drag & drop images here -->

## Security Check
<!-- Only check if applicable -->
- [ ] Introduces new input validation
- [ ] Modifies authentication/authorization
- [ ] Affects data privacy/GDPR

### Code Quality
- [ ] Database: Propel ORM only, no raw SQL
- [ ] No deprecated attributes (align, valign, nowrap, border, cellpadding, cellspacing, bgcolor)
- [ ] Bootstrap CSS classes used
- [ ] All CSS bundled via webpack

## Pre-Merge
- [ ] Tested locally
- [ ] No new warnings
- [ ] Build passes
- [ ] Backward compatible (or migration documented)