### PR TITLE
Fix issue #7954: Add timezone-aware date operations throughout applic…

### DIFF
--- a/src/Checkin.php
+++ b/src/Checkin.php
@@ -14,6 +14,7 @@ use ChurchCRM\model\ChurchCRM\EventAttendQuery;
 use ChurchCRM\model\ChurchCRM\EventQuery;
 use ChurchCRM\model\ChurchCRM\EventTypeQuery;
 use ChurchCRM\model\ChurchCRM\PersonQuery;
+use ChurchCRM\Utils\DateTimeUtils;
 use ChurchCRM\Utils\InputUtils;
 use Propel\Runtime\ActiveQuery\Criteria;
 
@@ -275,7 +276,7 @@ if (isset($_POST['EventID']) && isset($_POST['child-id']) && (isset($_POST['Chec
             $attendee = new EventAttend();
             $attendee->setEventId($EventID);
             $attendee->setPersonId($iChildID);
-            $attendee->setCheckinDate(date("Y-m-d H:i:s"));
+            $attendee->setCheckinDate(DateTimeUtils::getNowDateTime());
             if (!empty($iAdultID)) {
                 $attendee->setCheckinId($iAdultID);
             }
@@ -289,7 +290,7 @@ if (isset($_POST['EventID']) && isset($_POST['child-id']) && (isset($_POST['Chec
         $attendee = EventAttendQuery::create()
             ->filterByEventId($EventID)
             ->findOneByPersonId($iChildID);
-        $attendee->setCheckoutDate(date("Y-m-d H:i:s"));
+        $attendee->setCheckoutDate(DateTimeUtils::getNowDateTime());
         if ($iAdultID) {
             $attendee->setCheckoutId($iAdultID);
         }

--- a/src/ChurchCRM/Authentication/AuthenticationProviders/LocalAuthentication.php
+++ b/src/ChurchCRM/Authentication/AuthenticationProviders/LocalAuthentication.php
@@ -10,11 +10,11 @@ use ChurchCRM\Authentication\Requests\LocalUsernamePasswordRequest;
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\dto\SystemURLs;
 use ChurchCRM\Emails\users\LockedEmail;
-use ChurchCRM\Utils\KeyManagerUtils;
 use ChurchCRM\model\ChurchCRM\User;
 use ChurchCRM\model\ChurchCRM\UserQuery;
+use ChurchCRM\Utils\DateTimeUtils;
+use ChurchCRM\Utils\KeyManagerUtils;
 use ChurchCRM\Utils\LoggerUtils;
-use DateTimeZone;
 use Endroid\QrCode\QrCode;
 use PragmaRX\Google2FA\Google2FA;
 
@@ -87,7 +87,7 @@ class LocalAuthentication implements IAuthenticationProvider
     private function prepareSuccessfulLoginOperations(): void
     {
         // Set the LastLogin and Increment the LoginCount
-        $date = new \DateTimeImmutable('now', new DateTimeZone(SystemConfig::getValue('sTimeZone')));
+        $date = new \DateTimeImmutable('now', DateTimeUtils::getConfiguredTimezone());
         $this->currentUser->setLastLogin($date->format('Y-m-d H:i:s'));
         $this->currentUser->setLoginCount($this->currentUser->getLoginCount() + 1);
         $this->currentUser->setFailedLogins(0);

--- a/src/ChurchCRM/Service/SystemService.php
+++ b/src/ChurchCRM/Service/SystemService.php
@@ -8,6 +8,7 @@ use ChurchCRM\dto\Prerequisite;
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\dto\SystemURLs;
 use ChurchCRM\Utils\ChurchCRMReleaseManager;
+use ChurchCRM\Utils\DateTimeUtils;
 use ChurchCRM\Utils\LoggerUtils;
 use PDO;
 use Propel\Runtime\Propel;
@@ -60,7 +61,7 @@ class SystemService
         if (empty($LastTime)) {
             return true;
         }
-        $tz = new \DateTimeZone(SystemConfig::getValue('sTimeZone'));
+        $tz = DateTimeUtils::getConfiguredTimezone();
         $now = new \DateTime('now', $tz);  //get the current time
         $previous = \DateTime::createFromFormat(SystemConfig::getValue('sDateFilenameFormat'), $LastTime, $tz); // get a DateTime object for the last time a backup was done.
         if ($previous === false) {

--- a/src/ChurchCRM/Slim/Middleware/Api/PublicCalendarMiddleware.php
+++ b/src/ChurchCRM/Slim/Middleware/Api/PublicCalendarMiddleware.php
@@ -8,6 +8,7 @@ use ChurchCRM\model\ChurchCRM\CalendarQuery;
 use ChurchCRM\model\ChurchCRM\EventQuery;
 use ChurchCRM\model\ChurchCRM\Map\EventTableMap;
 use ChurchCRM\Slim\SlimUtils;
+use ChurchCRM\Utils\DateTimeUtils;
 use ChurchCRM\Utils\InputUtils;
 use DateTime;
 use Propel\Runtime\ActiveQuery\Criteria;
@@ -52,7 +53,8 @@ class PublicCalendarMiddleware implements MiddlewareInterface
         if (isset($params['start'])) {
             $start_date = DateTime::createFromFormat('Y-m-d', $params['start']);
         } else {
-            $start_date = new DateTime();
+            // Use configured timezone for default start date
+            $start_date = DateTimeUtils::getToday();
         }
         $start_date->setTime(0, 0, 0);
 

--- a/src/ChurchCRM/SystemCalendars/AnniversariesCalendar.php
+++ b/src/ChurchCRM/SystemCalendars/AnniversariesCalendar.php
@@ -4,6 +4,7 @@ namespace ChurchCRM\SystemCalendars;
 
 use ChurchCRM\model\ChurchCRM\Event;
 use ChurchCRM\model\ChurchCRM\FamilyQuery;
+use ChurchCRM\Utils\DateTimeUtils;
 use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\Collection\ObjectCollection;
 
@@ -67,7 +68,7 @@ class AnniversariesCalendar implements SystemCalendar
             $anniversary->setId($family->getId());
             $anniversary->setEditable(false);
             $anniversary->setTitle(gettext('Anniversary') . ': ' . $family->getFamilyString());
-            $year = date('Y');
+            $year = DateTimeUtils::getCurrentYear();
             $anniversary->setStart($year . '-' . $family->getWeddingMonth() . '-' . $family->getWeddingDay());
             $anniversary->setURL($family->getViewURI());
             $events->push($anniversary);

--- a/src/ChurchCRM/SystemCalendars/BirthdaysCalendar.php
+++ b/src/ChurchCRM/SystemCalendars/BirthdaysCalendar.php
@@ -4,6 +4,7 @@ namespace ChurchCRM\SystemCalendars;
 
 use ChurchCRM\model\ChurchCRM\Event;
 use ChurchCRM\model\ChurchCRM\PersonQuery;
+use ChurchCRM\Utils\DateTimeUtils;
 use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\Collection\ObjectCollection;
 
@@ -65,8 +66,9 @@ class BirthdaysCalendar implements SystemCalendar
         $events = new ObjectCollection();
         $events->setModel(Event::class);
 
-        $startDate = $start ? new \DateTimeImmutable($start) : new \DateTimeImmutable(date('Y') . '-01-01');
-        $endDate = $end ? new \DateTimeImmutable($end) : new \DateTimeImmutable((date('Y') + 1) . '-12-31');
+        $currentYear = DateTimeUtils::getCurrentYear();
+        $startDate = $start ? new \DateTimeImmutable($start) : new \DateTimeImmutable($currentYear . '-01-01');
+        $endDate = $end ? new \DateTimeImmutable($end) : new \DateTimeImmutable(($currentYear + 1) . '-12-31');
 
         $maxYears = 2;
         if ($startDate->diff($endDate)->y > $maxYears) {

--- a/src/ChurchCRM/SystemCalendars/HolidayCalendar.php
+++ b/src/ChurchCRM/SystemCalendars/HolidayCalendar.php
@@ -6,6 +6,7 @@ use ChurchCRM\data\Countries;
 use ChurchCRM\data\Country;
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\model\ChurchCRM\Event;
+use ChurchCRM\Utils\DateTimeUtils;
 use Propel\Runtime\Collection\ObjectCollection;
 use Yasumi\Holiday;
 use Yasumi\Yasumi;
@@ -50,8 +51,8 @@ class HolidayCalendar implements SystemCalendar
     public function getEvents(string $start, string $end): ObjectCollection
     {
         $Country = Countries::getCountryByName(SystemConfig::getValue('sChurchCountry'));
-        $year = date('Y');
-        $holidays = Yasumi::create($Country->getCountryNameYasumi(), (int) $year);
+        $year = DateTimeUtils::getCurrentYear();
+        $holidays = Yasumi::create($Country->getCountryNameYasumi(), $year);
         $events = new ObjectCollection();
         $events->setModel(Event::class);
 

--- a/src/ChurchCRM/utils/DateTimeUtils.php
+++ b/src/ChurchCRM/utils/DateTimeUtils.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace ChurchCRM\Utils;
+
+use ChurchCRM\dto\SystemConfig;
+
+/**
+ * Utility class for timezone-aware date/time operations.
+ *
+ * All methods use the configured sTimeZone system setting to ensure
+ * consistent date calculations across the application.
+ */
+class DateTimeUtils
+{
+    /**
+     * Get the configured timezone for the church.
+     *
+     * @return \DateTimeZone The timezone configured in sTimeZone system setting
+     */
+    public static function getConfiguredTimezone(): \DateTimeZone
+    {
+        return new \DateTimeZone(SystemConfig::getValue('sTimeZone'));
+    }
+
+    /**
+     * Get today's date in the configured timezone.
+     *
+     * Use this instead of `new \DateTime()` to ensure "today" is calculated
+     * correctly for the church's timezone, not the server's default timezone.
+     *
+     * @return \DateTime Today's date/time in the configured timezone
+     */
+    public static function getToday(): \DateTime
+    {
+        return new \DateTime('now', self::getConfiguredTimezone());
+    }
+
+    /**
+     * Create a DateTime object for a specific date in the configured timezone.
+     *
+     * @param string $dateString A date string (e.g., "2026-02-07", "next monday")
+     *
+     * @return \DateTime The DateTime object in the configured timezone
+     */
+    public static function createDateTime(string $dateString): \DateTime
+    {
+        return new \DateTime($dateString, self::getConfiguredTimezone());
+    }
+
+    /**
+     * Get the current year in the configured timezone.
+     *
+     * @return int The current year (e.g., 2026)
+     */
+    public static function getCurrentYear(): int
+    {
+        return (int) self::getToday()->format('Y');
+    }
+
+    /**
+     * Get the current month in the configured timezone.
+     *
+     * @return int The current month (1-12)
+     */
+    public static function getCurrentMonth(): int
+    {
+        return (int) self::getToday()->format('m');
+    }
+
+    /**
+     * Get the current day of month in the configured timezone.
+     *
+     * @return int The current day (1-31)
+     */
+    public static function getCurrentDay(): int
+    {
+        return (int) self::getToday()->format('d');
+    }
+
+    /**
+     * Get the current date formatted as Y-m-d in the configured timezone.
+     *
+     * Use this instead of `date('Y-m-d')` to ensure the correct date
+     * for the church's configured timezone.
+     *
+     * @return string Today's date in Y-m-d format
+     */
+    public static function getTodayDate(): string
+    {
+        return self::getToday()->format('Y-m-d');
+    }
+
+    /**
+     * Get the current datetime formatted as Y-m-d H:i:s in the configured timezone.
+     *
+     * Use this instead of `date('Y-m-d H:i:s')` for timestamps that should
+     * reflect the church's local time.
+     *
+     * @return string Current datetime in Y-m-d H:i:s format
+     */
+    public static function getNowDateTime(): string
+    {
+        return self::getToday()->format('Y-m-d H:i:s');
+    }
+
+    /**
+     * Format a date using strtotime relative to the configured timezone.
+     *
+     * Use this instead of `date('Y-m-d', strtotime($modifier))` to ensure
+     * timezone-aware date calculations.
+     *
+     * @param string $modifier A strtotime modifier (e.g., "+1 week", "last monday")
+     * @param string $format   The output format (default: Y-m-d)
+     *
+     * @return string The formatted date string
+     */
+    public static function getRelativeDate(string $modifier, string $format = 'Y-m-d'): string
+    {
+        $date = self::getToday();
+        $date->modify($modifier);
+
+        return $date->format($format);
+    }
+
+    /**
+     * Format a date relative to a base date in the configured timezone.
+     *
+     * Use this for calculations like "next occurrence of this event".
+     *
+     * @param string $baseDate The base date string (Y-m-d format)
+     * @param string $modifier A strtotime modifier (e.g., "+1 week")
+     * @param string $format   The output format (default: Y-m-d)
+     *
+     * @return string The formatted date string
+     */
+    public static function getDateRelativeTo(string $baseDate, string $modifier, string $format = 'Y-m-d'): string
+    {
+        $date = self::createDateTime($baseDate);
+        $date->modify($modifier);
+
+        return $date->format($format);
+    }
+
+    /**
+     * Create a date from year, month, day components in the configured timezone.
+     *
+     * Use this instead of `mktime()` to ensure timezone-aware date construction.
+     *
+     * @param int    $year   The year
+     * @param int    $month  The month (1-12)
+     * @param int    $day    The day of month (1-31)
+     * @param string $format The output format (default: Y-m-d)
+     *
+     * @return string The formatted date string
+     */
+    public static function formatDateFromComponents(int $year, int $month, int $day, string $format = 'Y-m-d'): string
+    {
+        $date = self::createDateTime(sprintf('%04d-%02d-%02d', $year, $month, $day));
+
+        return $date->format($format);
+    }
+}

--- a/src/EventEditor.php
+++ b/src/EventEditor.php
@@ -14,6 +14,7 @@ use ChurchCRM\model\ChurchCRM\EventCountsQuery;
 use ChurchCRM\model\ChurchCRM\EventQuery;
 use ChurchCRM\model\ChurchCRM\EventTypeQuery;
 use ChurchCRM\model\ChurchCRM\GroupQuery;
+use ChurchCRM\Utils\DateTimeUtils;
 use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\LoggerUtils;
 use ChurchCRM\Utils\RedirectUtils;
@@ -115,7 +116,7 @@ if ($sAction === 'Create Event' && !empty($tyid)) {
     // definitions, recurrence type, etc.
     switch ($sDefRecurType) {
         case 'none':
-            $sEventStartDate = date('Y-m-d');
+            $sEventStartDate = DateTimeUtils::getTodayDate();
             $sEventEndDate = $sEventStartDate;
             $aStartTimeTokens = explode(':', $sDefStartTime);
             $iEventStartHour = $aStartTimeTokens[0];
@@ -136,7 +137,7 @@ if ($sAction === 'Create Event' && !empty($tyid)) {
                 extract($ecRow);
                 $aStartTokens = explode(' ', $event_start);
                 $ceEventStartDate = $aStartTokens[0];
-                $sEventStartDate = date('Y-m-d', strtotime("$ceEventStartDate +1 week"));
+                $sEventStartDate = DateTimeUtils::getDateRelativeTo($ceEventStartDate, '+1 week');
 
                 $aEventStartTimeTokens = explode(':', $sDefStartTime);
                 $iEventStartHour = $aEventStartTimeTokens[0];
@@ -147,7 +148,7 @@ if ($sAction === 'Create Event' && !empty($tyid)) {
                 $iEventEndMins = $iEventStartMins;
             } else {
                 // Use the event type definition
-                $sEventStartDate = date('Y-m-d', strtotime("last $iDefRecurDOW"));
+                $sEventStartDate = DateTimeUtils::getRelativeDate("last $iDefRecurDOW");
                 $aStartTimeTokens = explode(':', $sDefStartTime);
                 $iEventStartHour = $aStartTimeTokens[0];
                 $iEventStartMins = $aStartTimeTokens[1];
@@ -172,7 +173,7 @@ if ($sAction === 'Create Event' && !empty($tyid)) {
                 $ceDMY = explode('-', $aStartTokens[0]);
                 $aEventStartTimeTokens = explode(':', $ceStartTokens[1]);
 
-                $sEventStartDate = date('Y-m-d', mktime(0, 0, 0, $ceDMY[1] + 1, $ceDMY[2], $ceDMY[0]));
+                $sEventStartDate = DateTimeUtils::formatDateFromComponents((int) $ceDMY[0], (int) $ceDMY[1] + 1, (int) $ceDMY[2]);
                 $iEventStartHour = $aEventStartTimeTokens[0];
                 $iEventStartMins = $aEventStartTimeTokens[1];
                 $sEventEndDate = $sEventStartDate;
@@ -180,11 +181,13 @@ if ($sAction === 'Create Event' && !empty($tyid)) {
                 $iEventEndMins = $aEventStartTimeTokens[1];
             } else {
                 // Use the event type definition
-                $currentDOM = date('d');
+                $currentDOM = DateTimeUtils::getCurrentDay();
+                $currentMonth = DateTimeUtils::getCurrentMonth();
+                $currentYear = DateTimeUtils::getCurrentYear();
                 if ($currentDOM < $iDefRecurDOM) {
-                    $sEventStartDate = date('Y-m-d', mktime(0, 0, 0, date('m') - 1, $iDefRecurDOM, date('Y')));
+                    $sEventStartDate = DateTimeUtils::formatDateFromComponents($currentYear, $currentMonth - 1, $iDefRecurDOM);
                 } else {
-                    $sEventStartDate = date('Y-m-d', mktime(0, 0, 0, date('m'), $iDefRecurDOM, date('Y')));
+                    $sEventStartDate = DateTimeUtils::formatDateFromComponents($currentYear, $currentMonth, $iDefRecurDOM);
                 }
 
                 $aStartTimeTokens = explode(':', $ceDefStartTime);
@@ -209,7 +212,7 @@ if ($sAction === 'Create Event' && !empty($tyid)) {
                 $aDMY = explode('-', $aStartTokens[0]);
                 $aEventStartTimeTokens = explode(':', $aStartTokens[1]);
 
-                $sEventStartDate = date('Y-m-d', mktime(0, 0, 0, $aDMY[1], $aDMY[2], $aDMY[0] + 1));
+                $sEventStartDate = DateTimeUtils::formatDateFromComponents((int) $aDMY[0] + 1, (int) $aDMY[1], (int) $aDMY[2]);
                 $iEventStartHour = $aEventStartTimeTokens[0];
                 $iEventStartMins = $aEventStartTimeTokens[1];
                 $sEventEndDate = $sEventStartDate;
@@ -219,17 +222,18 @@ if ($sAction === 'Create Event' && !empty($tyid)) {
                 // Use the event type definition
                 $currentDOY = time();
                 $defaultDOY = strtotime($sDefRecurDOY);
+                $currentYear = DateTimeUtils::getCurrentYear();
                 if ($currentDOY < $defaultDOY) {
                     // Event is in the future
                     $sEventStartDate = $sDefRecurDOY;
                 } elseif ($currentDOY > $defaultDOY + (365 * 24 * 60 * 60)) {
                     // Event is over 1 year in the past
                     $aDMY = explode('-', $sDefRecurDOY);
-                    $sEventStartDate = date('Y-m-d', mktime(0, 0, 0, $aDMY[1], $aDMY[2], date('Y') - 1));
+                    $sEventStartDate = DateTimeUtils::formatDateFromComponents($currentYear - 1, (int) $aDMY[1], (int) $aDMY[2]);
                 } else {
                     // Event is past
                     $aDMY = explode('-', $sDefRecurDOY);
-                    $sEventStartDate = date('Y-m-d', mktime(0, 0, 0, $aDMY[1], $aDMY[2], date('Y')));
+                    $sEventStartDate = DateTimeUtils::formatDateFromComponents($currentYear, (int) $aDMY[1], (int) $aDMY[2]);
                 }
 
                 $aStartTimeTokens = explode(':', $sDefStartTime);

--- a/src/FundRaiserEditor.php
+++ b/src/FundRaiserEditor.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/Include/Functions.php';
 use ChurchCRM\Authentication\AuthenticationManager;
 use ChurchCRM\model\ChurchCRM\FundRaiser;
 use ChurchCRM\model\ChurchCRM\FundRaiserQuery;
+use ChurchCRM\Utils\DateTimeUtils;
 use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
@@ -54,7 +55,7 @@ if (isset($_POST['FundRaiserSubmit'])) {
                 ->setTitle($sTitle)
                 ->setDescription($sDescription)
                 ->setEnteredBy(AuthenticationManager::getCurrentUser()->getId())
-                ->setEnteredDate(date('YmdHis'));
+                ->setEnteredDate(DateTimeUtils::getToday()->format('YmdHis'));
             $fundraiser->save();
             $fundraiser->reload();
 
@@ -67,7 +68,7 @@ if (isset($_POST['FundRaiserSubmit'])) {
                 ->setTitle($sTitle)
                 ->setDescription($sDescription)
                 ->setEnteredBy(AuthenticationManager::getCurrentUser()->getId())
-                ->setEnteredDate(date('YmdHis'));
+                ->setEnteredDate(DateTimeUtils::getToday()->format('YmdHis'));
             $fundraiser->save();
         }
 

--- a/src/Include/Header.php
+++ b/src/Include/Header.php
@@ -87,6 +87,7 @@ $MenuFirst = 1;
             systemLocale: "<?= $localeInfo->getSystemLocale() ?>",
             locale: "<?= $localeInfo->getLocale() ?>",
             shortLocale: "<?= $localeInfo->getShortLocale() ?>",
+            timeZone: "<?= SystemConfig::getValue('sTimeZone') ?>",
             maxUploadSize: "<?= SystemService::getMaxUploadFileSize(true) ?>",
             maxUploadSizeBytes: "<?= SystemService::getMaxUploadFileSize(false) ?>",
             datePickerformat:"<?= SystemConfig::getValue('sDatePickerPlaceHolder') ?>",

--- a/src/ListEvents.php
+++ b/src/ListEvents.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/Include/Functions.php';
 use ChurchCRM\Authentication\AuthenticationManager;
 use ChurchCRM\model\ChurchCRM\EventQuery;
 use ChurchCRM\model\ChurchCRM\EventTypeQuery;
+use ChurchCRM\Utils\DateTimeUtils;
 use ChurchCRM\Utils\InputUtils;
 
 $eType = 'All';
@@ -26,7 +27,7 @@ if ($eType != 'All') {
 if (isset($_POST['WhichYear'])) {
     $EventYear = InputUtils::legacyFilterInput($_POST['WhichYear'], 'int');
 } else {
-    $EventYear = date('Y');
+    $EventYear = DateTimeUtils::getCurrentYear();
 }
 
 require_once __DIR__ . '/Include/Header.php';

--- a/src/Reports/AdvancedDeposit.php
+++ b/src/Reports/AdvancedDeposit.php
@@ -9,6 +9,7 @@ use ChurchCRM\Authentication\AuthenticationManager;
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\Service\FinancialService;
 use ChurchCRM\Utils\CsvExporter;
+use ChurchCRM\Utils\DateTimeUtils;
 use ChurchCRM\Utils\InputUtils;
 
 // Security
@@ -62,7 +63,7 @@ if (!$output) {
 }
 
 // Normalize date range
-$today = date('Y-m-d');
+$today = DateTimeUtils::getTodayDate();
 if (!$sDateEnd && $sDateStart) {
     $sDateEnd = $sDateStart;
 }

--- a/src/Reports/TaxReport.php
+++ b/src/Reports/TaxReport.php
@@ -9,6 +9,7 @@ use ChurchCRM\Authentication\AuthenticationManager;
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\Service\FinancialService;
 use ChurchCRM\Utils\CsvExporter;
+use ChurchCRM\Utils\DateTimeUtils;
 use ChurchCRM\Utils\InputUtils;
 
 // Security
@@ -46,7 +47,7 @@ if (!empty($_POST['family'])) {
 }
 
 // Normalize date range
-$today = date('Y-m-d');
+$today = DateTimeUtils::getTodayDate();
 if (!$sDateEnd && $sDateStart) {
     $sDateEnd = $sDateStart;
 }

--- a/src/Reports/ZeroGivers.php
+++ b/src/Reports/ZeroGivers.php
@@ -9,6 +9,7 @@ use ChurchCRM\Authentication\AuthenticationManager;
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\Service\FinancialService;
 use ChurchCRM\Utils\CsvExporter;
+use ChurchCRM\Utils\DateTimeUtils;
 use ChurchCRM\Utils\InputUtils;
 
 // Security
@@ -23,7 +24,7 @@ $letterhead = InputUtils::legacyFilterInput($_POST['letterhead']);
 $remittance = InputUtils::legacyFilterInput($_POST['remittance']);
 
 // Normalize date range
-$today = date('Y-m-d');
+$today = DateTimeUtils::getTodayDate();
 if (!$sDateEnd && $sDateStart) {
     $sDateEnd = $sDateStart;
 }

--- a/src/api/routes/finance/finance-deposits.php
+++ b/src/api/routes/finance/finance-deposits.php
@@ -7,6 +7,7 @@ use ChurchCRM\model\ChurchCRM\PledgeQuery;
 use ChurchCRM\Service\DepositService;
 use ChurchCRM\Slim\Middleware\Request\Auth\FinanceRoleAuthMiddleware;
 use ChurchCRM\Slim\SlimUtils;
+use ChurchCRM\Utils\DateTimeUtils;
 use ChurchCRM\Utils\InputUtils;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
@@ -18,7 +19,7 @@ $app->group('/deposits', function (RouteCollectorProxy $group): void {
         $input = $request->getParsedBody();
         $depositType = $input['depositType'] ?? '';
         $depositComment = InputUtils::sanitizeText($input['depositComment']) ?? '';
-        $depositDate = $input['depositDate'] ?? date('Y-m-d');
+        $depositDate = $input['depositDate'] ?? DateTimeUtils::getTodayDate();
 
         // Validate depositType against allowed values
         $allowedTypes = ['Bank', 'CreditCard', 'BankDraft'];
@@ -38,7 +39,7 @@ $app->group('/deposits', function (RouteCollectorProxy $group): void {
 
     $group->get('/dashboard', function (Request $request, Response $response, array $args): Response {
         $list = DepositQuery::create()
-            ->filterByDate(['min' => date('Y-m-d', strtotime('-90 days'))])
+            ->filterByDate(['min' => DateTimeUtils::getRelativeDate('-90 days')])
             ->find();
 
         return SlimUtils::renderJSON($response, $list->toArray());

--- a/src/api/routes/people/people-families.php
+++ b/src/api/routes/people/people-families.php
@@ -10,6 +10,7 @@ use ChurchCRM\model\ChurchCRM\Token;
 use ChurchCRM\model\ChurchCRM\TokenQuery;
 use ChurchCRM\Service\FinancialService;
 use ChurchCRM\Slim\SlimUtils;
+use ChurchCRM\Utils\DateTimeUtils;
 use Propel\Runtime\ActiveQuery\Criteria;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
@@ -111,7 +112,7 @@ $app->group('/families', function (RouteCollectorProxy $group): void {
         $pendingTokens = TokenQuery::create()
             ->filterByType(Token::TYPE_FAMILY_VERIFY)
             ->filterByRemainingUses(['min' => 1])
-            ->filterByValidUntilDate(['min' => new DateTime()])
+            ->filterByValidUntilDate(['min' => DateTimeUtils::getToday()])
             ->addJoin(TokenTableMap::COL_REFERENCE_ID, FamilyTableMap::COL_FAM_ID)
             ->withColumn(FamilyTableMap::COL_FAM_NAME, 'FamilyName')
             ->withColumn(TokenTableMap::COL_REFERENCE_ID, 'FamilyId')
@@ -133,7 +134,8 @@ $app->group('/families', function (RouteCollectorProxy $group): void {
 function getFamiliesWithAnniversaries(Request $request, Response $response, array $args): Response
 {
     // Get anniversaries for 14-day range: 7 days before to 7 days after today
-    $today = new \DateTime();
+    // Use configured timezone to ensure correct "today" calculation
+    $today = DateTimeUtils::getToday();
     $conditions = [];
 
     for ($i = -7; $i <= 7; $i++) {

--- a/src/api/routes/people/people-persons.php
+++ b/src/api/routes/people/people-persons.php
@@ -7,6 +7,7 @@ use ChurchCRM\model\ChurchCRM\ListOptionQuery;
 use ChurchCRM\model\ChurchCRM\Person;
 use ChurchCRM\model\ChurchCRM\PersonQuery;
 use ChurchCRM\Slim\SlimUtils;
+use ChurchCRM\Utils\DateTimeUtils;
 use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\Collection\Collection;
 use Propel\Runtime\Propel;
@@ -127,7 +128,8 @@ function getUpdatedPersons(Request $request, Response $response, array $args): R
 function getPersonsWithBirthdays(Request $request, Response $response, array $args): Response
 {
     // Get birthdays for 14-day range: 7 days before to 7 days after today
-    $today = new \DateTime();
+    // Use configured timezone to ensure correct "today" calculation
+    $today = DateTimeUtils::getToday();
     $dates = [];
     
     for ($i = -7; $i <= 7; $i++) {
@@ -186,12 +188,12 @@ function getPersonsWithBirthdays(Request $request, Response $response, array $ar
         // Calculate days until birthday this year (for sorting)
         $birthMonth = $person->getBirthMonth();
         $birthDay = $person->getBirthDay();
-        $birthdayThisYear = new \DateTime("{$thisYear}-{$birthMonth}-{$birthDay}");
+        $birthdayThisYear = DateTimeUtils::createDateTime("{$thisYear}-{$birthMonth}-{$birthDay}");
         $diff = (int) $today->diff($birthdayThisYear)->format('%r%a');
         
         // If birthday already passed this year (more than 7 days ago), calculate next year's birthday
         if ($diff < -7) {
-            $birthdayNextYear = new \DateTime(($thisYear + 1) . "-{$birthMonth}-{$birthDay}");
+            $birthdayNextYear = DateTimeUtils::createDateTime(($thisYear + 1) . "-{$birthMonth}-{$birthDay}");
             $diff = (int) $today->diff($birthdayNextYear)->format('%r%a');
         }
         

--- a/src/external/templates/calendar/calendar.php
+++ b/src/external/templates/calendar/calendar.php
@@ -39,6 +39,7 @@ document.addEventListener('DOMContentLoaded', function() {
       editable: false,
       selectMirror: true,
       locale: window.CRM.lang,
+      timeZone: '<?= ChurchMetaData::getChurchTimeZone() ?>',
       eventSources: [
         '<?= $eventSource ?>'
       ]

--- a/src/kiosk/routes/device.php
+++ b/src/kiosk/routes/device.php
@@ -5,6 +5,7 @@ use ChurchCRM\dto\Photo;
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\model\ChurchCRM\PersonQuery;
 use ChurchCRM\Slim\SlimUtils;
+use ChurchCRM\Utils\DateTimeUtils;
 use ChurchCRM\Utils\InputUtils;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
@@ -101,9 +102,11 @@ $app->group('/device', function (RouteCollectorProxy $group) use ($app): void {
         $groupName = $groups->count() > 0 ? $groups->getFirst()->getName() : '';
 
         // Build response array using Person object methods
-        $currentMonth = (int) date('n');
-        $currentDay = (int) date('j');
-        $currentYear = (int) date('Y');
+        // Use configured timezone for "today" calculations
+        $today = DateTimeUtils::getToday();
+        $currentMonth = (int) $today->format('n');
+        $currentDay = (int) $today->format('j');
+        $currentYear = (int) $today->format('Y');
         $peopleData = [];
         foreach ($members as $person) {
             $photo = new Photo('Person', $person->getId());
@@ -117,8 +120,7 @@ $app->group('/device', function (RouteCollectorProxy $group) use ($app): void {
             $age = null;
             if (!empty($birthYear) && $birthMonth > 0 && $birthDay > 0) {
                 // Calculate age manually to avoid hideAge() interference
-                $birthDate = new \DateTime("$birthYear-$birthMonth-$birthDay");
-                $today = new \DateTime('today');
+                $birthDate = DateTimeUtils::createDateTime("$birthYear-$birthMonth-$birthDay");
                 $ageInterval = $today->diff($birthDate);
                 $age = $ageInterval->y;
             }
@@ -131,10 +133,9 @@ $app->group('/device', function (RouteCollectorProxy $group) use ($app): void {
             $birthdayRecent = false;
             $birthdayToday = false;
             if ($birthMonth > 0 && $birthDay > 0) {
-                // Calculate this year's birthday
-                $thisBirthday = new \DateTime();
+                // Calculate this year's birthday using configured timezone
+                $thisBirthday = DateTimeUtils::getToday();
                 $thisBirthday->setDate($currentYear, $birthMonth, $birthDay);
-                $today = new \DateTime('today');
 
                 // Get the difference in days
                 $interval = $today->diff($thisBirthday);

--- a/src/skin/js/Calendar.js
+++ b/src/skin/js/Calendar.js
@@ -405,6 +405,7 @@ function initializeCalendar() {
     // -----------------------------------------------------------------
     window.CRM.fullcalendar = new FullCalendar.Calendar(document.getElementById("calendar"), {
         locale: window.CRM.lang || "en",
+        timeZone: window.CRM.calendarJSArgs.sTimeZone || "local",
         headerToolbar: {
             start: "prev,next today",
             center: "title",

--- a/src/v2/routes/calendar.php
+++ b/src/v2/routes/calendar.php
@@ -34,5 +34,6 @@ function getCalendarJSArgs(): array
         'isModifiable'               => AuthenticationManager::getCurrentUser()->isAddEvent(),
         'countCalendarAccessTokens'  => CalendarQuery::create()->filterByAccessToken(null, Criteria::NOT_EQUAL)->count(),
         'bEnableExternalCalendarAPI' => SystemConfig::getBooleanValue('bEnableExternalCalendarAPI'),
+        'sTimeZone'                  => SystemConfig::getValue('sTimeZone'),
     ];
 }

--- a/src/v2/templates/people/family-view.php
+++ b/src/v2/templates/people/family-view.php
@@ -6,13 +6,14 @@ use ChurchCRM\dto\Photo;
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\dto\SystemURLs;
 use ChurchCRM\Service\MailChimpService;
+use ChurchCRM\Utils\DateTimeUtils;
 use ChurchCRM\Utils\FiscalYearUtils;
 use ChurchCRM\Utils\InputUtils;
 
 $sPageTitle =  $family->getName() . " - " . gettext("Family");
 require SystemURLs::getDocumentRoot() . '/Include/Header.php';
 
-$curYear = (new DateTime())->format("Y");
+$curYear = DateTimeUtils::getCurrentYear();
 $familyAddress = $family->getAddress();
 $mailchimp = new MailChimpService();
 

--- a/webpack/kiosk/kiosk-jsom.ts
+++ b/webpack/kiosk/kiosk-jsom.ts
@@ -252,9 +252,8 @@ function renderBirthdaySection(birthdayPeople: ClassMember[]): void {
  */
 function renderBirthdayCard(person: ClassMember, monthNames: string[], cardType: string): JQuery {
     let cardClass = 'birthday-card';
-    const today = new Date();
-    const isToday =
-        person.birthdayToday || (person.birthMonth === today.getMonth() + 1 && person.birthDay === today.getDate());
+    // Use server-provided birthdayToday flag (calculated with correct timezone)
+    const isToday = person.birthdayToday;
 
     if (isToday) {
         cardClass += ' today';


### PR DESCRIPTION
## Summary

Fixes #7954 - Birthday "Today" appears one day early due to timezone mismatch between server default and configured church timezone.

This PR introduces a comprehensive solution by creating a centralized `DateTimeUtils` utility class and updating all date/time operations throughout the application to use the configured `sTimeZone` system setting instead of relying on the server's default timezone.

## Changes

### New Utility Class
- **DateTimeUtils.php** - Central timezone-aware date operations utility providing:
  - `getConfiguredTimezone()` - Returns DateTimeZone from sTimeZone setting
  - `getToday()` / `getTodayDate()` - Timezone-aware "today" calculations
  - `getNowDateTime()` - Current timestamp in configured timezone
  - `getCurrentYear()` / `getCurrentMonth()` / `getCurrentDay()` - Date components
  - `createDateTime()` - Create DateTime in configured timezone
  - `getRelativeDate()` / `getDateRelativeTo()` - Relative date calculations
  - `formatDateFromComponents()` - Build dates from year/month/day

### Backend Updates
- **Birthday/Anniversary APIs** (`people-persons.php`, `people-families.php`) - Use DateTimeUtils for "today" calculations
- **System Calendars** (`BirthdaysCalendar.php`, `AnniversariesCalendar.php`, `HolidayCalendar.php`) - Use `getCurrentYear()` instead of `date('Y')`
- **Event Management** (`EventEditor.php`, `Checkin.php`, `ListEvents.php`) - Timezone-aware event dates and check-in timestamps
- **Finance** (`FundRaiserEditor.php`, `finance-deposits.php`, reports) - Timezone-aware date defaults
- **Authentication** (`LocalAuthentication.php`) - Login timestamps use configured timezone
- **System Service** (`SystemService.php`) - Timer calculations use configured timezone
- **Calendar Middleware** (`PublicCalendarMiddleware.php`) - Default start date uses configured timezone

### Frontend Updates
- **Calendar.js** - FullCalendar now uses `timeZone: window.CRM.calendarJSArgs.sTimeZone`
- **Header.php** - Exposes `window.CRM.timeZone` for JavaScript access
- **calendar.php (route)** - Passes sTimeZone to calendar JS args
- **kiosk-jsom.ts** - Uses server-provided `birthdayToday` flag instead of browser date comparison
- **External calendar template** - Fixed `ChurchMetaData::getChurchTimeZone()` call

## Why This Matters

When a server runs in UTC (common for cloud hosting) but the church is configured for a different timezone (e.g., America/New_York), date calculations like "is today someone's birthday?" would be incorrect because `new DateTime()` and `date()` use the server's timezone, not the church's configured timezone.

This fix ensures all date operations respect the `sTimeZone` system configuration, providing correct behavior regardless of server timezone.

## Testing

- PHP syntax validated for all 24 modified files
- Import statements alphabetically ordered per coding standards
- DateTimeUtils follows project patterns with proper PHPDoc documentation

## Files Changed (24)

| Category | Files |
|----------|-------|
| New | `src/ChurchCRM/utils/DateTimeUtils.php` |
| APIs | `people-persons.php`, `people-families.php`, `finance-deposits.php`, `device.php` |
| Calendars | `BirthdaysCalendar.php`, `AnniversariesCalendar.php`, `HolidayCalendar.php`, `PublicCalendarMiddleware.php` |
| Events | `EventEditor.php`, `Checkin.php`, `ListEvents.php` |
| Finance | `FundRaiserEditor.php`, `AdvancedDeposit.php`, `TaxReport.php`, `ZeroGivers.php` |
| Auth/System | `LocalAuthentication.php`, `SystemService.php` |
| Frontend | `Calendar.js`, `kiosk-jsom.ts`, `Header.php`, `calendar.php`, `family-view.php`, `external/calendar.php` |