### PR TITLE
Refactor: remove legacy table row classes

### DIFF
--- a/src/CartToFamily.php
+++ b/src/CartToFamily.php
@@ -150,18 +150,16 @@ echo $sError;
                 ->orderByLastName()
                 ->find();
 
-            echo "<table class='table'>";
+            echo "<table class='table table-striped'>";
             echo '<tr>';
             echo '<td>&nbsp;</td>';
             echo '<td><b>' . gettext('Name') . '</b></td>';
             echo '<td class="text-center"><b>' . gettext('Assign Role') . '</b></td>';
 
             $count = 1;
-            $sRowClass = 'RowColorA';
             foreach ($cartPersons as $cartPerson) {
-                $sRowClass = AlternateRowStyle($sRowClass);
 
-                echo '<tr class="' . $sRowClass . '">';
+                echo '<tr>';
                 echo '<td class="text-center">' . $count++ . '</td>';
                 $personPhoto = new \ChurchCRM\dto\Photo('person', $cartPerson->getId());
                 $photoIcon = '';

--- a/src/FundRaiserEditor.php
+++ b/src/FundRaiserEditor.php
@@ -198,8 +198,8 @@ require_once __DIR__ . '/Include/Header.php';
                         $di_Item = '~';
                     }
 
-                    $sRowClass = 'RowColorA'; ?>
-                    <tr class="<?= $sRowClass ?>">
+                    ?>
+                    <tr>
                         <td>
                             <a href="DonatedItemEditor.php?DonatedItemID=<?= $di_ID . '&linkBack=FundRaiserEditor.php?FundRaiserID=' . $iFundRaiserID ?>"><?= $di_Item ?></a>
                         </td>

