### PR TITLE
Bundle jQuery via Webpack and fix Font Awesome icon paths

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -152,13 +152,6 @@ module.exports = function (grunt) {
                         expand: true,
                         filter: "isFile",
                         flatten: true,
-                        src: ["node_modules/jquery/dist/jquery.min.js"],
-                        dest: "src/skin/external/jquery/",
-                    },
-                    {
-                        expand: true,
-                        filter: "isFile",
-                        flatten: true,
                         src: [
                             "node_modules/jquery-steps/build/jquery.steps.min.js",
                             "node_modules/jquery-steps/demo/css/jquery.steps.css",

--- a/src/Include/Header-HTML-Scripts.php
+++ b/src/Include/Header-HTML-Scripts.php
@@ -8,10 +8,7 @@ use ChurchCRM\dto\SystemURLs;
 <!-- Custom ChurchCRM styles -->
 <link rel="stylesheet" href="<?= SystemURLs::getRootPath() ?>/skin/v2/churchcrm.min.css">
 
-<!-- jQuery JS -->
-<script src="<?= SystemURLs::getRootPath() ?>/skin/external/jquery/jquery.min.js"></script>
-
-<!-- Core ChurchCRM bundle -->
+<!-- Core ChurchCRM bundle (includes jQuery) -->
 <script src="<?= SystemURLs::getRootPath() ?>/skin/v2/churchcrm.min.js"></script>
 
 <script src="<?= SystemURLs::getRootPath() ?>/skin/external/moment/moment.min.js"></script>

--- a/src/Include/HeaderNotLoggedIn.php
+++ b/src/Include/HeaderNotLoggedIn.php
@@ -13,10 +13,7 @@ require_once 'Header-Security.php';
     <meta http-equiv="Content-Type" content="text/html">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <!-- jQuery JS -->
-    <script src="<?= SystemURLs::getRootPath() ?>/skin/external/jquery/jquery.min.js"></script>
-
-    <!-- Core ChurchCRM bundle -->
+    <!-- Core ChurchCRM bundle (includes jQuery) -->
     <script src="<?= SystemURLs::getRootPath() ?>/skin/v2/churchcrm.min.js"></script>
     <link rel="stylesheet" href="<?= SystemURLs::getRootPath() ?>/skin/v2/churchcrm.min.css">
 

--- a/src/skin/js/cart.js
+++ b/src/skin/js/cart.js
@@ -4,7 +4,6 @@
  */
 
 import $ from "jquery";
-import "bootstrap-notify";
 
 /**
  * Cart Manager Class

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,8 @@ module.exports = {
   },
   output: {
     path:path.resolve('./src/skin/v2'),
-    filename:'[name].min.js'
+    filename:'[name].min.js',
+    publicPath: '/skin/v2/'
   },
   resolve: {
     extensions: [".ts", ".tsx", ".js"],
@@ -60,12 +61,6 @@ module.exports = {
     new MiniCssExtractPlugin({
       filename: '[name].min.css',
       ignoreOrder: false,
-    }),
-    new webpack.ProvidePlugin({
-      $: 'jquery',
-      jQuery: 'jquery',
-      'window.jQuery': 'jquery',
-      'window.$': 'jquery',
     }),
   ],
 }

--- a/webpack/skin-main.js
+++ b/webpack/skin-main.js
@@ -9,6 +9,10 @@
  * Used by both logged-in and logged-out pages to provide core styling and functionality.
  */
 
+// Import jQuery and expose it globally for legacy code compatibility
+import $ from 'jquery';
+window.jQuery = window.$ = $;
+
 // Import FontAwesome CSS - webfonts are automatically bundled by webpack
 import '@fortawesome/fontawesome-free/css/all.min.css';
 


### PR DESCRIPTION

## What Changed
<!-- Short summary - what and why (not how) -->

- Import jQuery explicitly in webpack/skin-main.js with global exposure
- Remove Webpack ProvidePlugin for jQuery
- Remove jQuery script tags from header files
- Remove jQuery copy task from Gruntfile
- Add publicPath to webpack config for correct asset URL resolution
- Fix bootstrap-notify import in cart.js


## Type
<!-- Check one -->
- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [x] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
<!-- How to verify this works -->

## Screenshots
<!-- Only for UI changes - drag & drop images here -->

## Security Check
<!-- Only check if applicable -->
- [ ] Introduces new input validation
- [ ] Modifies authentication/authorization
- [ ] Affects data privacy/GDPR

### Code Quality
- [ ] Database: Propel ORM only, no raw SQL
- [ ] No deprecated attributes (align, valign, nowrap, border, cellpadding, cellspacing, bgcolor)
- [ ] Bootstrap CSS classes used
- [ ] All CSS bundled via webpack

## Pre-Merge
- [ ] Tested locally
- [ ] No new warnings
- [ ] Build passes
- [ ] Backward compatible (or migration documented)