### PR TITLE
Add previous/next navigation buttons to Deposit Slip Editor

### DIFF
--- a/src/ChurchCRM/model/ChurchCRM/Deposit.php
+++ b/src/ChurchCRM/model/ChurchCRM/Deposit.php
@@ -4,6 +4,7 @@ namespace ChurchCRM\model\ChurchCRM;
 
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\model\ChurchCRM\Base\Deposit as BaseDeposit;
+use ChurchCRM\model\ChurchCRM\DepositQuery;
 use ChurchCRM\model\ChurchCRM\Map\DonationFundTableMap;
 use ChurchCRM\model\ChurchCRM\Map\PledgeTableMap;
 use ChurchCRM\model\ChurchCRM\PledgeQuery as ChildPledgeQuery;
@@ -483,5 +484,27 @@ class Deposit extends BaseDeposit
         $query->joinWith('DonationFund', Criteria::RIGHT_JOIN);
 
         return $this->getPledges($query, $con);
+    }
+
+    /**
+     * Get the previous deposit (by ID).
+     */
+    public static function getPreviousDeposit(int $currentId): ?Deposit
+    {
+        return DepositQuery::create()
+            ->filterById($currentId, Criteria::LESS_THAN)
+            ->orderById(Criteria::DESC)
+            ->findOne();
+    }
+
+    /**
+     * Get the next deposit (by ID).
+     */
+    public static function getNextDeposit(int $currentId): ?Deposit
+    {
+        return DepositQuery::create()
+            ->filterById($currentId, Criteria::GREATER_THAN)
+            ->orderById(Criteria::ASC)
+            ->findOne();
     }
 }

--- a/src/DepositSlipEditor.php
+++ b/src/DepositSlipEditor.php
@@ -5,6 +5,7 @@ require_once 'Include/Functions.php';
 
 use ChurchCRM\Authentication\AuthenticationManager;
 use ChurchCRM\dto\SystemURLs;
+use ChurchCRM\model\ChurchCRM\Deposit;
 use ChurchCRM\model\ChurchCRM\DepositQuery;
 use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
@@ -45,6 +46,10 @@ if ($noDeposit) {
 
 $sPageTitle = $thisDeposit->getType() . ' ' . gettext('Deposit Slip Number: ') . $iDepositSlipID;
 
+// Get previous and next deposits for navigation
+$prevDeposit = Deposit::getPreviousDeposit($iDepositSlipID);
+$nextDeposit = Deposit::getNextDeposit($iDepositSlipID);
+
 //Is this the second pass?
 if (isset($_POST['DepositSlipLoadAuthorized'])) {
     $thisDeposit->loadAuthorized();
@@ -61,6 +66,29 @@ $currentUser->save();
 
 require_once 'Include/Header.php';
 ?>
+<!-- Deposit Navigation -->
+<div class="row mb-3">
+  <div class="col-12">
+    <div class="d-flex justify-content-between align-items-center">
+      <a href="FindDepositSlip.php" class="btn btn-outline-secondary">
+        <i class="fa-solid fa-arrow-left"></i> <?= gettext('Back to Deposits'); ?>
+      </a>
+      <div class="btn-group" role="group" aria-label="<?= gettext('Deposit Navigation'); ?>">
+        <a href="<?= $prevDeposit ? 'DepositSlipEditor.php?DepositSlipID=' . $prevDeposit->getId() : '#'; ?>" 
+           class="btn btn-outline-primary <?= $prevDeposit ? '' : 'disabled'; ?>"
+           <?= $prevDeposit ? '' : 'aria-disabled="true"'; ?>>
+          <i class="fa-solid fa-chevron-left"></i> <?= gettext('Previous'); ?>
+        </a>
+        <a href="<?= $nextDeposit ? 'DepositSlipEditor.php?DepositSlipID=' . $nextDeposit->getId() : '#'; ?>" 
+           class="btn btn-outline-primary <?= $nextDeposit ? '' : 'disabled'; ?>"
+           <?= $nextDeposit ? '' : 'aria-disabled="true"'; ?>>
+          <?= gettext('Next'); ?> <i class="fa-solid fa-chevron-right"></i>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+
 <!-- Deposit Slip Editor Main Container -->
 <div id="depositSlipEditorContainer">
   <div class="row">


### PR DESCRIPTION


## What Changed
<!-- Short summary - what and why (not how) -->

Fixes #5043: Users can now navigate between deposits without returning to the deposit list. Adds Previous/Next buttons and a Back to Deposits link for improved workflow during deposit review and reconciliation.

## Type
<!-- Check one -->
- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security



## Screenshots
<!-- Only for UI changes - drag & drop images here -->
<img width="1951" height="538" alt="image" src="https://github.com/user-attachments/assets/a529b88f-f71f-4910-853a-e2863b18e6cb" />


## Security Check
<!-- Only check if applicable -->
- [ ] Introduces new input validation
- [ ] Modifies authentication/authorization
- [ ] Affects data privacy/GDPR

### Code Quality
- [ ] Database: Propel ORM only, no raw SQL
- [ ] No deprecated attributes (align, valign, nowrap, border, cellpadding, cellspacing, bgcolor)
- [ ] Bootstrap CSS classes used
- [ ] All CSS bundled via webpack

## Pre-Merge
- [x] Tested locally
- [ ] No new warnings
- [ ] Build passes
- [ ] Backward compatible (or migration documented)