### PR TITLE
Fix: Remove misleading deposit counter from menu (issue #6515)

### DIFF
--- a/src/ChurchCRM/Config/Menu/Menu.php
+++ b/src/ChurchCRM/Config/Menu/Menu.php
@@ -147,7 +147,6 @@ class Menu
         $depositsMenu->addSubMenu(new MenuItem(gettext('View All Deposits'), 'FindDepositSlip.php', AuthenticationManager::getCurrentUser()->isFinanceEnabled()));
         $depositsMenu->addSubMenu(new MenuItem(gettext('Deposit Reports'), 'FinancialReports.php', AuthenticationManager::getCurrentUser()->isFinanceEnabled()));
         $depositsMenu->addSubMenu(new MenuItem(gettext('Edit Deposit Slip'), 'DepositSlipEditor.php?DepositSlipID=' . $_SESSION['iCurrentDeposit'], AuthenticationManager::getCurrentUser()->isFinanceEnabled()));
-        $depositsMenu->addCounter(new MenuCounter('iCurrentDeposit', 'bg-green', $_SESSION['iCurrentDeposit']));
 
         $adminMenu = new MenuItem(gettext('Admin'), '', AuthenticationManager::getCurrentUser()->isAdmin());
         $adminMenu->addSubMenu(new MenuItem(gettext('Envelope Manager'), 'ManageEnvelopes.php', AuthenticationManager::getCurrentUser()->isAdmin()));


### PR DESCRIPTION
## What Changed
<!-- Short summary - what and why (not how) -->

User Confusion: The badge showing "2" next to "Deposit" doesn't mean "2 deposits exist" — it means "Deposit #2 is currently active." This is very confusing for users.



## Type
<!-- Check one -->
- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
<!-- How to verify this works -->

## Screenshots
<!-- Only for UI changes - drag & drop images here -->

## Security Check
<!-- Only check if applicable -->
- [ ] Introduces new input validation
- [ ] Modifies authentication/authorization
- [ ] Affects data privacy/GDPR

### Code Quality
- [ ] Database: Propel ORM only, no raw SQL
- [ ] No deprecated attributes (align, valign, nowrap, border, cellpadding, cellspacing, bgcolor)
- [ ] Bootstrap CSS classes used
- [ ] All CSS bundled via webpack

## Pre-Merge
- [ ] Tested locally
- [ ] No new warnings
- [ ] Build passes
- [ ] Backward compatible (or migration documented)