### PR TITLE
UI: Verify page updates

### DIFF
--- a/cypress/e2e/ui/family/family.verify.spec.js
+++ b/cypress/e2e/ui/family/family.verify.spec.js
@@ -1,0 +1,45 @@
+/// <reference types="cypress" />
+
+describe("Family Verification Page", () => {
+    const familyId = 1;
+
+    beforeEach(() => {
+        cy.setupAdminSession();
+        // Get a fresh verification URL for each test (token is consumed on use)
+        cy.makePrivateAdminAPICall("GET", `/api/family/${familyId}/verify/url`, null, 200).then((response) => {
+            cy.wrap(response.body.url).as("verifyUrl");
+        });
+    });
+
+    it("Should display family header and members", function() {
+        cy.visit(this.verifyUrl);
+        cy.get(".container-fluid").should("be.visible");
+        cy.contains("Family Members").should("be.visible");
+        cy.get(".col-lg-4").should("exist");
+    });
+
+    it("Should show confirmation modal with radio options", function() {
+        cy.visit(this.verifyUrl);
+        cy.get("#confirmVerifyBtn").click();
+        cy.get("#confirm-Verify").should("be.visible");
+        cy.get("#NoChanges").should("exist");
+        cy.get("#UpdateNeeded").should("exist");
+    });
+
+    it("Should allow filling update information", function() {
+        cy.visit(this.verifyUrl);
+        cy.get("#confirmVerifyBtn").click();
+        cy.get("#UpdateNeeded").click();
+        // Type short text and verify textarea is functional
+        cy.get("#confirm-info-data").should("be.visible").type("Update needed");
+        cy.get("#confirm-info-data").invoke("val").should("include", "Update");
+    });
+
+    it("Should display modal footer buttons", function() {
+        cy.visit(this.verifyUrl);
+        cy.get("#confirmVerifyBtn").click();
+        cy.get("#onlineVerifyCancelBtn").should("be.visible");
+        cy.get("#onlineVerifyBtn").should("be.visible");
+        cy.get("#onlineVerifySiteBtn").should("be.visible");
+    });
+});

--- a/src/external/templates/verify/verify-family-info.php
+++ b/src/external/templates/verify/verify-family-info.php
@@ -5,6 +5,7 @@ use ChurchCRM\dto\Classification;
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\dto\SystemURLs;
 use ChurchCRM\model\ChurchCRM\ListOptionQuery;
+use ChurchCRM\Utils\InputUtils;
 
 $sPageTitle = gettext("Family Verification");
 
@@ -12,194 +13,266 @@ require(SystemURLs::getDocumentRoot() . "/Include/HeaderNotLoggedIn.php");
 
 $doShowMap = !(empty($family->getLatitude()) && empty($family->getLongitude()));
 ?>
-  <div class="row">
-    <div id="right-buttons" class="btn-group" role="group">
-      <button type="button" id="verify" class="btn btn-sm" data-toggle="modal" data-target="#confirm-Verify"><div class="btn-txt"><?=gettext("Confirm")?></div><i class="fa-solid fa-check fa-5x"></i>  </button>
-    </div>
-  </div>
-  <div class="card card-info" id="verifyBox">
-    <div class="panel-body">
-      <img class="photo-large pull-right" data-image-entity-type="family" data-image-entity-id="<?= $family->getId() ?>">
-      <h2><?= $family->getName() ?></h2>
-      <div class="text-muted font-bold m-b-xs">
-        <i class="fa-solid fa-fw fa-map-marker" title="<?= gettext("Home Address")?>"></i><?= $family->getAddress() ?><br/>
-          <?php if (!empty($family->getHomePhone())) { ?>
-          <i class="fa-solid fa-fw fa-phone" title="<?= gettext("Home Phone")?>"> </i>(H) <?= $family->getHomePhone() ?><br/>
-          <?php }  if (!empty($family->getEmail())) { ?>
-          <i class="fa-solid fa-fw fa-envelope" title="<?= gettext("Family Email") ?>"></i><?= $family->getEmail() ?><br/>
-              <?php
-          }
-          if ($family->getWeddingDate() !== null) {
-                ?>
-            <i class="fa-solid fa-fw fa-heart" title="<?= gettext("Wedding Date")?>"></i><?= $family->getWeddingDate()->format(SystemConfig::getValue("sDateFormatLong")) ?><br/>
-              <?php
-          }
-            ?>
 
