### PR TITLE
Add CSP nonce to admin export page inline script

### DIFF
--- a/src/admin/views/export.php
+++ b/src/admin/views/export.php
@@ -81,7 +81,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
 
 </div>
 
-<script>
+<script nonce="<?= SystemURLs::getCSPNonce() ?>">
 document.getElementById('exportChMeetingsBtn').addEventListener('click', function () {
     const btn = this;
     const originalHtml = btn.innerHTML;


### PR DESCRIPTION
## Summary

Follow-up to #8475 — the new `/admin/export` landing page had an inline `<script>` block missing the CSP nonce, causing the ChMeetings export button to be silently blocked when `bEnforceCSP` is enabled.

Note: A broader nonce audit is tracked in #8502, which fixes the same issue across 6 other pages.

## Changes

- `src/admin/views/export.php`: adds `nonce="<?= SystemURLs::getCSPNonce() ?>"` to the ChMeetings export `<script>` tag

## Testing

- `npm run build:php` ✅
- Manual: enable `bEnforceCSP`, visit `/admin/export`, confirm the ChMeetings export button works

## Related

- #8475 — the PR that introduced this page
- #8502 — companion PR fixing nonce on 6 other pages