### PR TITLE
Validate and sanitize JSON system settings

### DIFF
--- a/src/ChurchCRM/dto/SystemConfig.php
+++ b/src/ChurchCRM/dto/SystemConfig.php
@@ -5,6 +5,7 @@ namespace ChurchCRM\dto;
 use ChurchCRM\Config;
 use ChurchCRM\data\Countries;
 use ChurchCRM\model\ChurchCRM\ListOptionQuery;
+use ChurchCRM\Utils\InputUtils;
 use Exception;
 use Monolog\Level;
 use Monolog\Logger;
@@ -418,15 +419,38 @@ class   SystemConfig
             throw new \Exception(gettext('An invalid configuration name has been requested') . ': ' . $name);
         }
 
-        self::$configs[$name]->setValue($value);
+        $configItem = self::$configs[$name];
+
+        // If this config item is declared as JSON, validate and sanitize it before saving
+        if ($configItem->getType() === 'json') {
+            try {
+                $decoded = InputUtils::validateJson($value);
+            } catch (\InvalidArgumentException $e) {
+                throw new \Exception(gettext('Invalid JSON provided for configuration') . ': ' . $name . ' - ' . $e->getMessage());
+            }
+
+            // Recursively sanitize any string values to reduce XSS risk
+            $sanitized = InputUtils::sanitizeJsonStrings($decoded);
+
+            try {
+                $value = json_encode($sanitized, JSON_THROW_ON_ERROR);
+            } catch (\JsonException $e) {
+                throw new \Exception(gettext('Unable to re-encode JSON for configuration') . ': ' . $name . ' - ' . $e->getMessage());
+            }
+        }
+
+        $configItem->setValue($value);
     }
+
+    
 
     public static function setValueById(string $Id, $value): void
     {
         $success = false;
         foreach (self::$configs as $configItem) {
             if ($configItem->getId() == $Id) {
-                $configItem->setValue($value);
+                // Delegate to setValue by name so JSON validation/sanitization is applied
+                self::setValue($configItem->getName(), $value);
                 $success = true;
             }
         }

--- a/src/ChurchCRM/utils/InputUtils.php
+++ b/src/ChurchCRM/utils/InputUtils.php
@@ -93,6 +93,57 @@ class InputUtils
     }
 
     /**
+     * Recursively sanitize JSON string values by stripping HTML tags.
+     * Use this for JSON configuration payloads where values should not contain HTML.
+     *
+     * @param mixed $data
+     * @return mixed
+     */
+    public static function sanitizeJsonStrings($data)
+    {
+        if (is_array($data)) {
+            $out = [];
+            foreach ($data as $k => $v) {
+                $out[$k] = self::sanitizeJsonStrings($v);
+            }
+
+            return $out;
+        }
+
+        if (is_string($data)) {
+            return self::sanitizeText($data);
+        }
+
+        return $data;
+    }
+
+    /**
+     * Validate JSON input and return decoded array/object.
+     * Accepts either a JSON string or already-decoded array. Throws on invalid JSON.
+     *
+     * @param mixed $json
+     * @return mixed
+     * @throws \InvalidArgumentException
+     */
+    public static function validateJson($json)
+    {
+        if (is_array($json) || is_object($json)) {
+            return $json;
+        }
+
+        if (is_string($json)) {
+            $trimmed = trim($json);
+            try {
+                return json_decode($trimmed, true, 512, JSON_THROW_ON_ERROR);
+            } catch (\JsonException $e) {
+                throw new \InvalidArgumentException('Invalid JSON: ' . $e->getMessage());
+            }
+        }
+
+        throw new \InvalidArgumentException('Invalid JSON input type');
+    }
+
+    /**
      * Escape HTML for safe display in HTML context (body content and attributes)
      * Converts special characters to HTML entities: &, <, >, ", '
      * Automatically handles stripslashes() for magic quotes compatibility


### PR DESCRIPTION
Add centralized JSON validation and sanitization for system settings. Moves JSON helpers into , validates JSON inputs via , sanitizes string values with , and ensures  delegates to  so API and admin UI updates are validated.