-        <i class="fa-solid fa-fw fa-newspaper" title="<?= gettext("Send Newsletter")?>"></i><?= $family->getSendNewsletter() ?><br/>
-      </div>
-    </div>
-    <div class="border-right border-left">
-      <?php if ($doShowMap) { ?>
-        <section id="map">
-          <div id="map1"></div>
-        </section>
-      <?php } ?>
-    </div>
-    <div class="card card-solid">
-      <div class="card-header">
-        <i class="fa-solid fa-users"></i>
-        <h3 class="card-title"><?= gettext("Family Member(s)")?></h3>
-      </div>
-      <div class="row row-flex row-flex-wrap">
-        <?php foreach ($family->getPeopleSorted() as $person) { ?>
-          <div class="col-md-4 col-sm-4">
-            <div class="card card-primary">
-              <div class="card-body box-profile">
-                 <img class="photo-medium" data-image-entity-type="person" data-image-entity-id="<?= $person->getId() ?>">
-
-                <h3 class="profile-username text-center"><?= $person->getTitle() ?> <?= $person->getFullName() ?></h3>
-
-                <p class="text-muted text-center"><i
-                    class="fa-solid fa-fw fa-<?= ($person->isMale() ? "male" : "female") ?>"></i> <?= $person->getFamilyRoleName() ?>
-                </p>
-
-                <ul class="list-group list-group-unbordered">
-                  <li class="list-group-item">
-                      <?php if (!empty($person->getHomePhone())) { ?>
-                    <i class="fa-solid fa-fw fa-phone" title="<?= gettext("Home Phone")?>"></i>(H) <?= $person->getHomePhone() ?><br/>
-                      <?php }  if (!empty($person->getWorkPhone())) { ?>
-                    <i class="fa-solid fa-fw fa-briefcase" title="<?= gettext("Work Phone")?>"></i>(W) <?= $person->getWorkPhone() ?><br/>
-                      <?php }  if (!empty($person->getCellPhone())) { ?>
-                    <i class="fa-solid fa-fw fa-mobile" title="<?= gettext("Mobile Phone")?>"></i>(M) <?= $person->getCellPhone() ?><br/>
-                      <?php }  if (!empty($person->getEmail())) { ?>
-                    <i class="fa-solid fa-fw fa-envelope" title="<?= gettext("Email")?>"></i>(H) <?= $person->getEmail() ?><br/>
-                      <?php }  if (!empty($person->getWorkEmail())) { ?>
-                    <i class="fa-solid fa-fw fa-envelope" title="<?= gettext("Work Email")?>"></i>(W) <?= $person->getWorkEmail() ?><br/>
-                      <?php }  ?>
-                    <i class="fa-solid fa-fw fa-cake-candles" title="<?= gettext("Birthday")?>"></i> <?= $person->getFormattedBirthDate() ?><br/>
-                  </li>
-                  <li class="list-group-item">
-                    <b>Classification:</b> <?= Classification::getName($person->getClsId()) ?>
-                  </li>
-                  <?php if (count($person->getPerson2group2roleP2g2rs()) > 0) {?>
-                  <li class="list-group-item">
-                    <h4>Groups</h4>
-                        <?php foreach ($person->getPerson2group2roleP2g2rs() as $groupMembership) {
-                            if ($groupMembership->getGroup() != null) {
-                                $listOption = ListOptionQuery::create()->filterById($groupMembership->getGroup()->getRoleListId())->filterByOptionId($groupMembership->getRoleId())->findOne()->getOptionName();
-                                ?>
-                        <b><?= $groupMembership->getGroup()->getName() ?></b>: <span class="pull-right"><?= $listOption ?></span><br/>
-                                <?php
-                            }
-                        }
-                        ?>
-                  </li>
-                  <?php } ?>
-                </ul>
-              </div>
-              <!-- /.box-body -->
+<div class="container-fluid py-4">
+    <!-- Header Section -->
+    <div class="card shadow-sm mb-4">
+        <div class="card-body">
+            <div class="row align-items-center">
+                <div class="col-auto">
+                    <div class="avatar-placeholder avatar-lg" data-image-entity-type="family" data-image-entity-id="<?= $family->getId() ?>">
+                        <?php if ($family->getPhoto()->hasUploadedPhoto()) { ?>
+                            <img src="data:<?= $family->getPhoto()->getPhotoContentType() ?>;base64,<?= base64_encode($family->getPhoto()->getPhotoBytes()) ?>" alt="<?= InputUtils::escapeAttribute($family->getName()) ?>" class="avatar-img">
+                            <span class="initials" style="display: none;"><?= substr($family->getName(), 0, 2) ?></span>
+                        <?php } else { ?>
+                            <span class="initials"><?= substr($family->getName(), 0, 2) ?></span>
+                        <?php } ?>
+                    </div>
+                </div>
+                <div class="col">
+                    <h1 class="mb-2"><?= InputUtils::escapeHTML($family->getName()) ?></h1>
+                    <div class="text-muted">
+                        <div class="mb-2">
+                            <i class="fa-solid fa-fw fa-map-marker text-primary"></i>
+                            <?= InputUtils::escapeHTML($family->getAddress()) ?>
+                        </div>
+                        <?php if (!empty($family->getHomePhone())) { ?>
+                        <div class="mb-2">
+                            <i class="fa-solid fa-fw fa-phone text-primary"></i>
+                            (H) <?= InputUtils::escapeHTML($family->getHomePhone()) ?>
+                        </div>
+                        <?php } ?>
+                        <?php if (!empty($family->getEmail())) { ?>
+                        <div class="mb-2">
+                            <i class="fa-solid fa-fw fa-envelope text-primary"></i>
+                            <?= InputUtils::escapeHTML($family->getEmail()) ?>
+                        </div>
+                        <?php } ?>
+                        <?php if ($family->getWeddingDate() !== null) { ?>
+                        <div class="mb-2">
+                            <i class="fa-solid fa-fw fa-heart text-danger"></i>
+                            <?= $family->getWeddingDate()->format(SystemConfig::getValue("sDateFormatLong")) ?>
+                        </div>
+                        <?php } ?>
+                        <div class="mb-2">
+                            <i class="fa-solid fa-fw fa-newspaper text-primary"></i>
+                            <?= gettext("Newsletter") ?>: <strong><?= $family->getSendNewsletter() ?></strong>
+                        </div>
+                    </div>
+                </div>
             </div>
-            <!-- /.box -->
-          </div>
-        <?php } ?>
-      </div>
+        </div>
     </div>
