### PR TITLE
Replace htmlentities/htmlspecialchars with InputUtils escaping methods

### DIFF
--- a/src/Checkin.php
+++ b/src/Checkin.php
@@ -514,7 +514,7 @@ function loadPerson($iPersonID)
     // Only show photo if person has uploaded one
     $personPhoto = new \ChurchCRM\dto\Photo('person', $iPersonID);
     if ($personPhoto->hasUploadedPhoto()) {
-        $html .= '<img src="' . SystemURLs::getRootPath() . '/api/person/' . $iPersonID . '/photo" alt="' . htmlspecialchars($person->getFullName()) . '" class="photo-medium">';
+        $html .= '<img src="' . SystemURLs::getRootPath() . '/api/person/' . $iPersonID . '/photo" alt="' . InputUtils::escapeAttribute($person->getFullName()) . '" class="photo-medium">';
     }
     
     $html .= '</div>';

--- a/src/ChurchCRM/Bootstrapper.php
+++ b/src/ChurchCRM/Bootstrapper.php
@@ -9,6 +9,7 @@ use ChurchCRM\dto\SystemURLs;
 use ChurchCRM\model\ChurchCRM\ConfigQuery;
 use ChurchCRM\model\ChurchCRM\Version;
 use ChurchCRM\Service\SystemService;
+use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\LoggerUtils;
 use ChurchCRM\Utils\RedirectUtils;
 use ChurchCRM\Utils\VersionUtils;
@@ -549,7 +550,7 @@ class Bootstrapper
             echo '<div style="max-width: 800px; margin: 50px auto; padding: 20px;">';
             echo '<h1>ChurchCRM Error</h1>';
             echo '<div style="padding: 15px; margin: 20px 0; border: 1px solid #f5c6cb; background-color: #f8d7da; color: #721c24; border-radius: 4px;">';
-            echo htmlspecialchars($message, ENT_QUOTES, 'UTF-8');
+            echo InputUtils::escapeHTML($message);
             echo '</div></div></body></html>';
         }
         exit();

--- a/src/ChurchCRM/model/ChurchCRM/Family.php
+++ b/src/ChurchCRM/model/ChurchCRM/Family.php
@@ -11,6 +11,7 @@ use ChurchCRM\Emails\notifications\NewPersonOrFamilyEmail;
 use ChurchCRM\model\ChurchCRM\Base\Family as BaseFamily;
 use ChurchCRM\PhotoInterface;
 use ChurchCRM\Utils\GeoUtils;
+use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\LoggerUtils;
 use DateTime;
 use Propel\Runtime\Connection\ConnectionInterface;
