### PR TITLE
Fix SQL injection in EventEditor.php via EID parameter

### DIFF
--- a/src/EventEditor.php
+++ b/src/EventEditor.php
@@ -337,14 +337,16 @@ if ($sAction === 'Create Event' && !empty($tyid)) {
             $iEventID = $event->getId();
             for ($c = 0; $c < $iNumCounts; $c++) {
                 $cCnt = ltrim(rtrim($aCountName[$c]));
+                $filteredCount = InputUtils::legacyFilterInput($aCount[$c]);
+                $filteredCountNotes = InputUtils::legacyFilterInput($sCountNotes);
                 $sSQL = "INSERT eventcounts_evtcnt
                        (evtcnt_eventid, evtcnt_countid, evtcnt_countname, evtcnt_countcount, evtcnt_notes)
                        VALUES
                        ('" . InputUtils::legacyFilterInput($iEventID) . "',
                         '" . InputUtils::legacyFilterInput($aCountID[$c]) . "',
                         '" . InputUtils::legacyFilterInput($aCountName[$c]) . "',
-                        '" . InputUtils::legacyFilterInput($aCount[$c]) . "',
-                        '" . InputUtils::legacyFilterInput($sCountNotes) . "') ON DUPLICATE KEY UPDATE evtcnt_countcount='$aCount[$c]', evtcnt_notes='$sCountNotes'";
+                        '" . $filteredCount . "',
+                        '" . $filteredCountNotes . "') ON DUPLICATE KEY UPDATE evtcnt_countcount='" . $filteredCount . "', evtcnt_notes='" . $filteredCountNotes . "'";
                 RunQuery($sSQL);
             }
         } else {
@@ -360,14 +362,16 @@ if ($sAction === 'Create Event' && !empty($tyid)) {
             $event->save();
             for ($c = 0; $c < $iNumCounts; $c++) {
                 $cCnt = ltrim(rtrim($aCountName[$c]));
+                $filteredCount = InputUtils::legacyFilterInput($aCount[$c]);
+                $filteredCountNotes = InputUtils::legacyFilterInput($sCountNotes);
                 $sSQL = "INSERT eventcounts_evtcnt
                        (evtcnt_eventid, evtcnt_countid, evtcnt_countname, evtcnt_countcount, evtcnt_notes)
                        VALUES
                        ('" . InputUtils::legacyFilterInput($iEventID) . "',
                         '" . InputUtils::legacyFilterInput($aCountID[$c]) . "',
                         '" . InputUtils::legacyFilterInput($aCountName[$c]) . "',
-                        '" . InputUtils::legacyFilterInput($aCount[$c]) . "',
-                        '" . InputUtils::legacyFilterInput($sCountNotes) . "') ON DUPLICATE KEY UPDATE evtcnt_countcount='$aCount[$c]', evtcnt_notes='$sCountNotes'";
+                        '" . $filteredCount . "',
+                        '" . $filteredCountNotes . "') ON DUPLICATE KEY UPDATE evtcnt_countcount='" . $filteredCount . "', evtcnt_notes='" . $filteredCountNotes . "'";
                 RunQuery($sSQL);
             }
         }


### PR DESCRIPTION


## What Changed
<!-- Short summary - what and why (not how) -->

Add InputUtils::filterInt() sanitization to EID parameter from both GET and POST requests. The unsanitized EID was being directly concatenated into SQL queries, allowing SQL injection attacks.

Fixes #6854

## Type
<!-- Check one -->
- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
<!-- How to verify this works -->

## Screenshots
<!-- Only for UI changes - drag & drop images here -->

## Security Check
<!-- Only check if applicable -->
- [ ] Introduces new input validation
- [ ] Modifies authentication/authorization
- [ ] Affects data privacy/GDPR

### Code Quality
- [ ] Database: Propel ORM only, no raw SQL
- [ ] No deprecated attributes (align, valign, nowrap, border, cellpadding, cellspacing, bgcolor)
- [ ] Bootstrap CSS classes used
- [ ] All CSS bundled via webpack

## Pre-Merge
- [ ] Tested locally
- [ ] No new warnings
- [ ] Build passes
- [ ] Backward compatible (or migration documented)