### PR TITLE
Fix broken access control in Kiosk Manager API endpoints

### DIFF
--- a/src/api/routes/kiosks.php
+++ b/src/api/routes/kiosks.php
@@ -2,6 +2,7 @@
 
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\model\ChurchCRM\KioskDeviceQuery;
+use ChurchCRM\Slim\Middleware\Request\Auth\AdminRoleAuthMiddleware;
 use ChurchCRM\Slim\SlimUtils;
 use ChurchCRM\Utils\LoggerUtils;
 use Propel\Runtime\ActiveQuery\Criteria;
@@ -79,4 +80,4 @@ $app->group('/kiosks', function (RouteCollectorProxy $group): void {
 
         return SlimUtils::renderSuccessJSON($response);
     });
-});
+})->add(AdminRoleAuthMiddleware::class);


### PR DESCRIPTION

## What Changed
<!-- Short summary - what and why (not how) -->

Add AdminRoleAuthMiddleware to the /kiosks API route group to restrict access to admin users only. This fixes a broken access control vulnerability where any authenticated user could:
- Allow kiosk registrations (/api/kiosks/allowRegistration)
- Accept kiosk devices (/api/kiosks/{id}/acceptKiosk)
- Reload kiosk devices (/api/kiosks/{id}/reloadKiosk)
- Identify kiosk devices (/api/kiosks/{id}/identifyKiosk)
- Set kiosk assignments (/api/kiosks/{id}/setAssignment)

These operations are now properly restricted to administrators only.


## Type
<!-- Check one -->
- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [x] 🔒 Security

## Testing
<!-- How to verify this works -->

## Screenshots
<!-- Only for UI changes - drag & drop images here -->

## Security Check
<!-- Only check if applicable -->
- [ ] Introduces new input validation
- [ ] Modifies authentication/authorization
- [ ] Affects data privacy/GDPR

### Code Quality
- [ ] Database: Propel ORM only, no raw SQL
- [ ] No deprecated attributes (align, valign, nowrap, border, cellpadding, cellspacing, bgcolor)
- [ ] Bootstrap CSS classes used
- [ ] All CSS bundled via webpack

## Pre-Merge
- [ ] Tested locally
- [ ] No new warnings
- [ ] Build passes
- [ ] Backward compatible (or migration documented)