### PR TITLE
Remove legacy phone normalization

### DIFF
--- a/src/CSVImport.php
+++ b/src/CSVImport.php
@@ -547,7 +547,7 @@ if (isset($_POST['DoImport'])) {
                         case 14:
                         case 15:
                         case 16:
-                                $sSQLpersonData .= "'" . addslashes(CollapsePhoneNumber($aData[$col], $sCountry)) . "',";
+                                $sSQLpersonData .= "'" . addslashes($aData[$col]) . "',";
                                 $sSQLpersonFields .= $aPersonTableFields[$currentType] . ', ';
                             break;
                         default:

--- a/src/CartToFamily.php
+++ b/src/CartToFamily.php
@@ -49,11 +49,8 @@ if (isset($_POST['Submit']) && count($_SESSION['aPeopleCart']) > 0) {
             $sState = InputUtils::legacyFilterInput($_POST['StateTextbox']);
         }
 
-        // Get and format any phone data from the form.
+        // Get phone data from the form (store as entered by user).
         $sHomePhone = InputUtils::legacyFilterInput($_POST['HomePhone']);
-        if (!isset($_POST['NoFormat_HomePhone'])) {
-            $sHomePhone = CollapsePhoneNumber($sHomePhone, $sCountry);
-        }
 
         $sEmail = InputUtils::legacyFilterInput($_POST['Email']);
 

--- a/src/FamilyEditor.php
+++ b/src/FamilyEditor.php
@@ -222,11 +222,6 @@ if (isset($_POST['FamilySubmit']) || isset($_POST['FamilySubmitAndAdd'])) {
 
     //If no errors, then let's update...
     if (!$bErrorFlag) {
-        // Format the phone numbers before we store them
-        if (!$bNoFormat_HomePhone) {
-            $sHomePhone = CollapsePhoneNumber($sHomePhone, $sCountry);
-        }
-
         //Write the base SQL depending on the Action
         $bSendNewsLetterString = $bSendNewsLetter ? 'TRUE' : 'FALSE';
 

--- a/src/Include/Functions.php
+++ b/src/Include/Functions.php
@@ -258,48 +258,6 @@ function FormatDate($dDate, bool $bWithTime = false): string
     return $formattedDate;
 }
 
-//
-// Collapses a formatted phone number as long as the Country is known
-// Eg. for United States:  555-555-1212 Ext. 123 ==> 5555551212e123
-//
-// Need to add other countries besides the US...
-//
-function CollapsePhoneNumber($sPhoneNumber, $sPhoneCountry)
-{
-    switch ($sPhoneCountry) {
-        case 'United States':
-            $sCollapsedPhoneNumber = '';
-            $bHasExtension = false;
-
-          // Loop through the input string
-            for ($iCount = 0; $iCount <= strlen($sPhoneNumber); $iCount++) {
-            // Take one character...
-                $sThisCharacter = mb_substr($sPhoneNumber, $iCount, 1);
-
-              // Is it a number?
-                if (ord($sThisCharacter) >= 48 && ord($sThisCharacter) <= 57) {
-                    // Yes, add it to the returned value.
-                    $sCollapsedPhoneNumber .= $sThisCharacter;
-                } elseif (!$bHasExtension && ($sThisCharacter == 'e' || $sThisCharacter == 'E')) {
-                    // Is the user trying to add an extension?
-                    // Yes, add the extension identifier 'e' to the stored string.
-                    $sCollapsedPhoneNumber .= 'e';
-                    // From now on, ignore other non-digits and process normally
-                    $bHasExtension = true;
-                }
-            }
-            break;
-
-        default:
-            $sCollapsedPhoneNumber = $sPhoneNumber;
-            break;
-    }
-
-    return $sCollapsedPhoneNumber;
-}
-
-
-
 // Returns a string of a person's full name, formatted as specified by $Style
 // $Style = 0  :  "Title FirstName MiddleName LastName, Suffix"
 // $Style = 1  :  "Title FirstName MiddleInitial. LastName, Suffix"
@@ -1018,11 +976,7 @@ function sqlCustomField(string &$sSQL, $type, $data, string $col_Name, $special)
     // phone
         case 11:
             if (strlen($data) > 0) {
-                if (!isset($_POST[$col_Name . 'noformat'])) {
-                    $sSQL .= $col_Name . " = '" . CollapsePhoneNumber($data, $special) . "', ";
-                } else {
-                    $sSQL .= $col_Name . " = '" . $data . "', ";
-                }
+                $sSQL .= $col_Name . " = '" . $data . "', ";
             } else {
                 $sSQL .= $col_Name . ' = NULL, ';
             }

--- a/src/PersonEditor.php
+++ b/src/PersonEditor.php
@@ -318,18 +318,6 @@ if (isset($_POST['PersonSubmit']) || isset($_POST['PersonSubmitAndAdd'])) {
 
     //If no errors, then let's update...
     if (!$bErrorFlag) {
-        $sPhoneCountry = $sCountry;
-
-        if (!$bNoFormat_HomePhone) {
-            $sHomePhone = CollapsePhoneNumber($sHomePhone, $sPhoneCountry);
-        }
-        if (!$bNoFormat_WorkPhone) {
-            $sWorkPhone = CollapsePhoneNumber($sWorkPhone, $sPhoneCountry);
-        }
-        if (!$bNoFormat_CellPhone) {
-            $sCellPhone = CollapsePhoneNumber($sCellPhone, $sPhoneCountry);
-        }
-
         //If no birth year, set to NULL
         if (strlen($iBirthYear) !== 4) {
             $iBirthYear = null;


### PR DESCRIPTION
## What Changed
<!-- Short summary - what and why (not how) -->

Phone numbers now respect user formatting preferences via UI masks rather than backend normalization. This preserves user input intent and supports multiple international formats without code modifications.


## Type
<!-- Check one -->
- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
<!-- How to verify this works -->

## Screenshots
<!-- Only for UI changes - drag & drop images here -->

## Security Check
<!-- Only check if applicable -->
- [ ] Introduces new input validation
- [ ] Modifies authentication/authorization
- [ ] Affects data privacy/GDPR

### Code Quality
- [ ] Database: Propel ORM only, no raw SQL
- [ ] No deprecated attributes (align, valign, nowrap, border, cellpadding, cellspacing, bgcolor)
- [ ] Bootstrap CSS classes used
- [ ] All CSS bundled via webpack

## Pre-Merge
- [ ] Tested locally
- [ ] No new warnings
- [ ] Build passes
- [ ] Backward compatible (or migration documented)