### PR TITLE
Cleanup: Remove family work/cell phone fields and consolidate forms

### DIFF
--- a/src/FamilyEditor.php
+++ b/src/FamilyEditor.php
@@ -94,8 +94,6 @@ if (isset($_POST['FamilySubmit']) || isset($_POST['FamilySubmitAndAdd'])) {
     }
 
     $sHomePhone = InputUtils::legacyFilterInput($_POST['HomePhone']);
-    $sWorkPhone = InputUtils::legacyFilterInput($_POST['WorkPhone']);
-    $sCellPhone = InputUtils::legacyFilterInput($_POST['CellPhone']);
     $sEmail = InputUtils::legacyFilterInput($_POST['Email']);
     $bSendNewsLetter = isset($_POST['SendNewsLetter']);
 
@@ -138,8 +136,6 @@ if (isset($_POST['FamilySubmit']) || isset($_POST['FamilySubmitAndAdd'])) {
     $dWeddingDate = InputUtils::legacyFilterInput($_POST['WeddingDate'] ?? '');
 
     $bNoFormat_HomePhone = isset($_POST['NoFormat_HomePhone']);
-    $bNoFormat_WorkPhone = isset($_POST['NoFormat_WorkPhone']);
-    $bNoFormat_CellPhone = isset($_POST['NoFormat_CellPhone']);
 
     //Loop through the Family Member 'quick entry' form fields
     for ($iCount = 1; $iCount <= $iFamilyMemberRows; $iCount++) {
@@ -230,12 +226,6 @@ if (isset($_POST['FamilySubmit']) || isset($_POST['FamilySubmitAndAdd'])) {
         if (!$bNoFormat_HomePhone) {
             $sHomePhone = CollapsePhoneNumber($sHomePhone, $sCountry);
         }
-        if (!$bNoFormat_WorkPhone) {
-            $sWorkPhone = CollapsePhoneNumber($sWorkPhone, $sCountry);
-        }
-        if (!$bNoFormat_CellPhone) {
-            $sCellPhone = CollapsePhoneNumber($sCellPhone, $sCountry);
-        }
 
         //Write the base SQL depending on the Action
         $bSendNewsLetterString = $bSendNewsLetter ? 'TRUE' : 'FALSE';
@@ -260,8 +250,6 @@ if (isset($_POST['FamilySubmit']) || isset($_POST['FamilySubmitAndAdd'])) {
             ->setZip($sZip)
             ->setCountry($sCountry)
             ->setHomePhone($sHomePhone)
-            ->setWorkPhone($sWorkPhone)
-            ->setCellPhone($sCellPhone)
             ->setSendNewsletter($bSendNewsLetterString)
             ->setEnvelope($nEnvelope)
             ->setWeddingdate($dWeddingDate)
@@ -449,8 +437,6 @@ if (isset($_POST['FamilySubmit']) || isset($_POST['FamilySubmitAndAdd'])) {
         $sZip = $family->getZip();
         $sCountry = $family->getCountry();
         $sHomePhone = $family->getHomePhone();
-        $sWorkPhone = $family->getWorkPhone();
-        $sCellPhone = $family->getCellPhone();
         $sEmail = $family->getEmail();
         $bSendNewsLetter = $family->getSendNewsletter() === 'TRUE';
         $dWeddingDate = $family->getWeddingdate(SystemConfig::getValue("sDatePickerFormat"));
@@ -459,8 +445,6 @@ if (isset($_POST['FamilySubmit']) || isset($_POST['FamilySubmitAndAdd'])) {
 
         // Expand the phone number
         $sHomePhone = ExpandPhoneNumber($sHomePhone, $sCountry, $bNoFormat_HomePhone);
-        $sWorkPhone = ExpandPhoneNumber($sWorkPhone, $sCountry, $bNoFormat_WorkPhone);
-        $sCellPhone = ExpandPhoneNumber($sCellPhone, $sCountry, $bNoFormat_CellPhone);
 
         $sSQL = 'SELECT * FROM family_custom WHERE fam_ID = ' . $iFamilyID;
         $rsCustomData = RunQuery($sSQL);
@@ -605,12 +589,18 @@ require_once 'Include/Header.php';
         </div>
     </div>
 
-    <!-- Card 2: Address -->
+    <!-- Card 2: Location & Contact Information -->
     <div class="card card-info clearfix">
         <div class="card-header">
-            <h3 class="card-title"><?= gettext('Address') ?></h3>
+            <h3 class="card-title"><?= gettext('Location & Contact Information') ?></h3>
         </div>
         <div class="card-body">
+            <!-- Location Section -->
+            <div class="row">
+                <div class="col-12">
+                    <h5 class="text-muted mb-3"><?= gettext('Address') ?></h5>
+                </div>
+            </div>
             <div class="row">
                 <div class="form-group col-md-6">
                     <label for="Address1"><?= gettext('Address') ?> 1:</label>
@@ -674,7 +664,7 @@ require_once 'Include/Header.php';
                                 <div class="input-group-prepend">
                                     <span class="input-group-text"><i class="fa-solid fa-globe"></i></span>
                                 </div>
-                                <input type="text" class="form-control" id="Latitude" name="Latitude" value="<?= $nLatitude ?>" maxlength="50">
+                                <input type="text" class="form-control" id="Latitude" name="Latitude" value="<?= $nLatitude && $nLatitude != 0 ? $nLatitude : '' ?>" maxlength="50">
                             </div>
                         </div>
                         <div class="form-group col-md-3">
@@ -683,49 +673,18 @@ require_once 'Include/Header.php';
                                 <div class="input-group-prepend">
                                     <span class="input-group-text"><i class="fa-solid fa-globe"></i></span>
                                 </div>
-                                <input type="text" class="form-control" id="Longitude" name="Longitude" value="<?= $nLongitude ?>" maxlength="50">
+                                <input type="text" class="form-control" id="Longitude" name="Longitude" value="<?= $nLongitude && $nLongitude != 0 ? $nLongitude : '' ?>" maxlength="50">
                             </div>
                         </div>
                     </div>
                     <?php
                 }
             } /* Lat/Lon can be hidden - General Settings */ ?>
-        </div>
-    </div>
 
-    <!-- Card 3: Contact Information -->
-    <div class="card card-info clearfix">
-        <div class="card-header">
-            <h3 class="card-title"><?= gettext('Contact Information') ?></h3>
-        </div>
-        <div class="card-body">
-            <div class="row">
-                <div class="form-group col-md-6">
-                    <label for="Email"><?= gettext('Email') ?>:</label>
-                    <div class="input-group">
-                        <div class="input-group-prepend">
-                            <span class="input-group-text"><i class="fa-solid fa-at"></i></span>
-                        </div>
-                        <input type="email" id="Email" name="Email" class="form-control" value="<?= InputUtils::escapeAttribute($sEmail) ?>" maxlength="100">
-                    </div>
-                    <?php if ($sEmailError) { ?>
-                    <span class="text-danger small"><?= $sEmailError ?></span>
-                    <?php } ?>
-                </div>
-                <div class="form-group col-md-6">
-                    <label for="CellPhone"><?= gettext('Mobile Phone') ?>:</label>
-                    <div class="input-group">
-                        <div class="input-group-prepend">
-                            <span class="input-group-text"><i class="fa-solid fa-mobile-screen"></i></span>
-                        </div>
-                        <input type="text" id="CellPhone" name="CellPhone" value="<?= InputUtils::escapeAttribute($sCellPhone) ?>" maxlength="30" class="form-control" data-inputmask='"mask": "<?= SystemConfig::getValue('sPhoneFormatCell') ?>"' data-mask>
-                        <div class="input-group-append">
-                            <div class="input-group-text">
-                                <input type="checkbox" name="NoFormat_CellPhone" value="1" <?= $bNoFormat_CellPhone ? 'checked' : '' ?>>
-                                <label class="mb-0 ml-1 small"><?= gettext('No format') ?></label>
-                            </div>
-                        </div>
-                    </div>
+            <!-- Contact Information Section -->
+            <div class="row mt-4">
+                <div class="col-12">
+                    <h5 class="text-muted mb-3"><?= gettext('Contact') ?></h5>
                 </div>
             </div>
             <div class="row">
@@ -745,19 +704,16 @@ require_once 'Include/Header.php';
                     </div>
                 </div>
                 <div class="form-group col-md-6">
-                    <label for="WorkPhone"><?= gettext('Work Phone') ?>:</label>
+                    <label for="Email"><?= gettext('Email') ?>:</label>
                     <div class="input-group">
                         <div class="input-group-prepend">
-                            <span class="input-group-text"><i class="fa-solid fa-briefcase"></i></span>
+                            <span class="input-group-text"><i class="fa-solid fa-at"></i></span>
                         </div>
-                        <input type="text" id="WorkPhone" name="WorkPhone" value="<?= InputUtils::escapeAttribute($sWorkPhone) ?>" maxlength="30" class="form-control" data-inputmask='"mask": "<?= SystemConfig::getValue('sPhoneFormatWithExt') ?>"' data-mask>
-                        <div class="input-group-append">
-                            <div class="input-group-text">
-                                <input type="checkbox" name="NoFormat_WorkPhone" value="1" <?= $bNoFormat_WorkPhone ? 'checked' : '' ?>>
-                                <label class="mb-0 ml-1 small"><?= gettext('No format') ?></label>
-                            </div>
-                        </div>
+                        <input type="email" id="Email" name="Email" class="form-control" value="<?= InputUtils::escapeAttribute($sEmail) ?>" maxlength="100">
                     </div>
+                    <?php if ($sEmailError) { ?>
+                    <span class="text-danger small"><?= $sEmailError ?></span>
+                    <?php } ?>
                 </div>
             </div>
             <?php if (!SystemConfig::getValue('bHideFamilyNewsletter')) { /* Newsletter can be hidden - General Settings */ ?>

--- a/src/Reports/ClassAttendance.php
+++ b/src/Reports/ClassAttendance.php
@@ -114,14 +114,6 @@ for ($i = 0; $i < $nGrps; $i++) {
             $homePhone = '';
             if (!empty($family)) {
                 $homePhone = $family->getHomePhone();
-
-                if (empty($homePhone)) {
-                    $homePhone = $family->getCellPhone();
-                }
-
-                if (empty($homePhone)) {
-                    $homePhone = $family->getWorkPhone();
-                }
             }
 
             $groupRole = ListOptionQuery::create()->filterById($group->getRoleListId())->filterByOptionId($groupRoleMembership->getRoleId())->findOne();

--- a/src/Reports/ClassList.php
+++ b/src/Reports/ClassList.php
@@ -99,14 +99,6 @@ for ($i = 0; $i < $nGrps; $i++) {
         $homePhone = '';
         if (!empty($family)) {
             $homePhone = $family->getHomePhone();
-
-            if (empty($homePhone)) {
-                $homePhone = $family->getCellPhone();
-            }
-
-            if (empty($homePhone)) {
-                $homePhone = $family->getWorkPhone();
-            }
         }
 
         $groupRole = ListOptionQuery::create()->filterById($group->getRoleListId())->filterByOptionId($groupRoleMembership->getRoleId())->findOne();

--- a/src/mysql/upgrade/6.5.0.sql
+++ b/src/mysql/upgrade/6.5.0.sql
@@ -40,3 +40,9 @@ DROP TABLE IF EXISTS `person_permission`;
 DROP TABLE IF EXISTS `person_roles`;
 DROP TABLE IF EXISTS `permissions`;
 DROP TABLE IF EXISTS `roles`;
+
+-- Remove Work Phone and Cell Phone from family table
+-- These fields belong to individuals, not families
+-- Family only keeps: Name, Address (1&2), City, State, Zip, Country, Home Phone, Email
+ALTER TABLE `family_fam` DROP COLUMN IF EXISTS `fam_WorkPhone`;
+ALTER TABLE `family_fam` DROP COLUMN IF EXISTS `fam_CellPhone`;


### PR DESCRIPTION
## What Changed
<!-- Short summary - what and why (not how) -->

- Remove fam_WorkPhone and fam_CellPhone columns via 6.5.0.sql migration
- Remove all work/cell phone input handling from FamilyEditor
- Simplify phone lookup logic in ClassList and ClassAttendance (use home phone only)
- Consolidate Address and Contact Information into single 'Location & Contact' card
- Reorder form fields: Home Phone (primary contact) before Email
- Display Latitude/Longitude as blank when value is 0 (invalid coordinate)

## Type
<!-- Check one -->
- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
<!-- How to verify this works -->

## Screenshots
<!-- Only for UI changes - drag & drop images here -->

## Security Check
<!-- Only check if applicable -->
- [ ] Introduces new input validation
- [ ] Modifies authentication/authorization
- [ ] Affects data privacy/GDPR

### Code Quality
- [ ] Database: Propel ORM only, no raw SQL
- [ ] No deprecated attributes (align, valign, nowrap, border, cellpadding, cellspacing, bgcolor)
- [ ] Bootstrap CSS classes used
- [ ] All CSS bundled via webpack

## Pre-Merge
- [ ] Tested locally
- [ ] No new warnings
- [ ] Build passes
- [ ] Backward compatible (or migration documented)