@@ -308,7 +309,7 @@ class Family extends BaseFamily implements PhotoInterface
      */
     public function getLinkHtml(bool $includePhoto = true, bool $strong = true): string
     {
-        $name = $strong ? '<strong>' . htmlspecialchars($this->getName()) . '</strong>' : htmlspecialchars($this->getName());
+        $name = $strong ? '<strong>' . InputUtils::escapeHTML($this->getName()) . '</strong>' : InputUtils::escapeHTML($this->getName());
         $html = '<a href="' . $this->getViewURI() . '">' . $name . '</a>';
 
         if ($includePhoto && $this->getPhoto() && $this->getPhoto()->hasUploadedPhoto()) {
@@ -329,7 +330,7 @@ class Family extends BaseFamily implements PhotoInterface
         if (mb_strlen($s) > $maxLen) {
             $s = mb_substr($s, 0, $maxLen) . '...';
         }
-        return htmlspecialchars($s);
+        return InputUtils::escapeHTML($s);
     }
 
     public function hasLatitudeAndLongitude(): bool

--- a/src/DonationFundEditor.php
+++ b/src/DonationFundEditor.php
@@ -267,8 +267,8 @@ require_once __DIR__ . '/Include/Header.php'; ?>
                                         </td>
                                         <td>
                                             <?php
-                                            $fundNameJs = htmlspecialchars(json_encode($aNameFields[$row]), ENT_QUOTES, 'UTF-8');
-                                            $fundIdJs = htmlspecialchars(json_encode($aIDFields[$row]), ENT_QUOTES, 'UTF-8');
+                                            $fundNameJs = InputUtils::escapeAttribute(json_encode($aNameFields[$row]));
+                                            $fundIdJs = InputUtils::escapeAttribute(json_encode($aIDFields[$row]));
                                             ?>
                                             <button type="button" class="btn btn-sm btn-danger" onclick="confirmDeleteFund(<?= $fundNameJs ?>, <?= $fundIdJs ?>)">
                                                 <i class="fa-solid fa-trash"></i>

--- a/src/FamilyCustomFieldsEditor.php
+++ b/src/FamilyCustomFieldsEditor.php
@@ -415,10 +415,10 @@ function GetSecurityList($aSecGrp, $fld_name, $currOpt = 'bAll')
                 ?>
                 <tr>
                     <td>
-                        <span class="badge badge-primary"><?= htmlspecialchars($aPropTypes[$aTypeFields[$row]], ENT_QUOTES, 'UTF-8') ?></span>
+                        <span class="badge badge-primary"><?= InputUtils::escapeHTML($aPropTypes[$aTypeFields[$row]]) ?></span>
                     </td>
                     <td>
-                        <input type="text" class="form-control form-control-sm" name="<?= $row . 'name' ?>" value="<?= htmlspecialchars(stripslashes($aNameFields[$row]), ENT_QUOTES, 'UTF-8') ?>" maxlength="40">
+                        <input type="text" class="form-control form-control-sm" name="<?= $row . 'name' ?>" value="<?= InputUtils::escapeAttribute($aNameFields[$row]) ?>" maxlength="40">
                         <?php
                         if ($aNameErrors[$row]) {
                             echo '<small class="text-danger"><br>' . gettext('You must enter a name') . '</small>';
@@ -437,11 +437,11 @@ function GetSecurityList($aSecGrp, $fld_name, $currOpt = 'bAll')
                         while ($aRow = mysqli_fetch_array($rsGroupList)) {
                             extract($aRow);
 
-                            echo '<option value="' . htmlspecialchars($grp_ID, ENT_QUOTES, 'UTF-8') . '"';
+                            echo '<option value="' . InputUtils::escapeAttribute($grp_ID) . '"';
                             if ($aSpecialFields[$row] == $grp_ID) {
                                 echo ' selected';
                             }
-                            echo '>' . htmlspecialchars($grp_Name, ENT_QUOTES, 'UTF-8') . '</option>';
+                            echo '>' . InputUtils::escapeHTML($grp_Name) . '</option>';
                         }
 
                         echo '</select>';

--- a/src/GroupPropsFormEditor.php
+++ b/src/GroupPropsFormEditor.php
@@ -405,11 +405,11 @@ require_once __DIR__ . '/Include/Header.php'; ?>
                                     while ($aRow = mysqli_fetch_array($rsGroupList)) {
                                         extract($aRow);
 
-                                        echo '<option value="' . htmlspecialchars($grp_ID, ENT_QUOTES, 'UTF-8') . '"';
+                                        echo '<option value="' . InputUtils::escapeAttribute($grp_ID) . '"';
                                         if ($aSpecialFields[$row] == $grp_ID) {
                                             echo ' selected';
                                         }
-                                        echo '>' . htmlspecialchars($grp_Name, ENT_QUOTES, 'UTF-8') . '</option>';
+                                        echo '>' . InputUtils::escapeHTML($grp_Name) . '</option>';
                                     }
 
                                     echo '</select>';
@@ -418,7 +418,7 @@ require_once __DIR__ . '/Include/Header.php'; ?>
                                         echo '<small class="text-danger d-block mt-1">' . gettext('You must select a group.') . '</small>';
                                     }
                                 } elseif ($aTypeFields[$row] == 12) {
-                                    echo '<a href="javascript:void(0)" onclick="window.open(\'OptionManager.php?mode=groupcustom&ListID=' . htmlspecialchars($aSpecialFields[$row], ENT_QUOTES, 'UTF-8') . '\',\'ListOptions\',\'toolbar=no,status=no,width=400,height=500\')">' . gettext('Edit List Options') . '</a>';
+                                    echo '<a href="javascript:void(0)" onclick="window.open(\'OptionManager.php?mode=groupcustom&ListID=' . InputUtils::escapeAttribute($aSpecialFields[$row]) . '\',\'ListOptions\',\'toolbar=no,status=no,width=400,height=500\')">' . gettext('Edit List Options') . '</a>';
                                 } else {
                                     echo '&nbsp;';
                                 } ?>
