### PR TITLE
fix(deps): resolve all 14 Dependabot security alerts for v7.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -225,9 +225,9 @@
             }
         },
         "node_modules/@biomejs/biome": {
-            "version": "2.4.8",
-            "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.8.tgz",
-            "integrity": "sha512-ponn0oKOky1oRXBV+rlSaUlixUxf1aZvWC19Z41zBfUOUesthrQqL3OtiAlSB1EjFjyWpn98Q64DHelhA6jNlA==",
+            "version": "2.4.10",
+            "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.10.tgz",
+            "integrity": "sha512-xxA3AphFQ1geij4JTHXv4EeSTda1IFn22ye9LdyVPoJU19fNVl0uzfEuhsfQ4Yue/0FaLs2/ccVi4UDiE7R30w==",
             "dev": true,
             "license": "MIT OR Apache-2.0",
             "bin": {
@@ -241,20 +241,20 @@
                 "url": "https://opencollective.com/biome"
             },
             "optionalDependencies": {
-                "@biomejs/cli-darwin-arm64": "2.4.8",
-                "@biomejs/cli-darwin-x64": "2.4.8",
-                "@biomejs/cli-linux-arm64": "2.4.8",
-                "@biomejs/cli-linux-arm64-musl": "2.4.8",
-                "@biomejs/cli-linux-x64": "2.4.8",
-                "@biomejs/cli-linux-x64-musl": "2.4.8",
-                "@biomejs/cli-win32-arm64": "2.4.8",
-                "@biomejs/cli-win32-x64": "2.4.8"
+                "@biomejs/cli-darwin-arm64": "2.4.10",
+                "@biomejs/cli-darwin-x64": "2.4.10",
+                "@biomejs/cli-linux-arm64": "2.4.10",
+                "@biomejs/cli-linux-arm64-musl": "2.4.10",
+                "@biomejs/cli-linux-x64": "2.4.10",
+                "@biomejs/cli-linux-x64-musl": "2.4.10",
+                "@biomejs/cli-win32-arm64": "2.4.10",
+                "@biomejs/cli-win32-x64": "2.4.10"
             }
         },
         "node_modules/@biomejs/cli-darwin-arm64": {
-            "version": "2.4.8",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.8.tgz",
-            "integrity": "sha512-ARx0tECE8I7S2C2yjnWYLNbBdDoPdq3oyNLhMglmuctThwUsuzFWRKrHmIGwIRWKz0Mat9DuzLEDp52hGnrxGQ==",
+            "version": "2.4.10",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.10.tgz",
+            "integrity": "sha512-vuzzI1cWqDVzOMIkYyHbKqp+AkQq4K7k+UCXWpkYcY/HDn1UxdsbsfgtVpa40shem8Kax4TLDLlx8kMAecgqiw==",
             "cpu": [
                 "arm64"
             ],
@@ -269,9 +269,9 @@
             }
         },
         "node_modules/@biomejs/cli-darwin-x64": {
-            "version": "2.4.8",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.8.tgz",
-            "integrity": "sha512-Jg9/PsB9vDCJlANE8uhG7qDhb5w0Ix69D7XIIc8IfZPUoiPrbLm33k2Ig3NOJ/7nb3UbesFz3D1aDKm9DvzjhQ==",
+            "version": "2.4.10",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.10.tgz",
+            "integrity": "sha512-14fzASRo+BPotwp7nWULy2W5xeUyFnTaq1V13Etrrxkrih+ez/2QfgFm5Ehtf5vSjtgx/IJycMMpn5kPd5ZNaA==",
             "cpu": [
                 "x64"
             ],
@@ -286,13 +286,16 @@
             }
         },
         "node_modules/@biomejs/cli-linux-arm64": {
-            "version": "2.4.8",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.8.tgz",
-            "integrity": "sha512-5CdrsJct76XG2hpKFwXnEtlT1p+4g4yV+XvvwBpzKsTNLO9c6iLlAxwcae2BJ7ekPGWjNGw9j09T5KGPKKxQig==",
+            "version": "2.4.10",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.10.tgz",
+            "integrity": "sha512-7MH1CMW5uuxQ/s7FLST63qF8B3Hgu2HRdZ7tA1X1+mk+St4JOuIrqdhIBnnyqeyWJNI+Bww7Es5QZ0wIc1Cmkw==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
@@ -303,13 +306,16 @@
             }
         },
         "node_modules/@biomejs/cli-linux-arm64-musl": {
-            "version": "2.4.8",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.8.tgz",
-            "integrity": "sha512-Zo9OhBQDJ3IBGPlqHiTISloo5H0+FBIpemqIJdW/0edJ+gEcLR+MZeZozcUyz3o1nXkVA7++DdRKQT0599j9jA==",
+            "version": "2.4.10",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.10.tgz",
+            "integrity": "sha512-WrJY6UuiSD/Dh+nwK2qOTu8kdMDlLV3dLMmychIghHPAysWFq1/DGC1pVZx8POE3ZkzKR3PUUnVrtZfMfaJjyQ==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
@@ -320,13 +326,16 @@
             }
         },
         "node_modules/@biomejs/cli-linux-x64": {
-            "version": "2.4.8",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.8.tgz",
-            "integrity": "sha512-PdKXspVEaMCQLjtZCn6vfSck/li4KX9KGwSDbZdgIqlrizJ2MnMcE3TvHa2tVfXNmbjMikzcfJpuPWH695yJrw==",
+            "version": "2.4.10",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.10.tgz",
+            "integrity": "sha512-tZLvEEi2u9Xu1zAqRjTcpIDGVtldigVvzug2fTuPG0ME/g8/mXpRPcNgLB22bGn6FvLJpHHnqLnwliOu8xjYrg==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
@@ -337,13 +346,16 @@
             }
         },
         "node_modules/@biomejs/cli-linux-x64-musl": {
-            "version": "2.4.8",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.8.tgz",
-            "integrity": "sha512-Gi8quv8MEuDdKaPFtS2XjEnMqODPsRg6POT6KhoP+VrkNb+T2ywunVB+TvOU0LX1jAZzfBr+3V1mIbBhzAMKvw==",
+            "version": "2.4.10",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.10.tgz",
+            "integrity": "sha512-kDTi3pI6PBN6CiczsWYOyP2zk0IJI08EWEQyDMQWW221rPaaEz6FvjLhnU07KMzLv8q3qSuoB93ua6inSQ55Tw==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
@@ -354,9 +366,9 @@
             }
         },
         "node_modules/@biomejs/cli-win32-arm64": {
-            "version": "2.4.8",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.8.tgz",
-            "integrity": "sha512-LoFatS0tnHv6KkCVpIy3qZCih+MxUMvdYiPWLHRri7mhi2vyOOs8OrbZBcLTUEWCS+ktO72nZMy4F96oMhkOHQ==",
+            "version": "2.4.10",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.10.tgz",
+            "integrity": "sha512-umwQU6qPzH+ISTf/eHyJ/QoQnJs3V9Vpjz2OjZXe9MVBZ7prgGafMy7yYeRGnlmDAn87AKTF3Q6weLoMGpeqdQ==",
             "cpu": [
                 "arm64"
             ],
@@ -371,9 +383,9 @@
             }
         },
         "node_modules/@biomejs/cli-win32-x64": {
-            "version": "2.4.8",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.8.tgz",
-            "integrity": "sha512-vAn7iXDoUbqFXqVocuq1sMYAd33p8+mmurqJkWl6CtIhobd/O6moe4rY5AJvzbunn/qZCdiDVcveqtkFh1e7Hg==",
+            "version": "2.4.10",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.10.tgz",
+            "integrity": "sha512-aW/JU5GuyH4uxMrNYpoC2kjaHlyJGLgIa3XkhPEZI0uKhZhJZU8BuEyJmvgzSPQNGozBwWjC972RaNdcJ9KyJg==",
             "cpu": [
                 "x64"
             ],
@@ -484,11 +496,17 @@
                 "stylis": "4.2.0"
             }
         },
