### PR TITLE
Fix database error handling to display proper error messages

### DIFF
--- a/src/ChurchCRM/Bootstrapper.php
+++ b/src/ChurchCRM/Bootstrapper.php
@@ -316,8 +316,13 @@ class Bootstrapper
         mysqli_set_charset($cnInfoCentral, self::DEFAULT_CHARSET);
 
         self::$bootStrapLogger->debug("Selecting database: " . self::$databaseName);
-        mysqli_select_db($cnInfoCentral, self::$databaseName) ||
-            self::systemFailure('Could not connect to the MySQL database <strong>' . self::$databaseName . '</strong>. Please check the settings in <strong>Include/Config.php</strong>.<br/>MySQL Error: ' . mysqli_error($cnInfoCentral));
+        try {
+            if (!mysqli_select_db($cnInfoCentral, self::$databaseName)) {
+                self::systemFailure('Could not select the MySQL database <strong>' . self::$databaseName . '</strong>. Please check the settings in <strong>Include/Config.php</strong>.<br/>MySQL Error: ' . mysqli_error($cnInfoCentral));
+            }
+        } catch (\mysqli_sql_exception $e) {
+            self::systemFailure('Could not access the MySQL database <strong>' . self::$databaseName . '</strong>. Please verify the database name in <strong>Include/Config.php</strong>.<br/>Error: ' . $e->getMessage());
+        }
         self::$bootStrapLogger->debug("Database selected: " . self::$databaseName);
     }
     private static function testMYSQLI(): void
@@ -359,17 +364,23 @@ class Bootstrapper
     private static function isDatabaseEmpty(): bool
     {
         self::$bootStrapLogger->debug("Checking for ChurchCRM Database tables");
-        $connection = Propel::getConnection();
-        $query = "SHOW TABLES FROM `" . self::$databaseName . "`";
-        $statement = $connection->prepare($query);
-        $statement->execute();
-        $results = $statement->fetchAll(\PDO::FETCH_ASSOC);
-        if (count($results) === 0) {
-            self::$bootStrapLogger->debug("No database tables found");
-            return true;
+        try {
+            $connection = Propel::getConnection();
+            $query = "SHOW TABLES FROM `" . self::$databaseName . "`";
+            $statement = $connection->prepare($query);
+            $statement->execute();
+            $results = $statement->fetchAll(\PDO::FETCH_ASSOC);
+            if (count($results) === 0) {
+                self::$bootStrapLogger->debug("No database tables found");
+                return true;
+            }
+            self::$bootStrapLogger->debug("Found " . count($results) . " Database tables");
+            return false;
+        } catch (\PDOException $e) {
+            self::$bootStrapLogger->error("Database check failed: " . $e->getMessage());
+            self::systemFailure('Could not access the MySQL database <strong>' . self::$databaseName . '</strong>. Please check the settings in <strong>Include/Config.php</strong>.<br/>Error: ' . $e->getMessage());
+            return true; // This line won't be reached due to systemFailure() calling exit()
         }
-        self::$bootStrapLogger->debug("Found " . count($results) . " Database tables");
-        return false;
     }
     private static function installChurchCRMSchema(): void
     {
@@ -471,19 +482,51 @@ class Bootstrapper
 
     public static function systemFailure($message, $header = 'Setup failure'): void
     {
+        // Clear any output buffers to ensure error message is displayed
+        while (ob_get_level() > 0) {
+            ob_end_clean();
+        }
+        
+        // Set HTTP status code
+        http_response_code(500);
+        
         $sPageTitle = $header;
         if (!SystemConfig::isInitialized()) {
             SystemConfig::init();
         }
-        require_once '../Include/HeaderNotLoggedIn.php'; ?>
+        
+        try {
+            $headerPath = SystemURLs::getDocumentRoot() . '/Include/HeaderNotLoggedIn.php';
+            $footerPath = SystemURLs::getDocumentRoot() . '/Include/FooterNotLoggedIn.php';
+            
+            if (file_exists($headerPath)) {
+                require_once $headerPath;
+            } else {
+                // Fallback to basic HTML header
+                echo '<!DOCTYPE html><html><head><meta charset="utf-8"><title>ChurchCRM - Error</title></head><body>';
+            }
+            ?>
     <div class='container'>
         <h3>ChurchCRM – <?= _($header) ?></h3>
-        <div class='alert alert-danger text-center' style='margin-top: 20px;'>
+        <div class='alert alert-danger text-center'>
             <?= gettext($message) ?>
         </div>
     </div>
-        <?php
-        require_once '../Include/FooterNotLoggedIn.php';
+            <?php
+            if (file_exists($footerPath)) {
+                require_once $footerPath;
+            } else {
+                echo '</body></html>';
+            }
+        } catch (\Exception $e) {
+            // Last resort: plain HTML error if header/footer includes fail
+            echo '<!DOCTYPE html><html><head><meta charset="utf-8"><title>ChurchCRM Error</title></head><body>';
+            echo '<div style="max-width: 800px; margin: 50px auto; padding: 20px;">';
+            echo '<h1>ChurchCRM Error</h1>';
+            echo '<div style="padding: 15px; margin: 20px 0; border: 1px solid #f5c6cb; background-color: #f8d7da; color: #721c24; border-radius: 4px;">';
+            echo htmlspecialchars($message, ENT_QUOTES, 'UTF-8');
+            echo '</div></div></body></html>';
+        }
         exit();
     }
     public static function isDBCurrent(): bool


### PR DESCRIPTION
## What Changed
<!-- Short summary - what and why (not how) -->

- Wrap mysqli_select_db in try-catch to handle mysqli_sql_exception
- Add PDOException handling in isDatabaseEmpty method
- Enhance systemFailure method with output buffer clearing and HTTP 500 status
- Use absolute paths for header/footer includes with fallback HTML
- Display clear error messages instead of blank 500 errors
- Use Bootstrap classes without redundant inline styles

## Type
<!-- Check one -->
- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
<!-- How to verify this works -->
<img width="1244" height="218" alt="image" src="https://github.com/user-attachments/assets/ea2a7387-25b8-4d57-97ff-a27aec70add4" />

## Screenshots
<!-- Only for UI changes - drag & drop images here -->

## Security Check
<!-- Only check if applicable -->
- [ ] Introduces new input validation
- [ ] Modifies authentication/authorization
- [ ] Affects data privacy/GDPR

### Code Quality
- [ ] Database: Propel ORM only, no raw SQL
- [ ] No deprecated attributes (align, valign, nowrap, border, cellpadding, cellspacing, bgcolor)
- [ ] Bootstrap CSS classes used
- [ ] All CSS bundled via webpack

## Pre-Merge
- [x] Tested locally
- [ ] No new warnings
- [ ] Build passes
- [ ] Backward compatible (or migration documented)