--- a/src/GroupView.php
+++ b/src/GroupView.php
@@ -266,7 +266,7 @@ while (list($per_CellPhone) = mysqli_fetch_row($rsPhoneList)) {
                             echo '<p><?= gettext("No member properties have been created")?></p>';
                         } else {
                             ?>
-                            <table class="table w-100">
+                            <table class="table table-striped w-100">
                                 <thead>
                                 <tr>
                                     <th><?= gettext('Type') ?></th>
@@ -276,10 +276,8 @@ while (list($per_CellPhone) = mysqli_fetch_row($rsPhoneList)) {
                                 </thead>
                                 <tbody>
                             <?php
-                            $sRowClass = 'RowColorA';
                             for ($row = 1; $row <= $numRows; $row++) {
-                                $sRowClass = AlternateRowStyle($sRowClass);
-                                echo '<tr class="' . $sRowClass . '">';
+                                echo '<tr>';
                                 echo '<td>' . $aPropTypes[$aTypeFields[$row]] . '</td>';
                                 echo '<td>' . $aNameFields[$row] . '</td>';
                                 echo '<td>' . $aDescFields[$row] . '&nbsp;</td>';
@@ -304,7 +302,7 @@ while (list($per_CellPhone) = mysqli_fetch_row($rsPhoneList)) {
                     } else {
                         // Display table of properties
                         ?>
-                            <table class="table w-100">
+                            <table class="table table-striped w-100">
                                 <thead>
                                 <tr>
                                     <th width="15%" class="align-top"><b><?= gettext('Type') ?></b></th>
@@ -327,19 +325,12 @@ while (list($per_CellPhone) = mysqli_fetch_row($rsPhoneList)) {
                                     extract($aRow);
 
                                     if ($pro_prt_ID != $last_pro_prt_ID) {
-                                        echo '<tr class="';
-                                        if ($bIsFirst) {
-                                            echo 'RowColorB';
-                                        } else {
-                                            echo 'RowColorC';
-                                        }
-                                        echo '"><td><b>' . $prt_Name . '</b></td>';
+                                        echo '<tr><td><b>' . $prt_Name . '</b></td>';
 
                                         $bIsFirst = false;
                                         $last_pro_prt_ID = $pro_prt_ID;
-                                        $sRowClass = 'RowColorB';
                                     } else {
-                                        echo '<tr class="' . $sRowClass . '">';
+                                        echo '<tr>';
                                         echo '<td class="align-top">&nbsp;</td>';
                                     }
 
@@ -360,8 +351,7 @@ while (list($per_CellPhone) = mysqli_fetch_row($rsPhoneList)) {
 
                                     echo '</tr>';
 
-                                    //Alternate the row style
-                                    $sRowClass = AlternateRowStyle($sRowClass); 
+ 
 
                                     $sAssignedProperties .= $pro_ID . ',';
                                 }

--- a/src/Include/Functions.php
+++ b/src/Include/Functions.php
@@ -261,17 +261,6 @@ function FormatDate($dDate, bool $bWithTime = false): string
     return $formattedDate;
 }
 
-function AlternateRowStyle(string $sCurrentStyle): string
-{
-    if ($sCurrentStyle === 'RowColorA') {
-        return 'RowColorB';
-    } else {
-        return 'RowColorA';
-    }
-}
-
-
-
 //
 // Collapses a formatted phone number as long as the Country is known
 // Eg. for United States:  555-555-1212 Ext. 123 ==> 5555551212e123

--- a/src/OptionManager.php
+++ b/src/OptionManager.php
@@ -280,8 +280,7 @@ for ($row = 1; $row <= $numRows; $row++) {
     $aSeqs[$row] = $aRow['lst_OptionSequence'];
 }
 
-//Set the starting row color
-$sRowClass = 'RowColorA';
+// Legacy per-row classes removed; Bootstrap tables handle zebra striping
 
 // Use a minimal page header if this form is going to be used within a frame
 if ($embedded) {

--- a/src/PaddleNumList.php
+++ b/src/PaddleNumList.php
@@ -37,7 +37,7 @@ require_once __DIR__ . '/Include/Header.php';
 </div>
 <div class="card card-body">
 
-    <table cellpadding="5" cellspacing="5">
+    <table class="table table-striped">
 
         <tr class="TableHeader">
             <td><?= gettext('Select') ?></td>
@@ -54,8 +54,8 @@ require_once __DIR__ . '/Include/Header.php';
             while ($aRow = mysqli_fetch_array($rsPaddleNums)) {
                 extract($aRow);
 
-                $sRowClass = 'RowColorA'; ?>
-                <tr class="<?= $sRowClass ?>">
+                ?>
+                <tr>
                     <td>
                         <input type="checkbox" name="Chk<?= $pn_ID . '"';
                         if (isset($_GET['SelectAll'])) {

--- a/src/PersonView.php
+++ b/src/PersonView.php
@@ -780,7 +780,7 @@ $bOkToEdit = (
                                                         extract($aProps);
                                                         $currentData = trim($aPersonProps[$prop_Field]);
                                                         if (strlen($currentData) > 0) {
-                                                            $sRowClass = AlternateRowStyle($sRowClass);
+
                                                             if ($type_ID == 11) {
                                                                 $prop_Special = null;
                                                             }

--- a/src/PrintView.php
+++ b/src/PrintView.php
@@ -304,7 +304,7 @@ require_once __DIR__ . '/Include/Header-Short.php';
 ?>
 
     <b><?= gettext('Family Members') ?>:</b>
-    <table cellpadding=5 cellspacing=0 width="100%">
+    <table class="table table-striped w-100">
         <tr class="TableHeader">
             <td><?= gettext('Name') ?></td>
             <td><?= gettext('Gender') ?></td>
@@ -312,7 +312,6 @@ require_once __DIR__ . '/Include/Header-Short.php';
             <td><?= gettext('Age') ?></td>
         </tr>
         <?php
-        $sRowClass = 'RowColorA';
 
         // Loop through all the family members
         while ($aRow = mysqli_fetch_array($rsFamilyMembers)) {
@@ -321,12 +320,11 @@ require_once __DIR__ . '/Include/Header-Short.php';
 
             extract($aRow);
 
-            // Alternate the row style
-            $sRowClass = AlternateRowStyle($sRowClass)
+
 
             // Display the family member
         ?>
-            <tr class="<?= $sRowClass ?>">
+            <tr>
                 <td>
                     <?= $per_FirstName . ' ' . $per_LastName ?>
                     <br>
@@ -358,16 +356,13 @@ require_once __DIR__ . '/Include/Header-Short.php';
 
     <?php
 
-    //Initialize row shading
-    $sRowClass = 'RowColorA';
-
     $sAssignedGroups = ',';
 
     //Was anything returned?
     if (mysqli_num_rows($rsAssignedGroups) === 0) {
         echo '<p align"center">' . gettext('No group assignments.') . '</p>';
     } else {
-        echo '<table width="100%" cellpadding="4" cellspacing="0">';
+        echo '<table class="table table-striped w-100">';
         echo '<tr class="TableHeader">';
         echo '<td width="15%"><b>' . gettext('Group Name') . '</b>';
         echo '<td><b>' . gettext('Role') . '</b></td>';
@@ -377,11 +372,8 @@ require_once __DIR__ . '/Include/Header-Short.php';
         while ($aRow = mysqli_fetch_array($rsAssignedGroups)) {
             extract($aRow);
 
-            //Alternate the row style
-            $sRowClass = AlternateRowStyle($sRowClass);
-
             // DISPLAY THE ROW
-            echo '<tr class="' . $sRowClass . '">';
+            echo '<tr>';
             echo ' <td>' . $grp_Name . '</td>';
             echo ' <td>' . gettext($roleName) . '</td>';
             echo '</tr>';
@@ -403,16 +395,16 @@ require_once __DIR__ . '/Include/Header-Short.php';
                     $currentData = trim($aPersonProps[$prop_Field]);
                     if (strlen($currentData) > 0) {
                         // only create the properties table if it's actually going to be used
-                        if ($firstRow) {
-                            echo '<tr><td colspan="2"><table width="50%"><tr><td width="15%"></td><td><table width="90%" cellspacing="0">';
-                            echo '<tr class="TinyTableHeader"><td>Property</td><td>Value</td></tr>';
-                            $firstRow = false;
-                        }
-                        $sRowClass = AlternateRowStyle($sRowClass);
+                            if ($firstRow) {
+                                echo '<tr><td colspan="2"><table class="table table-sm"><tr><td style="width:15%"></td><td><table class="table table-sm">';
+                                echo '<tr class="TinyTableHeader"><td>Property</td><td>Value</td></tr>';
+                                $firstRow = false;
+                            }
+
                         if ($type_ID == 11) {
                             $prop_Special = $sCountry;
                         }
-                        echo "<tr class=\"$sRowClass\"><td>" . $prop_Name . '</td><td>' . displayCustomField($type_ID, $currentData, $prop_Special) . '</td></tr>';
+                        echo '<tr><td>' . $prop_Name . '</td><td>' . displayCustomField($type_ID, $currentData, $prop_Special) . '</td></tr>';
                     }
                 }
                 if (!$firstRow) {
@@ -430,16 +422,13 @@ require_once __DIR__ . '/Include/Header-Short.php';
 
     <?php
 
-    //Initialize row shading
-    $sRowClass = 'RowColorA';
-
     $sAssignedProperties = ',';
 
     //Was anything returned?
     if (mysqli_num_rows($rsAssignedProperties) === 0) {
         echo '<p align"center">' . gettext('No property assignments.') . '</p>';
     } else {
-        echo '<table width="100%" cellpadding="4" cellspacing="0">';
+        echo '<table class="table table-striped w-100">';
         echo '<tr class="TableHeader">';
         echo '<td width="25%" class="align-top"><b>' . gettext('Name') . '</b>';
         echo '<td class="align-top"><b>' . gettext('Value') . '</td>';
@@ -450,11 +439,8 @@ require_once __DIR__ . '/Include/Header-Short.php';
             $r2p_Value = '';
             extract($aRow);
 
-            //Alternate the row style
-            $sRowClass = AlternateRowStyle($sRowClass);
-
             //Display the row
-            echo '<tr class="' . $sRowClass . '">';
+            echo '<tr>';
             echo '<td class="align-top">' . gettext($pro_Name) . '&nbsp;</td>';
             echo '<td class="align-top">' . $r2p_Value . '&nbsp;</td>';
 

--- a/src/QuerySQL.php
+++ b/src/QuerySQL.php
@@ -114,11 +114,8 @@ function RunFreeQuery(string $sSQL, &$rsQueryResults)
     if (mysqli_error($cnInfoCentral) != '') {
         echo gettext('An error occurred') . ': ' . mysqli_errno($cnInfoCentral) . '--' . mysqli_error($cnInfoCentral);
     } else {
-        $sRowClass = 'RowColorA';
-
-        echo '<table class="mx-auto table-spaced">';
-
-        echo '<tr class="' . $sRowClass . '">';
+        echo '<table class="table table-striped mx-auto">';
+        echo '<thead><tr class="table-light">';
 
         //Loop through the fields and write the header row
         for ($iCount = 0; $iCount < mysqli_num_fields($rsQueryResults); $iCount++) {
@@ -131,13 +128,11 @@ function RunFreeQuery(string $sSQL, &$rsQueryResults)
             }
         }
 
-        echo '</tr>';
+        echo '</tr></thead><tbody>';
 
         //Loop through the recordset
         while ($aRow = mysqli_fetch_array($rsQueryResults)) {
-            $sRowClass = AlternateRowStyle($sRowClass);
-
-            echo '<tr class="' . $sRowClass . '">';
+            echo '<tr>';
 
             //Loop through the fields and write each one
             for ($iCount = 0; $iCount < mysqli_num_fields($rsQueryResults); $iCount++) {

--- a/src/QueryView.php
+++ b/src/QueryView.php
@@ -227,12 +227,8 @@ function DoQuery()
     <?php
     $aAddToCartIDs = [];
 
-    $sRowClass = 'RowColorA';
     while ($aRow = mysqli_fetch_array($rsQueryResults)) {
-        // Alternate the background color of the row
-        $sRowClass = AlternateRowStyle($sRowClass);
-
-        echo '<tr class="' . $sRowClass . '">';
+        echo '<tr>';
 
         // Loop through the fields and write each one
         for ($iCount = 0; $iCount < mysqli_num_fields($rsQueryResults); $iCount++) {

--- a/src/Reports/PDFLabel.php
+++ b/src/Reports/PDFLabel.php
@@ -573,7 +573,6 @@ function GenerateLabels(&$pdf, $mode, $iBulkMailPresort, $bToParents, $bOnlyComp
     $sSQL .= 'WHERE per_ID IN (' . convertCartToString($_SESSION['aPeopleCart']) . ') ';
     $sSQL .= 'ORDER BY per_LastName, per_FirstName, fam_Zip';
     $rsCartItems = RunQuery($sSQL);
-    $sRowClass = 'RowColorA';
     $didFam = [];
 
     while ($aRow = mysqli_fetch_array($rsCartItems)) {
@@ -584,7 +583,7 @@ function GenerateLabels(&$pdf, $mode, $iBulkMailPresort, $bToParents, $bOnlyComp
         // At most one label for all others (for example, another church or a landscape
         // company)
 
-        $sRowClass = AlternateRowStyle($sRowClass);
+
 
         if (($aRow['per_fam_ID'] == 0) && ($mode == 'fam')) {
             // Skip people with no family ID

--- a/src/SelectDelete.php
+++ b/src/SelectDelete.php
@@ -185,7 +185,7 @@ require_once __DIR__ . '/Include/Header.php';
                  LEFT JOIN donationfund_fun b ON plg_fundID = b.fun_ID
                  WHERE plg_famID = ' . $iFamilyID . ' ORDER BY pledge_plg.plg_date';
             $rsPledges = RunQuery($sSQL); ?>
-            <table cellpadding="5" cellspacing="0" width="100%">
+            <table class="table table-striped w-100">
                 <tr class="TableHeader">
                     <td><?= gettext('Type') ?></td>
                     <td><?= gettext('Fund') ?></td>
@@ -214,21 +214,8 @@ require_once __DIR__ . '/Include/Header.php';
                     $plg_EditedBy = '';
                     extract($aRow);
 
-                    //Alternate the row style
-                    if ($tog) {
-                        $sRowClass = 'RowColorA';
-                    } else {
-                        $sRowClass = 'RowColorB';
-                    }
-
-                    if ($plg_PledgeOrPayment === 'Payment') {
-                        if ($tog) {
-                            $sRowClass = 'PaymentRowColorA';
-                        } else {
-                            $sRowClass = 'PaymentRowColorB';
-                        }
-                    } ?>
-                    <tr class="<?= $sRowClass ?>">
+                    ?>
+                    <tr>
                         <td><?= $plg_PledgeOrPayment ?>&nbsp;</td>
                         <td><?= $fundName ?>&nbsp;</td>
                         <td><?= MakeFYString($plg_FYID ? (int) $plg_FYID : null) ?>&nbsp;</td>


### PR DESCRIPTION

## What Changed
<!-- Short summary - what and why (not how) -->

- Removed AlternateRowStyle and sRowClass usage
- Converted data tables to use Bootstrap  (where applicable)
- Cleaned up orphaned row-class attributes


## Type
<!-- Check one -->
- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
<!-- How to verify this works -->

## Screenshots
<!-- Only for UI changes - drag & drop images here -->

## Security Check
<!-- Only check if applicable -->
- [ ] Introduces new input validation
- [ ] Modifies authentication/authorization
- [ ] Affects data privacy/GDPR

### Code Quality
- [ ] Database: Propel ORM only, no raw SQL
- [ ] No deprecated attributes (align, valign, nowrap, border, cellpadding, cellspacing, bgcolor)
- [ ] Bootstrap CSS classes used
- [ ] All CSS bundled via webpack

## Pre-Merge
- [ ] Tested locally
- [ ] No new warnings
- [ ] Build passes
- [ ] Backward compatible (or migration documented)