### PR TITLE
docs: update 7.1.0 changelog for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Release notes are stored in the [`changelog/`](./changelog/) folder — one file
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| [7.1.0](./changelog/7.1.0.md) | April 2026 | Tabler/BS5 UI overhaul, 46 locales, security hardening, export hub, Functions.php removal |
 | [7.0.5](./changelog/7.0.5.md) | March 2026 | Effortless upgrades, mapping precision, 100% translations |
 | [7.0.4](./changelog/7.0.4.md) | March 2026 | Smoother upgrades, standardized logging, geocoding refinements |
 | [7.0.3](./changelog/7.0.3.md) | March 2026 | Maps improvements, Church Info page, FrankenPHP support |

--- a/changelog/7.1.0.md
+++ b/changelog/7.1.0.md
@@ -1,6 +1,6 @@
 # ChurchCRM 7.1.0
 
-**Release Date**: April 2026  
+**Release Date**: April 5, 2026  
 **Previous Release**: [7.0.5](./7.0.5.md)
 
 ---
@@ -77,6 +77,7 @@ This release represents a **complete redesign of the entire user interface**. Ev
 - **Groups Section Cleanup** – Reports, map, settings panel, Sunday School class view updates (#8324)
 - **Post-Login Redirect** – Unauthenticated users are now redirected to their originally requested URL after login (server-side, no open-redirect exposure) (#8444)
 - **Notification System Improvements** – Wildcard version matching and per-user dismissal for in-app notifications (#8402)
+- **Export Landing Page** – New `/admin/export` page consolidating CSV exports, ChMeetings export, and database backup into a single hub (#8475)
 
 ### Media & Photos
 - **Avatar Click-to-View Lightbox** – System-wide photo viewing via avatar clicks with Uppy v5.1.1 upgrade (#8376)
@@ -90,6 +91,7 @@ This release represents a **complete redesign of the entire user interface**. Ev
 - **Fiscal Year Formatting** – Unified with `FinancialService::formatFiscalYear()` (#8380)
 - **Functions.php Removal** – Deleted legacy global include; all 17 functions migrated to typed static methods on `Utils/` classes; 94 pages updated (#8448)
 - **People/Family Settings Split** – Separated People Setup settings into People, Families, and New Members panels (#8369)
+- **Type-Safe SystemConfig Getters** – Replaced raw `SystemConfig::getValue()` calls with typed getters and added output escaping for XSS prevention (#8467)
 
 ### Bug Fixes
 - **Add-to-Group Bug** – Fixed broken add-to-group for multi-role groups + GroupPropsEditor trim(null) (#8345)
@@ -105,6 +107,7 @@ This release represents a **complete redesign of the entire user interface**. Ev
 - **PersonEditor/FamilyEditor Form Submission** – Replaced unreliable FAB buttons with standard form submit buttons; fixed form submission failures (#8406)
 - **Button Icon Gap** – Fixed missing icon-text spacing in buttons sitewide after BS5/Tabler migration (#8447)
 - **Email Copy Links** – Fixed email copying behavior across family and person views (#8403)
+- **Person Custom Fields Fatal Error** – Fixed fatal error when saving Person Custom Fields (#8474)
 
 ### Infrastructure & Dependencies
 - **PHP Version Update** – Updated all references to PHP 8.4 minimum (#8381)
@@ -120,6 +123,7 @@ This release represents a **complete redesign of the entire user interface**. Ev
   - Updated `@fortawesome/fontawesome-free` to 7.2.0
   - Migrated from `i18next-parser` to `i18next-cli` (#8374)
   - Updated `@tabler/icons-webfont`, `@uppy/xhr-upload`, `mini-css-extract-plugin`
+  - Consolidated locale build system and cleanup scripts (#8463)
   - Updated various patch versions in composer and npm dependencies
 - **Security**
   - Fixed Quill XSS vulnerability (downgraded to 2.0.2)
@@ -129,20 +133,27 @@ This release represents a **complete redesign of the entire user interface**. Ev
   - Hardened session cookies: `HttpOnly`, `SameSite=Lax`, `Secure` flags (#8446)
   - Added missing HTTP headers: `X-Content-Type-Options`, `Referrer-Policy` (#8446)
   - Fixed reflected/stored XSS, API auth bypass, and command injection across 11 files; converted 6 raw-SQL files to Propel ORM (#8460)
+  - Patched 6 additional SQL injection and permission bypass vulnerabilities (#8464)
   - Updated minimum password length default to 8 characters (NIST SP 800-63B) (#8446)
   - Allowed Gravatar images in CSP policy
+  - Added Discord webhook notifications for security events (real-time alerting)
 
 ## 🌍 Internationalization
 
 ### Complete Translation Coverage
-- **565 translated UI terms** across 30+ languages
+- **46 active locales** with translated UI terms across every major region
 - Full locale support for:
   - **Middle East**: Arabic (Egypt), Hebrew
   - **Africa**: Amharic (Ethiopia), Afrikaans, Swahili
-  - **Asia**: Chinese (Simplified & Traditional), Hindi, Indonesian, Japanese, Korean, Thai, Telugu, Tamil, Turkish, Ukrainian, Vietnamese
-  - **Europe**: Albanian, Czech, Dutch, Estonian, Finnish, French, German, Greek, Hungarian, Italian, Norwegian Bokmål, Polish, Portuguese (Portugal & Brazil), Romanian, Russian, Spanish (Spain, Mexico, Colombia, Argentina, El Salvador), Swedish
+  - **South Asia**: Hindi, Malayalam (new), Tamil, Telugu
+  - **Southeast Asia**: Filipino/Tagalog (new), Indonesian, Thai, Vietnamese
+  - **East Asia**: Chinese (Simplified & Traditional), Japanese, Korean
+  - **Europe**: Albanian, Czech, Dutch, Estonian, Finnish, French, German, Greek, Hungarian, Italian, Norwegian Bokmål, Polish, Portuguese (Portugal & Brazil), Romanian, Russian, Spanish (Spain, Mexico, Colombia, Argentina, El Salvador), Swedish, Turkish, Ukrainian
+  - **English Variants**: Australia, Canada, Great Britain, Jamaica, South Africa
+- **New in 7.1.0**: Filipino (Tagalog — tl_PH) (#8481) and Malayalam (ml_IN) (#8480) locales added
 - **RTL Layout Support** – Tabler RTL layout with deduplicated skin bundles
 - **AI-Assisted Translation Skill** – New locale-translate skill for future translation workflows
+- **Locale Build System Consolidation** – Streamlined build scripts and POEditor integration (#8463)
 
 ## 📊 Dashboard & UI Redesigns
 
@@ -195,7 +206,7 @@ Every dashboard has been redesigned with the new Tabler aesthetic:
 - **200+ commits** since 7.0.5
 - **30+ features** and major improvements
 - **15+ bug fixes** addressing critical issues
-- **30+ languages** with complete translation coverage
+- **46 locales** with complete translation coverage (including 2 new languages)
 - **100% test coverage** for new APIs (Notes CRUD)
 - **0 npm vulnerabilities** (14 Dependabot alerts resolved)
 


### PR DESCRIPTION
- Set release date to April 5, 2026
- Add Export Landing Page (#8475), Person Custom Fields fix (#8474)
- Add Type-Safe SystemConfig getters (#8467), SQL injection patches (#8464)
- Add Filipino (tl_PH) and Malayalam (ml_IN) locales (#8481, #8480)
- Update locale count to 46, reorganize regional groupings
- Add Discord security webhook notifications, locale build consolidation
- Add 7.1.0 row to CHANGELOG.md releases table

https://claude.ai/code/session_01XVFjsJqQBVsxgscoyU7iCj