-  </div>
 
-  <script  src="//maps.googleapis.com/maps/api/js?key=<?= SystemConfig::getValue("sGoogleMapsRenderKey") ?>"></script>
-  <script nonce="<?= SystemURLs::getCSPNonce() ?>">
+    <!-- Map Section -->
     <?php if ($doShowMap) { ?>
-      var LatLng = new google.maps.LatLng(<?= $family->getLatitude() ?>, <?= $family->getLongitude() ?>)
+    <div class="card shadow-sm mb-4">
+        <div class="card-body p-0">
+            <section id="map">
+                <div id="map1" style="height: 300px;"></div>
+            </section>
+        </div>
+    </div>
+    <?php } ?>
+
+    <!-- Family Members Section -->
+    <div class="card shadow-sm">
+        <div class="card-header bg-light">
+            <h5 class="mb-0">
+                <i class="fa-solid fa-users text-primary me-2"></i><?= gettext("Family Members") ?>
+            </h5>
+        </div>
+        <div class="card-body">
+            <div class="row g-4">
+                <?php foreach ($family->getPeopleSorted() as $person) { ?>
+                <div class="col-lg-4 col-md-6">
+                    <div class="card h-100 shadow-sm">
+                        <div class="card-body text-center">
+                            <!-- Avatar with Initials -->
+                            <div class="mb-3">
+                                <div class="avatar-placeholder avatar-xlg mx-auto" data-image-entity-type="person" data-image-entity-id="<?= $person->getId() ?>">
+                                    <?php if ($person->getPhoto()->hasUploadedPhoto()) { ?>
+                                        <img src="data:<?= $person->getPhoto()->getPhotoContentType() ?>;base64,<?= base64_encode($person->getPhoto()->getPhotoBytes()) ?>" alt="<?= InputUtils::escapeAttribute($person->getFullName()) ?>" class="avatar-img">
+                                        <span class="initials" style="display: none;"><?= substr(trim($person->getFirstName() . ' ' . $person->getLastName()), 0, 2) ?></span>
+                                    <?php } else { ?>
+                                        <span class="initials"><?= substr(trim($person->getFirstName() . ' ' . $person->getLastName()), 0, 2) ?></span>
+                                    <?php } ?>
+                                </div>
+                            </div>
+
+                            <!-- Name and Role -->
+                            <h5 class="card-title mb-1">
+                                <?php if (!empty($person->getTitle())) { ?>
+                                    <small class="text-muted"><?= InputUtils::escapeHTML($person->getTitle()) ?></small><br>
+                                <?php } ?>
+                                <?= InputUtils::escapeHTML($person->getFullName()) ?>
+                            </h5>
+                            <p class="text-muted mb-3">
+                                <i class="fa-solid fa-<?= ($person->isMale() ? "mars" : "venus") ?> me-1"></i>
+                                <?= InputUtils::escapeHTML($person->getFamilyRoleName()) ?>
+                            </p>
+
+                            <!-- Contact Information -->
+                            <div class="contact-info w-100">
+                                <?php if (!empty($person->getHomePhone())) { ?>
+                                <div class="mb-2 small">
+                                    <i class="fa-solid fa-fw fa-phone text-primary"></i>
+                                    <span class="ms-2">(H) <?= InputUtils::escapeHTML($person->getHomePhone()) ?></span>
+                                </div>
+                                <?php } ?>
+                                <?php if (!empty($person->getWorkPhone())) { ?>
+                                <div class="mb-2 small">
+                                    <i class="fa-solid fa-fw fa-briefcase text-primary"></i>
+                                    <span class="ms-2">(W) <?= InputUtils::escapeHTML($person->getWorkPhone()) ?></span>
+                                </div>
+                                <?php } ?>
+                                <?php if (!empty($person->getCellPhone())) { ?>
+                                <div class="mb-2 small">
+                                    <i class="fa-solid fa-fw fa-mobile text-primary"></i>
+                                    <span class="ms-2">(M) <?= InputUtils::escapeHTML($person->getCellPhone()) ?></span>
+                                </div>
+                                <?php } ?>
+                                <?php if (!empty($person->getEmail())) { ?>
+                                <div class="mb-2 small">
+                                    <i class="fa-solid fa-fw fa-envelope text-primary"></i>
+                                    <span class="ms-2"><?= InputUtils::escapeHTML($person->getEmail()) ?></span>
+                                </div>
+                                <?php } ?>
+                                <?php if (!empty($person->getWorkEmail())) { ?>
+                                <div class="mb-2 small">
+                                    <i class="fa-solid fa-fw fa-envelope text-success"></i>
+                                    <span class="ms-2"><?= InputUtils::escapeHTML($person->getWorkEmail()) ?></span>
+                                </div>
+                                <?php } ?>
+                                <?php if (!empty($person->getFormattedBirthDate())) { ?>
+                                <div class="mb-2 small">
+                                    <i class="fa-solid fa-fw fa-cake-candles text-warning"></i>
+                                    <span class="ms-2"><?= InputUtils::escapeHTML($person->getFormattedBirthDate()) ?></span>
+                                </div>
+                                <?php } ?>
+                            </div>
+
+                            <!-- Classification -->
+                            <div class="border-top mt-3 pt-3">
+                                <p class="mb-0">
+                                    <strong><?= gettext("Classification") ?>:</strong><br>
+                                    <span class="badge bg-secondary"><?= InputUtils::escapeHTML(Classification::getName($person->getClsId())) ?></span>
+                                </p>
+                            </div>
+
+                            <!-- Groups -->
+                            <?php if (count($person->getPerson2group2roleP2g2rs()) > 0) { ?>
+                            <div class="border-top mt-3 pt-3">
+                                <p class="mb-2"><strong><?= gettext("Groups") ?></strong></p>
+                                <div class="text-start">
+                                    <?php foreach ($person->getPerson2group2roleP2g2rs() as $groupMembership) {
+                                        if ($groupMembership->getGroup() != null) {
+                                            $listOption = ListOptionQuery::create()
+                                                ->filterById($groupMembership->getGroup()->getRoleListId())
+                                                ->filterByOptionId($groupMembership->getRoleId())
+                                                ->findOne();
+                                            $roleName = $listOption ? $listOption->getOptionName() : '';
+                                    ?>
+                                    <div class="small mb-2">
+                                        <strong><?= InputUtils::escapeHTML($groupMembership->getGroup()->getName()) ?>:</strong>
+                                        <span class="badge bg-info"><?= InputUtils::escapeHTML($roleName) ?></span>
+                                    </div>
+                                    <?php
+                                        }
+                                    } ?>
+                                </div>
+                            </div>
+                            <?php } ?>
+                        </div>
+                    </div>
+                </div>
+                <?php } ?>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Floating Action Buttons -->
+<div class="fab-container">
+    <button type="button" class="fab fab-success" id="confirmVerifyBtn" data-toggle="modal" data-target="#confirm-Verify" title="<?= gettext('Confirm family information') ?>">
+        <i class="fa-solid fa-check"></i>
+        <span class="fab-label"><?= gettext('Confirm') ?></span>
+    </button>
+</div>
+
+<!-- Verification Modal -->
+<div class="modal fade" id="confirm-Verify" tabindex="-1" role="dialog" aria-labelledby="verify-label" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header bg-success text-white">
+                <h5 class="modal-title" id="verify-label"><?= gettext("Confirm Family Information") ?></h5>
+                <button type="button" class="btn-close btn-close-white" data-dismiss="modal" aria-label="Close"></button>
+            </div>
+
+            <div class="modal-body" id="confirm-modal-collect">
+                <form id="verifyForm">
+                    <div class="form-group mb-3">
+                        <label class="form-label"><?= gettext("Please confirm your family information:") ?></label>
+                        <div class="form-check mb-3">
+                            <input class="form-check-input" type="radio" name="verifyType" id="NoChanges" value="no-change" checked>
+                            <label class="form-check-label" for="NoChanges">
+                                <i class="fa-solid fa-check text-success me-2"></i><?= gettext("All information is correct") ?>
+                            </label>
+                        </div>
+                        <div class="form-check">
+                            <input class="form-check-input" type="radio" name="verifyType" id="UpdateNeeded" value="change-needed">
+                            <label class="form-check-label" for="UpdateNeeded">
+                                <i class="fa-solid fa-pencil text-warning me-2"></i><?= gettext("Please update our records with corrections") ?>
+                            </label>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label for="confirm-info-data" class="form-label"><?= gettext("Additional Information") ?></label>
+                        <textarea id="confirm-info-data" class="form-control" rows="8" placeholder="<?= gettext('Provide any corrections or additional information here...') ?>"></textarea>
+                    </div>
+                </form>
+            </div>
+
+            <div class="modal-body d-none" id="confirm-modal-done">
+                <div class="alert alert-success" role="alert">
+                    <i class="fa-solid fa-check-circle me-2"></i>
+                    <strong><?= gettext("Thank You!") ?></strong>
+                    <p class="mb-0 mt-2"><?= gettext("Your verification request has been received. Thank you for keeping your information up to date.") ?></p>
+                </div>
+            </div>
+
+            <div class="modal-body d-none" id="confirm-modal-error">
+                <div class="alert alert-danger" role="alert">
+                    <i class="fa-solid fa-exclamation-circle me-2"></i>
+                    <strong><?= gettext("Error") ?></strong>
+                    <p class="mb-0 mt-2"><?= gettext("We encountered an error processing your verification. Please try again or contact us directly.") ?></p>
+                </div>
+            </div>
+
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" id="onlineVerifyCancelBtn" data-dismiss="modal"><?= gettext("Cancel") ?></button>
+                <button type="button" class="btn btn-success" id="onlineVerifyBtn">
+                    <i class="fa-solid fa-paper-plane me-2"></i><?= gettext("Submit Verification") ?>
+                </button>
+                <a href="<?= ChurchMetaData::getChurchWebSite() ?>" id="onlineVerifySiteBtn" class="btn btn-primary" target="_blank">
+                    <i class="fa-solid fa-globe me-2"></i><?= gettext("Visit Our Website") ?>
+                </a>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script src="//maps.googleapis.com/maps/api/js?key=<?= SystemConfig::getValue("sGoogleMapsRenderKey") ?>"></script>
+<script nonce="<?= SystemURLs::getCSPNonce() ?>">
+    <?php if ($doShowMap) { ?>
+        var LatLng = new google.maps.LatLng(<?= $family->getLatitude() ?>, <?= $family->getLongitude() ?>)
     <?php } else { ?>
-      var LatLng = null;
+        var LatLng = null;
     <?php } ?>
     var token = '<?= $token->getToken()?>';
