### PR TITLE
Fix menu highlighting to show correct active page

### DIFF
--- a/src/ChurchCRM/view/MenuRenderer.php
+++ b/src/ChurchCRM/view/MenuRenderer.php
@@ -25,7 +25,7 @@ class MenuRenderer
     {
         ?>
         <li class="nav-item<?= $menuItem->isActive() ? " active" : ""?>">
-            <a href="<?= htmlspecialchars($menuItem->getURI(), ENT_QUOTES, 'UTF-8') ?>" <?= $menuItem->isExternal() ? "target='_blank'" : "" ?> class="nav-link">
+            <a href="<?= htmlspecialchars($menuItem->getURI(), ENT_QUOTES, 'UTF-8') ?>" <?= $menuItem->isExternal() ? "target='_blank'" : "" ?> class="nav-link<?= $menuItem->isActive() ? " active" : ""?>">
                 <i class='nav-icon fa <?= $menuItem->getIcon() ?>'></i>
                 <p>
                     <span><?= htmlspecialchars($menuItem->getName()) ?></span>
@@ -41,8 +41,8 @@ class MenuRenderer
     private static function renderSubMenuItem(MenuItem $menuItem): void
     {
         ?>
-        <div class="nav-item<?= $menuItem->openMenu() ? " menu-open active" : "" ?>">
-            <a href="#" class="nav-link">
+        <li class="nav-item<?= $menuItem->openMenu() ? " menu-open" : "" ?>">
+            <a href="#" class="nav-link<?= $menuItem->openMenu() ? " active" : "" ?>">
                 <i class="nav-icon fa <?= $menuItem->getIcon() ?>"></i>
                 <p>
                     <span><?= htmlspecialchars($menuItem->getName()) ?></span>
@@ -63,7 +63,7 @@ class MenuRenderer
                 }
             } ?>
             </ul>
-        </div>
+        </li>
         <?php
     }
 


### PR DESCRIPTION

## What Changed
<!-- Short summary - what and why (not how) -->

- Improve isActive() to properly match URLs with query parameters
- Menu items with query params only match when params are present
- Menu items without query params only match when URL has no params
- Make openMenu() recursive for nested submenu support
- Change submenu container from div to li for proper AdminLTE styling
- Add active class to nav-link for proper visual highlighting

## Type
<!-- Check one -->
- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Screenshots
<!-- Only for UI changes - drag & drop images here -->

<img width="428" height="733" alt="image" src="https://github.com/user-attachments/assets/86d83566-a7f9-4a23-9a68-e686f5af5670" />


## Security Check
<!-- Only check if applicable -->
- [ ] Introduces new input validation
- [ ] Modifies authentication/authorization
- [ ] Affects data privacy/GDPR

### Code Quality
- [ ] Database: Propel ORM only, no raw SQL
- [ ] No deprecated attributes (align, valign, nowrap, border, cellpadding, cellspacing, bgcolor)
- [ ] Bootstrap CSS classes used
- [ ] All CSS bundled via webpack

## Pre-Merge
- [x] Tested locally
- [ ] No new warnings
- [ ] Build passes
- [ ] Backward compatible (or migration documented)