### PR TITLE
Add ChMeetings export button to CSVExport.php 

### DIFF
--- a/src/CSVExport.php
+++ b/src/CSVExport.php
@@ -4,6 +4,7 @@ require_once 'Include/Config.php';
 require_once 'Include/Functions.php';
 
 use ChurchCRM\Authentication\AuthenticationManager;
+use ChurchCRM\dto\SystemURLs;
 use ChurchCRM\Utils\RedirectUtils;
 
 // If user does not have CSV Export permission, redirect to the menu.
@@ -446,6 +447,79 @@ require_once 'Include/Header.php';
     </div>
   </div>
 
+  </div>
+  <div class="row">
+    <div class="col-lg-12">
+      <div class="card">
+        <div class="card-header with-border">
+          <h3 class="card-title"><?= gettext('ChMeetings Export') ?></h3>
+        </div>
+        <div class="card-body">
+          <p><?= gettext('Export all people data in ChMeetings format for import into external systems.') ?></p>
+          <button type="button" class="btn btn-primary" id="exportChMeetingsBtn">
+            <i class="fa-solid fa-download"></i> <?= gettext('Export to ChMeetings CSV') ?>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
 </form>
+
+<script>
+document.getElementById('exportChMeetingsBtn').addEventListener('click', function() {
+    var btn = this;
+    var originalText = btn.innerHTML;
+    
+    // Show loading state
+    btn.disabled = true;
+    btn.innerHTML = '<i class="fa-solid fa-spinner fa-spin"></i> <?= gettext("Exporting...") ?>';
+    
+    var downloadUrl = window.CRM.root + '/admin/api/database/people/export/chmeetings';
+    
+    fetch(downloadUrl)
+        .then(function(response) {
+            if (!response.ok) {
+                throw new Error(response.statusText);
+            }
+            return response.blob();
+        })
+        .then(function(blob) {
+            // Trigger file download
+            var blobUrl = window.URL.createObjectURL(blob);
+            var link = document.createElement('a');
+            link.href = blobUrl;
+            link.download = 'ChMeetings-' + new Date().toISOString().split('T')[0] + '.csv';
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+            window.URL.revokeObjectURL(blobUrl);
+            
+            // Restore button state
+            btn.disabled = false;
+            btn.innerHTML = originalText;
+            
+            // Show success notification
+            window.CRM.notify(i18next.t('ChMeetings export completed successfully'), {
+                type: 'success',
+                delay: 3000
+            });
+        })
+        .catch(function(error) {
+            console.error('Export failed:', error);
+            
+            // Restore button state
+            btn.disabled = false;
+            btn.innerHTML = originalText;
+            
+            // Show error notification
+            window.CRM.notify(i18next.t('Failed to export ChMeetings CSV'), {
+                type: 'error',
+                delay: 3000
+            });
+        });
+});
+</script>
+
 <?php
 require_once 'Include/Footer.php';

--- a/src/admin/routes/api/database.php
+++ b/src/admin/routes/api/database.php
@@ -2,13 +2,18 @@
 
 use ChurchCRM\Authentication\AuthenticationManager;
 use ChurchCRM\Slim\SlimUtils;
+use ChurchCRM\Utils\CsvExporter;
 use ChurchCRM\Utils\LoggerUtils;
 use Propel\Runtime\Propel;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Routing\RouteCollectorProxy;