-        "node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-            "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-            "license": "MIT"
+        "node_modules/@emotion/babel-plugin/node_modules/escape-string-regexp": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/@emotion/cache": {
             "version": "11.14.0",
@@ -1144,12 +1162,12 @@
             }
         },
         "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-            "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
             "license": "MIT",
             "dependencies": {
-                "ansi-regex": "^6.0.1"
+                "ansi-regex": "^6.2.2"
             },
             "engines": {
                 "node": ">=12"
@@ -1284,18 +1302,18 @@
             "license": "Apache-2.0"
         },
         "node_modules/@parcel/watcher": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
-            "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+            "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "detect-libc": "^1.0.3",
+                "detect-libc": "^2.0.3",
                 "is-glob": "^4.0.3",
-                "micromatch": "^4.0.5",
-                "node-addon-api": "^7.0.0"
+                "node-addon-api": "^7.0.0",
+                "picomatch": "^4.0.3"
             },
             "engines": {
                 "node": ">= 10.0.0"
@@ -1305,25 +1323,25 @@
                 "url": "https://opencollective.com/parcel"
             },
             "optionalDependencies": {
-                "@parcel/watcher-android-arm64": "2.5.1",
-                "@parcel/watcher-darwin-arm64": "2.5.1",
-                "@parcel/watcher-darwin-x64": "2.5.1",
-                "@parcel/watcher-freebsd-x64": "2.5.1",
-                "@parcel/watcher-linux-arm-glibc": "2.5.1",
-                "@parcel/watcher-linux-arm-musl": "2.5.1",
-                "@parcel/watcher-linux-arm64-glibc": "2.5.1",
-                "@parcel/watcher-linux-arm64-musl": "2.5.1",
-                "@parcel/watcher-linux-x64-glibc": "2.5.1",
-                "@parcel/watcher-linux-x64-musl": "2.5.1",
-                "@parcel/watcher-win32-arm64": "2.5.1",
-                "@parcel/watcher-win32-ia32": "2.5.1",
-                "@parcel/watcher-win32-x64": "2.5.1"
+                "@parcel/watcher-android-arm64": "2.5.6",
+                "@parcel/watcher-darwin-arm64": "2.5.6",
+                "@parcel/watcher-darwin-x64": "2.5.6",
+                "@parcel/watcher-freebsd-x64": "2.5.6",
+                "@parcel/watcher-linux-arm-glibc": "2.5.6",
+                "@parcel/watcher-linux-arm-musl": "2.5.6",
+                "@parcel/watcher-linux-arm64-glibc": "2.5.6",
+                "@parcel/watcher-linux-arm64-musl": "2.5.6",
+                "@parcel/watcher-linux-x64-glibc": "2.5.6",
+                "@parcel/watcher-linux-x64-musl": "2.5.6",
+                "@parcel/watcher-win32-arm64": "2.5.6",
+                "@parcel/watcher-win32-ia32": "2.5.6",
+                "@parcel/watcher-win32-x64": "2.5.6"
             }
         },
         "node_modules/@parcel/watcher-android-arm64": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz",
-            "integrity": "sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==",
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+            "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
             "cpu": [
                 "arm64"
             ],
@@ -1342,9 +1360,9 @@
             }
         },
         "node_modules/@parcel/watcher-darwin-arm64": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz",
-            "integrity": "sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==",
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+            "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
             "cpu": [
                 "arm64"
             ],
@@ -1363,9 +1381,9 @@
             }
         },
         "node_modules/@parcel/watcher-darwin-x64": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz",
-            "integrity": "sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==",
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+            "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
             "cpu": [
                 "x64"
             ],
@@ -1384,9 +1402,9 @@
             }
         },
         "node_modules/@parcel/watcher-freebsd-x64": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz",
-            "integrity": "sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==",
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+            "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
             "cpu": [
                 "x64"
             ],
@@ -1405,13 +1423,16 @@
             }
         },
         "node_modules/@parcel/watcher-linux-arm-glibc": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz",
-            "integrity": "sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==",
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+            "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1426,13 +1447,16 @@
             }
         },
         "node_modules/@parcel/watcher-linux-arm-musl": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz",
-            "integrity": "sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==",
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+            "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1447,13 +1471,16 @@
             }
         },
         "node_modules/@parcel/watcher-linux-arm64-glibc": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz",
-            "integrity": "sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==",
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+            "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1468,13 +1495,16 @@
             }
         },
         "node_modules/@parcel/watcher-linux-arm64-musl": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz",
-            "integrity": "sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==",
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+            "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1489,13 +1519,16 @@
             }
         },
         "node_modules/@parcel/watcher-linux-x64-glibc": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz",
-            "integrity": "sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==",
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+            "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1510,13 +1543,16 @@
             }
         },
         "node_modules/@parcel/watcher-linux-x64-musl": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz",
-            "integrity": "sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==",
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+            "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1531,9 +1567,9 @@
             }
         },
         "node_modules/@parcel/watcher-win32-arm64": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz",
-            "integrity": "sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==",
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+            "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
             "cpu": [
                 "arm64"
             ],
@@ -1552,9 +1588,9 @@
             }
         },
         "node_modules/@parcel/watcher-win32-ia32": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz",
-            "integrity": "sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==",
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+            "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
             "cpu": [
                 "ia32"
             ],
@@ -1573,9 +1609,9 @@
             }
         },
         "node_modules/@parcel/watcher-win32-x64": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz",
-            "integrity": "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==",
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+            "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
             "cpu": [
                 "x64"
             ],
@@ -1614,13 +1650,10 @@
             }
         },
         "node_modules/@postalsys/gettext": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@postalsys/gettext/-/gettext-4.1.0.tgz",
