### PR TITLE
feat: add 7.1.1 UI feedback notification

### DIFF
--- a/notifications.json
+++ b/notifications.json
@@ -2,6 +2,17 @@
     "TTL": 300,
     "messages": [
         {
+            "id": "7.1.1-feedback",
+            "title": "How do you like the new look?",
+            "message": "ChurchCRM 7.1.1 shipped a redesigned UI — we'd love your feedback.",
+            "icon": "message-circle",
+            "type": "info",
+            "link": "https://github.com/ChurchCRM/CRM/discussions",
+            "adminOnly": false,
+            "targetVersionPattern": "7.1.*",
+            "timeout": 8000,
+            "placement": "bottom",
+            "align": "right"
         }
     ]
 }


### PR DESCRIPTION
## Summary

- Adds a dismissible in-app notification for users on 7.1.x asking for feedback on the redesigned UI
- Links to GitHub Discussions
- Targets `7.1.*` version pattern only
- Non-admin (shown to all users)

## notifications.json change

```json
{
    "id": "7.1.1-feedback",
    "title": "How do you like the new look?",
    "message": "ChurchCRM 7.1.1 shipped a redesigned UI — we'd love your feedback.",
    "icon": "message-circle",
    "type": "info",
    "link": "https://github.com/ChurchCRM/CRM/discussions",
    "adminOnly": false,
    "targetVersionPattern": "7.1.*",
    "timeout": 8000
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)