### PR TITLE
Fix fiscal year display and add SystemConfig::getIntValue() method

### DIFF
--- a/src/ChurchCRM/Authentication/AuthenticationProviders/LocalAuthentication.php
+++ b/src/ChurchCRM/Authentication/AuthenticationProviders/LocalAuthentication.php
@@ -215,8 +215,8 @@ class LocalAuthentication implements IAuthenticationProvider
         }
 
         // Next, check for login timeout.  If login has expired, redirect to login page
-        if (SystemConfig::getValue('iSessionTimeout') > 0) {
-            if ((time() - $this->tLastOperationTimestamp) > SystemConfig::getValue('iSessionTimeout')) {
+        if (SystemConfig::getIntValue('iSessionTimeout') > 0) {
+            if ((time() - $this->tLastOperationTimestamp) > SystemConfig::getIntValue('iSessionTimeout')) {
                 LoggerUtils::getAuthLogger()->debug('User session timed out', $logCtx);
                 $authenticationResult->isAuthenticated = false;
 

--- a/src/ChurchCRM/Emails/BaseEmail.php
+++ b/src/ChurchCRM/Emails/BaseEmail.php
@@ -35,7 +35,7 @@ abstract class BaseEmail
         $this->mail = new PHPMailer();
         $this->mail->IsSMTP();
         $this->mail->CharSet = 'UTF-8';
-        $this->mail->Timeout = intval(SystemConfig::getValue('iSMTPTimeout'));
+        $this->mail->Timeout = SystemConfig::getIntValue('iSMTPTimeout');
         $this->mail->Host = SystemConfig::getValue('sSMTPHost');
         $this->mail->SMTPAutoTLS = SystemConfig::getBooleanValue('bPHPMailerAutoTLS');
         $this->mail->SMTPSecure = SystemConfig::getValue('sPHPMailerSMTPSecure');

--- a/src/ChurchCRM/Service/FinancialService.php
+++ b/src/ChurchCRM/Service/FinancialService.php
@@ -438,7 +438,7 @@ class FinancialService
      */
     public static function formatFiscalYear(int $fyId): string
     {
-        if (SystemConfig::getValue('iFYMonth') === 1) {
+        if (SystemConfig::getIntValue('iFYMonth') === 1) {
             return (string) (1996 + $fyId);
         } else {
             return (1995 + $fyId) . '/' . mb_substr(1996 + $fyId, 2, 2);
@@ -604,7 +604,7 @@ class FinancialService
      */
     public function getFiscalYearDates(): array
     {
-        $iFYMonth = (int) SystemConfig::getValue('iFYMonth');
+        $iFYMonth = SystemConfig::getIntValue('iFYMonth');
         $currentYear = (int) date('Y');
         $currentMonth = (int) date('n');
 

--- a/src/ChurchCRM/Service/UserService.php
+++ b/src/ChurchCRM/Service/UserService.php
@@ -29,7 +29,7 @@ class UserService
             ->select(['failedLogins', 'twoFactorAuthSecret'])
             ->find();
         
-        $maxFailedLogins = SystemConfig::getValue('iMaxFailedLogins');
+        $maxFailedLogins = SystemConfig::getIntValue('iMaxFailedLogins');
         $totalUsers = $users->count();
         $activeUsers = 0;
         $lockedUsers = 0;
@@ -73,7 +73,7 @@ class UserService
      */
     public function isUserLocked(User $user): bool
     {
-        $maxFailedLogins = SystemConfig::getValue('iMaxFailedLogins');
+        $maxFailedLogins = SystemConfig::getIntValue('iMaxFailedLogins');
         return $maxFailedLogins > 0 && $user->getFailedLogins() >= $maxFailedLogins;
     }
 
@@ -83,7 +83,7 @@ class UserService
      */
     public function getLockedUsers()
     {
-        $maxFailedLogins = SystemConfig::getValue('iMaxFailedLogins');
+        $maxFailedLogins = SystemConfig::getIntValue('iMaxFailedLogins');
         return UserQuery::create()
             ->filterByFailedLogins(['min' => $maxFailedLogins])
             ->find();

--- a/src/ChurchCRM/dto/Photo.php
+++ b/src/ChurchCRM/dto/Photo.php
@@ -288,7 +288,7 @@ class Photo
             ];
         }
         
-        $style = (int)SystemConfig::getValue('iPersonInitialStyle');
+        $style = SystemConfig::getIntValue('iPersonInitialStyle');
         $email = $person->getEmail();
         
         return [

--- a/src/ChurchCRM/dto/SystemConfig.php
+++ b/src/ChurchCRM/dto/SystemConfig.php
@@ -389,6 +389,15 @@ class   SystemConfig
         return self::$configs[$name]->getBooleanValue();
     }
 
+    public static function getIntValue(string $name): int
+    {
+        if (!isset(self::$configs[$name])) {
+            throw new \Exception(gettext('An invalid configuration name has been requested') . ': ' . $name);
+        }
+
+        return (int) self::$configs[$name]->getValue();
+    }
+
     public static function setValue(string $name, $value): void
     {
         if (!isset(self::$configs[$name])) {

--- a/src/ChurchCRM/model/ChurchCRM/Person.php
+++ b/src/ChurchCRM/model/ChurchCRM/Person.php
@@ -31,7 +31,7 @@ class Person extends BasePerson implements PhotoInterface
 
     public function getFullName(): string
     {
-        return $this->getFormattedName(SystemConfig::getValue('iPersonNameStyle'));
+        return $this->getFormattedName(SystemConfig::getIntValue('iPersonNameStyle'));
     }
 
     public function isMale(): bool

--- a/src/ChurchCRM/model/ChurchCRM/User.php
+++ b/src/ChurchCRM/model/ChurchCRM/User.php
@@ -212,7 +212,7 @@ class User extends BaseUser
 
     public function isLocked(): bool
     {
-        return SystemConfig::getValue('iMaxFailedLogins') > 0 && $this->getFailedLogins() >= SystemConfig::getValue('iMaxFailedLogins');
+        return SystemConfig::getIntValue('iMaxFailedLogins') > 0 && $this->getFailedLogins() >= SystemConfig::getIntValue('iMaxFailedLogins');
     }
 
     public function resetPasswordToRandom(): string
@@ -230,7 +230,7 @@ class User extends BaseUser
         $alphabet = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890';
         $pass = []; //remember to declare $pass as an array
         $alphaLength = strlen($alphabet) - 1; //put the length -1 in cache
-        for ($i = 0; $i < SystemConfig::getValue('iMinPasswordLength'); $i++) {
+        for ($i = 0; $i < SystemConfig::getIntValue('iMinPasswordLength'); $i++) {
             $n = random_int(0, $alphaLength);
             $pass[] = $alphabet[$n];
         }
@@ -527,15 +527,15 @@ class User extends BaseUser
             throw new PasswordChangeException('New', gettext('Your password choice is too obvious. Please choose something else.'));
         }
 
-        if (strlen($newPassword) < SystemConfig::getValue('iMinPasswordLength')) {
-            throw new PasswordChangeException('New', gettext('Your new password must be at least') . ' ' . SystemConfig::getValue('iMinPasswordLength') . ' ' . gettext('characters'));
+        if (strlen($newPassword) < SystemConfig::getIntValue('iMinPasswordLength')) {
+            throw new PasswordChangeException('New', gettext('Your new password must be at least') . ' ' . SystemConfig::getIntValue('iMinPasswordLength') . ' ' . gettext('characters'));
         }
 
         if ($newPassword == $oldPassword) {
             throw new PasswordChangeException('New', gettext('Your new password must not match your old one.'));
         }
 
-        if (levenshtein(strtolower($newPassword), strtolower($oldPassword)) < SystemConfig::getValue('iMinPasswordChange')) {
+        if (levenshtein(strtolower($newPassword), strtolower($oldPassword)) < SystemConfig::getIntValue('iMinPasswordChange')) {
             throw new PasswordChangeException('New', gettext('Your new password is too similar to your old one.'));
         }
 

--- a/src/Reports/ClassAttendance.php
+++ b/src/Reports/ClassAttendance.php
@@ -244,7 +244,7 @@ for ($i = 0; $i < $nGrps; $i++) {
     }
 }
 
-if ((int) SystemConfig::getValue('iPDFOutputType') === 1) {
+if (SystemConfig::getIntValue('iPDFOutputType') === 1) {
     $pdf->Output('ClassAttendance' . date(SystemConfig::getValue('sDateFilenameFormat')) . '.pdf', 'D');
 } else {
     $pdf->Output();

--- a/src/Reports/ClassList.php
+++ b/src/Reports/ClassList.php
@@ -259,7 +259,7 @@ for ($i = 0; $i < $nGrps; $i++) {
     $pdf->writeAt($phoneX - 7, $y + 5, FormatDate(date('Y-m-d')));
 }
 
-if ((int) SystemConfig::getValue('iPDFOutputType') === 1) {
+if (SystemConfig::getIntValue('iPDFOutputType') === 1) {
     $pdf->Output('ClassList' . date(SystemConfig::getValue('sDateFilenameFormat')) . '.pdf', 'D');
 } else {
     $pdf->Output();

--- a/src/Reports/ConfirmLabels.php
+++ b/src/Reports/ConfirmLabels.php
@@ -49,7 +49,7 @@ foreach ($families as $family) {
     $pdf->addPdfLabel($labelText);
 }
 
-if ((int) SystemConfig::getValue('iPDFOutputType') === 1) {
+if (SystemConfig::getIntValue('iPDFOutputType') === 1) {
     $pdf->Output('ConfirmDataLabels' . date(SystemConfig::getValue('sDateFilenameFormat')) . '.pdf', 'D');
 } else {
     $pdf->Output();

--- a/src/Reports/ConfirmReport.php
+++ b/src/Reports/ConfirmReport.php
@@ -323,7 +323,7 @@ if ($_GET['familyId']) {
         $pdf->finishPage($curY);
     }
 
-if ((int) SystemConfig::getValue('iPDFOutputType') === 1) {
+if (SystemConfig::getIntValue('iPDFOutputType') === 1) {
     $pdf->Output($filename, 'D');
 } else {
     $pdf->Output();

--- a/src/Reports/DirectoryReport.php
+++ b/src/Reports/DirectoryReport.php
@@ -325,7 +325,7 @@ if ($mysqlversion == 3 && $mysqlsubversion >= 22) {
     mysqli_query($cnInfoCentral, $sSQL);
 }
 
-if ((int) SystemConfig::getValue('iPDFOutputType') === 1) {
+if (SystemConfig::getIntValue('iPDFOutputType') === 1) {
     $pdf->Output('Directory-' . date(SystemConfig::getValue('sDateFilenameFormat')) . '.pdf', 'D');
 } else {
     $pdf->Output();

--- a/src/Reports/EnvelopeReport.php
+++ b/src/Reports/EnvelopeReport.php
@@ -117,7 +117,7 @@ foreach ($families as $family) {
     $pdf->addRecord($OutStr, $numlines);
 }
 
-if ((int) SystemConfig::getValue('iPDFOutputType') === 1) {
+if (SystemConfig::getIntValue('iPDFOutputType') === 1) {
     $pdf->Output('EnvelopeAssignments-' . date(SystemConfig::getValue('sDateFilenameFormat')) . '.pdf', 'D');
 } else {
     $pdf->Output();

--- a/src/Reports/FRBidSheets.php
+++ b/src/Reports/FRBidSheets.php
@@ -84,7 +84,7 @@ while ($oneItem = mysqli_fetch_array($rsItems)) {
     }
 }
 
-if ((int) SystemConfig::getValue('iPDFOutputType') === 1) {
+if (SystemConfig::getIntValue('iPDFOutputType') === 1) {
     $pdf->Output('FRBidSheets' . date(SystemConfig::getValue('sDateFilenameFormat')) . '.pdf', 'D');
 } else {
     $pdf->Output();

--- a/src/Reports/FRCatalog.php
+++ b/src/Reports/FRCatalog.php
@@ -104,7 +104,7 @@ while ($oneItem = mysqli_fetch_array($rsItems)) {
     $pdf->Write(6, "\n");
 }
 
-if ((int) SystemConfig::getValue('iPDFOutputType') === 1) {
+if (SystemConfig::getIntValue('iPDFOutputType') === 1) {
     $pdf->Output('FRCatalog' . date(SystemConfig::getValue('sDateFilenameFormat')) . '.pdf', 'D');
 } else {
     $pdf->Output();

--- a/src/Reports/FRCertificates.php
+++ b/src/Reports/FRCertificates.php
@@ -46,7 +46,7 @@ while ($oneItem = mysqli_fetch_array($rsItems)) {
     }
 }
 
-if ((int) SystemConfig::getValue('iPDFOutputType') === 1) {
+if (SystemConfig::getIntValue('iPDFOutputType') === 1) {
     $pdf->Output('FRCertificates' . date(SystemConfig::getValue('sDateFilenameFormat')) . '.pdf', 'D');
 } else {
     $pdf->Output();

--- a/src/Reports/FamilyPledgeSummary.php
+++ b/src/Reports/FamilyPledgeSummary.php
@@ -337,7 +337,7 @@ while ($aFam = mysqli_fetch_array($rsFamilies)) {
     }
 }
 
-if ((int) SystemConfig::getValue('iPDFOutputType') === 1) {
+if (SystemConfig::getIntValue('iPDFOutputType') === 1) {
     $pdf->Output('FamilyPledgeSummary' . date(SystemConfig::getValue('sDateFilenameFormat')) . '.pdf', 'D');
 } else {
     $pdf->Output();

--- a/src/Reports/GroupReport.php
+++ b/src/Reports/GroupReport.php
@@ -144,7 +144,7 @@ while ($aRow = mysqli_fetch_array($rsRecords)) {
     $pdf->addRecord($pdf->sFamily, $OutStr, $numlines);
 }
 
-if ((int) SystemConfig::getValue('iPDFOutputType') === 1) {
+if (SystemConfig::getIntValue('iPDFOutputType') === 1) {
     $pdf->Output('GroupDirectory-' . date(SystemConfig::getValue('sDateFilenameFormat')) . '.pdf', 'D');
 } else {
     $pdf->Output();

--- a/src/Reports/NameTags.php
+++ b/src/Reports/NameTags.php
@@ -72,7 +72,7 @@ while ($aPer = mysqli_fetch_array($rsPersons)) {
     }
 }
 
-if ((int) SystemConfig::getValue('iPDFOutputType') === 1) {
+if (SystemConfig::getIntValue('iPDFOutputType') === 1) {
     $pdf->Output('NameTags' . date(SystemConfig::getValue('sDateFilenameFormat')) . '.pdf', 'D');
 } else {
     $pdf->Output();

--- a/src/Reports/NewsLetterLabels.php
+++ b/src/Reports/NewsLetterLabels.php
@@ -51,7 +51,7 @@ foreach ($families as $family) {
     $pdf->addPdfLabel($labelText);
 }
 
-if ((int) SystemConfig::getValue('iPDFOutputType') === 1) {
+if (SystemConfig::getIntValue('iPDFOutputType') === 1) {
     $pdf->Output('NewsLetterLabels' . date(SystemConfig::getValue('sDateFilenameFormat')) . '.pdf', 'D');
 } else {
     $pdf->Output();

--- a/src/Reports/PDFLabel.php
+++ b/src/Reports/PDFLabel.php
@@ -773,7 +773,7 @@ $aLabelList = unserialize(
 );
 
 if ($sFileType === 'PDF') {
-    if ((int) SystemConfig::getValue('iPDFOutputType') === 1) {
+    if (SystemConfig::getIntValue('iPDFOutputType') === 1) {
         $pdf->Output('Labels-' . date(SystemConfig::getValue('sDateFilenameFormat')) . '.pdf', 'D');
     } else {
         $pdf->Output();

--- a/src/Reports/PhotoBook.php
+++ b/src/Reports/PhotoBook.php
@@ -153,7 +153,7 @@ foreach ($aGrp as $groupID) {
     $pdf->drawGroup($groupID);
 }
 
-if ((int) SystemConfig::getValue('iPDFOutputType') === 1) {
+if (SystemConfig::getIntValue('iPDFOutputType') === 1) {
     $pdf->Output('ClassList' . date(SystemConfig::getValue('sDateFilenameFormat')) . '.pdf', 'D');
 } else {
     $pdf->Output();

--- a/src/Reports/PledgeSummary.php
+++ b/src/Reports/PledgeSummary.php
@@ -258,7 +258,7 @@ if ($output === 'pdf') {
         $curY += SystemConfig::getValue('incrementY');
     }
 
-    if ((int) SystemConfig::getValue('iPDFOutputType') === 1) {
+    if (SystemConfig::getIntValue('iPDFOutputType') === 1) {
         $pdf->Output('PledgeSummaryReport' . date(SystemConfig::getValue('sDateFilenameFormat')) . '.pdf', 'D');
     } else {
         $pdf->Output();

--- a/src/Reports/ReminderReport.php
+++ b/src/Reports/ReminderReport.php
@@ -463,7 +463,7 @@ while ($aFam = mysqli_fetch_array($rsFamilies)) {
     $pdf->finishPage($curY);
 }
 
-if ((int) SystemConfig::getValue('iPDFOutputType') === 1) {
+if (SystemConfig::getIntValue('iPDFOutputType') === 1) {
     $pdf->Output('ReminderReport' . date(SystemConfig::getValue('sDateFilenameFormat')) . '.pdf', 'D');
 } else {
     $pdf->Output();

--- a/src/Reports/TaxReport.php
+++ b/src/Reports/TaxReport.php
@@ -420,7 +420,7 @@ if ($output === 'pdf') {
         );
     }
 
-    if ((int) SystemConfig::getValue('iPDFOutputType') === 1) {
+    if (SystemConfig::getIntValue('iPDFOutputType') === 1) {
         $pdf->Output('TaxReport' . date(SystemConfig::getValue('sDateFilenameFormat')) . '.pdf', 'D');
     } else {
         $pdf->Output();

--- a/src/Reports/VotingMembers.php
+++ b/src/Reports/VotingMembers.php
@@ -109,7 +109,7 @@ while ($aFam = mysqli_fetch_array($rsFamilies)) {
 $curY += 5;
 $pdf->writeAt(SystemConfig::getValue('leftX'), $curY, 'Number of Voting Members: ' . $votingMemberCount);
 
-if ((int) SystemConfig::getValue('iPDFOutputType') === 1) {
+if (SystemConfig::getIntValue('iPDFOutputType') === 1) {
     $pdf->Output('VotingMembers' . date(SystemConfig::getValue('sDateFilenameFormat')) . '.pdf', 'D');
 } else {
     $pdf->Output();

--- a/src/Reports/ZeroGivers.php
+++ b/src/Reports/ZeroGivers.php
@@ -139,7 +139,7 @@ if ($output === 'pdf') {
         $pdf->finishPage($curY, $fam_ID, $fam_Name, $fam_Address1, $fam_Address2, $fam_City, $fam_State, $fam_Zip, $fam_Country);
     }
 
-    if ((int) SystemConfig::getValue('iPDFOutputType') === 1) {
+    if (SystemConfig::getIntValue('iPDFOutputType') === 1) {
         $pdf->Output('ZeroGivers' . date(SystemConfig::getValue('sDateFilenameFormat')) . '.pdf', 'D');
     } else {
         $pdf->Output();

--- a/src/finance/views/reports.php
+++ b/src/finance/views/reports.php
@@ -7,7 +7,7 @@ use ChurchCRM\dto\SystemURLs;
 require SystemURLs::getDocumentRoot() . '/Include/Header.php';
 
 // Get fiscal year info for display
-$iFYMonth = (int) SystemConfig::getValue('iFYMonth');
+$iFYMonth = SystemConfig::getIntValue('iFYMonth');
 $currentYear = (int) date('Y');
 
 if ($iFYMonth === 1) {


### PR DESCRIPTION


## What Changed
<!-- Short summary - what and why (not how) -->

- Add getIntValue() method to SystemConfig for type-safe integer retrieval
- Fix fiscal year display bug: iFYMonth string '1' was not matching integer 1 in strict comparison
- Update all integer config retrieval to use getIntValue() instead of getValue() with casting
- Affected configs: iFYMonth, iPDFOutputType, iPersonInitialStyle, iSessionTimeout, iMaxFailedLogins, iMinPasswordLength, iMinPasswordChange, iSMTPTimeout, iPersonNameStyle
- Prevents type mismatch bugs when comparing config values with === operator
- 29 files updated for consistent type-safe integer config handling

## Type
<!-- Check one -->
- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
<!-- How to verify this works -->

## Screenshots
<!-- Only for UI changes - drag & drop images here -->

## Security Check
<!-- Only check if applicable -->
- [ ] Introduces new input validation
- [ ] Modifies authentication/authorization
- [ ] Affects data privacy/GDPR

### Code Quality
- [ ] Database: Propel ORM only, no raw SQL
- [ ] No deprecated attributes (align, valign, nowrap, border, cellpadding, cellspacing, bgcolor)
- [ ] Bootstrap CSS classes used
- [ ] All CSS bundled via webpack

## Pre-Merge
- [x] Tested locally
- [ ] No new warnings
- [ ] Build passes
- [ ] Backward compatible (or migration documented)