-            "integrity": "sha512-DNUqMXvCW/wVKA/UaAYME2oXZbNfrz6ZjmfOy0xDwRtI6If1alUzc7s500TuvEW07UPJ5vJ7dGALvI08cXsG7Q==",
-            "dev": true,
-            "dependencies": {
-                "lodash.get": "4.4.2"
-            }
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@postalsys/gettext/-/gettext-4.1.1.tgz",
+            "integrity": "sha512-kOK8LVJ5imGo9cyR6td98OwSfMX/mtcoHiJ8Z3dCsEowkbbE6xmooVs9EYO4ZknQ7m9TkoGcMbUVY2UNH5XTqg==",
+            "dev": true
         },
         "node_modules/@react-aria/ssr": {
             "version": "3.9.10",
@@ -1811,6 +1844,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -1828,6 +1864,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -1845,6 +1884,9 @@
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -1862,6 +1904,9 @@
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -1879,6 +1924,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -1896,6 +1944,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -1964,13 +2015,19 @@
             "license": "Apache-2.0"
         },
         "node_modules/@swc/helpers": {
-            "version": "0.5.18",
-            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
-            "integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
+            "version": "0.5.21",
+            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+            "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.8.0"
             }
+        },
+        "node_modules/@swc/helpers/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "license": "0BSD"
         },
         "node_modules/@swc/types": {
             "version": "0.1.26",
@@ -2098,9 +2155,9 @@
             "license": "MIT"
         },
         "node_modules/@types/jquery": {
-            "version": "3.5.33",
-            "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.33.tgz",
-            "integrity": "sha512-SeyVJXlCZpEki5F0ghuYe+L+PprQta6nRZqhONt9F13dWBtR/ftoaIbdRQ7cis7womE+X2LKhsDdDtkkDhJS6g==",
+            "version": "3.5.34",
+            "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.34.tgz",
+            "integrity": "sha512-3m3939S3erqmTLJANS/uy0B6V7BorKx7RorcGZVjZ62dF5PAGbKEDZK1CuLtKombJkFA2T1jl8LAIIs7IV6gBQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2115,12 +2172,12 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "25.0.3",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
-            "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
+            "version": "25.5.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
+            "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~7.16.0"
+                "undici-types": "~7.18.0"
             }
         },
         "node_modules/@types/parse-json": {
@@ -2508,10 +2565,9 @@
             }
         },
         "node_modules/@xmldom/xmldom": {
-            "version": "0.7.13",
-            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.13.tgz",
-            "integrity": "sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==",
-            "deprecated": "this version is no longer supported, please update to at least 0.8.*",
+            "version": "0.8.12",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
+            "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
@@ -2614,6 +2670,23 @@
                 "node": ">=8"
             }
         },
+        "node_modules/ajv": {
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+            "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
         "node_modules/ajv-formats": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
@@ -2632,29 +2705,18 @@
                 }
             }
         },
-        "node_modules/ajv-formats/node_modules/ajv": {
-            "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+        "node_modules/ajv-keywords": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+            "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "fast-deep-equal": "^3.1.3",
-                "fast-uri": "^3.0.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2"
+                "fast-deep-equal": "^3.1.3"
             },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
+            "peerDependencies": {
+                "ajv": "^8.8.2"
             }
