### PR TITLE
fix: address review issues in FrankenPHP Docker support (#8213)

### DIFF
--- a/docker/Dockerfile.churchcrm-frankenphp
+++ b/docker/Dockerfile.churchcrm-frankenphp
@@ -52,7 +52,7 @@ RUN install-php-extensions \
     zip
 
 # Configure PHP settings
-RUN cp "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini" && \
+RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini" && \
     sed -i 's/^upload_max_filesize.*$/upload_max_filesize = 2G/g' $PHP_INI_DIR/php.ini && \
     sed -i 's/^post_max_size.*$/post_max_size = 2G/g' $PHP_INI_DIR/php.ini && \
     sed -i 's/^memory_limit.*$/memory_limit = 256M/g' $PHP_INI_DIR/php.ini && \

--- a/docker/README.md
+++ b/docker/README.md
@@ -204,8 +204,7 @@ The `Dockerfile.churchcrm-fpm-php8` installs all of these.
 
 ---
 
-Self-Hosted / Production (FrankenPHP)
----
+### Self-Hosted / Production (FrankenPHP)
 
 The `docker-compose.frankenphp.yaml` and `frankenphp/Caddyfile` files provide a
 reference configuration for deploying ChurchCRM with **FrankenPHP** — an


### PR DESCRIPTION
Follow-up fixes for #8213 based on code review.

## Changes

- **`Dockerfile.churchcrm-frankenphp`**: Use `mv` instead of `cp` for `php.ini-production` — avoids leaving the unused template in the image layer, consistent with `Dockerfile.churchcrm-fpm-php8`
- **`docker/README.md`**: Convert setext `---` heading to ATX `###` style for consistency with the rest of the file
- **`docker/README.md`**: Add missing newline at end of file

## Test plan

- [ ] Verify `docker build -f Dockerfile.churchcrm-frankenphp --target prod .` succeeds
- [ ] Confirm `php.ini-production` is absent and `php.ini` is present in the built image
- [ ] Confirm README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)