### PR TITLE
Improve registration link UX on login page

### DIFF
--- a/src/session/templates/begin-session.php
+++ b/src/session/templates/begin-session.php
@@ -70,9 +70,10 @@ require SystemURLs::getDocumentRoot() . '/Include/HeaderNotLoggedIn.php';
                 </p>
             <?php }
             if (SystemConfig::getBooleanValue('bEnableSelfRegistration')) { ?>
-                <p class="mb-0">
-                    <a href="<?= SystemURLs::getRootPath() ?>/external/register/" class="text-center"><?= gettext('Register a new Family'); ?></a>
-                </p>
+                <div class="mt-3 pt-2 border-top">
+                    <p class="text-muted small mb-2"><?= gettext('New to') ?> <?= ChurchMetaData::getChurchName() ?>?</p>
+                    <a href="<?= SystemURLs::getRootPath() ?>/external/register/" class="btn btn-outline-primary btn-block"><?= gettext('Register a New Family'); ?></a>
+                </div>
             <?php } ?>
         </div>
         <!-- /.card-body -->


### PR DESCRIPTION
…ton with church name

## What Changed
<!-- Short summary - what and why (not how) -->

Converted "Register a new Family" from small text link to prominent secondary button
Added "New to [Church Name]?" context text
Styled with [btn btn-outline-primary btn-block](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) for full-width button appearance
Added visual separation with [border-top](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) divider
Dynamically uses actual church name from ChurchMetaData::getChurchName()

## Type
<!-- Check one -->
- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
<!-- How to verify this works -->

## Screenshots
<!-- Only for UI changes - drag & drop images here -->
<img width="720" height="652" alt="image" src="https://github.com/user-attachments/assets/8c1d6e4f-9d03-4910-ad22-f03f7d58dc5a" />


## Security Check
<!-- Only check if applicable -->
- [ ] Introduces new input validation
- [ ] Modifies authentication/authorization
- [ ] Affects data privacy/GDPR

### Code Quality
- [ ] Database: Propel ORM only, no raw SQL
- [ ] No deprecated attributes (align, valign, nowrap, border, cellpadding, cellspacing, bgcolor)
- [ ] Bootstrap CSS classes used
- [ ] All CSS bundled via webpack

## Pre-Merge
- [ ] Tested locally
- [ ] No new warnings
- [ ] Build passes
- [ ] Backward compatible (or migration documented)