-        },
-        "node_modules/ajv-formats/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/ansi-colors": {
             "version": "4.1.3",
@@ -2791,10 +2853,14 @@
             }
         },
         "node_modules/argparse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "license": "Python-2.0"
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "sprintf-js": "~1.0.2"
+            }
         },
         "node_modules/array-buffer-byte-length": {
             "version": "1.0.2",
@@ -3070,6 +3136,21 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/b4a": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+            "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peerDependencies": {
+                "react-native-b4a": "*"
+            },
+            "peerDependenciesMeta": {
+                "react-native-b4a": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/babel-plugin-macros": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
@@ -3086,10 +3167,13 @@
             }
         },
         "node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "license": "MIT"
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
         },
         "node_modules/bare-events": {
             "version": "2.8.2",
@@ -3104,6 +3188,88 @@
                 "bare-abort-controller": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/bare-fs": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.6.0.tgz",
+            "integrity": "sha512-2YkS7NuiJceSEbyEOdSNLE9tsGd+f4+f7C+Nik/MCk27SYdwIMPT/yRKvg++FZhQXgk0KWJKJyXX9RhVV0RGqA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "bare-events": "^2.5.4",
+                "bare-path": "^3.0.0",
+                "bare-stream": "^2.6.4",
+                "bare-url": "^2.2.2",
+                "fast-fifo": "^1.3.2"
+            },
+            "engines": {
+                "bare": ">=1.16.0"
+            },
+            "peerDependencies": {
+                "bare-buffer": "*"
+            },
+            "peerDependenciesMeta": {
+                "bare-buffer": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/bare-os": {
+            "version": "3.8.7",
+            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.7.tgz",
+            "integrity": "sha512-G4Gr1UsGeEy2qtDTZwL7JFLo2wapUarz7iTMcYcMFdS89AIQuBoyjgXZz0Utv7uHs3xA9LckhVbeBi8lEQrC+w==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "bare": ">=1.14.0"
+            }
+        },
+        "node_modules/bare-path": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+            "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "bare-os": "^3.0.1"
+            }
+        },
+        "node_modules/bare-stream": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.12.0.tgz",
+            "integrity": "sha512-w28i8lkBgREV3rPXGbgK+BO66q+ZpKqRWrZLiCdmmUlLPrQ45CzkvRhN+7lnv00Gpi2zy5naRxnUFAxCECDm9g==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "streamx": "^2.25.0",
+                "teex": "^1.0.1"
+            },
+            "peerDependencies": {
+                "bare-abort-controller": "*",
+                "bare-buffer": "*",
+                "bare-events": "*"
+            },
+            "peerDependenciesMeta": {
+                "bare-abort-controller": {
+                    "optional": true
+                },
+                "bare-buffer": {
+                    "optional": true
+                },
+                "bare-events": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/bare-url": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.0.tgz",
+            "integrity": "sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "bare-path": "^3.0.0"
             }
         },
         "node_modules/base64-js": {
@@ -3127,13 +3293,16 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.9.11",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.11.tgz",
-            "integrity": "sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==",
+            "version": "2.10.14",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.14.tgz",
+            "integrity": "sha512-fOVLPAsFTsQfuCkvahZkzq6nf8KvGWanlYoTh0SVA0A/PIUxQGU2AOZAoD95n2gFLVDW/jP6sbGLny95nmEuHA==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
-                "baseline-browser-mapping": "dist/cli.js"
+                "baseline-browser-mapping": "dist/cli.cjs"
+            },
+            "engines": {
+                "node": ">=6.0.0"
             }
         },
         "node_modules/bcrypt-pbkdf": {
@@ -3215,12 +3384,15 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
             "license": "MIT",
             "dependencies": {
-                "balanced-match": "^1.0.0"
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
             }
         },
         "node_modules/braces": {
@@ -3246,9 +3418,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.28.1",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-            "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+            "version": "4.28.2",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+            "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
             "dev": true,
             "funding": [
                 {
@@ -3266,11 +3438,11 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "baseline-browser-mapping": "^2.9.0",
-                "caniuse-lite": "^1.0.30001759",
-                "electron-to-chromium": "^1.5.263",
-                "node-releases": "^2.0.27",
-                "update-browserslist-db": "^1.2.0"
+                "baseline-browser-mapping": "^2.10.12",
+                "caniuse-lite": "^1.0.30001782",
+                "electron-to-chromium": "^1.5.328",
+                "node-releases": "^2.0.36",
+                "update-browserslist-db": "^1.2.3"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -3462,9 +3634,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001762",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001762.tgz",
-            "integrity": "sha512-PxZwGNvH7Ak8WX5iXzoK1KPZttBXNPuaOvI2ZYU7NrlM+d9Ov+TUvlLOBNGzVXAntMSMMlJPd+jY6ovrVjSmUw==",
+            "version": "1.0.30001784",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001784.tgz",
+            "integrity": "sha512-WU346nBTklUV9YfUl60fqRbU5ZqyXlqvo1SgigE1OAXK5bFL8LL9q1K7aap3N739l4BvNqnkm3YrGHiY9sfUQw==",
             "dev": true,
             "funding": [
                 {
@@ -3526,6 +3698,31 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/cheerio": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0.tgz",
+            "integrity": "sha512-quS9HgjQpdaXOvsZz82Oz7uxtXiy6UIsIQcpBj7HRw2M63Skasm9qlDocAM7jNuaxdhpPU7c4kJN+gA5MCu4ww==",
+            "license": "MIT",
+            "dependencies": {
+                "cheerio-select": "^2.1.0",
+                "dom-serializer": "^2.0.0",
+                "domhandler": "^5.0.3",
+                "domutils": "^3.1.0",
+                "encoding-sniffer": "^0.2.0",
+                "htmlparser2": "^9.1.0",
+                "parse5": "^7.1.2",
+                "parse5-htmlparser2-tree-adapter": "^7.0.0",
+                "parse5-parser-stream": "^7.1.2",
+                "undici": "^6.19.5",
+                "whatwg-mimetype": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=18.17"
+            },
+            "funding": {
+                "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+            }
+        },
         "node_modules/cheerio-select": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
@@ -3544,16 +3741,16 @@
             }
         },
         "node_modules/chokidar": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-            "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+            "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "readdirp": "^4.0.1"
+                "readdirp": "^5.0.0"
             },
             "engines": {
-                "node": ">= 14.16.0"
+                "node": ">= 20.19.0"
             },
             "funding": {
                 "url": "https://paulmillr.com/funding/"
@@ -3579,9 +3776,9 @@
             }
         },
         "node_modules/ci-info": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
-            "integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+            "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
             "dev": true,
             "funding": [
                 {
@@ -3865,6 +4062,12 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/convert-source-map": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+            "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+            "license": "MIT"
+        },
         "node_modules/core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -3886,6 +4089,15 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/cosmiconfig/node_modules/yaml": {
+            "version": "1.10.3",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+            "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/crc-32": {
@@ -4148,29 +4360,6 @@
                 "cypress": ">=10.0.0"
             }
         },
-        "node_modules/cypress/node_modules/fs-extra": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "at-least-node": "^1.0.0",
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/cypress/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "dev": true,
-            "license": "0BSD"
-        },
         "node_modules/dashdash": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -4371,9 +4560,9 @@
             }
         },
         "node_modules/dayjs": {
-            "version": "1.11.19",
-            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
-            "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
+            "version": "1.11.20",
+            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+            "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -4470,17 +4659,14 @@
             }
         },
         "node_modules/detect-libc": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-            "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
             "dev": true,
             "license": "Apache-2.0",
             "optional": true,
-            "bin": {
-                "detect-libc": "bin/detect-libc.js"
-            },
             "engines": {
-                "node": ">=0.10"
+                "node": ">=8"
             }
         },
         "node_modules/dfa": {
@@ -4564,9 +4750,9 @@
             }
         },
         "node_modules/dotenv": {
-            "version": "17.3.1",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
-            "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+            "version": "17.4.0",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.0.tgz",
+            "integrity": "sha512-kCKF62fwtzwYm0IGBNjRUjtJgMfGapII+FslMHIjMR5KTnwEmBmWLDRSnc3XSNP8bNy34tekgQyDT0hr7pERRQ==",
             "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
@@ -4609,9 +4795,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.267",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
-            "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
+            "version": "1.5.331",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.331.tgz",
+            "integrity": "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==",
             "dev": true,
             "license": "ISC"
         },
@@ -4655,9 +4841,9 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.20.0",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz",
-            "integrity": "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==",
+            "version": "5.20.1",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
+            "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4884,15 +5070,27 @@
             }
         },
         "node_modules/escape-string-regexp": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=10"
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/eslint-scope": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+            "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "esrecurse": "^4.3.0",
+                "estraverse": "^4.1.1"
             },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+            "engines": {
+                "node": ">=8.0.0"
             }
         },
         "node_modules/eslint-visitor-keys": {
@@ -4951,10 +5149,20 @@
                 "node": ">=4.0"
             }
         },
-        "node_modules/estraverse": {
+        "node_modules/esrecurse/node_modules/estraverse": {
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/estraverse": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
             "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
@@ -4979,9 +5187,9 @@
             "license": "MIT"
         },
         "node_modules/eventemitter3": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-            "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+            "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
             "license": "MIT"
         },
         "node_modules/events": {
@@ -5252,16 +5460,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/figures/node_modules/escape-string-regexp": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
         "node_modules/file-sync-cmp": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz",
@@ -5293,6 +5491,20 @@
             "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
             "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
             "license": "MIT"
+        },
+        "node_modules/find-up": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/findup-sync": {
             "version": "5.0.0",
@@ -5474,6 +5686,22 @@
             },
             "engines": {
                 "node": ">=12.20.0"
+            }
+        },
+        "node_modules/fs-extra": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "at-least-node": "^1.0.0",
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/fs-minipass": {
@@ -5684,9 +5912,9 @@
             }
         },
         "node_modules/gettext-converter": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/gettext-converter/-/gettext-converter-1.3.0.tgz",
