### PR TITLE
docs(readme): fix 404 on "Get Started" Documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Whether you’re a developer, designer, tester, or simply passionate about impro
 
 ## 🚀 Get Started
 
-If you're new to ChurchCRM, start with our **[Documentation](https://docs.churchcrm.io/manual/)**.
+If you're new to ChurchCRM, start with our **[Documentation](https://docs.churchcrm.io/)**.
 You'll find step-by-step installation instructions, configuration notes, and user guides there.
 
 Quick start: see the "Quick Start" section in the Documentation for a fast setup.


### PR DESCRIPTION
## Problem

The **Documentation** link under `## 🚀 Get Started` in `README.md` points to `https://docs.churchcrm.io/manual/`, which returns a GitHub Pages 404. New users landing on the repo and clicking the first "start here" link hit a blank page instead of the documentation.

## Fix

Point the link to `https://docs.churchcrm.io/` — the Docusaurus Welcome landing page of the ChurchCRM documentation. This is the same URL already used by the other two Documentation links in this file.

## Verification

- `curl -I https://docs.churchcrm.io/manual/` → `HTTP/2 404`
- `curl -I https://docs.churchcrm.io/` → `HTTP/2 200`
- Remaining README URLs checked; no other broken links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)