### PR TITLE
Replace direct $.ajax calls with AdminAPIRequest wrapper for /admin/api

### DIFF
--- a/src/admin/views/orphaned-files.php
+++ b/src/admin/views/orphaned-files.php
@@ -187,11 +187,9 @@ $hasOrphanedFiles = $orphanedCount > 0;
             '<i class="fa fa-spinner fa-spin mr-2"></i>' + i18next.t('Deleting...')
         );
 
-        $.ajax({
-            url: window.CRM.root + '/admin/api/orphaned-files/delete-all',
-            method: 'POST',
-            contentType: 'application/json',
-            dataType: 'json'
+        window.CRM.AdminAPIRequest({
+            path: 'orphaned-files/delete-all',
+            method: 'POST'
         })
         .done(function(response) {
             showResults(response);

--- a/src/admin/views/system-reset.php
+++ b/src/admin/views/system-reset.php
@@ -68,35 +68,35 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
                     },
                     callback: function (result) {
                         if (result) {
-                            $.ajax({
-                                url: window.CRM.root + '/admin/api/database/reset',
-                                method: 'DELETE',
-                                success: function (data) {
-                                    // Show default credentials to the admin after reset (matches other flows)
-                                    var username = (data && data.defaultUsername) ? data.defaultUsername : 'admin';
-                                    var password = (data && data.defaultPassword) ? data.defaultPassword : 'changeme';
-                                    var message = i18next.t('The database has been cleared.') + '<br><br>' +
-                                        '<strong>' + i18next.t('Default admin credentials') + ':</strong><br>' +
-                                        '<code>' + username + '</code> / <code>' + password + '</code>';
+                            window.CRM.AdminAPIRequest({
+                                path: 'database/reset',
+                                method: 'DELETE'
+                            })
+                            .done(function (data) {
+                                // Show default credentials to the admin after reset (matches other flows)
+                                var username = (data && data.defaultUsername) ? data.defaultUsername : 'admin';
+                                var password = (data && data.defaultPassword) ? data.defaultPassword : 'changeme';
+                                var message = i18next.t('The database has been cleared.') + '<br><br>' +
+                                    '<strong>' + i18next.t('Default admin credentials') + ':</strong><br>' +
+                                    '<code>' + username + '</code> / <code>' + password + '</code>';
 
-                                    bootbox.alert({
-                                        title: i18next.t('Reset Complete'),
-                                        message: message,
-                                        callback: function () {
-                                            window.location.href = window.CRM.root + "/";
-                                        }
-                                    });
-                                },
-                                error: function (xhr, status, error) {
-                                    var errorMessage = i18next.t('Database reset failed');
-                                    if (xhr.responseJSON && xhr.responseJSON.msg) {
-                                        errorMessage = xhr.responseJSON.msg;
+                                bootbox.alert({
+                                    title: i18next.t('Reset Complete'),
+                                    message: message,
+                                    callback: function () {
+                                        window.location.href = window.CRM.root + "/";
                                     }
-                                    window.CRM.notify(errorMessage, {
-                                        type: 'error',
-                                        delay: 5000
-                                    });
+                                });
+                            })
+                            .fail(function (xhr, status, error) {
+                                var errorMessage = i18next.t('Database reset failed');
+                                if (xhr.responseJSON && xhr.responseJSON.msg) {
+                                    errorMessage = xhr.responseJSON.msg;
                                 }
+                                window.CRM.notify(errorMessage, {
+                                    type: 'error',
+                                    delay: 5000
+                                });
                             });
                         }
                     }

--- a/src/skin/js/CRMJSOM.js
+++ b/src/skin/js/CRMJSOM.js
@@ -5,7 +5,7 @@
 window.CRM.APIRequest = function (options) {
     if (!options.method) {
         options.method = "GET";
-    } 
+    }
     options.dataType = "json";
     options.url = window.CRM.root + "/api/" + options.path;
     options.contentType = "application/json";
@@ -26,7 +26,7 @@ window.CRM.APIRequest = function (options) {
 window.CRM.AdminAPIRequest = function (options) {
     if (!options.method) {
         options.method = "GET";
-    } 
+    }
     options.dataType = "json";
     options.url = window.CRM.root + "/admin/api/" + options.path;
     options.contentType = "application/json";

--- a/src/skin/js/importDemoData.js
+++ b/src/skin/js/importDemoData.js
@@ -320,86 +320,85 @@
 
         $button.prop("disabled", true);
 
-        $.ajax({
-            url: window.CRM.root + "/admin/api/demo/load",
+        window.CRM.AdminAPIRequest({
+            path: "demo/load",
             method: "POST",
-            contentType: "application/json",
             data: JSON.stringify({
                 includeFinancial: includeFinancial,
                 includeEvents: includeEvents,
                 includeSundaySchool: includeSundaySchool,
                 force: forceImport || false,
-            }),
-            success: function (data) {
-                hideSpinnerOverlay();
+            })
+        })
+        .done(function (data) {
+            hideSpinnerOverlay();
 
-                if ($status.length) {
-                    $status.hide();
-                }
-                $button.prop("disabled", false);
+            if ($status.length) {
+                $status.hide();
+            }
+            $button.prop("disabled", false);
 
-                if (data && data.success) {
-                    // Reset force import mode on success
-                    forceImportMode = false;
-                    resetImportButton();
+            if (data && data.success) {
+                // Reset force import mode on success
+                forceImportMode = false;
+                resetImportButton();
 
-                    if ($resultsList.length) {
-                        $resultsList.empty();
-                        var imported = data.imported || {};
-                        for (var key in imported) {
-                            if (Object.prototype.hasOwnProperty.call(imported, key) && imported[key] > 0) {
-                                var label = key.replace(/_/g, " ").replace(/\b\w/g, function (l) {
-                                    return l.toUpperCase();
-                                });
-                                $resultsList.append("<li>" + label + ": <strong>" + imported[key] + "</strong></li>");
-                            }
+                if ($resultsList.length) {
+                    $resultsList.empty();
+                    var imported = data.imported || {};
+                    for (var key in imported) {
+                        if (Object.prototype.hasOwnProperty.call(imported, key) && imported[key] > 0) {
+                            var label = key.replace(/_/g, " ").replace(/\b\w/g, function (l) {
+                                return l.toUpperCase();
+                            });
+                            $resultsList.append("<li>" + label + ": <strong>" + imported[key] + "</strong></li>");
                         }
-                        if (data.warnings && data.warnings.length > 0) {
-                            $resultsList.append(
-                                '<li class="text-warning">' +
-                                    i18next.t("Warnings") +
-                                    ": " +
-                                    data.warnings.length +
-                                    "</li>",
-                            );
-                        }
-                        $results.show();
                     }
-
-                    window.CRM.notify(i18next.t("Demo data imported successfully"), { type: "success", delay: 3000 });
-                } else {
-                    // Enable force import mode on failure
-                    forceImportMode = true;
-
-                    var errorMsg = data && data.error ? data.error : i18next.t("Unknown error");
-
-                    // Update button to Force Import and show overlay again with error
-                    setForceImportButton(errorMsg);
-                    showConfirmOverlay();
+                    if (data.warnings && data.warnings.length > 0) {
+                        $resultsList.append(
+                            '<li class="text-warning">' +
+                                i18next.t("Warnings") +
+                                ": " +
+                                data.warnings.length +
+                                "</li>",
+                        );
+                    }
+                    $results.show();
                 }
-            },
-            error: function (xhr) {
-                hideSpinnerOverlay();
 
-                if ($status.length) {
-                    $status.hide();
-                }
-                $button.prop("disabled", false);
-
-                // Enable force import mode on error
+                window.CRM.notify(i18next.t("Demo data imported successfully"), { type: "success", delay: 3000 });
+            } else {
+                // Enable force import mode on failure
                 forceImportMode = true;
 
-                var errorMessage = i18next.t("An error occurred during demo data import");
-                if (xhr && xhr.responseJSON && xhr.responseJSON.error) {
-                    errorMessage = xhr.responseJSON.error;
-                } else if (xhr && xhr.status) {
-                    errorMessage = i18next.t("Server error") + " (" + xhr.status + ")";
-                }
+                var errorMsg = data && data.error ? data.error : i18next.t("Unknown error");
 
                 // Update button to Force Import and show overlay again with error
-                setForceImportButton(errorMessage);
+                setForceImportButton(errorMsg);
                 showConfirmOverlay();
-            },
+            }
+        })
+        .fail(function (xhr) {
+            hideSpinnerOverlay();
+
+            if ($status.length) {
+                $status.hide();
+            }
+            $button.prop("disabled", false);
+
+            // Enable force import mode on error
+            forceImportMode = true;
+
+            var errorMessage = i18next.t("An error occurred during demo data import");
+            if (xhr && xhr.responseJSON && xhr.responseJSON.error) {
+                errorMessage = xhr.responseJSON.error;
+            } else if (xhr && xhr.status) {
+                errorMessage = i18next.t("Server error") + " (" + xhr.status + ")";
+            }
+
+            // Update button to Force Import and show overlay again with error
+            setForceImportButton(errorMessage);
+            showConfirmOverlay();
         });
     }
 


### PR DESCRIPTION
## What Changed
<!-- Short summary - what and why (not how) -->

- Updated src/admin/views/orphaned-files.php to use AdminAPIRequest for delete-all endpoint
- Updated src/admin/views/system-reset.php to use AdminAPIRequest for database reset endpoint
- Updated src/skin/js/importDemoData.js to use AdminAPIRequest for demo/load endpoint
- Converted success/error callbacks to .done()/.fail() promises
- Removed manual URL construction, contentType, and dataType settings (handled by wrapper)
- Fixed whitespace in CRMJSOM.js for consistency

Benefits:
- Consistent use of AdminAPIRequest wrapper across all admin API calls
- Automatic /admin/api prefix handling
- Proper error handling integration with CRM error system
- Cleaner, more maintainable code


## Type
<!-- Check one -->
- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
<!-- How to verify this works -->

## Screenshots
<!-- Only for UI changes - drag & drop images here -->

## Security Check
<!-- Only check if applicable -->
- [ ] Introduces new input validation
- [ ] Modifies authentication/authorization
- [ ] Affects data privacy/GDPR

### Code Quality
- [ ] Database: Propel ORM only, no raw SQL
- [ ] No deprecated attributes (align, valign, nowrap, border, cellpadding, cellspacing, bgcolor)
- [ ] Bootstrap CSS classes used
- [ ] All CSS bundled via webpack

## Pre-Merge
- [ ] Tested locally
- [ ] No new warnings
- [ ] Build passes
- [ ] Backward compatible (or migration documented)