### PR TITLE
fix(admin): redesign system reset page UX

### DIFF
--- a/cypress/e2e/new-system/04-system-reset.spec.js
+++ b/cypress/e2e/new-system/04-system-reset.spec.js
@@ -77,9 +77,10 @@ describe('04 - System Reset', () => {
             manualLogin();
             cy.visit('/admin/system/reset');
 
-            // Danger banner at top
-            cy.get('.alert-danger', { timeout: 15000 }).should('be.visible');
-            cy.contains('Destructive Operation').should('be.visible');
+            // Danger banner at top — scope to the top warning banner so it
+            // doesn't match hidden backup status alerts also in the DOM.
+            cy.contains('.alert-danger', 'Destructive Operation', { timeout: 15000 })
+                .should('be.visible');
 
             // Reset button should be disabled until user types RESET
             cy.get('#resetBtn').should('be.disabled');

--- a/src/admin/views/system-reset.php
+++ b/src/admin/views/system-reset.php
@@ -44,14 +44,14 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
                     <label class="form-label"><?= gettext('Backup Type') ?></label>
                     <div class="form-selectgroup form-selectgroup-boxes d-flex flex-column gap-2">
                         <label class="form-selectgroup-item flex-fill">
-                            <input type="radio" name="archiveType" value="0" class="form-selectgroup-input" checked>
+                            <input type="radio" name="archiveType" value="2" class="form-selectgroup-input" checked>
                             <div class="form-selectgroup-label d-flex align-items-center p-3">
                                 <div class="me-3">
                                     <span class="form-selectgroup-check"></span>
                                 </div>
                                 <div>
                                     <strong><?= gettext('SQL Only') ?></strong>
-                                    <div class="text-secondary"><?= gettext('Database dump only (smaller, faster)') ?></div>
+                                    <div class="text-secondary"><?= gettext('Database dump only (.sql)') ?></div>
                                 </div>
                             </div>
                         </label>
@@ -116,13 +116,13 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
             </div>
             <div class="card-body">
                 <p class="text-secondary"><?= gettext('Resetting will permanently delete:') ?></p>
-                <ul class="list-unstyled space-y-1">
-                    <li><i class="ti ti-x text-danger me-1"></i><?= gettext('All people and family records') ?></li>
-                    <li><i class="ti ti-x text-danger me-1"></i><?= gettext('All groups, roles, and memberships') ?></li>
-                    <li><i class="ti ti-x text-danger me-1"></i><?= gettext('All financial data (pledges, payments, deposits)') ?></li>
-                    <li><i class="ti ti-x text-danger me-1"></i><?= gettext('All events and attendance records') ?></li>
-                    <li><i class="ti ti-x text-danger me-1"></i><?= gettext('All uploaded photos and documents') ?></li>
-                    <li><i class="ti ti-x text-danger me-1"></i><?= gettext('All system settings and custom fields') ?></li>
+                <ul class="list-unstyled">
+                    <li class="mb-1"><i class="ti ti-x text-danger me-1"></i><?= gettext('All people and family records') ?></li>
+                    <li class="mb-1"><i class="ti ti-x text-danger me-1"></i><?= gettext('All groups, roles, and memberships') ?></li>
+                    <li class="mb-1"><i class="ti ti-x text-danger me-1"></i><?= gettext('All financial data (pledges, payments, deposits)') ?></li>
+                    <li class="mb-1"><i class="ti ti-x text-danger me-1"></i><?= gettext('All events and attendance records') ?></li>
+                    <li class="mb-1"><i class="ti ti-x text-danger me-1"></i><?= gettext('All uploaded photos and documents') ?></li>
+                    <li class="mb-0"><i class="ti ti-x text-danger me-1"></i><?= gettext('All system settings and custom fields') ?></li>
                 </ul>
 
                 <div class="hr-text"><?= gettext('Confirm') ?></div>


### PR DESCRIPTION
## Summary

- **Replace jarring double-bootbox flow** (page-load "I AGREE" prompt + confirm dialog) with a modern Tabler two-card layout
- **Step 1: Create a Backup** — SQL-only or full backup selector with progress indicator and download button, giving admins one last chance to preserve data before reset
- **Step 2: Reset Database** — clear list of what gets deleted, type `RESET` to enable the button, single final confirmation dialog with spinner feedback
- **Danger alert banner** at the top clearly communicates the destructive nature of the page
- **Updated Cypress tests** to match the new UI selectors

## What changed

| Before | After |
|--------|-------|
| Immediate bootbox prompt blocks the page | Inline danger banner, no modal on load |
| "Warning!!!" with `rubberBand animated` | Clean Tabler alert with icon |
| Type "I AGREE" in a modal to see the page | Type `RESET` inline to enable the button |
| Two separate dialogs to confirm | One final confirmation dialog |
| No backup option on the page | Integrated backup with download |
| Narrow `col-lg-4` card | Two `col-lg-6` cards side-by-side |

## Test plan

- [ ] Visit `/admin/system/reset` — danger banner visible, reset button disabled
- [ ] Type `RESET` in confirm input — reset button becomes enabled
- [ ] Click "Generate & Download Backup" — progress bar shows, download button appears
- [ ] Click reset button — final confirmation modal appears with "Reset Database" danger button
- [ ] Confirm reset — spinner on button, credentials shown on success, redirect to login
- [ ] Cypress tests in `04-system-reset.spec.js` pass with updated selectors

https://claude.ai/code/session_018wpgjQEhtz8wPVZeP8uhVS