### PR TITLE
chore: upgrade webpack and webpack-cli to latest stable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,8 +81,8 @@
                 "style-loader": "^4.0.0",
                 "ts-loader": "^9.5.4",
                 "typescript": "^5.9.3",
-                "webpack": "^5.102.1",
-                "webpack-cli": "^5.1.4"
+                "webpack": "^5.105.2",
+                "webpack-cli": "^6.0.1"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -396,13 +396,13 @@
             }
         },
         "node_modules/@discoveryjs/json-ext": {
-            "version": "0.5.7",
-            "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
-            "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.6.3.tgz",
+            "integrity": "sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=10.0.0"
+                "node": ">=14.17.0"
             }
         },
         "node_modules/@emotion/babel-plugin": {
@@ -2699,45 +2699,45 @@
             }
         },
         "node_modules/@webpack-cli/configtest": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.1.tgz",
-            "integrity": "sha512-wy0mglZpDSiSS0XHrVR+BAdId2+yxPSoJW8fsna3ZpYSlufjvxnP4YbKTCBZnNIcGN4r6ZPXV55X4mYExOfLmw==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-3.0.1.tgz",
+            "integrity": "sha512-u8d0pJ5YFgneF/GuvEiDA61Tf1VDomHHYMjv/wc9XzYj7nopltpG96nXN5dJRstxZhcNpV1g+nT6CydO7pHbjA==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=14.15.0"
+                "node": ">=18.12.0"
             },
             "peerDependencies": {
-                "webpack": "5.x.x",
-                "webpack-cli": "5.x.x"
+                "webpack": "^5.82.0",
+                "webpack-cli": "6.x.x"
             }
         },
         "node_modules/@webpack-cli/info": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.2.tgz",
-            "integrity": "sha512-zLHQdI/Qs1UyT5UBdWNqsARasIA+AaF8t+4u2aS2nEpBQh2mWIVb8qAklq0eUENnC5mOItrIB4LiS9xMtph18A==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-3.0.1.tgz",
+            "integrity": "sha512-coEmDzc2u/ffMvuW9aCjoRzNSPDl/XLuhPdlFRpT9tZHmJ/039az33CE7uH+8s0uL1j5ZNtfdv0HkfaKRBGJsQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=14.15.0"
+                "node": ">=18.12.0"
             },
             "peerDependencies": {
-                "webpack": "5.x.x",
-                "webpack-cli": "5.x.x"
+                "webpack": "^5.82.0",
+                "webpack-cli": "6.x.x"
             }
         },
         "node_modules/@webpack-cli/serve": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.5.tgz",
-            "integrity": "sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-3.0.1.tgz",
+            "integrity": "sha512-sbgw03xQaCLiT6gcY/6u3qBDn01CWw/nbaXl3gTdTFuJJ75Gffv3E3DBpgvY2fkkrdS1fpjaXNOmJlnbtKauKg==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=14.15.0"
+                "node": ">=18.12.0"
             },
             "peerDependencies": {
-                "webpack": "5.x.x",
-                "webpack-cli": "5.x.x"
+                "webpack": "^5.82.0",
+                "webpack-cli": "6.x.x"
             },
             "peerDependenciesMeta": {
                 "webpack-dev-server": {
@@ -5517,14 +5517,14 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.18.4",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.4.tgz",
-            "integrity": "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==",
+            "version": "5.19.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz",
+            "integrity": "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.4",
-                "tapable": "^2.2.0"
+                "tapable": "^2.3.0"
             },
             "engines": {
                 "node": ">=10.13.0"
@@ -14024,9 +14024,9 @@
             }
         },
         "node_modules/watchpack": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.0.tgz",
-            "integrity": "sha512-e6vZvY6xboSwLz2GD36c16+O/2Z6fKvIf4pOXptw2rY9MVwE/TXc6RGqxD3I3x0a28lwBY7DE+76uTPSsBrrCA==",
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
+            "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -14038,9 +14038,9 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.104.1",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.104.1.tgz",
-            "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
+            "version": "5.105.2",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.2.tgz",
+            "integrity": "sha512-dRXm0a2qcHPUBEzVk8uph0xWSjV/xZxenQQbLwnwP7caQCYpqG1qddwlyEkIDkYn0K8tvmcrZ+bOrzoQ3HxCDw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -14054,7 +14054,7 @@
                 "acorn-import-phases": "^1.0.3",
                 "browserslist": "^4.28.1",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.17.4",
+                "enhanced-resolve": "^5.19.0",
                 "es-module-lexer": "^2.0.0",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