+use ChurchCRM\dto\SystemConfig;
+use ChurchCRM\model\ChurchCRM\PersonQuery;
 
 $app->group('/api/database', function (RouteCollectorProxy $group): void {
+
+    $group->get('/people/export/chmeetings', 'exportChMeetings');
 
     /**
      * Reset database - drops all tables and views
@@ -86,3 +91,92 @@ $app->group('/api/database', function (RouteCollectorProxy $group): void {
     });
 
 });
+
+function exportChMeetings(Request $request, Response $response, array $args): Response
+{
+    $header_data = [
+        'First Name',
+        'Last Name',
+        'Middle Name',
+        'Gender',
+        'Marital Status',
+        'Anniversary',
+        'Engagement Date',
+        'Birthdate',
+        'Mobile Phone',
+        'Home Phone',
+        'Email',
+        'Facebook',
+        'School',
+        'Grade',
+        'Employer',
+        'Job Title',
+        'Talents And Hobbies',
+        'Address Line',
+        'Address Line 2',
+        'City',
+        'State',
+        'ZIP Code',
+        'Notes',
+        'Join Date',
+        'Family Id',
+        'Family Role',
+        'Baptism Date',
+        'Baptism Location',
+        'Nickname',
+    ];
+    $people = PersonQuery::create()->find();
+    $list = [];
+    foreach ($people as $person) {
+        $family = $person->getFamily();
+        $anniversary = ($family ? $family->getWeddingdate(SystemConfig::getValue('sDateFormatLong')) : '');
+        $familyRole = $person->getFamilyRoleName();
+        if ($familyRole === 'Head of Household') {
+            $familyRole = 'Primary';
+        }
+
+        $chPerson = [
+            $person->getFirstName(),
+            $person->getLastName(),
+            $person->getMiddleName(),
+            $person->getGenderName(),
+            '',
+            $anniversary,
+            '',
+            $person->getFormattedBirthDate(),
+            $person->getCellPhone(),
+            $person->getHomePhone(),
+            $person->getEmail(),
+            $person->getFacebook(),
+            '',
+            '',
+            '',
+            '',
+            '',
+            $person->getAddress1(),
+            $person->getAddress2(),
+            $person->getCity(),
+            $person->getState(),
+            $person->getZip(),
+            '',
+            $person->getMembershipDate(SystemConfig::getValue('sDateFormatLong')),
+            $family ? $family->getId() : '',
+            $familyRole,
+            '',
+            '',
+            ''
+        ];
+        $list[] = $chPerson;
+    }
+
+    // Use CsvExporter for RFC 4180 compliance and formula injection prevention
+    CsvExporter::create(
+        $header_data,
+        $list,
+        'ChMeetings',
+        SystemConfig::getValue('sCSVExportCharset'),
+        true
+    );
+
+    return $response;
+}

--- a/src/api/routes/system/system-database.php
+++ b/src/api/routes/system/system-database.php
@@ -5,7 +5,6 @@ use ChurchCRM\Backup\BackupDownloader;
 use ChurchCRM\Backup\BackupJob;
 use ChurchCRM\Backup\RestoreJob;
 use ChurchCRM\dto\SystemConfig;
-use ChurchCRM\model\ChurchCRM\PersonQuery;
 use ChurchCRM\Slim\Middleware\Request\Auth\AdminRoleAuthMiddleware;
 use ChurchCRM\Slim\SlimUtils;
 use ChurchCRM\Utils\LoggerUtils;
@@ -15,8 +14,6 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Routing\RouteCollectorProxy;
 
 $app->group('/database', function (RouteCollectorProxy $group): void {
-
-    $group->get('/people/export/chmeetings', 'exportChMeetings');
 
     $group->post('/backup', function (Request $request, Response $response, array $args): Response {
         $input = $request->getParsedBody();
@@ -95,99 +92,3 @@ $app->group('/database', function (RouteCollectorProxy $group): void {
         return $response;
     });
 })->add(AdminRoleAuthMiddleware::class);
-
-function exportChMeetings(Request $request, Response $response, array $args): Response
-{
-    $header_data = [
-        'First Name',
-        'Last Name',
-        'Middle Name',
-        'Gender',
-        'Marital Status',
-        'Anniversary',
-        'Engagement Date',
-        'Birthdate',
-        'Mobile Phone',
-        'Home Phone',
-        'Email',
-        'Facebook',
-        'School',
-        'Grade',
-        'Employer',
-        'Job Title',
-        'Talents And Hobbies',
-        'Address Line',
-        'Address Line 2',
-        'City',
-        'State',
-        'ZIP Code',
-        'Notes',
-        'Join Date',
-        'Family Id',
-        'Family Role',
-        'Baptism Date',
-        'Baptism Location',
-        'Nickname',
-    ];
-    $people = PersonQuery::create()->find();
-    $list = [];
-    foreach ($people as $person) {
-        $family = $person->getFamily();
-        $anniversary = ($family ? $family->getWeddingdate(SystemConfig::getValue('sDateFormatLong')) : '');
-        $familyRole = $person->getFamilyRoleName();
-        if ($familyRole === 'Head of Household') {
-            $familyRole = 'Primary';
-        }
-
-        $chPerson = [
-            $person->getFirstName(),
-            $person->getLastName(),
-            $person->getMiddleName(),
-            $person->getGenderName(),
-            '',
-            $anniversary,
-            '',
-            $person->getFormattedBirthDate(),
-            $person->getCellPhone(),
-            $person->getHomePhone(),
-            $person->getEmail(),
-            $person->getFacebook(),
-            '',
-            '',
-            '',
-            '',
-            '',
-            $person->getAddress1(),
-            $person->getAddress2(),
-            $person->getCity(),
-            $person->getState(),
-            $person->getZip(),
-            '',
-            $person->getMembershipDate(SystemConfig::getValue('sDateFormatLong')),
-            $family ? $family->getId() : '',
-            $familyRole,
-            '',
-            '',
-            ''
-        ];
-        $list[] = $chPerson;
-    }
-
-    $out = fopen('php://temp', 'w+');
-    fputcsv($out, $header_data);
-    foreach ($list as $fields) {
-        fputcsv($out, $fields, ',');
-    }
-    rewind($out);
-    $csvData = stream_get_contents($out);
-    fclose($out);
-
-    $response = $response->withHeader('Content-Type', 'text/csv');
-    $response = $response->withHeader(
-        'Content-Disposition',
-        'attachment; filename="ChMeetings-' . date(SystemConfig::getValue('sDateFilenameFormat')) . '.csv"'
-    );
-    $response->getBody()->write($csvData);
-
-    return $response;
-}


### PR DESCRIPTION
## What Changed
<!-- Short summary - what and why (not how) -->

- Add ChMeetings Export section to CSVExport.php UI with download button
- Implement fetch-based API call to /admin/api/database/people/export/chmeetings
- Auto-trigger file download with date-stamped filename (ChMeetings-YYYY-MM-DD.csv)
- Add loading state feedback and error/success notifications via window.CRM.notify()
- Use fetch() for file downloads since CSV endpoints return raw text, not JSON
- All UI text wrapped with gettext() for internationalization

This allows admins to easily export all people data in ChMeetings format directly from the CSV Export page.

## Type
<!-- Check one -->
- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
<!-- How to verify this works -->

## Screenshots
<!-- Only for UI changes - drag & drop images here -->

## Security Check
<!-- Only check if applicable -->
- [ ] Introduces new input validation
- [ ] Modifies authentication/authorization
- [ ] Affects data privacy/GDPR

### Code Quality
- [ ] Database: Propel ORM only, no raw SQL
- [ ] No deprecated attributes (align, valign, nowrap, border, cellpadding, cellspacing, bgcolor)
- [ ] Bootstrap CSS classes used
- [ ] All CSS bundled via webpack

## Pre-Merge
- [ ] Tested locally
- [ ] No new warnings
- [ ] Build passes
- [ ] Backward compatible (or migration documented)