### PR TITLE
Fix stored XSS in ListOption name rendering (GHSA-j9gv-26c7-3qrh)

### DIFF
--- a/src/CartToEvent.php
+++ b/src/CartToEvent.php
@@ -102,7 +102,7 @@ if (count($_SESSION['aPeopleCart']) > 0) {
                                                 </a>
                                             </div>
                                         </td>
-                                        <td><?= $person->getClsid() ? $person->getClassification()->getOptionName() : '<em class="text-muted">' . gettext('Unclassified') . '</em>' ?></td>
+                                        <td><?= $person->getClsid() ? InputUtils::escapeHTML($person->getClassification()->getOptionName()) : '<em class="text-muted">' . gettext('Unclassified') . '</em>' ?></td>
                                     </tr>
                                 <?php } ?>
                             </tbody>

--- a/src/CartToFamily.php
+++ b/src/CartToFamily.php
@@ -143,7 +143,7 @@ echo $sError;
                 $sRoleOptionsHTML .= sprintf(
                     '<option value="%s">%s</option>',
                     $roleOption->getOptionId(),
-                    $roleOption->getOptionName()
+                    InputUtils::escapeHTML($roleOption->getOptionName())
                 );
             }
 

--- a/src/ChurchCRM/utils/CustomFieldUtils.php
+++ b/src/ChurchCRM/utils/CustomFieldUtils.php
@@ -246,7 +246,7 @@ class CustomFieldUtils
                 echo '<option value="" disabled>-----------------------</option>';
 
                 foreach ($listOptions as $option) {
-                    echo '<option value="' . $option->getOptionId() . '"' . ($data == $option->getOptionId() ? ' selected' : '') . '>' . $option->getOptionName() . '</option>';
+                    echo '<option value="' . $option->getOptionId() . '"' . ($data == $option->getOptionId() ? ' selected' : '') . '>' . InputUtils::escapeHTML($option->getOptionName()) . '</option>';
                 }
 
                 echo '</select></div>';

--- a/src/GroupEditor.php
+++ b/src/GroupEditor.php
@@ -94,7 +94,7 @@ require_once __DIR__ . '/Include/Header.php';
                     if ($thisGroup->getType() == $groupType->getOptionId()) {
                         echo ' selected';
                     }
-                    echo '>' . $groupType->getOptionName() . '</option>';
+                    echo '>' . InputUtils::escapeHTML($groupType->getOptionName()) . '</option>';
                 } ?>
             </select>
             <?php

--- a/src/MemberRoleChange.php
+++ b/src/MemberRoleChange.php
@@ -112,7 +112,7 @@ require_once __DIR__ . '/Include/Header.php'
                     // Loop through all the possible roles
                     foreach ($allRoles as $role) {
                         $sSelected = ($iRoleID == $role->getOptionId()) ? 'selected' : '';
-                        echo '<option value="' . (int)$role->getOptionId() . '" ' . $sSelected . '>' . gettext($role->getOptionName()) . '</option>';
+                        echo '<option value="' . (int)$role->getOptionId() . '" ' . $sSelected . '>' . InputUtils::escapeHTML(gettext($role->getOptionName())) . '</option>';
                     }
                     ?>
                 </select>

--- a/src/external/templates/registration/family-register.php
+++ b/src/external/templates/registration/family-register.php
@@ -3,6 +3,7 @@
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\dto\SystemURLs;
 use ChurchCRM\dto\ChurchMetaData;
+use ChurchCRM\Utils\InputUtils;
 
 $sPageTitle = gettext("Family Registration");
 require(SystemURLs::getDocumentRoot() ."/Include/HeaderNotLoggedIn.php");
@@ -176,7 +177,7 @@ require(SystemURLs::getDocumentRoot() ."/Include/HeaderNotLoggedIn.php");
                                             <label><?= gettext('Role in Family') ?></label>
                                             <select class="form-select member-role">
                                                 <?php foreach ($familyRoles as $role) { ?>
-                                                    <option value="<?= $role->getOptionId() ?>"><?= $role->getOptionName() ?></option>
+                                                    <option value="<?= $role->getOptionId() ?>"><?= InputUtils::escapeHTML($role->getOptionName()) ?></option>
                                                 <?php } ?>
                                             </select>
                                         </div>


### PR DESCRIPTION
## Summary

- Wraps all `getOptionName()` HTML output with `InputUtils::escapeHTML()` across 6 files
- Prevents stored XSS attacks via crafted group role names, family roles, group type names, and custom field option names
- Adds `InputUtils` import to `family-register.php` (was missing)

## Files Changed

| File | Context |
|------|---------|
| `src/MemberRoleChange.php` | Group role dropdown options |
| `src/CartToFamily.php` | Family role dropdown options |
| `src/GroupEditor.php` | Group type dropdown options |
| `src/CartToEvent.php` | Classification name in table cell |
| `src/ChurchCRM/utils/CustomFieldUtils.php` | Custom field list option dropdowns |
| `src/external/templates/registration/family-register.php` | Family role options (public registration) |

## Why

`ListOption::getOptionName()` values are admin-entered strings stored in the database. Without output escaping, any admin who can manage group roles, family roles, or custom field options could inject persistent JavaScript into pages viewed by other users — including higher-privileged admins.

## Related

Fixes GHSA-j9gv-26c7-3qrh (CVE-2025-67876) — patched version set to 7.1.1 on the advisory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)