### PR TITLE
Refactor API services to use lazy initialization

### DIFF
--- a/src/api/index.php
+++ b/src/api/index.php
@@ -3,44 +3,17 @@
 require_once '../Include/LoadConfig.php';
 require_once __DIR__ . '/../vendor/autoload.php';
 
-use ChurchCRM\Service\DepositService;
-use ChurchCRM\Service\FinancialService;
-use ChurchCRM\Service\GroupService;
-use ChurchCRM\Service\PersonService;
-use ChurchCRM\Service\SystemService;
 use ChurchCRM\Slim\Middleware\AuthMiddleware;
 use ChurchCRM\Slim\Middleware\CorsMiddleware;
 use ChurchCRM\Slim\Middleware\VersionMiddleware;
 use ChurchCRM\Slim\SlimUtils;
 use Slim\Factory\AppFactory;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 // Get base path by combining $sRootPath from Config.php with /api endpoint
 // Examples: '' + '/api' = '/api' (root install)
 //           '/churchcrm' + '/api' = '/churchcrm/api' (subdirectory install)
 $basePath = SlimUtils::getBasePath('/api');
 
-
-$container = new ContainerBuilder();
-// Lazy initialization - services created only when requested
-$container->set('PersonService', function() {
-    return new PersonService();
-});
-$container->set('GroupService', function() {
-    return new GroupService();
-});
-$container->set('FinancialService', function() {
-    return new FinancialService();
-});
-$container->set('SystemService', function() {
-    return new SystemService();
-});
-$container->set('DepositService', function() {
-    return new DepositService();
-});
-$container->compile();
-
-AppFactory::setContainer($container);
 $app = AppFactory::create();
 $app->setBasePath($basePath);
 

--- a/src/api/routes/finance/finance-deposits.php
+++ b/src/api/routes/finance/finance-deposits.php
@@ -4,6 +4,7 @@ use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\model\ChurchCRM\Deposit;
 use ChurchCRM\model\ChurchCRM\DepositQuery;
 use ChurchCRM\model\ChurchCRM\PledgeQuery;
+use ChurchCRM\Service\DepositService;
 use ChurchCRM\Slim\Middleware\Request\Auth\FinanceRoleAuthMiddleware;
 use ChurchCRM\Slim\SlimUtils;
 use ChurchCRM\Utils\InputUtils;