@@ -440,10 +440,10 @@ require_once __DIR__ . '/Include/Header.php'; ?>
                                     </button>
                                     <?php
                                     if ($row != 1) {
-                                        echo '<a href="GroupPropsFormRowOps.php?GroupID=' . $iGroupID . '&PropID=' . $row . '&Field=' . htmlspecialchars($aFieldFields[$row], ENT_QUOTES, 'UTF-8') . '&Action=up" class="btn btn-outline-secondary" title="' . gettext('Move up') . '"><i class="fa-solid fa-arrow-up"></i></a>';
+                                        echo '<a href="GroupPropsFormRowOps.php?GroupID=' . $iGroupID . '&PropID=' . $row . '&Field=' . InputUtils::escapeAttribute($aFieldFields[$row]) . '&Action=up" class="btn btn-outline-secondary" title="' . gettext('Move up') . '"><i class="fa-solid fa-arrow-up"></i></a>';
                                     }
                                     if ($row < $numRows) {
-                                        echo '<a href="GroupPropsFormRowOps.php?GroupID=' . $iGroupID . '&PropID=' . $row . '&Field=' . htmlspecialchars($aFieldFields[$row], ENT_QUOTES, 'UTF-8') . '&Action=down" class="btn btn-outline-secondary" title="' . gettext('Move down') . '"><i class="fa-solid fa-arrow-down"></i></a>';
+                                        echo '<a href="GroupPropsFormRowOps.php?GroupID=' . $iGroupID . '&PropID=' . $row . '&Field=' . InputUtils::escapeAttribute($aFieldFields[$row]) . '&Action=down" class="btn btn-outline-secondary" title="' . gettext('Move down') . '"><i class="fa-solid fa-arrow-down"></i></a>';
                                     } ?>
                                 </div>
                             </td>

--- a/src/Include/Functions.php
+++ b/src/Include/Functions.php
@@ -16,21 +16,6 @@ if (empty($bSuppressSessionTests)) {  // This is used for the login page only.
     AuthenticationManager::ensureAuthentication();
 }
 
