### PR TITLE
Fix SQL injection via FieldSec parameter in custom field editors

### DIFF
--- a/src/FamilyCustomFieldsEditor.php
+++ b/src/FamilyCustomFieldsEditor.php
@@ -55,7 +55,7 @@ if (isset($_POST['SaveChanges'])) {
             $aNameErrors[$iFieldID] = false;
         }
 
-        $aFieldSecurity[$iFieldID] = $_POST[$iFieldID . 'FieldSec'];
+        $aFieldSecurity[$iFieldID] = InputUtils::legacyFilterInput($_POST[$iFieldID . 'FieldSec'], 'int');
 
         if (isset($_POST[$iFieldID . 'special'])) {
             $aSpecialFields[$iFieldID] = InputUtils::legacyFilterInput($_POST[$iFieldID . 'special'], 'int');
@@ -86,7 +86,7 @@ if (isset($_POST['SaveChanges'])) {
     if (isset($_POST['AddField'])) {
         $newFieldType = InputUtils::legacyFilterInput($_POST['newFieldType'], 'int');
         $newFieldName = InputUtils::legacyFilterInput($_POST['newFieldName']);
-        $newFieldSec = $_POST['newFieldSec'];
+        $newFieldSec = InputUtils::legacyFilterInput($_POST['newFieldSec'], 'int');
 
         if (strlen($newFieldName) === 0) {
             $bNewNameError = true;

--- a/src/PersonCustomFieldsEditor.php
+++ b/src/PersonCustomFieldsEditor.php
@@ -54,7 +54,7 @@ require_once 'Include/Header.php'; ?>
                 $aNameErrors[$iFieldID] = false;
             }
 
-            $aFieldSecurity[$iFieldID] = $_POST[$iFieldID . 'FieldSec'];
+            $aFieldSecurity[$iFieldID] = InputUtils::legacyFilterInput($_POST[$iFieldID . 'FieldSec'], 'int');
 
             if (isset($_POST[$iFieldID . 'special'])) {
                 $aSpecialFields[$iFieldID] = InputUtils::legacyFilterInput($_POST[$iFieldID . 'special'], 'int');
@@ -84,7 +84,7 @@ require_once 'Include/Header.php'; ?>
         if (isset($_POST['AddField'])) {
             $newFieldType = InputUtils::legacyFilterInput($_POST['newFieldType'], 'int');
             $newFieldName = InputUtils::legacyFilterInput($_POST['newFieldName']);
-            $newFieldSec = $_POST['newFieldSec'];
+            $newFieldSec = InputUtils::legacyFilterInput($_POST['newFieldSec'], 'int');
 
             if (strlen($newFieldName) === 0) {
                 $bNewNameError = true;


### PR DESCRIPTION


## What Changed
<!-- Short summary - what and why (not how) -->

The PersonCustomFieldsEditor.php and FamilyCustomFieldsEditor.php files were vulnerable to time-based blind SQL injection via the FieldSec parameters (e.g., 1FieldSec, newFieldSec). The POST values were used directly in SQL UPDATE and INSERT statements without sanitization.

Fix: Apply InputUtils::legacyFilterInput() with 'int' type to all FieldSec parameters before use in SQL queries. This ensures only integer values are accepted, preventing SQL injection payloads.

## Type
<!-- Check one -->
- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [x] 🔒 Security

## Testing
<!-- How to verify this works -->

## Screenshots
<!-- Only for UI changes - drag & drop images here -->

## Security Check
<!-- Only check if applicable -->
- [ ] Introduces new input validation
- [ ] Modifies authentication/authorization
- [ ] Affects data privacy/GDPR

### Code Quality
- [ ] Database: Propel ORM only, no raw SQL
- [ ] No deprecated attributes (align, valign, nowrap, border, cellpadding, cellspacing, bgcolor)
- [ ] Bootstrap CSS classes used
- [ ] All CSS bundled via webpack

## Pre-Merge
- [ ] Tested locally
- [ ] No new warnings
- [ ] Build passes
- [ ] Backward compatible (or migration documented)