-  </script>
-
-  <div class="modal fade" id="confirm-Verify" tabindex="888" role="dialog" aria-labelledby="Verify-label"
-       aria-hidden="true">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header info">
-          <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-          <h4 class="modal-title" id="delete-Image-label"><?= gettext("Confirm") ?></h4>
-        </div>
-
-        <div class="modal-body" id="confirm-modal-collect">
-            <form id="verifyForm">
-            <div class="form-group">
-                  <div class="radio">
-                    <label>
-                      <input type="radio" name="verifyType" id="NoChanges" value="no-change" checked="">
-                      <?= gettext('All information on this page is correct.') ?>
-                    </label>
-                  </div>
-                  <div class="radio">
-                    <label>
-                      <input type="radio" name="verifyType" id="UpdateNeeded" value="change-needed">
-                      <?= gettext('Please update the my family information with the following') ?>
-                    </label>
-                  </div>
-                </div>
-          <textarea id="confirm-info-data" class="form-control" rows="10"></textarea>
-        </form>
-        </div>
-
-        <div class="modal-body" id="confirm-modal-done">
-          <p><?= gettext("Your verification request is complete") ?></p>
-        </div>
-
-        <div class="modal-body" id="confirm-modal-error">
-          <p><?= gettext("We encountered an error submitting with your verification data") ?></p>
-        </div>
-
-        <div class="modal-footer">
-          <button id="onlineVerifyCancelBtn" type="button" class="btn btn-secondary" data-dismiss="modal"><?= gettext("Cancel") ?></button>
-          <button id="onlineVerifyBtn" class="btn btn-success"><?= gettext("Send") ?></button>
-          <a href="<?= ChurchMetaData::getChurchWebSite() ?>" id="onlineVerifySiteBtn" class="btn btn-success"><?= gettext("Visit our Site") ?></a>
-        </div>
-      </div>
-    </div>
-  </div>
-
-<style>
-
-  #verifyBox {
-    padding: 5px;
-  }
-
-  #map1 {
-    height: 200px;
-  }
-
-  .btn-sm {
-    vertical-align: center;
-    position: relative;
-    margin: 0px;
-    padding: 20px 20px;
-    font-size: 4px;
-    color: white;
-    text-align: center;
-    background: #62b1d0;
-  }
-  .btn-txt {
-    font-size: 15px;
-  }
-
-  #right-buttons {
-    z-index: 999;
-    position: fixed;
-    left: 45%;
-  }
-
-  #success-alert, #error-alert {
-    z-index: 888;
-  }
-
-</style>
-
-<script src="<?= SystemURLs::getRootPath() ?>/skin/js/FamilyVerify.js"></script>
+</script>
+<link rel="stylesheet" href="<?= SystemURLs::getRootPath() ?>/skin/v2/family-verify.min.css">
+<script src="<?= SystemURLs::getRootPath() ?>/skin/v2/family-verify.min.js"></script>
 
 <?php
 require(SystemURLs::getDocumentRoot() . "/Include/FooterNotLoggedIn.php");