-            "integrity": "sha512-vXjx4vRBjw6rd3Zg73IMyNLZuPjs8/lE9gJZs270YJJI0t5vlCpdsyX5E0TmSd+KcRWzwPbwjwd6bnNpF72sFQ==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/gettext-converter/-/gettext-converter-1.3.1.tgz",
+            "integrity": "sha512-2BTfkX9g9EbfjJVEQFT5BMqY/2HbtZ0RTXWKTgn9xW7gzSXqkAfYAIFtpoiJ1A3/iL9MC9Sp/BlrshqHKP8wxQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5715,6 +5943,7 @@
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
             "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "license": "ISC",
             "dependencies": {
                 "foreground-child": "^3.1.0",
@@ -5957,16 +6186,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/grunt-contrib-copy/node_modules/escape-string-regexp": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
         "node_modules/grunt-contrib-copy/node_modules/strip-ansi": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -6059,20 +6278,17 @@
                 "node": ">=10"
             }
         },
-        "node_modules/grunt/node_modules/argparse": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+        "node_modules/grunt/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "sprintf-js": "~1.0.2"
-            }
+            "license": "MIT"
         },
         "node_modules/grunt/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6091,7 +6307,7 @@
             "version": "7.1.7",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
             "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -6143,24 +6359,10 @@
                 "nopt": "bin/nopt.js"
             }
         },
-        "node_modules/grunt/node_modules/js-yaml": {
-            "version": "3.14.2",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-            "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
-            }
-        },
         "node_modules/grunt/node_modules/minimatch": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
-            "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
+            "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -6169,13 +6371,6 @@
             "engines": {
                 "node": "*"
             }
-        },
-        "node_modules/grunt/node_modules/sprintf-js": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-            "dev": true,
-            "license": "BSD-3-Clause"
         },
         "node_modules/grunt/node_modules/v8flags": {
             "version": "3.2.0",
@@ -6311,16 +6506,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/hasha/node_modules/type-fest": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-            "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-            "dev": true,
-            "license": "(MIT OR CC0-1.0)",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/hasown": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -6381,6 +6566,25 @@
                 "void-elements": "3.1.0"
             }
         },
+        "node_modules/htmlparser2": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+            "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+            "funding": [
+                "https://github.com/fb55/htmlparser2?sponsor=1",
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fb55"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.3",
+                "domutils": "^3.1.0",
+                "entities": "^4.5.0"
+            }
+        },
         "node_modules/http-cache-semantics": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
@@ -6439,29 +6643,29 @@
             }
         },
         "node_modules/i18next": {
-            "version": "25.8.18",
-            "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.8.18.tgz",
-            "integrity": "sha512-lzY5X83BiL5AP77+9DydbrqkQHFN9hUzWGjqjLpPcp5ZOzuu1aSoKaU3xbBLSjWx9dAzW431y+d+aogxOZaKRA==",
+            "version": "25.10.10",
+            "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.10.10.tgz",
+            "integrity": "sha512-cqUW2Z3EkRx7NqSyywjkgCLK7KLCL6IFVFcONG7nVYIJ3ekZ1/N5jUsihHV6Bq37NfhgtczxJcxduELtjTwkuQ==",
             "funding": [
                 {
                     "type": "individual",
-                    "url": "https://locize.com"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://locize.com/i18next.html"
+                    "url": "https://www.locize.com/i18next"
                 },
                 {
                     "type": "individual",
                     "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.locize.com"
                 }
             ],
             "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.28.6"
+                "@babel/runtime": "^7.29.2"
             },
             "peerDependencies": {
-                "typescript": "^5"
+                "typescript": "^5 || ^6"
             },
             "peerDependenciesMeta": {
                 "typescript": {
@@ -6470,9 +6674,9 @@
             }
         },
         "node_modules/i18next-cli": {
-            "version": "1.51.5",
-            "resolved": "https://registry.npmjs.org/i18next-cli/-/i18next-cli-1.51.5.tgz",
-            "integrity": "sha512-WjNfP2D61NjxH9KNpsCq0dg6PRcSo4ZWxEx6MawiX/ZXIB8QeKVQEMFGe+5mP+1QN88Wz5Zgopjll1WXB4g/kg==",
+            "version": "1.51.6",
+            "resolved": "https://registry.npmjs.org/i18next-cli/-/i18next-cli-1.51.6.tgz",
+            "integrity": "sha512-s1eBAvWiDqABtpG54balm5oyTtWaqmjfgMNJHX+7OdB9th9Nnn0DLQpkZr/j3bVuO8dumfGiAl/oCRYQd6aNoQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6487,10 +6691,10 @@
                 "jiti": "^2.6.1",
                 "jsonc-parser": "^3.3.1",
                 "magic-string": "^0.30.21",
-                "minimatch": "^10.2.4",
+                "minimatch": "^10.2.5",
                 "ora": "^9.3.0",
                 "react": "^19.2.4",
-                "react-i18next": "^17.0.1",
+                "react-i18next": "^17.0.2",
                 "yaml": "^2.8.3"
             },
             "bin": {
@@ -6498,45 +6702,6 @@
             },
             "engines": {
                 "node": ">=22"
-            }
-        },
-        "node_modules/i18next-cli/node_modules/balanced-match": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/i18next-cli/node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^4.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/i18next-cli/node_modules/chokidar": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-            "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "readdirp": "^5.0.0"
-            },
-            "engines": {
-                "node": ">= 20.19.0"
-            },
-            "funding": {
-                "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/i18next-cli/node_modules/commander": {
@@ -6736,20 +6901,6 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/i18next-cli/node_modules/readdirp": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-            "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 20.19.0"
-            },
-            "funding": {
-                "type": "individual",
-                "url": "https://paulmillr.com/funding/"
-            }
-        },
         "node_modules/i18next-cli/node_modules/signal-exit": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -6776,22 +6927,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/i18next-cli/node_modules/yaml": {
-            "version": "2.8.3",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-            "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "yaml": "bin.mjs"
-            },
-            "engines": {
-                "node": ">= 14.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/eemeli"
-            }
-        },
         "node_modules/i18next-conv": {
             "version": "16.0.0",
             "resolved": "https://registry.npmjs.org/i18next-conv/-/i18next-conv-16.0.0.tgz",
@@ -6814,9 +6949,9 @@
             }
         },
         "node_modules/i18next-conv/node_modules/commander": {
-            "version": "14.0.2",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz",
-            "integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
+            "version": "14.0.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+            "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6837,52 +6972,6 @@
             },
             "bin": {
                 "i18next-resources-for-ts": "bin/i18next-resources-for-ts.js"
-            }
-        },
-        "node_modules/i18next-resources-for-ts/node_modules/chokidar": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-            "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "readdirp": "^5.0.0"
-            },
-            "engines": {
-                "node": ">= 20.19.0"
-            },
-            "funding": {
-                "url": "https://paulmillr.com/funding/"
-            }
-        },
-        "node_modules/i18next-resources-for-ts/node_modules/readdirp": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-            "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 20.19.0"
-            },
-            "funding": {
-                "type": "individual",
-                "url": "https://paulmillr.com/funding/"
-            }
-        },
-        "node_modules/i18next-resources-for-ts/node_modules/yaml": {
-            "version": "2.8.3",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-            "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "yaml": "bin.mjs"
-            },
-            "engines": {
-                "node": ">= 14.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/eemeli"
             }
         },
         "node_modules/iconv-lite": {
@@ -7773,6 +7862,20 @@
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
             "license": "MIT"
         },
