### PR TITLE
Fix issue #7917: Volunteer opportunity assignment fails

### DIFF
--- a/cypress/e2e/ui/people/standard.volunteer-opportunity.spec.js
+++ b/cypress/e2e/ui/people/standard.volunteer-opportunity.spec.js
@@ -1,0 +1,76 @@
+/// <reference types="cypress" />
+
+/**
+ * Test for GitHub Issue #7917: Bug assigning Volunteer Opportunities
+ * @see https://github.com/ChurchCRM/CRM/issues/7917
+ * 
+ * This test verifies that volunteer opportunities can be assigned to people
+ * without causing a blank page / BadMethodCallException error.
+ */
+describe("Volunteer Opportunity Assignment - Issue #7917", () => {
+    beforeEach(() => {
+        cy.setupAdminSession();
+    });
+
+    it("should assign a volunteer opportunity without error", () => {
+        // Visit a person's profile page
+        cy.visit("PersonView.php?PersonID=1");
+        cy.contains("Person Profile");
+
+        // Click on the Volunteer tab
+        cy.get("#nav-item-volunteer").click();
+        cy.get("#volunteer").should("be.visible");
+
+        // Check if there are volunteer opportunities to assign
+        cy.get("#volunteer").then(($volunteerTab) => {
+            // Look for the volunteer opportunity select/checkbox elements
+            if ($volunteerTab.find('input[name="VolunteerOpportunityIDs[]"]').length > 0) {
+                // Get an unassigned opportunity checkbox
+                cy.get('input[name="VolunteerOpportunityIDs[]"]:not(:checked)').first().then(($checkbox) => {
+                    if ($checkbox.length > 0) {
+                        const opportunityId = $checkbox.val();
+                        
+                        // Check the opportunity
+                        cy.wrap($checkbox).check();
+                        
+                        // Submit the form
+                        cy.get('input[name="VolunteerOpportunityAssign"]').click();
+
+                        // Should not show an error - page should reload successfully
+                        cy.url().should("contain", "PersonView.php?PersonID=1");
+                        cy.contains("Person Profile");
+
+                        // The opportunity should now be assigned (listed in assigned section)
+                        // This verifies the fix worked - previously this would show a blank page
+                        cy.get("#nav-item-volunteer").click();
+                        cy.get("#volunteer").should("be.visible");
+
+                        // Clean up: Remove the assigned opportunity
+                        cy.get(`a[href*="RemoveVO=${opportunityId}"]`).first().click();
+                        cy.url().should("contain", "PersonView.php?PersonID=1");
+                    } else {
+                        cy.log("No unassigned volunteer opportunities available to test");
+                    }
+                });
+            } else {
+                cy.log("No volunteer opportunities configured in the system");
+            }
+        });
+    });
+
+    it("should display volunteer tab content without errors", () => {
+        // Visit a person's profile page
+        cy.visit("PersonView.php?PersonID=1");
+        cy.contains("Person Profile");
+
+        // Click on the Volunteer tab
+        cy.get("#nav-item-volunteer").click();
+
+        // Volunteer tab should be visible and functional
+        cy.get("#volunteer").should("be.visible");
+        
+        // Should not have any PHP errors on page
+        cy.get("body").should("not.contain", "Fatal error");
+        cy.get("body").should("not.contain", "BadMethodCallException");
+    });
+});

--- a/src/ChurchCRM/Service/PersonService.php
+++ b/src/ChurchCRM/Service/PersonService.php
@@ -101,8 +101,8 @@ class PersonService
     public function addVolunteerOpportunity(int $personId, int $opportunityId): bool
     {
         $assignment = new PersonVolunteerOpportunity();
-        $assignment->setPerID($personId);
-        $assignment->setVolID($opportunityId);
+        $assignment->setPersonId($personId);
+        $assignment->setVolunteerOpportunityId($opportunityId);
 
         return (bool)$assignment->save();
     }
@@ -113,8 +113,8 @@ class PersonService
     public function removeVolunteerOpportunity(int $personId, int $opportunityId): void
     {
         PersonVolunteerOpportunityQuery::create()
-            ->filterByPerID($personId)
-            ->filterByVolID($opportunityId)
+            ->filterByPersonId($personId)
+            ->filterByVolunteerOpportunityId($opportunityId)
             ->delete();
     }
 


### PR DESCRIPTION
## Summary

Fixes #7917 - Assigning volunteer opportunities in PersonView.php fails with a blank page due to `BadMethodCallException: Call to undefined method: setPerID`.

## Root Cause

The `PersonService` was using incorrect Propel ORM method names that don't match the generated phpName mappings:

| Database Column | Wrong Method | Correct Method |
|-----------------|--------------|----------------|
| `p2vo_per_id` | `setPerID()` / `filterByPerID()` | `setPersonId()` / `filterByPersonId()` |
| `p2vo_vol_id` | `setVolID()` / `filterByVolID()` | `setVolunteerOpportunityId()` / `filterByVolunteerOpportunityId()` |

Propel generates method names based on the `phpName` attribute in the schema, not the raw database column names.

## Changes

- [PersonService.php](src/ChurchCRM/Service/PersonService.php) - Corrected method names in `addVolunteerOpportunity()` and `removeVolunteerOpportunity()`
- Added Cypress test [standard.volunteer-opportunity.spec.js](cypress/e2e/ui/people/standard.volunteer-opportunity.spec.js) to verify the fix

## Testing

- ✅ `standard.volunteer-opportunity.spec.js` - 2 tests pass (assignment and tab display)
- ✅ `standard.person.profile.spec.js` - 3 tests pass (no regression)
- ✅ No PHP errors logged