### PR TITLE
fix(ddev): remove empty OSTypes restriction from setup-churchcrm command

### DIFF
--- a/.ddev/commands/web/setup-churchcrm
+++ b/.ddev/commands/web/setup-churchcrm
@@ -7,7 +7,6 @@
 ## Flags: []
 ## AutocompleteTerminators: []
 ## CanRunGlobally: false
-## OSTypes: []
 
 set -e
 


### PR DESCRIPTION
## Problem

Running `ddev setup-churchcrm` fails on Linux (and likely all platforms) with:

> Command 'setup-churchcrm' cannot be used with your OS, skipping
> .ddev/commands/web/setup-churchcrm

## Cause

The command file declares:

```
## OSTypes: []
```

DDEV parses an empty `OSTypes` list as "no OSes allowed", so the command is skipped on every platform. The directive was likely added as a placeholder but the empty value silently disables the command.

## Fix (chosen)

Remove the `## OSTypes: []` line entirely. Per DDEV docs, omitting the directive means the command runs on all platforms — which is the intended behavior for this frontend-build helper (it only runs `npm` commands inside the web container, so host OS is irrelevant).

## Alternative considered

Explicitly list the supported host OSes instead of removing the directive:

```
## OSTypes: darwin,linux,windows
```

This would also fix the bug and documents intent. Rejected because:

- The command executes entirely inside the DDEV web container (`npm ci`, webpack build), so host OS genuinely does not matter.
- Any future OS DDEV adds support for would require another PR to add it to the list.
- Omission is the DDEV-idiomatic way to express "runs everywhere".

If maintainers prefer the explicit form for documentation value, I'm happy to switch the patch.

## Test plan

- [x] `ddev restart`
- [x] `ddev setup-churchcrm` runs successfully on Linux/WSL2
- [ ] Confirm it still runs on macOS and Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)