@@ -14067,7 +14067,7 @@
                 "schema-utils": "^4.3.3",
                 "tapable": "^2.3.0",
                 "terser-webpack-plugin": "^5.3.16",
-                "watchpack": "^2.4.4",
+                "watchpack": "^2.5.1",
                 "webpack-sources": "^3.3.3"
             },
             "bin": {
@@ -14087,43 +14087,40 @@
             }
         },
         "node_modules/webpack-cli": {
-            "version": "5.1.4",
-            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
-            "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-6.0.1.tgz",
+            "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@discoveryjs/json-ext": "^0.5.0",
-                "@webpack-cli/configtest": "^2.1.1",
-                "@webpack-cli/info": "^2.0.2",
-                "@webpack-cli/serve": "^2.0.5",
+                "@discoveryjs/json-ext": "^0.6.1",
+                "@webpack-cli/configtest": "^3.0.1",
+                "@webpack-cli/info": "^3.0.1",
+                "@webpack-cli/serve": "^3.0.1",
                 "colorette": "^2.0.14",
-                "commander": "^10.0.1",
+                "commander": "^12.1.0",
                 "cross-spawn": "^7.0.3",
-                "envinfo": "^7.7.3",
+                "envinfo": "^7.14.0",
                 "fastest-levenshtein": "^1.0.12",
                 "import-local": "^3.0.2",
                 "interpret": "^3.1.1",
                 "rechoir": "^0.8.0",
-                "webpack-merge": "^5.7.3"
+                "webpack-merge": "^6.0.1"
             },
             "bin": {
                 "webpack-cli": "bin/cli.js"
             },
             "engines": {
-                "node": ">=14.15.0"
+                "node": ">=18.12.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
             },
             "peerDependencies": {
-                "webpack": "5.x.x"
+                "webpack": "^5.82.0"
             },
             "peerDependenciesMeta": {
-                "@webpack-cli/generators": {
-                    "optional": true
-                },
                 "webpack-bundle-analyzer": {
                     "optional": true
                 },
@@ -14133,13 +14130,13 @@
             }
         },
         "node_modules/webpack-cli/node_modules/commander": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-            "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+            "version": "12.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+            "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=14"
+                "node": ">=18"
             }
         },
         "node_modules/webpack-cli/node_modules/interpret": {
@@ -14187,18 +14184,18 @@
             }
         },
         "node_modules/webpack-merge": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
+            "integrity": "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "clone-deep": "^4.0.1",
                 "flat": "^5.0.2",
