### PR TITLE
Fix issue #7641: Remove duplicate Quill editor toolbar instances

### DIFF
--- a/react/components/QuillEditor.tsx
+++ b/react/components/QuillEditor.tsx
@@ -19,9 +19,7 @@ const QuillEditor: React.FunctionComponent<{
   const editorRef = useRef<HTMLDivElement>(null);
   const quillRef = useRef<Quill | null>(null);
 
-  // We intentionally only initialize Quill once on mount. The effect references
-  // props that are intentionally stable for our usage pattern; disable the
-  // exhaustive-deps rule for this effect.
+  // Initialize Quill editor once on mount
   useEffect(() => {
     if (!editorRef.current || quillRef.current) {
       return;
@@ -73,7 +71,7 @@ const QuillEditor: React.FunctionComponent<{
         delete window.quillEditors[name];
       }
     };
-  }, [name, onChange, placeholder, value]);
+  }, [name]);
 
   return (
     <div


### PR DESCRIPTION
## What Changed
<!-- Short summary - what and why (not how) -->

The useEffect dependency array was causing the Quill editor to reinitialize whenever the value prop changed, resulting in stacked duplicate toolbars. Changed dependency array to only [name] to ensure each editor initializes once when mounted.

Fixes #7641


## Type
<!-- Check one -->
- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
<!-- How to verify this works -->

## Screenshots
<!-- Only for UI changes - drag & drop images here -->

## Security Check
<!-- Only check if applicable -->
- [ ] Introduces new input validation
- [ ] Modifies authentication/authorization
- [ ] Affects data privacy/GDPR

### Code Quality
- [ ] Database: Propel ORM only, no raw SQL
- [ ] No deprecated attributes (align, valign, nowrap, border, cellpadding, cellspacing, bgcolor)
- [ ] Bootstrap CSS classes used
- [ ] All CSS bundled via webpack

## Pre-Merge
- [x] Tested locally
- [ ] No new warnings
- [ ] Build passes
- [ ] Backward compatible (or migration documented)