### PR TITLE
Fix stored XSS in Calendar name (CVE-2023-24690)

### DIFF
--- a/src/api/routes/calendar/calendar.php
+++ b/src/api/routes/calendar/calendar.php
@@ -193,7 +193,7 @@ function NewCalendar(Request $request, Response $response, $args): Response
 {
     $input = $request->getParsedBody();
     $Calendar = new Calendar();
-    $Calendar->setName(strip_tags($input['Name']));
+    $Calendar->setName(InputUtils::filterString($input['Name']));
     $Calendar->setForegroundColor($input['ForegroundColor']);
     $Calendar->setBackgroundColor($input['BackgroundColor']);
     $Calendar->save();


### PR DESCRIPTION

## What Changed
<!-- Short summary - what and why (not how) -->

Add strip_tags() sanitization when creating new calendars to prevent XSS payloads from being stored in the database.

This is part of CVE-2023-24690 which covers multiple XSS vulnerabilities:
- Calendar Name XSS (fixed here)
- Group Name XSS (fixed in PR #7675)
- Group Description XSS (fixed in PR #7675)

Fixes #6444


## Type
<!-- Check one -->
- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [x] 🔒 Security

## Testing
<!-- How to verify this works -->

## Screenshots
<!-- Only for UI changes - drag & drop images here -->

## Security Check
<!-- Only check if applicable -->
- [ ] Introduces new input validation
- [ ] Modifies authentication/authorization
- [ ] Affects data privacy/GDPR

### Code Quality
- [ ] Database: Propel ORM only, no raw SQL
- [ ] No deprecated attributes (align, valign, nowrap, border, cellpadding, cellspacing, bgcolor)
- [ ] Bootstrap CSS classes used
- [ ] All CSS bundled via webpack

## Pre-Merge
- [ ] Tested locally
- [ ] No new warnings
- [ ] Build passes
- [ ] Backward compatible (or migration documented)