+        "node_modules/js-yaml": {
+            "version": "3.14.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+            "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
         "node_modules/jsbn": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -7811,6 +7914,13 @@
             "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
             "dev": true,
             "license": "(AFL-2.1 OR BSD-3-Clause)"
+        },
+        "node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/json-stringify-safe": {
             "version": "5.0.1",
@@ -8108,30 +8218,35 @@
                 "url": "https://opencollective.com/webpack"
             }
         },
+        "node_modules/locate-path": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-locate": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/lodash": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "license": "MIT"
         },
         "node_modules/lodash-es": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-            "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+            "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
             "license": "MIT"
         },
         "node_modules/lodash.clonedeep": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
             "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
-            "license": "MIT"
-        },
-        "node_modules/lodash.get": {
-            "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-            "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-            "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/lodash.isequal": {
@@ -8466,12 +8581,12 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.7.tgz",
+            "integrity": "sha512-MOwgjc8tfrpn5QQEvjijjmDVtMw2oL88ugTevzxQnzRLm6l3fVEF2gzU0kYeYYKD8C66+IdGX6peJ4MyUlUnPg==",
             "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^5.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -8529,10 +8644,10 @@
             }
         },
         "node_modules/minipass-flush": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
-            "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
-            "license": "ISC",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+            "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
                 "minipass": "^3.0.0"
             },
@@ -8732,9 +8847,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.6.tgz",
-            "integrity": "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==",
+            "version": "5.1.7",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.7.tgz",
+            "integrity": "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==",
             "funding": [
                 {
                     "type": "github",
@@ -8891,9 +9006,9 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.27",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-            "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+            "version": "2.0.37",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+            "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
             "dev": true,
             "license": "MIT"
         },
@@ -8995,10 +9110,17 @@
                 "node": ">=4"
             }
         },
+        "node_modules/npm-run-all/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/npm-run-all/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9055,16 +9177,6 @@
                 "node": ">=4.8"
             }
         },
-        "node_modules/npm-run-all/node_modules/escape-string-regexp": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
         "node_modules/npm-run-all/node_modules/has-flag": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -9076,9 +9188,9 @@
             }
         },
         "node_modules/npm-run-all/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
+            "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -9579,6 +9691,35 @@
                 "node": ">=18.0"
             }
         },
+        "node_modules/p-limit": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-try": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-locate": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-limit": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/p-map": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
@@ -9917,13 +10058,12 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-            "dev": true,
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "license": "MIT",
             "engines": {
-                "node": ">=8.6"
+                "node": ">=12"
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
@@ -9974,62 +10114,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/pkg-dir/node_modules/find-up": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "locate-path": "^5.0.0",
-                "path-exists": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/pkg-dir/node_modules/locate-path": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "p-locate": "^4.1.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/pkg-dir/node_modules/p-limit": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "p-try": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/pkg-dir/node_modules/p-locate": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "p-limit": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/png-js": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
@@ -10046,9 +10130,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.6",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-            "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+            "version": "8.5.8",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+            "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
             "dev": true,
             "funding": [
                 {
@@ -10178,9 +10262,9 @@
             }
         },
         "node_modules/preact": {
-            "version": "10.28.2",
-            "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.2.tgz",
-            "integrity": "sha512-lbteaWGzGHdlIuiJ0l2Jq454m6kcpI1zNje6d8MlGAFlYvP2GO4ibnat7P74Esfz4sPTdM6UxtTwh/d3pwM9JA==",
+            "version": "10.29.1",
+            "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
+            "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
             "license": "MIT",
             "funding": {
                 "type": "opencollective",
@@ -10296,9 +10380,9 @@
             "license": "MIT"
         },
         "node_modules/pump": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-            "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+            "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10425,9 +10509,9 @@
             }
         },
         "node_modules/react-i18next": {
-            "version": "17.0.1",
-            "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.1.tgz",
-            "integrity": "sha512-iG65FGnFHcYyHNuT01ukffYWCOBFTWSdVD8EZd/dCVWgtjFPObcSsvYYNwcsokO/rDcTb5d6D8Acv8MrOdm6Hw==",
+            "version": "17.0.2",
+            "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.2.tgz",
+            "integrity": "sha512-shBftH2vaTWK2Bsp7FiL+cevx3xFJlvFxmsDFQSrJc+6twHkP0tv/bGa01VVWzpreUVVwU+3Hev5iFqRg65RwA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10591,10 +10675,27 @@
                 "minimatch": "^5.1.0"
             }
         },
+        "node_modules/readdir-glob/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/readdir-glob/node_modules/brace-expansion": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+            "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
         "node_modules/readdir-glob/node_modules/minimatch": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+            "version": "5.1.8",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.8.tgz",
+            "integrity": "sha512-7RN35vit8DeBclkofOVmBY0eDAZZQd1HzmukRdSyz95CRh8FT54eqnbj0krQr3mrHR6sfRyYkyhwBWjoV5uqlQ==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -10605,13 +10706,13 @@
             }
         },
         "node_modules/readdirp": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-            "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+            "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">= 14.18.0"
+                "node": ">= 20.19.0"
             },
             "funding": {
                 "type": "individual",
@@ -10826,6 +10927,13 @@
                 "tslib": "^2.1.0"
             }
         },
+        "node_modules/rxjs/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
         "node_modules/safe-array-concat": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
@@ -10908,9 +11016,9 @@
             "license": "MIT"
         },
         "node_modules/sass": {
-            "version": "1.98.0",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.98.0.tgz",
-            "integrity": "sha512-+4N/u9dZ4PrgzGgPlKnaaRQx64RO0JBKs9sDhQ2pLgN6JQZ25uPQZKQYaBJU48Kd5BxgXoJ4e09Dq7nMcOUW3A==",
+            "version": "1.99.0",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.99.0.tgz",
+            "integrity": "sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10969,6 +11077,36 @@
                 }
             }
         },
+        "node_modules/sass/node_modules/chokidar": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+            "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "readdirp": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 14.16.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/sass/node_modules/readdirp": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+            "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14.18.0"
+            },
+            "funding": {
+                "type": "individual",
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
         "node_modules/sax": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
@@ -11004,47 +11142,10 @@
                 "url": "https://opencollective.com/webpack"
             }
         },
