### PR TITLE
Fix stored XSS via CSV Import (CVE-2023-24686)

### DIFF
--- a/src/CSVImport.php
+++ b/src/CSVImport.php
@@ -378,6 +378,7 @@ if (isset($_POST['DoImport'])) {
                     // handler for each of the 20 person_per table column possibilities
                     switch ($currentType) {
                         // Address goes with family record if creating families
+                        // Sanitize to prevent XSS - strip HTML tags from input
                         case 8:
                         case 9:
                         case 10:
@@ -385,28 +386,29 @@ if (isset($_POST['DoImport'])) {
                         case 12:
                             // if not making family records, add to person
                             if (!isset($_POST['MakeFamilyRecords'])) {
-                                $sSQLpersonData .= "'" . addslashes($aData[$col]) . "',";
+                                $sSQLpersonData .= "'" . addslashes(strip_tags($aData[$col])) . "',";
                             } else {
                                 switch ($currentType) {
                                     case 8:
-                                        $sAddress1 = addslashes($aData[$col]);
+                                        $sAddress1 = addslashes(strip_tags($aData[$col]));
                                         break;
                                     case 9:
-                                        $sAddress2 = addslashes($aData[$col]);
+                                        $sAddress2 = addslashes(strip_tags($aData[$col]));
                                         break;
                                     case 10:
-                                        $sCity = addslashes($aData[$col]);
+                                        $sCity = addslashes(strip_tags($aData[$col]));
                                         break;
                                     case 11:
-                                        $sState = addslashes($aData[$col]);
+                                        $sState = addslashes(strip_tags($aData[$col]));
                                         break;
                                     case 12:
-                                        $sZip = addslashes($aData[$col]);
+                                        $sZip = addslashes(strip_tags($aData[$col]));
                                 }
                             }
                             break;
 
                         // Simple strings.. no special processing
+                        // Sanitize to prevent XSS - strip HTML tags from input
                         case 1:
                         case 2:
                         case 3:
@@ -414,7 +416,7 @@ if (isset($_POST['DoImport'])) {
                         case 5:
                         case 17:
                         case 18:
-                                        $sSQLpersonData .= "'" . addslashes($aData[$col]) . "',";
+                                        $sSQLpersonData .= "'" . addslashes(strip_tags($aData[$col])) . "',";
                             break;
 
                         // Country.. also set $sCountry for use later!
@@ -695,7 +697,8 @@ if (isset($_POST['DoImport'])) {
                                     $currentFieldData = ConvertToBoolean($currentFieldData);
                                 }
                             } else {
-                                $currentFieldData = addslashes($currentFieldData);
+                                // Sanitize to prevent XSS - strip HTML tags from input
+                                $currentFieldData = addslashes(strip_tags($currentFieldData));
                             }
 
                             // aColumnID is the custom table column name
@@ -748,7 +751,8 @@ if (isset($_POST['DoImport'])) {
                                 $currentFieldData = ConvertToBoolean($currentFieldData);
                             }
                         } else {
-                            $currentFieldData = addslashes($currentFieldData);
+                            // Sanitize to prevent XSS - strip HTML tags from input
+                            $currentFieldData = addslashes(strip_tags($currentFieldData));
                         }
 
                         // aColumnID is the custom table column name


### PR DESCRIPTION
## What Changed
<!-- Short summary - what and why (not how) -->

Add strip_tags() sanitization to all string fields imported from CSV:
- Person fields: Title, FirstName, MiddleName, LastName, Suffix, Email, WorkEmail
- Address fields: Address1, Address2, City, State, Zip
- Custom fields: Family and Person custom field data

This prevents XSS payloads from being stored in the database when importing malicious CSV files.

Fixes #6442

## Type
<!-- Check one -->
- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [x] 🔒 Security

## Testing
<!-- How to verify this works -->

## Screenshots
<!-- Only for UI changes - drag & drop images here -->

## Security Check
<!-- Only check if applicable -->
- [ ] Introduces new input validation
- [ ] Modifies authentication/authorization
- [ ] Affects data privacy/GDPR

### Code Quality
- [ ] Database: Propel ORM only, no raw SQL
- [ ] No deprecated attributes (align, valign, nowrap, border, cellpadding, cellspacing, bgcolor)
- [ ] Bootstrap CSS classes used
- [ ] All CSS bundled via webpack

## Pre-Merge
- [ ] Tested locally
- [ ] No new warnings
- [ ] Build passes
- [ ] Backward compatible (or migration documented)