### PR TITLE
Fix issue #7954: Add date validation and timezone handling to public calendar API

### DIFF
--- a/src/ChurchCRM/Slim/Middleware/Api/PublicCalendarMiddleware.php
+++ b/src/ChurchCRM/Slim/Middleware/Api/PublicCalendarMiddleware.php
@@ -42,19 +42,26 @@ class PublicCalendarMiddleware implements MiddlewareInterface
 
         $request = $request->withAttribute('calendar', $calendar);
         $events = $this->getEvents($request, $calendar);
+        if ($events === null) {
+            return SlimUtils::renderJSON($response, ['message' => gettext('Invalid date format in start parameter')], 400);
+        }
         $request = $request->withAttribute('events', $events);
 
         return $handler->handle($request);
     }
 
-    private function getEvents(ServerRequestInterface $request, Calendar $calendar)
+    private function getEvents(ServerRequestInterface $request, Calendar $calendar): mixed
     {
         $params = $request->getQueryParams();
         if (isset($params['start'])) {
-            $start_date = DateTime::createFromFormat('Y-m-d', $params['start']);
+            $start_date = DateTime::createFromFormat('Y-m-d', $params['start'], DateTimeUtils::getConfiguredTimezone());
+            if ($start_date === false) {
+                // Invalid date format - return null to indicate error
+                return null;
+            }
         } else {
             // Use configured timezone for default start date
-            $start_date = DateTimeUtils::getToday();
+            $start_date = DateTimeUtils::getStartOfToday();
         }
         $start_date->setTime(0, 0, 0);
 

--- a/src/ChurchCRM/utils/DateTimeUtils.php
+++ b/src/ChurchCRM/utils/DateTimeUtils.php
@@ -23,16 +23,34 @@ class DateTimeUtils
     }
 
     /**
-     * Get today's date in the configured timezone.
+     * Get the current date and time ("now") in the configured timezone.
      *
-     * Use this instead of `new \DateTime()` to ensure "today" is calculated
-     * correctly for the church's timezone, not the server's default timezone.
+     * Use this instead of `new \DateTime()` to ensure the current moment is
+     * calculated correctly for the church's timezone, not the server's
+     * default timezone.
      *
-     * @return \DateTime Today's date/time in the configured timezone
+     * Note: This returns a timestamp with the current time. For midnight at
+     * the start of today, use getStartOfToday().
+     *
+     * @return \DateTime Current date/time in the configured timezone
      */
     public static function getToday(): \DateTime
     {
         return new \DateTime('now', self::getConfiguredTimezone());
+    }
+
+    /**
+     * Get a DateTime representing the start of today (midnight) in the
+     * configured timezone.
+     *
+     * This is useful for date-only comparisons where the time of day should
+     * be normalized to 00:00:00.
+     *
+     * @return \DateTime Today's date at midnight in the configured timezone
+     */
+    public static function getStartOfToday(): \DateTime
+    {
+        return new \DateTime('today', self::getConfiguredTimezone());
     }
 
     /**


### PR DESCRIPTION
## What Changed
<!-- Short summary - what and why (not how) -->

Fixes #7954

- Add getStartOfToday() method to DateTimeUtils for midnight comparisons
- Validate start date parameter format in PublicCalendarMiddleware
- Return HTTP 400 with proper error message for invalid date format
- Use configured timezone when parsing start date parameter

## Type
<!-- Check one -->
- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
<!-- How to verify this works -->

## Screenshots
<!-- Only for UI changes - drag & drop images here -->

## Security Check
<!-- Only check if applicable -->
- [ ] Introduces new input validation
- [ ] Modifies authentication/authorization
- [ ] Affects data privacy/GDPR

### Code Quality
- [ ] Database: Propel ORM only, no raw SQL
- [ ] No deprecated attributes (align, valign, nowrap, border, cellpadding, cellspacing, bgcolor)
- [ ] Bootstrap CSS classes used
- [ ] All CSS bundled via webpack

## Pre-Merge
- [ ] Tested locally
- [ ] No new warnings
- [ ] Build passes
- [ ] Backward compatible (or migration documented)