-        "node_modules/schema-utils/node_modules/ajv": {
-            "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3",
-                "fast-uri": "^3.0.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/schema-utils/node_modules/ajv-keywords": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-            "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3"
-            },
-            "peerDependencies": {
-                "ajv": "^8.8.2"
-            }
-        },
-        "node_modules/schema-utils/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/semver": {
-            "version": "7.7.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-            "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -11360,16 +11461,16 @@
             }
         },
         "node_modules/spdx-license-ids": {
-            "version": "3.0.22",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
-            "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
+            "version": "3.0.23",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+            "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
             "dev": true,
             "license": "CC0-1.0"
         },
         "node_modules/sprintf-js": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
             "dev": true,
             "license": "BSD-3-Clause"
         },
@@ -11455,9 +11556,9 @@
             }
         },
         "node_modules/streamx": {
-            "version": "2.23.0",
-            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
-            "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+            "version": "2.25.0",
+            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+            "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11755,6 +11856,12 @@
                 "svg2ttf": "svg2ttf.js"
             }
         },
+        "node_modules/svg2ttf/node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "license": "Python-2.0"
+        },
         "node_modules/svgicons2svgfont": {
             "version": "15.0.1",
             "resolved": "https://registry.npmjs.org/svgicons2svgfont/-/svgicons2svgfont-15.0.1.tgz",
@@ -11784,27 +11891,6 @@
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=18"
-            }
-        },
-        "node_modules/svgicons2svgfont/node_modules/balanced-match": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-            "license": "MIT",
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/svgicons2svgfont/node_modules/brace-expansion": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-            "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^4.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
             }
         },
         "node_modules/svgicons2svgfont/node_modules/commander": {
@@ -11865,12 +11951,12 @@
             }
         },
         "node_modules/svgicons2svgfont/node_modules/minimatch": {
-            "version": "10.2.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-            "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^5.0.2"
+                "brace-expansion": "^5.0.5"
             },
             "engines": {
                 "node": "18 || 20 || >=22"
@@ -11976,31 +12062,6 @@
                 }
             }
         },
-        "node_modules/svgtofont/node_modules/cheerio": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0.tgz",
-            "integrity": "sha512-quS9HgjQpdaXOvsZz82Oz7uxtXiy6UIsIQcpBj7HRw2M63Skasm9qlDocAM7jNuaxdhpPU7c4kJN+gA5MCu4ww==",
-            "license": "MIT",
-            "dependencies": {
-                "cheerio-select": "^2.1.0",
-                "dom-serializer": "^2.0.0",
-                "domhandler": "^5.0.3",
-                "domutils": "^3.1.0",
-                "encoding-sniffer": "^0.2.0",
-                "htmlparser2": "^9.1.0",
-                "parse5": "^7.1.2",
-                "parse5-htmlparser2-tree-adapter": "^7.0.0",
-                "parse5-parser-stream": "^7.1.2",
-                "undici": "^6.19.5",
-                "whatwg-mimetype": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=18.17"
-            },
-            "funding": {
-                "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
-            }
-        },
         "node_modules/svgtofont/node_modules/fs-extra": {
             "version": "11.2.0",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
@@ -12015,38 +12076,10 @@
                 "node": ">=14.14"
             }
         },
-        "node_modules/svgtofont/node_modules/htmlparser2": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
-            "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
-            "funding": [
-                "https://github.com/fb55/htmlparser2?sponsor=1",
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fb55"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "domelementtype": "^2.3.0",
-                "domhandler": "^5.0.3",
-                "domutils": "^3.1.0",
-                "entities": "^4.5.0"
-            }
-        },
-        "node_modules/svgtofont/node_modules/undici": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-            "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.17"
-            }
-        },
         "node_modules/systeminformation": {
-            "version": "5.31.1",
-            "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.1.tgz",
-            "integrity": "sha512-6pRwxoGeV/roJYpsfcP6tN9mep6pPeCtXbUOCdVa0nme05Brwcwdge/fVNhIZn2wuUitAKZm4IYa7QjnRIa9zA==",
+            "version": "5.31.5",
+            "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.5.tgz",
+            "integrity": "sha512-5SyLdip4/3alxD4Kh+63bUQTJmu7YMfYQTC+koZy7X73HgNqZSD2P4wOZQWtUncvPvcEmnfIjCoygN4MRoEejQ==",
             "dev": true,
             "license": "MIT",
             "os": [
@@ -12077,9 +12110,9 @@
             "license": "MIT"
         },
         "node_modules/tapable": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
-            "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
+            "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -12091,9 +12124,9 @@
             }
         },
         "node_modules/tar": {
-            "version": "7.5.12",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.12.tgz",
-            "integrity": "sha512-9TsuLcdhOn4XztcQqhNyq1KOwOOED/3k58JAvtULiYqbO8B/0IBAAIE1hj0Svmm58k27TmcigyDI0deMlgG3uw==",
+            "version": "7.5.13",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+            "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
             "license": "BlueOak-1.0.0",
             "dependencies": {
                 "@isaacs/fs-minipass": "^4.0.0",
@@ -12107,36 +12140,32 @@
             }
         },
         "node_modules/tar-stream": {
-            "version": "3.1.7",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
-            "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+            "version": "3.1.8",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
+            "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "b4a": "^1.6.4",
+                "bare-fs": "^4.5.5",
                 "fast-fifo": "^1.2.0",
                 "streamx": "^2.15.0"
             }
         },
-        "node_modules/tar-stream/node_modules/b4a": {
-            "version": "1.7.3",
-            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
-            "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+        "node_modules/teex": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+            "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
             "dev": true,
-            "license": "Apache-2.0",
-            "peerDependencies": {
-                "react-native-b4a": "*"
-            },
-            "peerDependenciesMeta": {
-                "react-native-b4a": {
-                    "optional": true
-                }
+            "license": "MIT",
+            "dependencies": {
+                "streamx": "^2.12.5"
             }
         },
         "node_modules/terser": {
-            "version": "5.46.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
-            "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
+            "version": "5.46.1",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz",
+            "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -12153,9 +12182,9 @@
             }
         },
         "node_modules/terser-webpack-plugin": {
-            "version": "5.3.17",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.17.tgz",
-            "integrity": "sha512-YR7PtUp6GMU91BgSJmlaX/rS2lGDbAF7D+Wtq7hRO+MiljNmodYvqslzCFiYVAgW+Qoaaia/QUIP4lGXufjdZw==",
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.4.0.tgz",
+            "integrity": "sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -12194,28 +12223,13 @@
             "license": "MIT"
         },
         "node_modules/text-decoder": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
