### PR TITLE
standardized the email dropdown buttons across all three dashboard files

### DIFF
--- a/src/GroupView.php
+++ b/src/GroupView.php
@@ -185,31 +185,25 @@ while (list($per_CellPhone, $fam_CellPhone) = mysqli_fetch_row($rsPhoneList)) {
                 <?php
                 // Email buttons
                 if ($sEmailLink && AuthenticationManager::getCurrentUser()->isEmailEnabled()) { ?>
-                    <div class="btn-group">
-                        <a class="btn btn-app bg-teal" href="mailto:<?= mb_substr($sEmailLink, 0, -3) ?>">
+                    <div class="dropdown d-inline-block">
+                        <button class="btn btn-app bg-teal dropdown-toggle" type="button" id="emailGroupDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                             <i class="fa-solid fa-paper-plane fa-3x"></i><br>
                             <?= gettext('Email Group') ?>
-                        </a>
-                        <button type="button" class="btn btn-app bg-teal dropdown-toggle" data-toggle="dropdown">
-                            <span class="caret"></span>
-                            <span class="sr-only">Toggle Dropdown</span>
                         </button>
-                        <ul class="dropdown-menu" role="menu">
+                        <div class="dropdown-menu" aria-labelledby="emailGroupDropdown">
+                            <a class="dropdown-item" href="mailto:<?= mb_substr($sEmailLink, 0, -3) ?>"><?= gettext('All Members') ?></a>
                             <?php generateGroupRoleEmailDropdown($roleEmails, 'mailto:') ?>
-                        </ul>
+                        </div>
                     </div>
-                    <div class="btn-group">
-                        <a class="btn btn-app bg-navy" href="mailto:?bcc=<?= mb_substr($sEmailLink, 0, -3) ?>">
-                            <i class="fa-regular fa-paper-plane fa-3x"></i><br>
+                    <div class="dropdown d-inline-block">
+                        <button class="btn btn-app bg-navy dropdown-toggle" type="button" id="emailGroupBccDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                            <i class="fa-solid fa-user-secret fa-3x"></i><br>
                             <?= gettext('Email (BCC)') ?>
-                        </a>
-                        <button type="button" class="btn btn-app bg-navy dropdown-toggle" data-toggle="dropdown">
-                            <span class="caret"></span>
-                            <span class="sr-only">Toggle Dropdown</span>
                         </button>
-                        <ul class="dropdown-menu" role="menu">
+                        <div class="dropdown-menu" aria-labelledby="emailGroupBccDropdown">
+                            <a class="dropdown-item" href="mailto:?bcc=<?= mb_substr($sEmailLink, 0, -3) ?>"><?= gettext('All Members') ?></a>
                             <?php generateGroupRoleEmailDropdown($roleEmails, 'mailto:?bcc=') ?>
-                        </ul>
+                        </div>
                     </div>
                 <?php }
                 // Text button

--- a/src/PeopleDashboard.php
+++ b/src/PeopleDashboard.php
@@ -103,27 +103,23 @@ if (SystemConfig::getBooleanValue("bEnableSelfRegistration")) {
             if (AuthenticationManager::getCurrentUser()->isEmailEnabled()) { // Does user have permission to email groups
                 // Display link
                 ?>
-                <div class="btn-group">
-                    <a class="btn btn-app bg-primary" href="mailto:<?= mb_substr($sEmailLink, 0, -3) ?>">
+                <div class="dropdown d-inline-block">
+                    <button class="btn btn-app bg-primary dropdown-toggle" type="button" id="emailAllDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                         <i class="fa-solid fa-mail-bulk fa-3x"></i><br>
                         <?= gettext('Email All') ?>
-                    </a>
-                    <button type="button" class="btn btn-app bg-primary dropdown-toggle dropdown-icon" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                        <span class="sr-only">Toggle Dropdown</span>
                     </button>
-                    <div class="dropdown-menu">
+                    <div class="dropdown-menu" aria-labelledby="emailAllDropdown">
+                        <a class="dropdown-item" href="mailto:<?= mb_substr($sEmailLink, 0, -3) ?>"><?= gettext('All People') ?></a>
                         <?php generateGroupRoleEmailDropdown($roleEmails, 'mailto:') ?>
                     </div>
                 </div>
-                <div class="btn-group">
-                    <a class="btn btn-app bg-info" href="mailto:?bcc=<?= mb_substr($sEmailLink, 0, -3) ?>">
-                        <i class="fa-solid fa-mail-bulk fa-3x"></i><br>
+                <div class="dropdown d-inline-block">
+                    <button class="btn btn-app bg-info dropdown-toggle" type="button" id="emailAllBccDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        <i class="fa-solid fa-user-secret fa-3x"></i><br>
                         <?= gettext('Email All (BCC)') ?>
-                    </a>
-                    <button type="button" class="btn btn-app bg-info dropdown-toggle dropdown-icon" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                        <span class="sr-only">Toggle Dropdown</span>
                     </button>
-                    <div class="dropdown-menu">
+                    <div class="dropdown-menu" aria-labelledby="emailAllBccDropdown">
+                        <a class="dropdown-item" href="mailto:?bcc=<?= mb_substr($sEmailLink, 0, -3) ?>"><?= gettext('All People') ?></a>
                         <?php generateGroupRoleEmailDropdown($roleEmails, 'mailto:?bcc=') ?>
                     </div>
                 </div>

--- a/src/skin/scss/_ui-components.scss
+++ b/src/skin/scss/_ui-components.scss
@@ -13,7 +13,7 @@
     height: auto;
     white-space: normal;
     word-wrap: break-word;
-    padding: 15px 5px;
+    padding: 15px 10px;
 
     // Large icon styling with proper spacing
     > .fa-3x {

--- a/src/sundayschool/SundaySchoolClassView.php
+++ b/src/sundayschool/SundaySchoolClassView.php
@@ -108,32 +108,26 @@ require_once '../Include/Header.php';
     if (AuthenticationManager::getCurrentUser()->isEmailEnabled()) { // Does user have permission to email groups
       // Display link
         ?>
-      <div class="btn-group">
-        <a class="btn btn-app bg-teal" href="mailto:<?= mb_substr($sEmailLink, 0, -3) ?>">
+      <div class="dropdown d-inline-block">
+        <button class="btn btn-app bg-teal dropdown-toggle" type="button" id="emailClassDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <i class="fa-solid fa-paper-plane fa-3x"></i><br>
             <?= gettext('Email') ?>
-        </a>
-        <button type="button" class="btn btn-app bg-teal dropdown-toggle" data-toggle="dropdown">
-          <span class="caret"></span>
-          <span class="sr-only"><?= gettext('Toggle Dropdown') ?></span>
         </button>
-        <ul class="dropdown-menu" role="menu">
+        <div class="dropdown-menu" aria-labelledby="emailClassDropdown">
+          <a class="dropdown-item" href="mailto:<?= mb_substr($sEmailLink, 0, -3) ?>"><?= gettext('All Members') ?></a>
           <?php generateGroupRoleEmailDropdown($roleEmails, 'mailto:') ?>
-        </ul>
+        </div>
       </div>
 
-      <div class="btn-group">
-        <a class="btn btn-app bg-navy" href="mailto:?bcc=<?= mb_substr($sEmailLink, 0, -3) ?>">
-            <i class="fa-regular fa-paper-plane fa-3x"></i><br>
+      <div class="dropdown d-inline-block">
+        <button class="btn btn-app bg-navy dropdown-toggle" type="button" id="emailClassBccDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <i class="fa-solid fa-user-secret fa-3x"></i><br>
             <?= gettext('Email (BCC)') ?>
-        </a>
-        <button type="button" class="btn btn-app bg-navy dropdown-toggle" data-toggle="dropdown">
-          <span class="caret"></span>
-          <span class="sr-only"><?= gettext('Toggle Dropdown') ?></span>
         </button>
-        <ul class="dropdown-menu" role="menu">
+        <div class="dropdown-menu" aria-labelledby="emailClassBccDropdown">
+          <a class="dropdown-item" href="mailto:?bcc=<?= mb_substr($sEmailLink, 0, -3) ?>"><?= gettext('All Members') ?></a>
           <?php generateGroupRoleEmailDropdown($roleEmails, 'mailto:?bcc=') ?>
-        </ul>
+        </div>
       </div>
         <?php
     }


### PR DESCRIPTION


## What Changed
<!-- Short summary - what and why (not how) -->

Replaced split button groups (btn-group with separate link + dropdown toggle) with single dropdown buttons Added proper IDs to each dropdown button for aria-labelledby accessibility Added "All Members"/"All People" as the first dropdown item (what used to be the direct link) Maintained all role-based email options from generateGroupRoleEmailDropdown()

## Type
<!-- Check one -->
- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
<!-- How to verify this works -->

## Screenshots
<!-- Only for UI changes - drag & drop images here -->

## Security Check
<!-- Only check if applicable -->
- [ ] Introduces new input validation
- [ ] Modifies authentication/authorization
- [ ] Affects data privacy/GDPR

### Code Quality
- [ ] Database: Propel ORM only, no raw SQL
- [ ] No deprecated attributes (align, valign, nowrap, border, cellpadding, cellspacing, bgcolor)
- [x] Bootstrap CSS classes used
- [ ] All CSS bundled via webpack

## Pre-Merge
- [ ] Tested locally
- [ ] No new warnings
- [ ] Build passes
- [ ] Backward compatible (or migration documented)