### PR TITLE
Add browser locale detection with version-specific dismissal

### DIFF
--- a/src/Include/Header.php
+++ b/src/Include/Header.php
@@ -90,6 +90,7 @@ $MenuFirst = 1;
             fullURL:"<?= SystemURLs::getURL() ?>",
             lang: "<?= $localeInfo->getLanguageCode() ?>",
             userId: "<?= AuthenticationManager::getCurrentUser()->getId() ?>",
+            version: "<?= $_SESSION['sSoftwareInstalledVersion'] ?? 'unknown' ?>",
             systemLocale: "<?= $localeInfo->getSystemLocale() ?>",
             locale: "<?= $localeInfo->getLocale() ?>",
             shortLocale: "<?= $localeInfo->getShortLocale() ?>",


### PR DESCRIPTION
- Detect browser language using navigator.language
- Compare browser language code with user's CRM locale
- Show dismissible prompt when languages differ
- Direct users to settings page to change locale
- Dismissal is version-specific (shows again after upgrade)
- Add window.CRM.version for version tracking
