### PR TITLE
Fix issue #7895: Remove setWorkPhone/setCellPhone from Family creation

### DIFF
--- a/cypress/e2e/ui/people/standard.person.new.spec.js
+++ b/cypress/e2e/ui/people/standard.person.new.spec.js
@@ -63,4 +63,28 @@ describe("Standard Person", () => {
         cy.url().should("contain", personViewPath);
         cy.contains(name);
     });
+
+    it("Add Person with Create New Family option", () => {
+        // Tests fix for issue #7895 - setWorkPhone error when creating new family
+        const firstName = "NewFam " + uniqueSeed;
+        const lastName = "TestFamily" + uniqueSeed;
+
+        cy.visit(personEditorPath);
+        cy.get("#FirstName").type(firstName);
+        cy.get("#LastName").type(lastName);
+        
+        // Select "Create a new family (using last name)" option (-1)
+        // Use force:true because Select2 covers the native select element
+        cy.get("#familyId").select("-1", { force: true });
+        
+        // Select Head of Household role
+        cy.get("#FamilyRole").select("1", { force: true });
+        
+        // Click FAB save button
+        cy.get(".fab-save").click();
+
+        // Should redirect to PersonView without error
+        cy.url().should("contain", personViewPath);
+        cy.contains(firstName);
+    });
 });

--- a/src/PersonEditor.php
+++ b/src/PersonEditor.php
@@ -336,8 +336,6 @@ if (isset($_POST['PersonSubmit']) || isset($_POST['PersonSubmitAndAdd'])) {
                 ->setZip($sZip)
                 ->setCountry($sCountry)
                 ->setHomePhone($sHomePhone)
-                ->setWorkPhone($sWorkPhone)
-                ->setCellPhone($sCellPhone)
                 ->setEmail($sEmail)
                 ->setDateEntered(new DateTimeImmutable())
                 ->setEnteredBy(AuthenticationManager::getCurrentUser()->getId());


### PR DESCRIPTION
## What Changed
<!-- Short summary - what and why (not how) -->

Fix issue #7895: Remove setWorkPhone/setCellPhone from Family creation

The fam_WorkPhone and fam_CellPhone columns were removed in 6.5.0 but
PersonEditor.php still called these methods when creating a new family.

- Remove setWorkPhone() and setCellPhone() calls on Family object
- Add Cypress test for 'Create a new family' person workflow"

## Type
<!-- Check one -->
- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
<!-- How to verify this works -->

## Screenshots
<!-- Only for UI changes - drag & drop images here -->

## Security Check
<!-- Only check if applicable -->
- [ ] Introduces new input validation
- [ ] Modifies authentication/authorization
- [ ] Affects data privacy/GDPR

### Code Quality
- [ ] Database: Propel ORM only, no raw SQL
- [ ] No deprecated attributes (align, valign, nowrap, border, cellpadding, cellspacing, bgcolor)
- [ ] Bootstrap CSS classes used
- [ ] All CSS bundled via webpack

## Pre-Merge
- [ ] Tested locally
- [ ] No new warnings
- [ ] Build passes
- [ ] Backward compatible (or migration documented)