-            "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+            "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "b4a": "^1.6.4"
-            }
-        },
-        "node_modules/text-decoder/node_modules/b4a": {
-            "version": "1.7.3",
-            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
-            "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "peerDependencies": {
-                "react-native-b4a": "*"
-            },
-            "peerDependenciesMeta": {
-                "react-native-b4a": {
-                    "optional": true
-                }
             }
         },
         "node_modules/thenify": {
@@ -12276,18 +12290,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/SuperchupuDev"
-            }
-        },
-        "node_modules/tinyglobby/node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/tldts": {
@@ -12404,9 +12406,9 @@
             "license": "Apache-2.0"
         },
         "node_modules/ts-loader": {
-            "version": "9.5.4",
-            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.4.tgz",
-            "integrity": "sha512-nCz0rEwunlTZiy6rXFByQU1kVVpCIgUpc/psFiKVrUwrizdnIbRFu8w7bxhUF0X613DYwT4XzrZHpVyMe758hQ==",
+            "version": "9.5.7",
+            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.7.tgz",
+            "integrity": "sha512-/ZNrKgA3K3PtpMYOC71EeMWIloGw3IYEa5/t1cyz2r5/PyUwTXGzYJvcD3kfUvmhlfpz1rhV8B2O6IVTQ0avsg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -12435,9 +12437,10 @@
             }
         },
         "node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true,
             "license": "0BSD"
         },
         "node_modules/ttf2eot": {
@@ -12452,6 +12455,12 @@
                 "ttf2eot": "ttf2eot.js"
             }
         },
+        "node_modules/ttf2eot/node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "license": "Python-2.0"
+        },
         "node_modules/ttf2woff": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/ttf2woff/-/ttf2woff-3.0.0.tgz",
@@ -12464,6 +12473,12 @@
             "bin": {
                 "ttf2woff": "ttf2woff.js"
             }
+        },
+        "node_modules/ttf2woff/node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "license": "Python-2.0"
         },
         "node_modules/ttf2woff2": {
             "version": "8.0.1",
@@ -12505,6 +12520,16 @@
             "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
             "dev": true,
             "license": "Unlicense"
+        },
+        "node_modules/type-fest": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+            "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/typed-array-buffer": {
             "version": "1.0.3",
@@ -12656,10 +12681,26 @@
                 "node": "*"
             }
         },
+        "node_modules/underscore.string/node_modules/sprintf-js": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/undici": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+            "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.17"
+            }
+        },
         "node_modules/undici-types": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-            "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+            "version": "7.18.2",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+            "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
             "license": "MIT"
         },
         "node_modules/unicode-properties": {
@@ -13048,30 +13089,6 @@
                 "node": ">=10.13.0"
             }
         },
-        "node_modules/webpack/node_modules/eslint-scope": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-            "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "esrecurse": "^4.3.0",
-                "estraverse": "^4.1.1"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "node_modules/webpack/node_modules/estraverse": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
         "node_modules/whatwg-encoding": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
@@ -13177,9 +13194,9 @@
             }
         },
         "node_modules/which-typed-array": {
-            "version": "1.1.19",
-            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
-            "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+            "version": "1.1.20",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+            "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -13287,12 +13304,12 @@
             }
         },
         "node_modules/wrap-ansi/node_modules/strip-ansi": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-            "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
             "license": "MIT",
             "dependencies": {
-                "ansi-regex": "^6.0.1"
+                "ansi-regex": "^6.2.2"
             },
             "engines": {
                 "node": ">=12"
@@ -13339,12 +13356,18 @@
             }
         },
         "node_modules/yaml": {
-            "version": "1.10.3",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-            "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+            "version": "2.8.3",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+            "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
             "license": "ISC",
+            "bin": {
+                "yaml": "bin.mjs"
+            },
             "engines": {
-                "node": ">= 6"
+                "node": ">= 14.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/eemeli"
             }
         },
         "node_modules/yaml-eslint-parser": {
@@ -13361,21 +13384,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ota-meshi"
-            }
-        },
-        "node_modules/yaml-eslint-parser/node_modules/yaml": {
-            "version": "2.8.3",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-            "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-            "license": "ISC",
-            "bin": {
-                "yaml": "bin.mjs"
-            },
-            "engines": {
-                "node": ">= 14.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/eemeli"
             }
         },
         "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -152,5 +152,32 @@
         "typescript": "^5.9.3",
         "webpack": "^5.105.4",
         "webpack-cli": "^7.0.2"
+    },
+    "overrides": {
+        "lodash": "4.18.1",
+        "lodash-es": "4.18.1",
+        "@xmldom/xmldom": "0.8.12",
+        "picomatch": "4.0.4",
+        "grunt": {
+            "minimatch": "3.1.4",
+            "brace-expansion": "1.1.13"
+        },
+        "npm-run-all": {
+            "minimatch": "3.1.4",
+            "brace-expansion": "1.1.13"
+        },
+        "archiver": {
+            "archiver-utils": {
+                "glob": {
+                    "minimatch": "9.0.7"
+                }
+            },
+            "readdir-glob": {
+                "minimatch": "5.1.8"
+            }
+        },
+        "svgicons2svgfont": {
+            "brace-expansion": "5.0.5"
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Adds npm `overrides` block to force patched versions of 6 vulnerable transitive dependencies
- Resolves all 14 open Dependabot security alerts blocking the v7.1.0 release
- `npm audit` now reports **0 vulnerabilities**

## Vulnerabilities Fixed

| Package | From | To | CVEs |
|---------|------|----|------|
| `lodash` / `lodash-es` | 4.17.23 | 4.18.1 | Code Injection via `_.template`, Prototype Pollution via `_.unset`/`_.omit` |
| `@xmldom/xmldom` | 0.7.13 | 0.8.12 | XML Injection via unsafe CDATA serialization |
| `picomatch` | 4.0.3 / 2.3.2 | 4.0.4 | ReDoS via extglob quantifiers, Method Injection in POSIX classes |
| `minimatch` | 9.0.5 / 5.1.6 / 3.0.8 | 9.0.7 / 5.1.8 / 3.1.4 | ReDoS via wildcards, GLOBSTAR, extglobs |
| `brace-expansion` | 5.0.4 / 2.0.2 / 1.1.12 | 5.0.5 / 2.0.3 / 1.1.13 | Zero-step sequence process hang |

## Why overrides?
All vulnerable packages are **transitive dependencies** pinned by direct deps (`grunt`, `archiver`, `@tabler/icons-webfont`, `ts-loader`, `npm-run-all`). Simple `npm update` cannot resolve them because parent packages constrain the version ranges. Scoped npm overrides force the patched versions without upgrading the parent packages to potentially breaking major versions.

## Test plan
- [x] `npm audit` — 0 vulnerabilities
- [x] `npm run lint` — passes
- [x] `npm run build:js:legacy` (grunt) — passes
- [x] `npm run build:webpack` — passes
- [ ] CI pipeline passes

Closes Dependabot alerts: #200, #203, #204, #205, #206, #221, #222, #223, #224, #226, #227, #228, #229, #230
Supersedes #8408

🤖 Generated with [Claude Code](https://claude.com/claude-code)