-                "wildcard": "^2.0.0"
+                "wildcard": "^2.0.1"
             },
             "engines": {
-                "node": ">=10.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/webpack-merge/node_modules/wildcard": {

--- a/package.json
+++ b/package.json
@@ -20,10 +20,11 @@
     "scripts": {
         "audit": "npm audit fix --only=prod --audit-level=high",
         "build": "run-p build:php build:frontend",
-        "build:frontend": "npm run build:js && npm run format:web",
+        "build:frontend": "NODE_ENV=production npm run build:js && npm run format:web",
         "build:js": "run-p build:js:legacy build:webpack",
         "build:js:legacy": "grunt copy && grunt patchDataTablesCSS",
         "build:webpack": "webpack",
+        "build:webpack:watch": "webpack --watch",
         "build:php": "run-s composer:install",
         "build:orm": "cd src/ && ./vendor/bin/propel build --config-dir=propel",
         "clean": "rm -rf node_modules/ temp src/vendor/ src/skin/external src/locale/vendor ai-notes/ src/logs/*.log",
@@ -147,7 +148,7 @@
         "style-loader": "^4.0.0",
         "ts-loader": "^9.5.4",
         "typescript": "^5.9.3",
-        "webpack": "^5.102.1",
-        "webpack-cli": "^5.1.4"
+        "webpack": "^5.105.2",
+        "webpack-cli": "^6.0.1"
     }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,46 +1,56 @@
 const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const webpack = require('webpack');
+
+const isProduction = process.env.NODE_ENV === 'production';
 
 module.exports = {
-  mode: "development",
+  mode: isProduction ? 'production' : 'development',
   entry: {
     'calendar-event-editor': './react/calendar-event-editor.tsx',
     'two-factor-enrollment': './react/two-factor-enrollment.tsx',
-    'churchcrm': './webpack/skin-main',  // Main bundle for all pages
-    'photo-uploader': './webpack/photo-uploader-entry',  // Photo uploader for specific pages
-    'setup': './webpack/setup',  // Setup wizard styles
-    'family-register': './webpack/family-register',  // Family registration styles and scripts
-    'family-verify': './webpack/family-verify',  // Family verification page styles and scripts
-    'upgrade-wizard': './webpack/upgrade-wizard',  // Upgrade wizard styles and scripts
-    'locale-loader': './webpack/locale-loader',  // Dynamic locale loader
-    'backup': './webpack/backup',  // Backup database page
-    'restore': './webpack/restore',  // Restore database page
-    'admin-dashboard': './webpack/admin-dashboard',  // Admin dashboard page styles and scripts
-    'system-settings-panel': './webpack/system-settings-panel',  // Reusable settings panel component
-    'kiosk-registration-closed': './webpack/kiosk-registration-closed',  // Kiosk registration disabled page
-    'kiosk': './webpack/kiosk',  // Kiosk check-in interface
+    churchcrm: './webpack/skin-main',
+    'photo-uploader': './webpack/photo-uploader-entry',
+    setup: './webpack/setup',
+    'family-register': './webpack/family-register',
+    'family-verify': './webpack/family-verify',
+    'upgrade-wizard': './webpack/upgrade-wizard',
+    'locale-loader': './webpack/locale-loader',
+    backup: './webpack/backup',
+    restore: './webpack/restore',
+    'admin-dashboard': './webpack/admin-dashboard',
+    'system-settings-panel': './webpack/system-settings-panel',
+    'kiosk-registration-closed': './webpack/kiosk-registration-closed',
+    kiosk: './webpack/kiosk',
     'people-list': './webpack/people/person-list',
-    'people-family-list': './webpack/people/family-list'
+    'people-family-list': './webpack/people/family-list',
   },
   output: {
     path: path.resolve('./src/skin/v2'),
     filename: '[name].min.js',
-    publicPath: 'auto'  // Auto-detect public path based on script location
+    publicPath: 'auto',
   },
   resolve: {
-    extensions: [".ts", ".tsx", ".js"],
+    extensions: ['.ts', '.tsx', '.js'],
     alias: {
       jquery: path.resolve(__dirname, 'node_modules/jquery'),
     },
   },
-
+  cache: {
+    type: 'filesystem',
+    buildDependencies: {
+      config: [__filename],
+    },
+  },
+  devtool: isProduction ? false : 'eval-cheap-module-source-map',
+  optimization: {
+    moduleIds: 'deterministic',
+    chunkIds: 'deterministic',
+  },
   module: {
     rules: [
-      // all files with a `.ts` or `.tsx` extension will be handled by `ts-loader`
       {
         test: /\.tsx?$/,
-        loader: "ts-loader"
+        loader: 'ts-loader',
       },
       {
         test: /\.(sa|sc|c)ss$/,
@@ -51,7 +61,6 @@ module.exports = {
             options: {
               url: {
                 filter: (url) => {
-                  // Only process relative URLs, skip absolute paths and data URIs
                   return !url.startsWith('/') && !url.startsWith('data:');
                 },
               },
@@ -64,10 +73,10 @@ module.exports = {
         test: /\.(woff2?|ttf|eot|svg|png|jpg|gif)$/,
         type: 'asset/resource',
         generator: {
-          filename: 'assets/[name].[hash][ext]',
+          filename: 'assets/[name].[contenthash][ext]',
         },
       },
-    ]
+    ],
   },
   plugins: [
     new MiniCssExtractPlugin({
@@ -75,4 +84,4 @@ module.exports = {
       ignoreOrder: false,
     }),
   ],
-}
+};


### PR DESCRIPTION
## chore: Upgrade webpack and webpack-cli to latest stable

### Summary
Upgrade webpack and webpack-cli to their latest stable versions and align config with current best practices.

### Changes
- **webpack**: ^5.102.1 → ^5.105.2
- **webpack-cli**: ^5.1.4 → ^6.0.1
- **Production builds**: `build:frontend` sets `NODE_ENV=production` for optimized/minified builds
- **Caching**: Enable `cache: { type: 'filesystem' }` for faster rebuilds
- **Assets**: Use `[contenthash]` instead of `[hash]` for font/image filenames
- **Optimization**: Use deterministic `moduleIds` and `chunkIds`
- **Source maps**: `eval-cheap-module-source-map` in dev, none in production
- **Scripts**: Add `build:webpack:watch` for development watch mode

### Checklist
- [x] Build passes (`npm run build:webpack`)
- [x] Production build runs without errors