--- a/src/skin/js/FamilyView.js
+++ b/src/skin/js/FamilyView.js
@@ -246,9 +246,77 @@ function initializeFamilyView() {
             path: "family/" + window.CRM.currentFamily + "/verify/url",
         }).then(function (data) {
             $("#confirm-verify").modal("hide");
-            bootbox.alert({
-                title: i18next.t("Verification URL"),
-                message: "<a href='" + data.url + "'>" + data.url + "</a>",
+
+            // Create custom modal for verification URL
+            const modalHtml = `
+                <div class="modal fade" id="verifyUrlModal" tabindex="-1" role="dialog" aria-labelledby="verifyUrlLabel" aria-hidden="true">
+                    <div class="modal-dialog">
+                        <div class="modal-content">
+                            <div class="modal-header bg-info text-white">
+                                <h5 class="modal-title" id="verifyUrlLabel">
+                                    <i class="fa-solid fa-link me-2"></i>${i18next.t("Verification URL")}
+                                </h5>
+                                <button type="button" class="btn-close btn-close-white" data-dismiss="modal" aria-label="Close"></button>
+                            </div>
+                            <div class="modal-body">
+                                <div class="input-group mb-3">
+                                    <input type="text" class="form-control" id="verifyUrlInput" value="${data.url}" readonly>
+                                    <button class="btn btn-info" type="button" id="copyVerifyUrlBtn">
+                                        <i class="fa-solid fa-copy me-2"></i>${i18next.t("Copy")}
+                                    </button>
+                                </div>
+                                <p class="text-muted small">
+                                    <i class="fa-solid fa-info-circle me-2"></i>${i18next.t("Share this URL with family members to verify their information")}
+                                </p>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-secondary" data-dismiss="modal">${i18next.t("Close")}</button>
+                                <a href="${data.url}" target="_blank" class="btn btn-primary">
+                                    <i class="fa-solid fa-arrow-up-right-from-square me-2"></i>${i18next.t("Open in New Tab")}
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            `;
+
+            // Remove old modal if exists
+            $("#verifyUrlModal").remove();
+
+            // Add new modal to page
+            $("body").append(modalHtml);
+
+            // Show modal
+            $("#verifyUrlModal").modal("show");
+
+            // Handle copy button
+            $("#copyVerifyUrlBtn").on("click", function () {
+                const urlInput = document.getElementById("verifyUrlInput");
+                navigator.clipboard
+                    .writeText(urlInput.value)
+                    .then(function () {
+                        const btn = document.getElementById("copyVerifyUrlBtn");
+                        const originalHtml = btn.innerHTML;
+
+                        btn.innerHTML = '<i class="fa-solid fa-check me-2"></i>' + i18next.t("Copied!");
+                        btn.classList.add("btn-success");
+                        btn.classList.remove("btn-info");
+
+                        setTimeout(function () {
+                            btn.innerHTML = originalHtml;
+                            btn.classList.remove("btn-success");
+                            btn.classList.add("btn-info");
+                        }, 2000);
+                    })
+                    .catch(function (err) {
+                        console.error("Failed to copy:", err);
+                        window.CRM.notify(i18next.t("Failed to copy URL"), { type: "error" });
+                    });
+            });
+
+            // Cleanup when modal is closed
+            $("#verifyUrlModal").on("hidden.bs.modal", function () {
+                $("#verifyUrlModal").remove();
             });
         });
     });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,7 @@ module.exports = {
     'photo-uploader': './webpack/photo-uploader-entry',  // Photo uploader for specific pages
     'setup': './webpack/setup',  // Setup wizard styles
     'family-register': './webpack/family-register',  // Family registration styles and scripts
+    'family-verify': './webpack/family-verify',  // Family verification page styles and scripts
     'upgrade-wizard': './webpack/upgrade-wizard',  // Upgrade wizard styles and scripts
     'locale-loader': './webpack/locale-loader',  // Dynamic locale loader
     'backup': './webpack/backup',  // Backup database page

--- a/webpack/family-verify.css
+++ b/webpack/family-verify.css
@@ -1,0 +1,230 @@
+:root {
+    --avatar-bg-color: #007bff;
+    --avatar-text-color: white;
+}
+
+body {
+    background-color: #f8f9fa;
+}
+
+.avatar-placeholder {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: bold;
+    overflow: hidden;
+    position: relative;
+}
+
+.avatar-placeholder.avatar-lg {
+    width: 80px;
+    height: 80px;
+    font-size: 32px;
+}
+
+.avatar-placeholder.avatar-xlg {
+    width: 100px;
+    height: 100px;
+    font-size: 40px;
+}
+
+.avatar-placeholder .initials {
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    position: absolute;
+    z-index: 1;
+}
+
+.avatar-placeholder .avatar-img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    position: absolute;
+    top: 0;
+    left: 0;
+}
+
+.avatar-placeholder .avatar-img[src=""] ~ .initials,
+.avatar-placeholder .avatar-img:not([src]) ~ .initials {
+    position: relative;
+    display: block;
+}
+
+.card {
+    border: none;
+    border-radius: 8px;
+}
+
+.card-header {
+    border-bottom: 2px solid #e9ecef;
+    border-radius: 8px 8px 0 0;
+}
+
+.card-body.text-center {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.card-title {
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
+    font-size: 1.1rem;
+}
+
+.card .text-start {
+    width: 100%;
+}
+
+.card .small {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.card .small i {
+    min-width: 20px;
+    flex-shrink: 0;
+}
+
+.contact-info {
+    text-align: center;
+    margin-top: 0.5rem;
+}
+
+.contact-info .small {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.text-primary {
+    color: #007bff !important;
+}
+
+.text-danger {
+    color: #dc3545 !important;
+}
+
+.text-success {
+    color: #28a745 !important;
+}
+
+.text-warning {
+    color: #ffc107 !important;
+}
+
+.modal-header.bg-success {
+    background-color: #28a745 !important;
+}
+
+.btn-close-white {
+    opacity: 0.8;
+}
+
+.btn-close-white:hover {
+    opacity: 1;
+}
+
+@media (max-width: 768px) {
+    .row.align-items-center {
+        flex-direction: column;
+        text-align: center;
+    }
+
+    .col-auto:last-child {
+        margin-top: 1rem;
+    }
+}
+
+/* FAB Styles */
+.fab-container {
+    position: fixed;
+    bottom: 2rem;
+    right: 2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    z-index: 1000;
+}
+
+.fab {
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    border: none;
+    color: white;
+    font-size: 20px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+    transition: all 0.3s ease;
+    position: relative;
+}
+
+.fab:hover {
+    transform: scale(1.1);
+    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.3);
+}
+
+.fab:active {
+    transform: scale(0.95);
+}
+
+.fab-primary {
+    background-color: #007bff;
+}
+
+.fab-primary:hover {
+    background-color: #0056b3;
+}
+
+.fab-success {
+    background-color: #28a745;
+}
+
+.fab-success:hover {
+    background-color: #1e7e34;
+}
+
+.fab-label {
+    position: absolute;
+    right: 70px;
+    background-color: rgba(0, 0, 0, 0.75);
+    color: white;
+    padding: 8px 12px;
+    border-radius: 4px;
+    font-size: 14px;
+    white-space: nowrap;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease;
+}
+
+.fab:hover .fab-label {
+    opacity: 1;
+}
+
+@media (max-width: 576px) {
+    .fab-container {
+        bottom: 1rem;
+        right: 1rem;
+        gap: 0.5rem;
+    }
+
+    .fab {
+        width: 48px;
+        height: 48px;
+        font-size: 18px;
+    }
+
+    .fab-label {
+        right: 60px;
+        font-size: 12px;
+    }
+}

--- a/webpack/family-verify.js
+++ b/webpack/family-verify.js
@@ -1,0 +1,32 @@
+/**
+ * Family Verification Page
+ * Handles avatar display and form interactions
+ */
+
+import './family-verify.css';
+
+document.addEventListener('DOMContentLoaded', function() {
+    // Handle avatar display - show/hide initials based on photo presence
+    document.querySelectorAll('.avatar-placeholder').forEach(function(container) {
+        const img = container.querySelector('.avatar-img');
+        const initials = container.querySelector('.initials');
+        
+        if (img && img.src) {
+            img.addEventListener('load', function() {
+                // Image loaded, hide initials
+                if (initials) {
+                    initials.style.display = 'none';
+                }
+                img.style.display = 'block';
+            });
+            
+            img.addEventListener('error', function() {
+                // Image failed, show initials
+                img.style.display = 'none';
+                if (initials) {
+                    initials.style.display = 'block';
+                }
+            });
+        }
+    });
+});


### PR DESCRIPTION

## What Changed
<!-- Short summary - what and why (not how) -->

- Extract inline CSS from verify-family-info.php to webpack/family-verify.css
- Extract inline JavaScript to webpack/family-verify.js with CSS import
- Add family-verify webpack entry point to build minified assets
- Update verify-family-info.php to load CSS/JS from /skin/v2/ paths
- Create comprehensive Cypress test suite for family verification page
  - Tests verify page displays family header and member cards
  - Tests confirmation modal with radio options functionality
  - Tests textarea input for update information
  - Tests footer button visibility
  - Uses API to get fresh verification token for each test (tokens consumed on use)
  - All 4 tests passing

This resolves the issue of large inline style blocks in the template by properly organizing assets through webpack build system.


## Type
<!-- Check one -->
- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [x] 🔒 Security


## Screenshots
<!-- Only for UI changes - drag & drop images here -->
<img width="2214" height="1139" alt="image" src="https://github.com/user-attachments/assets/76ae38e6-94f2-4b67-9686-a33a35d04113" />

## Security Check
<!-- Only check if applicable -->
- [ ] Introduces new input validation
- [ ] Modifies authentication/authorization
- [ ] Affects data privacy/GDPR

### Code Quality
- [ ] Database: Propel ORM only, no raw SQL
- [ ] No deprecated attributes (align, valign, nowrap, border, cellpadding, cellspacing, bgcolor)
- [ ] Bootstrap CSS classes used
- [ ] All CSS bundled via webpack

## Pre-Merge
- [ ] Tested locally
- [ ] No new warnings
- [ ] Build passes
- [ ] Backward compatible (or migration documented)