@@ -13,8 +14,7 @@ use Slim\Routing\RouteCollectorProxy;
 
 $app->group('/deposits', function (RouteCollectorProxy $group): void {
     $group->post('', function (Request $request, Response $response, array $args): Response {
-        /** @var ChurchCRM\Service\DepositService $depositService */
-        $depositService = $this->get('DepositService');
+        $depositService = new DepositService();
         $input = $request->getParsedBody();
         $depositType = $input['depositType'] ?? '';
         $depositComment = InputUtils::sanitizeText($input['depositComment']) ?? '';
@@ -136,16 +136,14 @@ $app->group('/deposits', function (RouteCollectorProxy $group): void {
 
     $group->get('/{id:[0-9]+}/pledges', function (Request $request, Response $response, array $args): Response {
         $id = (int) $args['id'];
-        /** @var ChurchCRM\Service\DepositService $depositService */
-        $depositService = $this->get('DepositService');
+        $depositService = new DepositService();
         $result = $depositService->getDepositItemsByType($id, 'Pledge');
         return SlimUtils::renderJSON($response, $result);
     });
 
     $group->get('/{id:[0-9]+}/payments', function (Request $request, Response $response, array $args): Response {
         $id = (int) $args['id'];
-        /** @var ChurchCRM\Service\DepositService $depositService */
-        $depositService = $this->get('DepositService');
+        $depositService = new DepositService();
         $result = $depositService->getDepositItemsByType($id, 'Payment');
         return SlimUtils::renderJSON($response, $result);
     });

--- a/src/api/routes/finance/finance-payments.php
+++ b/src/api/routes/finance/finance-payments.php
@@ -13,8 +13,7 @@ use ChurchCRM\Service\FinancialService;
 
 $app->group('/payments', function (RouteCollectorProxy $group): void {
     $group->get('/', function (Request $request, Response $response, array $args): Response {
-        /** @var FinancialService  $financialService */
-        $financialService = $this->get('FinancialService');
+        $financialService = new FinancialService();
 
         return SlimUtils::renderJSON(
             $response,
@@ -24,8 +23,7 @@ $app->group('/payments', function (RouteCollectorProxy $group): void {
 
     $group->post('/', function (Request $request, Response $response, array $args): Response {
         $payment = (object) $request->getParsedBody();
-        /** @var FinancialService  $financialService */
-        $financialService = $this->get('FinancialService');
+        $financialService = new FinancialService();
 
         return SlimUtils::renderJSON(
             $response,
@@ -70,7 +68,7 @@ $app->group('/payments', function (RouteCollectorProxy $group): void {
 
     $group->delete('/{groupKey}', function (Request $request, Response $response, array $args): Response {
         $groupKey = $args['groupKey'];
-        $financialService = $this->get('FinancialService');
+        $financialService = new FinancialService();
         $financialService->deletePayment($groupKey);
 
         return SlimUtils::renderSuccessJSON($response);

--- a/src/api/routes/people/people-families.php
+++ b/src/api/routes/people/people-families.php
@@ -128,8 +128,7 @@ $app->group('/families', function (RouteCollectorProxy $group): void {
     $group->get('/byCheckNumber/{scanString}', function (Request $request, Response $response, array $args): Response {
         $scanString = $args['scanString'];
 
-        /** @var FinancialService $financialService */
-        $financialService = $this->get('FinancialService');
+        $financialService = new FinancialService();
 
         return SlimUtils::renderJSON($response, $financialService->getMemberByScanString($scanString));
     });

--- a/src/api/routes/people/people-groups.php
+++ b/src/api/routes/people/people-groups.php
@@ -222,7 +222,7 @@ $app->group('/groups', function (RouteCollectorProxy $group): void {
     $group->delete('/{groupID:[0-9]+}/roles/{roleID:[0-9]+}', function (Request $request, Response $response, array $args): Response {
         $groupID = $args['groupID'];
         $roleID = $args['roleID'];
-        $groupService = $this->get('GroupService');
+        $groupService = new GroupService();
 
         return SlimUtils::renderJSON($response, $groupService->deleteGroupRole($groupID, $roleID));
     });
@@ -230,7 +230,7 @@ $app->group('/groups', function (RouteCollectorProxy $group): void {
     $group->post('/{groupID:[0-9]+}/roles', function (Request $request, Response $response, array $args): Response {
         $groupID = $args['groupID'];
         $roleName = $request->getParsedBody()['roleName'];
-        $groupService = $this->get('GroupService');
+        $groupService = new GroupService();
 
         return SlimUtils::renderJSON($response, $groupService->addGroupRole($groupID, $roleName));
     });
@@ -247,7 +247,7 @@ $app->group('/groups', function (RouteCollectorProxy $group): void {
     $group->post('/{groupID:[0-9]+}/setGroupSpecificPropertyStatus', function (Request $request, Response $response, array $args): Response {
         $groupID = $args['groupID'];
         $input = $request->getParsedBody();
-        $groupService = $this->get('GroupService');
+        $groupService = new GroupService();
 
         if ($input['GroupSpecificPropertyStatus']) {
             $groupService->enableGroupSpecificProperties($groupID);


### PR DESCRIPTION


## What Changed
<!-- Short summary - what and why (not how) -->

- Convert eager service instantiation to factory callbacks
- Services now created only when requested via container->get()
- Reduces memory overhead on API requests
- Only instantiates services actually used per request

Before: All 5 services created on every API request
After: Services created on-demand when accessed

## Type
<!-- Check one -->
- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
<!-- How to verify this works -->

## Screenshots
<!-- Only for UI changes - drag & drop images here -->

## Security Check
<!-- Only check if applicable -->
- [ ] Introduces new input validation
- [ ] Modifies authentication/authorization
- [ ] Affects data privacy/GDPR

### Code Quality
- [ ] Database: Propel ORM only, no raw SQL
- [ ] No deprecated attributes (align, valign, nowrap, border, cellpadding, cellspacing, bgcolor)
- [ ] Bootstrap CSS classes used
- [ ] All CSS bundled via webpack

## Pre-Merge
- [ ] Tested locally
- [ ] No new warnings
- [ ] Build passes
- [ ] Backward compatible (or migration documented)