### PR TITLE
Remove unused i18n npm package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,6 @@
                 "daterangepicker": "^3.1.0",
                 "flag-icons": "^7.5.0",
                 "fullcalendar": "^6.1.19",
-                "i18n": "^0.15.3",
                 "i18next": "^25.8.8",
                 "inputmask": "^5.0.9",
                 "jquery": "^3.7.1",
@@ -1342,50 +1341,6 @@
             "resolved": "https://registry.npmjs.org/@lgaitan/pace-progress/-/pace-progress-1.0.7.tgz",
             "integrity": "sha512-GMoTcF6WBpno7a7Iyx7M79os26d5bCDbh7YTZmXZM8YuLR3DDtwo0/CBYddStGD6QIBTieFDz4IAQiO0dAdRGw==",
             "license": "MIT"
-        },
-        "node_modules/@messageformat/core": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/@messageformat/core/-/core-3.4.0.tgz",
-            "integrity": "sha512-NgCFubFFIdMWJGN5WuQhHCNmzk7QgiVfrViFxcS99j7F5dDS5EP6raR54I+2ydhe4+5/XTn/YIEppFaqqVWHsw==",
-            "license": "MIT",
-            "dependencies": {
-                "@messageformat/date-skeleton": "^1.0.0",
-                "@messageformat/number-skeleton": "^1.0.0",
-                "@messageformat/parser": "^5.1.0",
-                "@messageformat/runtime": "^3.0.1",
-                "make-plural": "^7.0.0",
-                "safe-identifier": "^0.4.1"
-            }
-        },
-        "node_modules/@messageformat/date-skeleton": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@messageformat/date-skeleton/-/date-skeleton-1.1.0.tgz",
-            "integrity": "sha512-rmGAfB1tIPER+gh3p/RgA+PVeRE/gxuQ2w4snFWPF5xtb5mbWR7Cbw7wCOftcUypbD6HVoxrVdyyghPm3WzP5A==",
-            "license": "MIT"
-        },
-        "node_modules/@messageformat/number-skeleton": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@messageformat/number-skeleton/-/number-skeleton-1.2.0.tgz",
-            "integrity": "sha512-xsgwcL7J7WhlHJ3RNbaVgssaIwcEyFkBqxHdcdaiJzwTZAWEOD8BuUFxnxV9k5S0qHN3v/KzUpq0IUpjH1seRg==",
-            "license": "MIT"
-        },
-        "node_modules/@messageformat/parser": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/@messageformat/parser/-/parser-5.1.1.tgz",
-            "integrity": "sha512-3p0YRGCcTUCYvBKLIxtDDyrJ0YijGIwrTRu1DT8gIviIDZru8H23+FkY6MJBzM1n9n20CiM4VeDYuBsrrwnLjg==",
-            "license": "MIT",
-            "dependencies": {
-                "moo": "^0.5.1"
-            }
-        },
-        "node_modules/@messageformat/runtime": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@messageformat/runtime/-/runtime-3.0.2.tgz",
-            "integrity": "sha512-dkIPDCjXcfhSHgNE1/qV6TeczQZR59Yx0xXeafVKgK3QVWoxc38ljwpksUpnzCGvN151KUbCJTDZVmahtf1YZw==",
-            "license": "MIT",
-            "dependencies": {
-                "make-plural": "^7.0.0"
-            }
         },
         "node_modules/@parcel/watcher": {
             "version": "2.5.1",
@@ -5473,15 +5428,6 @@
             "integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==",
             "license": "MIT"
         },
