### PR TITLE
Fix GHSA-49qp-cfqx-c767: Stored XSS in Calendar Events Description

### DIFF
--- a/src/api/routes/calendar/events.php
+++ b/src/api/routes/calendar/events.php
@@ -136,9 +136,9 @@ function newEvent(Request $request, Response $response, array $args): Response
 
     // we have event type and pined calendars.  now create the event.
     $event = new Event();
-    $event->setTitle($input['Title']);
+    $event->setTitle(InputUtils::sanitizeText($input['Title']));
     $event->setEventType($type);
-    $event->setDesc($input['Desc']);
+    $event->setDesc(InputUtils::sanitizeHTML($input['Desc']));
     $event->setStart(str_replace('T', ' ', $input['Start']));
     $event->setEnd(str_replace('T', ' ', $input['End']));
     $event->setText(InputUtils::sanitizeHTML($input['Text']));
@@ -154,6 +154,18 @@ function updateEvent(Request $request, Response $response, array $args): Respons
     /** @var Event $Event */
     $Event = $request->getAttribute('event');
     $id = $Event->getId();
+
+    // Sanitize user-controlled fields before applying to the model
+    if (isset($input['Title'])) {
+        $input['Title'] = InputUtils::sanitizeText($input['Title']);
+    }
+    if (isset($input['Desc'])) {
+        $input['Desc'] = InputUtils::sanitizeHTML($input['Desc']);
+    }
+    if (isset($input['Text'])) {
+        $input['Text'] = InputUtils::sanitizeHTML($input['Text']);
+    }
+
     $Event->fromArray($input);
     $Event->setId($id);
     $PinnedCalendars = CalendarQuery::create()


### PR DESCRIPTION

## What Changed
<!-- Short summary - what and why (not how) -->

Sanitize user-controlled fields in the events API:
- newEvent: Apply InputUtils::sanitizeText() to Title, InputUtils::sanitizeHTML() to Desc
- updateEvent: Sanitize Title, Desc, and Text fields before fromArray() call

The vulnerability allowed low-privilege users to inject XSS payloads via the Desc field when creating events. The payload was stored in the database and executed when other users (including admins) viewed the event, enabling session hijacking and account takeover.


## Type
<!-- Check one -->
- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
<!-- How to verify this works -->

## Screenshots
<!-- Only for UI changes - drag & drop images here -->

## Security Check
<!-- Only check if applicable -->
- [ ] Introduces new input validation
- [ ] Modifies authentication/authorization
- [ ] Affects data privacy/GDPR

### Code Quality
- [ ] Database: Propel ORM only, no raw SQL
- [ ] No deprecated attributes (align, valign, nowrap, border, cellpadding, cellspacing, bgcolor)
- [ ] Bootstrap CSS classes used
- [ ] All CSS bundled via webpack

## Pre-Merge
- [ ] Tested locally
- [ ] No new warnings
- [ ] Build passes
- [ ] Backward compatible (or migration documented)