-// If magic_quotes off and array
-function addslashes_deep($value)
-{
-    return is_array($value) ?
-        array_map('addslashes_deep', $value) :
-        addslashes($value);
-}
-
-// If Magic Quotes is turned off, do the same thing manually..
-if (!isset($_SESSION['bHasMagicQuotes'])) {
-    foreach ($_REQUEST as $value) {
-        $value = addslashes_deep($value);
-    }
-}
-
 // Constants
 $aPropTypes = [
   1  => gettext('True / False'),
@@ -519,7 +504,7 @@ function formCustomField($type, string $fieldname, $data, ?string $special, bool
             '<div class="input-group-prepend">' .
             '<span class="input-group-text"><i class="fa-solid fa-font"></i></span>' .
             '</div>' .
-            '<input class="form-control" type="text" id="' . $fieldname . '" name="' . $fieldname . '" maxlength="50" value="' . htmlentities(stripslashes($data), ENT_QUOTES, 'UTF-8') . '">' .
+            '<input class="form-control" type="text" id="' . $fieldname . '" name="' . $fieldname . '" maxlength="50" value="' . InputUtils::escapeAttribute($data) . '">' .
             '</div>';
             break;
 
@@ -529,7 +514,7 @@ function formCustomField($type, string $fieldname, $data, ?string $special, bool
             '<div class="input-group-prepend">' .
             '<span class="input-group-text"><i class="fa-solid fa-align-left"></i></span>' .
             '</div>' .
-            '<textarea class="form-control" id="' . $fieldname . '" name="' . $fieldname . '" rows="2" maxlength="100">' . htmlentities(stripslashes($data), ENT_QUOTES, 'UTF-8') . '</textarea>' .
+            '<textarea class="form-control" id="' . $fieldname . '" name="' . $fieldname . '" rows="2" maxlength="100">' . InputUtils::escapeHTML($data) . '</textarea>' .
             '</div>';
             break;
 
@@ -539,7 +524,7 @@ function formCustomField($type, string $fieldname, $data, ?string $special, bool
             '<div class="input-group-prepend">' .
             '<span class="input-group-text"><i class="fa-solid fa-paragraph"></i></span>' .
             '</div>' .
-            '<textarea class="form-control" id="' . $fieldname . '" name="' . $fieldname . '" rows="4" maxlength="65535">' . htmlentities(stripslashes($data), ENT_QUOTES, 'UTF-8') . '</textarea>' .
+            '<textarea class="form-control" id="' . $fieldname . '" name="' . $fieldname . '" rows="4" maxlength="65535">' . InputUtils::escapeHTML($data) . '</textarea>' .
             '</div>';
             break;
 
@@ -666,7 +651,7 @@ function formCustomField($type, string $fieldname, $data, ?string $special, bool
             echo '<span class="input-group-text"><i class="fa-solid fa-phone"></i></span>';
             echo '</div>';
             // Note: using data-phone-mask instead of data-inputmask to prevent auto-initialization
-            echo '<input class="form-control" type="text" id="' . $fieldname . '" name="' . $fieldname . '" maxlength="30" value="' . htmlentities(stripslashes($data), ENT_QUOTES, 'UTF-8') . '" data-phone-mask=\'{"mask": "' . SystemConfig::getValue('sPhoneFormat') . '"}\'>'; 
+            echo '<input class="form-control" type="text" id="' . $fieldname . '" name="' . $fieldname . '" maxlength="30" value="' . InputUtils::escapeAttribute($data) . '" data-phone-mask=\'{"mask": "' . SystemConfig::getValue('sPhoneFormat') . '"}\'>'; 
             echo '<div class="input-group-append">';
             echo '<div class="input-group-text">';
             echo '<div class="custom-control custom-checkbox mb-0">';


### PR DESCRIPTION
## What Changed
<!-- Short summary - what and why (not how) -->

- Remove legacy magic_quotes code (addslashes_deep function)
- Remove stripslashes() calls throughout codebase (no longer needed)
- Replace all htmlentities(stripslashes(...), ENT_QUOTES, 'UTF-8') with InputUtils methods
- Replace htmlspecialchars() with InputUtils::escapeAttribute() for attributes
- Replace htmlspecialchars() with InputUtils::escapeHTML() for HTML content
- Add InputUtils import to Family.php and Bootstrapper.php

This improves code consistency by using InputUtils for all HTML escaping, which provides proper sanitization and follows project standards.

## Type
<!-- Check one -->
- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
<!-- How to verify this works -->

## Screenshots
<!-- Only for UI changes - drag & drop images here -->

## Security Check
<!-- Only check if applicable -->
- [ ] Introduces new input validation
- [ ] Modifies authentication/authorization
- [ ] Affects data privacy/GDPR

### Code Quality
- [ ] Database: Propel ORM only, no raw SQL
- [ ] No deprecated attributes (align, valign, nowrap, border, cellpadding, cellspacing, bgcolor)
- [ ] Bootstrap CSS classes used
- [ ] All CSS bundled via webpack

## Pre-Merge
- [ ] Tested locally
- [ ] No new warnings
- [ ] Build passes
- [ ] Backward compatible (or migration documented)