-        "node_modules/fast-printf": {
-            "version": "1.6.10",
-            "resolved": "https://registry.npmjs.org/fast-printf/-/fast-printf-1.6.10.tgz",
-            "integrity": "sha512-GwTgG9O4FVIdShhbVF3JxOgSBY2+ePGsu2V/UONgoCPzF9VY6ZdBMKsHKCYQHZwNk3qNouUolRDsgVxcVA5G1w==",
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">=10.0"
-            }
-        },
         "node_modules/fast-uri": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -6874,26 +6820,6 @@
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=8.12.0"
-            }
-        },
-        "node_modules/i18n": {
-            "version": "0.15.3",
-            "resolved": "https://registry.npmjs.org/i18n/-/i18n-0.15.3.tgz",
-            "integrity": "sha512-tW/AA5R4lJZLnd60Agcd0PfXB1C2G7UqTrdNewuv/SIYdxcHkCE8w4Zx1SgCjJ+2BLuAAGIG/KXb/xNYF1lO5Q==",
-            "license": "MIT",
-            "dependencies": {
-                "@messageformat/core": "^3.4.0",
-                "debug": "^4.4.3",
-                "fast-printf": "^1.6.10",
-                "make-plural": "^7.4.0",
-                "math-interval-parser": "^2.0.1",
-                "mustache": "^4.2.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/mashpie"
             }
         },
         "node_modules/i18next": {
@@ -8566,12 +8492,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/make-plural": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-7.5.0.tgz",
-            "integrity": "sha512-0booA+aVYyVFoR67JBHdfVk0U08HmrBH2FrtmBqBa+NldlqXv/G2Z9VQuQq6Wgp2jDWdybEWGfBkk1cq5264WA==",
-            "license": "Unicode-DFS-2016"
-        },
         "node_modules/map-cache": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -8618,15 +8538,6 @@
             },
             "engines": {
                 "node": "*"
-            }
-        },
-        "node_modules/math-interval-parser": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/math-interval-parser/-/math-interval-parser-2.0.1.tgz",
-            "integrity": "sha512-VmlAmb0UJwlvMyx8iPhXUDnVW1F9IrGEd9CIOmv+XL8AErCUUuozoDMrgImvnYt2A+53qVX/tPW6YJurMKYsvA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/math-intrinsics": {
@@ -8814,26 +8725,11 @@
                 "node": "*"
             }
         },
-        "node_modules/moo": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
-            "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
-            "license": "BSD-3-Clause"
-        },
         "node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "license": "MIT"
-        },
-        "node_modules/mustache": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
-            "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
-            "license": "MIT",
-            "bin": {
-                "mustache": "bin/mustache"
-            }
         },
         "node_modules/mysql2": {
             "version": "3.17.1",
@@ -10835,12 +10731,6 @@
                 }
             ],
             "license": "MIT"
-        },
-        "node_modules/safe-identifier": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/safe-identifier/-/safe-identifier-0.4.2.tgz",
-            "integrity": "sha512-6pNbSMW6OhAi9j+N8V+U715yBQsaWJ7eyEUaOrawX+isg5ZxhUlV1NipNtgaKHmFGiABwt+ZF04Ii+3Xjkg+8w==",
-            "license": "ISC"
         },
         "node_modules/safe-push-apply": {
             "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
         "daterangepicker": "^3.1.0",
         "flag-icons": "^7.5.0",
         "fullcalendar": "^6.1.19",
-        "i18n": "^0.15.3",
         "i18next": "^25.8.8",
         "inputmask": "^5.0.9",
         "jquery": "^3.7.1",


### PR DESCRIPTION
## Summary
This PR removes the unused `i18n` npm package (mashpie/i18n-node v0.15.3) from the project dependencies.

## Analysis
The `i18n` package is **not used anywhere** in the ChurchCRM codebase:
- ❌ No `require('i18n')` or `import from 'i18n'` statements found
- ❌ No actual usage of the package
- ✅ All i18n references are either `i18next` usage or naming conventions

## ChurchCRM's Actual i18n Architecture
- **Backend**: PHP with `gettext()` functions
- **Frontend**: JavaScript with `i18next` library (v25.8.8)
- **No Node.js backend** = No need for server-side `i18n` package

## Reason for Confusion
The `i18n` package (mashpie/i18n-node) is a Node.js **server-side** internationalization library that was likely added by mistake due to:
1. Name similarity with `i18next`
2. Confusion about which package handles internationalization
3. Copy-paste from another project that uses Node.js backend

## Impact
- ✅ Removes unused package and reduces bloat
- ✅ Removes 12 packages total (i18n + transitive dependencies)
- ✅ Saves ~500KB in node_modules
- ✅ Eliminates confusion between i18n and i18next
- ✅ No breaking changes - package was never used

## Testing
- `npm ls i18n` confirms package is removed
- `npm install` completes successfully
- No code changes required (package was never imported)

## Related Packages (Keeping)
- ✅ **i18next** (v25.8.8) - actively used for client-side i18n
- ✅ **i18next-conv** (v15.1.2) - converts .po files to JSON
- ✅ **i18next-parser** (v9.3.0) - extracts translation strings
