### PR TITLE
Fix issue #7651: Add missing variable extraction in Advanced Deposit …

### DIFF
--- a/src/Reports/AdvancedDeposit.php
+++ b/src/Reports/AdvancedDeposit.php
@@ -628,17 +628,17 @@ $page = 1;
     } elseif ($sort === 'family') {
         // Sort by Family  Report
         foreach ($rsReport as $aRow) {
-            $fun_ID = $aRow['fun_ID'];
-            $fun_Name = $aRow['fun_Name'];
-            $fam_ID = $aRow['fam_ID'];
-            $fam_Name = $aRow['fam_Name'];
-            $fam_Address1 = $aRow['fam_Address1'];
-            $plg_depID = $aRow['plg_depID'];
-            $plg_amount = $aRow['plg_amount'];
-            $plg_method = $aRow['plg_method'];
-            $plg_comment = $aRow['plg_comment'];
-            $plg_CheckNo = $aRow['plg_CheckNo'];
-            $dep_Date = $aRow['dep_Date'];
+            $fun_ID = isset($aRow['fun_ID']) ? $aRow['fun_ID'] : null;
+            $fun_Name = isset($aRow['fun_Name']) ? $aRow['fun_Name'] : null;
+            $fam_ID = isset($aRow['fam_ID']) ? $aRow['fam_ID'] : null;
+            $fam_Name = isset($aRow['fam_Name']) ? $aRow['fam_Name'] : null;
+            $fam_Address1 = isset($aRow['fam_Address1']) ? $aRow['fam_Address1'] : null;
+            $plg_depID = isset($aRow['plg_depID']) ? $aRow['plg_depID'] : null;
+            $plg_amount = isset($aRow['plg_amount']) ? $aRow['plg_amount'] : null;
+            $plg_method = isset($aRow['plg_method']) ? $aRow['plg_method'] : null;
+            $plg_comment = isset($aRow['plg_comment']) ? $aRow['plg_comment'] : null;
+            $plg_CheckNo = isset($aRow['plg_CheckNo']) ? $aRow['plg_CheckNo'] : null;
+            $dep_Date = isset($aRow['dep_Date']) ? $aRow['dep_Date'] : null;
             
             if (!$fun_ID) {
                 $fun_ID = -1;


### PR DESCRIPTION

When refactoring from while...extract() to foreach, the fund and family sort loops were missing variable extractions from the $aRow array, causing undefined variable errors and blank screens when generating reports with these sort options.

- Sort by Fund loop: Add extraction of fam_Address1, plg_depID, plg_amount, plg_method, plg_comment, plg_CheckNo, dep_Date with null-safe checks
- Sort by Family loop: Add complete extraction of all 11 required variables (fun_ID, fun_Name, fam_ID, fam_Name, fam_Address1, plg_depID, plg_amount, plg_method, plg_comment, plg_CheckNo, dep_Date)

This fixes blank screen issues when users select these sort options or PDF/CSV export formats for Advanced Deposit Reports.

Fix #7651

## What Changed
<!-- Short summary - what and why (not how) -->

Fixes #

## Type
<!-- Check one -->
- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
<!-- How to verify this works -->

## Screenshots
<!-- Only for UI changes - drag & drop images here -->

## Security Check
<!-- Only check if applicable -->
- [ ] Introduces new input validation
- [ ] Modifies authentication/authorization
- [ ] Affects data privacy/GDPR

### Code Quality
- [ ] Database: Propel ORM only, no raw SQL
- [ ] No deprecated attributes (align, valign, nowrap, border, cellpadding, cellspacing, bgcolor)
- [ ] Bootstrap CSS classes used
- [ ] All CSS bundled via webpack

## Pre-Merge
- [ ] Tested locally
- [ ] No new warnings
- [ ] Build passes
- [ ] Backward compatible (or migration documented)