### PR TITLE
Fix SSRF vulnerability in AppIntegrityService::hasModRewrite()

### DIFF
--- a/src/ChurchCRM/Service/AppIntegrityService.php
+++ b/src/ChurchCRM/Service/AppIntegrityService.php
@@ -259,13 +259,13 @@ class AppIntegrityService
             $ch = curl_init();
 
             // Security fix: Do NOT use HTTP_REFERER header as it's user-controlled (SSRF vulnerability)
-            // Instead, determine scheme from server variables and use HTTP_HOST
+            // Use SERVER_NAME instead of HTTP_HOST since HTTP_HOST is also user-controlled
             $request_scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
             if (isset($_SERVER['REQUEST_SCHEME'])) {
                 $request_scheme = $_SERVER['REQUEST_SCHEME'];
             }
-            $request_host = $_SERVER['HTTP_HOST'] ?? 'localhost';
-            
+            $request_host = $_SERVER['SERVER_NAME'] ?? 'localhost';
+
             // Run a test against an URL we know does not exist to check for ModRewrite like functionality
             $rewrite_chk_url = $request_scheme . '://' . $request_host . SystemURLs::getRootPath() . '/INVALID';
             $logger->debug("Testing CURL loopback check to: $rewrite_chk_url");


### PR DESCRIPTION

## What Changed
<!-- Short summary - what and why (not how) -->

The hasModRewrite() function was using the user-controlled HTTP_REFERER header to construct a URL for a server-side CURL request. An attacker could supply a malicious Referer header causing the server to make outbound requests to arbitrary hosts (SSRF).

Fix: Instead of parsing the Referer header, determine the request scheme from trusted server variables (HTTPS, REQUEST_SCHEME) and use HTTP_HOST for the hostname. This ensures the loopback check only contacts the server itself, not attacker-controlled domains.

GHSA-44x3-28jv-mrwq


## Type
<!-- Check one -->
- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [x] 🔒 Security

## Testing
<!-- How to verify this works -->

## Screenshots
<!-- Only for UI changes - drag & drop images here -->

## Security Check
<!-- Only check if applicable -->
- [ ] Introduces new input validation
- [ ] Modifies authentication/authorization
- [ ] Affects data privacy/GDPR

### Code Quality
- [ ] Database: Propel ORM only, no raw SQL
- [ ] No deprecated attributes (align, valign, nowrap, border, cellpadding, cellspacing, bgcolor)
- [ ] Bootstrap CSS classes used
- [ ] All CSS bundled via webpack

## Pre-Merge
- [x] Tested locally
- [ ] No new warnings
- [ ] Build passes
- [ ] Backward compatible (or migration documented)