### PR TITLE
fix(ux): comprehensive mobile UX cleanup with cypress tests

### DIFF
--- a/cypress/e2e/ui/mobile/mobile-ux.spec.js
+++ b/cypress/e2e/ui/mobile/mobile-ux.spec.js
@@ -1,0 +1,166 @@
+/// <reference types="cypress" />
+
+/**
+ * Mobile UX Regression Tests
+ *
+ * Verifies that the mobile UX cleanup for logged-out pages, family
+ * registration, dashboards, profile views, and editors holds up on a
+ * 375×812 (iPhone X) viewport — no horizontal scroll, form fields stack,
+ * buttons wrap, touch targets are large enough.
+ */
+
+const MOBILE_VIEWPORT = [375, 812];
+
+/** Assert the document has no horizontal overflow at the current viewport. */
+function assertNoHorizontalOverflow() {
+    cy.document().then((doc) => {
+        const scrollWidth = doc.documentElement.scrollWidth;
+        const clientWidth = doc.documentElement.clientWidth;
+        // Allow 2px tolerance for rounding / scrollbar
+        expect(scrollWidth, "document scrollWidth").to.be.lessThan(clientWidth + 3);
+    });
+}
+
+describe("Mobile UX — Logged-Out Pages", () => {
+    beforeEach(() => {
+        cy.viewport(...MOBILE_VIEWPORT);
+    });
+
+    it("login page fits mobile viewport without horizontal scroll", () => {
+        cy.visit("/session/begin");
+        cy.get("body").should("have.class", "page-auth");
+        cy.get(".login-container").should("be.visible");
+        cy.get("input[name='User']").should("be.visible");
+        cy.get("input[name='Password']").should("be.visible");
+        cy.get(".btn-sign-in").should("be.visible");
+        assertNoHorizontalOverflow();
+    });
+
+    it("login inputs use 16px font to prevent iOS auto-zoom", () => {
+        cy.visit("/session/begin");
+        cy.get("input[name='User']").then(($el) => {
+            const fontSize = parseFloat($el.css("font-size"));
+            expect(fontSize, "input font-size").to.be.gte(16);
+        });
+    });
+
+    it("auth footer social icons meet 44px minimum touch target", () => {
+        cy.visit("/session/begin");
+        cy.get(".auth-footer-social a").first().then(($el) => {
+            const width = parseFloat($el.css("width"));
+            const height = parseFloat($el.css("height"));
+            expect(width, "social link width").to.be.gte(44);
+            expect(height, "social link height").to.be.gte(44);
+        });
+    });
+
+    it("password reset page fits mobile viewport", () => {
+        cy.visit("/session/forgot-password/reset-request");
+        cy.get(".forgot-password-card").should("be.visible");
+        cy.get("input[name='username']").should("be.visible");
+        cy.get(".btn-reset").should("be.visible");
+        assertNoHorizontalOverflow();
+    });
+
+    it("password reset error page fits mobile viewport", () => {
+        cy.visit("/session/forgot-password/set/invalid-token-mobile-test");
+        cy.get(".alert.alert-danger").should("be.visible");
+        cy.get(".alert-buttons a, .alert-buttons button")
+            .should("have.length.at.least", 1);
+        assertNoHorizontalOverflow();
+    });
+});
+
+describe("Mobile UX — Family Registration", () => {
+    beforeEach(() => {
+        cy.viewport(...MOBILE_VIEWPORT);
+    });
+
+    it("family register page fits mobile viewport and fields stack", () => {
+        cy.visit("/external/register/");
+        cy.get("#registration-stepper").should("be.visible");
+        cy.get("#familyName").should("be.visible");
+        cy.get("#familyAddress1").should("be.visible");
+        assertNoHorizontalOverflow();
+    });
+
+    it("family register form inputs use 16px font (iOS zoom prevention)", () => {
+        cy.visit("/external/register/");
+        cy.get("#familyName").then(($el) => {
+            const fontSize = parseFloat($el.css("font-size"));
+            expect(fontSize, "input font-size").to.be.gte(16);
+        });
+    });
+
+    it("family register step nav buttons take full width on mobile", () => {
+        cy.visit("/external/register/");
+        cy.get("#family-info-next").then(($btn) => {
+            const btnWidth = $btn.outerWidth();
+            const parentWidth = $btn.parent().innerWidth();
+            // Stacked buttons should be at least ~90% of parent width
+            expect(btnWidth / parentWidth, "button width ratio").to.be.gte(0.9);
+        });
+    });
+});
+
+describe("Mobile UX — Authenticated Pages", () => {
+    beforeEach(() => {
+        cy.viewport(...MOBILE_VIEWPORT);
+        cy.setupStandardSession();
+    });
+
+    it("root dashboard fits mobile viewport without horizontal scroll", () => {
+        cy.visit("/v2/dashboard");
+        cy.get(".page-body").should("be.visible");
+        assertNoHorizontalOverflow();
+    });
+
+    it("root dashboard member tables are wrapped in table-responsive", () => {
+        cy.visit("/v2/dashboard");
+        cy.get("#latestFamiliesDashboardItem")
+            .parents(".table-responsive")
+            .should("exist");
+        cy.get("#PersonBirthdayDashboardItem")
+            .parents(".table-responsive")
+            .should("exist");
+    });
+
+    it("groups dashboard fits mobile viewport", () => {
+        cy.visit("/v2/groups");
+        cy.get("#groupsTable")
+            .parents(".table-responsive")
+            .should("exist");
+        assertNoHorizontalOverflow();
+    });
+
+    it("family view stacks columns on mobile", () => {
+        cy.visit("/v2/family/1");
+        // Both main and sidebar columns should be visible (stacked on mobile)
+        cy.get(".col-12.col-lg-8").should("be.visible");
+        cy.get(".col-12.col-lg-4").should("be.visible");
+        assertNoHorizontalOverflow();
+    });
+
+    it("PersonEditor form fields stack full-width on mobile", () => {
+        cy.visit("/PersonEditor.php");
+        cy.get("#FirstName").should("be.visible").then(($el) => {
+            // First name field should take most of the viewport width (col-12 on mobile)
+            const fieldWidth = $el.closest(".mb-3").outerWidth();
+            const containerWidth = $el.closest(".row").innerWidth();
+            expect(fieldWidth / containerWidth, "first name column ratio")
+                .to.be.gte(0.9);
+        });
+        assertNoHorizontalOverflow();
+    });
+
+    it("FamilyEditor form fields stack full-width on mobile", () => {
+        cy.visit("/FamilyEditor.php");
+        cy.get("#FamilyName").should("be.visible").then(($el) => {
+            const fieldWidth = $el.closest(".mb-3").outerWidth();
+            const containerWidth = $el.closest(".row").innerWidth();
+            expect(fieldWidth / containerWidth, "family name column ratio")
+                .to.be.gte(0.9);
+        });
+        assertNoHorizontalOverflow();
+    });
+});

--- a/cypress/e2e/ui/mobile/mobile-ux.spec.js
+++ b/cypress/e2e/ui/mobile/mobile-ux.spec.js
@@ -112,6 +112,10 @@ describe("Mobile UX — Authenticated Pages", () => {
     it("root dashboard fits mobile viewport without horizontal scroll", () => {
         cy.visit("/v2/dashboard");
         cy.get(".page-body").should("be.visible");
+        // Wait for DataTables to finish initializing (async AJAX + render)
+        // before checking overflow, otherwise columns may still be resizing.
+        cy.get("#latestFamiliesDashboardItem_wrapper", { timeout: 15000 })
+            .should("be.visible");
         assertNoHorizontalOverflow();
     });
 
@@ -130,6 +134,9 @@ describe("Mobile UX — Authenticated Pages", () => {
         cy.get("#groupsTable")
             .parents(".table-responsive")
             .should("exist");
+        // Wait for DataTables to finish drawing so overflow reflects
+        // the final rendered width.
+        cy.get("#groupsTable_wrapper", { timeout: 15000 }).should("be.visible");
         assertNoHorizontalOverflow();
     });
 

--- a/src/FamilyEditor.php
+++ b/src/FamilyEditor.php
@@ -566,7 +566,7 @@ require_once __DIR__ . '/Include/Header.php';
         </div>
         <div class="card-body">
             <div class="row">
-                <div class="mb-3 col-md-6">
+                <div class="mb-3 col-12 col-md-6">
                     <label for="FamilyName"><?= gettext('Family Name') ?>:</label>
                     <div class="input-group">
                         <span class="input-group-text"><i class="fa-solid fa-people-roof"></i></span>
@@ -580,7 +580,7 @@ require_once __DIR__ . '/Include/Header.php';
                     if (empty($dWeddingDate)) {
                         $dWeddingDate = '';
                     } ?>
-                <div class="mb-3 col-md-4">
+                <div class="mb-3 col-12 col-sm-6 col-md-4">
                     <label for="WeddingDate"><?= gettext('Wedding Date') ?>:</label>
                     <div class="input-group">
                         <span class="input-group-text"><i class="fa-solid fa-heart"></i></span>
@@ -608,14 +608,14 @@ require_once __DIR__ . '/Include/Header.php';
                 </div>
             </div>
             <div class="row">
-                <div class="mb-3 col-md-6">
+                <div class="mb-3 col-12 col-md-6">
                     <label for="Address1"><?= gettext('Address') ?> 1:</label>
                     <div class="input-group">
                         <span class="input-group-text"><i class="fa-solid fa-location-dot"></i></span>
                         <input type="text" id="Address1" name="Address1" value="<?= InputUtils::escapeAttribute($sAddress1) ?>" maxlength="250" class="form-control">
                     </div>
                 </div>
-                <div class="mb-3 col-md-6">
+                <div class="mb-3 col-12 col-md-6">
                     <label for="Address2"><?= gettext('Address') ?> 2:</label>
                     <div class="input-group">
                         <span class="input-group-text"><i class="fa-solid fa-location-dot"></i></span>
@@ -624,23 +624,23 @@ require_once __DIR__ . '/Include/Header.php';
                 </div>
             </div>
             <div class="row">
-                <div class="mb-3 col-md-4">
+                <div class="mb-3 col-12 col-sm-6 col-md-4">
                     <label for="City"><?= gettext('City') ?>:</label>
                     <div class="input-group">
                         <span class="input-group-text"><i class="fa-solid fa-city"></i></span>
                         <input type="text" id="City" name="City" value="<?= InputUtils::escapeAttribute($sCity) ?>" maxlength="50" class="form-control">
                     </div>
                 </div>
-                <div id="stateOptionDiv" class="mb-3 col-md-3">
+                <div id="stateOptionDiv" class="mb-3 col-12 col-sm-6 col-md-3">
                     <label for="State"><?= gettext('State') ?>:</label>
                     <select id="State" name="State" class="form-select" data-user-selected="<?= InputUtils::escapeAttribute($sState) ?>" data-system-default="<?= SystemConfig::getValueForAttr('sDefaultState') ?>">
                     </select>
                 </div>
-                <div id="stateInputDiv" class="mb-3 col-md-3 d-none">
+                <div id="stateInputDiv" class="mb-3 col-12 col-sm-6 col-md-3 d-none">
                     <label for="StateTextbox"><?= gettext('State') ?>:</label>
                     <input id="StateTextbox" type="text" class="form-control" name="StateTextbox" value="<?= InputUtils::escapeAttribute($sState) ?>" maxlength="30">
                 </div>
-                <div class="mb-3 col-md-2">
+                <div class="mb-3 col-6 col-md-2">
                     <label for="Zip"><?= gettext('Zip') ?>:</label>
                     <input type="text" id="Zip" name="Zip" class="form-control" <?php
                     if (SystemConfig::getBooleanValue('bForceUppercaseZip')) {
@@ -648,7 +648,7 @@ require_once __DIR__ . '/Include/Header.php';
                     }
                     echo 'value="' . InputUtils::escapeAttribute($sZip) . '" '; ?> maxlength="10">
                 </div>
-                <div class="mb-3 col-md-3">
+                <div class="mb-3 col-12 col-sm-6 col-md-3">
                     <label for="Country"><?= gettext('Country') ?>:</label>
                     <select id="Country" name="Country" class="form-select" data-user-selected="<?= InputUtils::escapeAttribute($sCountry) ?>" data-system-default="<?= SystemConfig::getValueForAttr('sDefaultCountry') ?>">
                     </select>
@@ -658,14 +658,14 @@ require_once __DIR__ . '/Include/Header.php';
                 if (!$bHaveXML) { // No point entering if values will just be overwritten
                     ?>
                     <div class="row">
-                        <div class="mb-3 col-md-3">
+                        <div class="mb-3 col-12 col-sm-6 col-md-3">
                             <label for="Latitude"><?= gettext('Latitude') ?>:</label>
                             <div class="input-group">
                                 <span class="input-group-text"><i class="fa-solid fa-globe"></i></span>
                                 <input type="text" class="form-control" id="Latitude" name="Latitude" value="<?= $nLatitude && $nLatitude !== 0 ? $nLatitude : '' ?>" maxlength="50">
                             </div>
                         </div>
-                        <div class="mb-3 col-md-3">
+                        <div class="mb-3 col-12 col-sm-6 col-md-3">
                             <label for="Longitude"><?= gettext('Longitude') ?>:</label>
                             <div class="input-group">
                                 <span class="input-group-text"><i class="fa-solid fa-globe"></i></span>
@@ -684,7 +684,7 @@ require_once __DIR__ . '/Include/Header.php';
                 </div>
             </div>
             <div class="row">
-                <div class="mb-3 col-md-6">
+                <div class="mb-3 col-12 col-md-6">
                     <label for="HomePhone"><?= gettext('Home Phone') ?>:</label>
                     <div class="input-group">
                         <span class="input-group-text"><i class="fa-solid fa-house"></i></span>
@@ -695,7 +695,7 @@ require_once __DIR__ . '/Include/Header.php';
                         </span>
                     </div>
                 </div>
-                <div class="mb-3 col-md-6">
+                <div class="mb-3 col-12 col-md-6">
                     <label for="Email"><?= gettext('Email') ?>:</label>
                     <div class="input-group">
                         <span class="input-group-text"><i class="fa-solid fa-at"></i></span>
@@ -708,7 +708,7 @@ require_once __DIR__ . '/Include/Header.php';
             </div>
             <?php if (!SystemConfig::getBooleanValue('bHideFamilyNewsletter')) { /* Newsletter can be hidden - General Settings */ ?>
             <div class="row">
-                <div class="mb-3 col-md-6">
+                <div class="mb-3 col-12 col-md-6">
                     <div class="form-check">
                         <input type="checkbox" class="form-check-input" id="SendNewsLetter" name="SendNewsLetter" value="1" <?= $bSendNewsLetter ? 'checked' : '' ?>>
                         <label class="form-check-label" for="SendNewsLetter"><?= gettext('Send Newsletter') ?></label>
@@ -724,7 +724,7 @@ require_once __DIR__ . '/Include/Header.php';
                 <h3 class="card-title"><?= gettext('Envelope Info') ?></h3>
             <div class="card-body">
                 <div class="row">
-                    <div class="mb-3 col-md-4">
+                    <div class="mb-3 col-12 col-sm-6 col-md-4">
                         <label for="Envelope"><?= gettext('Envelope Number') ?>:</label>
                         <div class="input-group">
                             <span class="input-group-text"><i class="fa-solid fa-envelope-open-text"></i></span>
@@ -751,7 +751,7 @@ require_once __DIR__ . '/Include/Header.php';
                     if (AuthenticationManager::getCurrentUser()->isEnabledSecurity($aSecurityType[$fam_custom_FieldSec])) {
                         ?>
                         <div class="row">
-                            <div class="mb-3 col-md-6">
+                            <div class="mb-3 col-12 col-md-6">
                                 <label for="<?= $fam_custom_Field ?>"><?= $fam_custom_Name ?></label>
                         <?php $currentFieldData = trim($aCustomData[$fam_custom_Field]);
 

--- a/src/FamilyEditor.php
+++ b/src/FamilyEditor.php
@@ -640,7 +640,7 @@ require_once __DIR__ . '/Include/Header.php';
                     <label for="StateTextbox"><?= gettext('State') ?>:</label>
                     <input id="StateTextbox" type="text" class="form-control" name="StateTextbox" value="<?= InputUtils::escapeAttribute($sState) ?>" maxlength="30">
                 </div>
-                <div class="mb-3 col-6 col-md-2">
+                <div class="mb-3 col-12 col-sm-6 col-md-2">
                     <label for="Zip"><?= gettext('Zip') ?>:</label>
                     <input type="text" id="Zip" name="Zip" class="form-control" <?php
                     if (SystemConfig::getBooleanValue('bForceUppercaseZip')) {

--- a/src/PersonEditor.php
+++ b/src/PersonEditor.php
@@ -604,13 +604,13 @@ require_once __DIR__ . '/Include/Header.php';
         </div>
         <div class="card-body">
             <div class="row">
-                <div class="mb-3 col-md-2">
+                <div class="mb-3 col-6 col-md-2">
                     <label for="Title"><?= gettext('Title') ?>:</label>
                     <input type="text" name="Title" id="Title"
                            value="<?= InputUtils::escapeAttribute(stripslashes($sTitle)) ?>"
                            class="form-control" placeholder="<?= gettext('Mr., Mrs., Dr.') ?>">
                 </div>
-                <div class="mb-3 col-md-3">
+                <div class="mb-3 col-12 col-sm-6 col-md-3">
                     <label for="FirstName"><?= gettext('First Name') ?>:</label>
                     <input type="text" name="FirstName" id="FirstName"
                            value="<?= InputUtils::escapeAttribute(stripslashes($sFirstName)) ?>"
@@ -619,7 +619,7 @@ require_once __DIR__ . '/Include/Header.php';
                         <span class="text-danger small"><?= $sFirstNameError ?></span>
                     <?php } ?>
                 </div>
-                <div class="mb-3 col-md-2">
+                <div class="mb-3 col-6 col-md-2">
                     <label for="MiddleName"><?= gettext('Middle') ?>:</label>
                     <input type="text" name="MiddleName" id="MiddleName"
                            value="<?= InputUtils::escapeAttribute(stripslashes($sMiddleName)) ?>"
@@ -628,7 +628,7 @@ require_once __DIR__ . '/Include/Header.php';
                         <span class="text-danger small"><?= $sMiddleNameError ?></span>
                     <?php } ?>
                 </div>
-                <div class="mb-3 col-md-3">
+                <div class="mb-3 col-12 col-sm-6 col-md-3">
                     <label for="LastName"><?= gettext('Last Name') ?>:</label>
                     <input type="text" name="LastName" id="LastName"
                            value="<?= InputUtils::escapeAttribute(stripslashes($sLastName)) ?>"
@@ -637,13 +637,13 @@ require_once __DIR__ . '/Include/Header.php';
                         <span class="text-danger small"><?= $sLastNameError ?></span>
                     <?php } ?>
                 </div>
-                <div class="mb-3 col-md-1">
+                <div class="mb-3 col-4 col-md-1">
                     <label for="Suffix"><?= gettext('Suffix') ?>:</label>
                     <input type="text" name="Suffix" id="Suffix"
                            value="<?= InputUtils::escapeAttribute(stripslashes($sSuffix)) ?>"
                            placeholder="<?= gettext('Jr., Sr.') ?>" class="form-control">
                 </div>
-                <div class="mb-3 col-md-1">
+                <div class="mb-3 col-4 col-md-1">
                     <label for="Gender"><?= gettext('Gender') ?>:</label>
                     <select id="Gender" name="Gender" class="form-select">
                         <option value="0">-</option>
@@ -662,7 +662,7 @@ require_once __DIR__ . '/Include/Header.php';
         </div>
         <div class="card-body">
             <div class="row">
-                <div class="mb-3 col-md-2">
+                <div class="mb-3 col-6 col-md-2">
                     <label for="BirthMonth"><?= gettext('Birth Month') ?>:</label>
                     <select id="BirthMonth" name="BirthMonth" class="form-select">
                         <option value="0" <?= $iBirthMonth === 0 ? 'selected' : '' ?>>-</option>
@@ -680,7 +680,7 @@ require_once __DIR__ . '/Include/Header.php';
                         <option value="12" <?= $iBirthMonth === 12 ? 'selected' : '' ?>><?= gettext('Dec') ?></option>
                     </select>
                 </div>
-                <div class="mb-3 col-md-1">
+                <div class="mb-3 col-4 col-md-1">
                     <label for="BirthDay"><?= gettext('Day') ?>:</label>
                     <select id="BirthDay" name="BirthDay" class="form-select">
                         <option value="0">-</option>
@@ -690,7 +690,7 @@ require_once __DIR__ . '/Include/Header.php';
                         <?php } ?>
                     </select>
                 </div>
-                <div class="mb-3 col-md-1">
+                <div class="mb-3 col-4 col-md-1">
                     <label for="BirthYear"><?= gettext('Year') ?>:</label>
                     <input type="text" id="BirthYear" name="BirthYear" value="<?= $iBirthYear ?>"
                            maxlength="4" placeholder="YYYY" class="form-control">
@@ -701,13 +701,13 @@ require_once __DIR__ . '/Include/Header.php';
                         <span class="text-danger small"><?= $sBirthDateError ?></span>
                     <?php } ?>
                 </div>
-                <div class="mb-3 col-md-1">
+                <div class="mb-3 col-4 col-md-1">
                     <label for="HideAge"><?= gettext('Hide Age') ?></label>
                     <div class="form-check mt-2">
                         <input type="checkbox" class="form-check-input" id="HideAge" name="HideAge" value="1" <?= $bHideAge ? 'checked' : '' ?>>
                     </div>
                 </div>
-                <div class="mb-3 col-md-4">
+                <div class="mb-3 col-12 col-sm-6 col-md-4">
                     <label for="familyId"><?= gettext('Family') ?>:</label>
                     <select name="Family" id="familyId" class="form-select">
                         <option value="0" selected><?= gettext('Unassigned') ?></option>
@@ -724,7 +724,7 @@ require_once __DIR__ . '/Include/Header.php';
                         } ?>
                     </select>
                 </div>
-                <div class="mb-3 col-md-3">
+                <div class="mb-3 col-12 col-sm-6 col-md-3">
                     <label for="FamilyRole"><?= gettext('Family Role') ?>:</label>
                     <select name="FamilyRole" id="FamilyRole" class="form-select">
                         <option value="0"><?= gettext('Unassigned') ?></option>
@@ -751,7 +751,7 @@ require_once __DIR__ . '/Include/Header.php';
         </div>
         <div class="card-body">
             <div class="row">
-                <div class="mb-3 col-md-6">
+                <div class="mb-3 col-12 col-md-6">
                     <label for="Address1">
                         <?= $bFamilyAddress1 ? '<span class="text-danger">' : '' ?>
                         <?= gettext('Address') ?> 1:
@@ -764,7 +764,7 @@ require_once __DIR__ . '/Include/Header.php';
                                maxlength="250" class="form-control">
                     </div>
                 </div>
-                <div class="mb-3 col-md-6">
+                <div class="mb-3 col-12 col-md-6">
                     <label for="Address2">
                         <?= $bFamilyAddress2 ? '<span class="text-danger">' : '' ?>
                         <?= gettext('Address') ?> 2:
@@ -776,7 +776,7 @@ require_once __DIR__ . '/Include/Header.php';
                 </div>
             </div>
             <div class="row">
-                <div class="mb-3 col-md-4">
+                <div class="mb-3 col-12 col-sm-6 col-md-4">
                     <label for="City">
                         <?= $bFamilyCity ? '<span class="text-danger">' : '' ?>
                         <?= gettext('City') ?>:
@@ -786,7 +786,7 @@ require_once __DIR__ . '/Include/Header.php';
                            value="<?= InputUtils::escapeAttribute(stripslashes($sCity)) ?>"
                            class="form-control">
                 </div>
-                <div id="stateOptionDiv" class="mb-3 col-md-3">
+                <div id="stateOptionDiv" class="mb-3 col-12 col-sm-6 col-md-3">
                     <label for="State">
                         <?= $bFamilyState ? '<span class="text-danger">' : '' ?>
                         <?= gettext('State') ?>:
@@ -795,13 +795,13 @@ require_once __DIR__ . '/Include/Header.php';
                     <select id="State" name="State" class="form-select" data-user-selected="<?= InputUtils::escapeAttribute($sState) ?>" data-system-default="<?= InputUtils::escapeAttribute(SystemConfig::getValue('sDefaultState')) ?>">
                     </select>
                 </div>
-                <div id="stateInputDiv" class="mb-3 col-md-3 d-none">
+                <div id="stateInputDiv" class="mb-3 col-12 col-sm-6 col-md-3 d-none">
                     <label for="StateTextbox"><?= gettext('State (Other)') ?>:</label>
                     <input type="text" name="StateTextbox" id="StateTextbox"
                            value="<?= InputUtils::escapeAttribute(stripslashes($sState)) ?>"
                            maxlength="30" class="form-control">
                 </div>
-                <div class="mb-3 col-md-2">
+                <div class="mb-3 col-6 col-md-2">
                     <label for="Zip">
                         <?= $bFamilyZip ? '<span class="text-danger">' : '' ?>
                         <?= gettext('Zip Code') ?>:
@@ -812,7 +812,7 @@ require_once __DIR__ . '/Include/Header.php';
                            value="<?= InputUtils::escapeAttribute(stripslashes($sZip)) ?>"
                            maxlength="10">
                 </div>
-                <div class="mb-3 col-md-3">
+                <div class="mb-3 col-12 col-sm-6 col-md-3">
                     <label for="Country">
                         <?= $bFamilyCountry ? '<span class="text-danger">' : '' ?>
                         <?= gettext('Country') ?>:
@@ -842,7 +842,7 @@ require_once __DIR__ . '/Include/Header.php';
         <div class="card-body">
             <div class="row">
                 <!-- Phones Column -->
-                <div class="col-md-6">
+                <div class="col-12 col-md-6">
                     <div class="mb-3">
                         <label for="HomePhone">
                             <?php
@@ -912,7 +912,7 @@ require_once __DIR__ . '/Include/Header.php';
                 </div>
 
                 <!-- Emails Column -->
-                <div class="col-md-6">
+                <div class="col-12 col-md-6">
                     <div class="mb-3">
                         <label for="Email">
                             <?php
@@ -957,7 +957,7 @@ require_once __DIR__ . '/Include/Header.php';
         </div>
         <div class="card-body">
             <div class="row">
-                <div class="mb-3 col-md-4">
+                <div class="mb-3 col-12 col-sm-6 col-md-4">
                     <label for="Facebook">Facebook:</label>
                     <div class="input-group">
                         <span class="input-group-text"><i class="fa-brands fa-facebook"></i></span>
@@ -969,7 +969,7 @@ require_once __DIR__ . '/Include/Header.php';
                         <span class="text-danger small"><?= $sFacebookError ?></span>
                     <?php } ?>
                 </div>
-                <div class="mb-3 col-md-4">
+                <div class="mb-3 col-12 col-sm-6 col-md-4">
                     <label for="Twitter">X:</label>
                     <div class="input-group">
                         <span class="input-group-text"><i class="fa-brands fa-x-twitter"></i></span>
@@ -981,7 +981,7 @@ require_once __DIR__ . '/Include/Header.php';
                         <span class="text-danger small"><?= $sTwitterError ?></span>
                     <?php } ?>
                 </div>
-                <div class="mb-3 col-md-4">
+                <div class="mb-3 col-12 col-sm-6 col-md-4">
                     <label for="LinkedIn">LinkedIn:</label>
                     <div class="input-group">
                         <span class="input-group-text"><i class="fa-brands fa-linkedin"></i></span>
@@ -1004,7 +1004,7 @@ require_once __DIR__ . '/Include/Header.php';
         </div>
         <div class="card-body">
             <div class="row">
-                <div class="mb-3 col-md-3">
+                <div class="mb-3 col-12 col-sm-6 col-md-3">
                     <label for="Classification"><?= gettext('Classification') ?>:</label>
                     <select id="Classification" name="Classification" class="form-select">
                         <option value="0"><?= gettext('Unassigned') ?></option>
@@ -1020,7 +1020,7 @@ require_once __DIR__ . '/Include/Header.php';
                         ?>
                     </select>
                 </div>
-                <div class="mb-3 col-md-3">
+                <div class="mb-3 col-12 col-sm-6 col-md-3">
                     <label for="MembershipDate"><?= gettext('Membership Date') ?>:</label>
                     <div class="input-group">
                         <span class="input-group-text"><i class="fa-solid fa-calendar"></i></span>
@@ -1033,7 +1033,7 @@ require_once __DIR__ . '/Include/Header.php';
                     <?php } ?>
                 </div>
                 <?php if (!SystemConfig::getBooleanValue('bHideFriendDate')) { ?>
-                <div class="mb-3 col-md-3">
+                <div class="mb-3 col-12 col-sm-6 col-md-3">
                     <label for="FriendDate"><?= gettext('Friend Date') ?>:</label>
                     <div class="input-group">
                         <span class="input-group-text"><i class="fa-solid fa-handshake"></i></span>
@@ -1061,7 +1061,7 @@ require_once __DIR__ . '/Include/Header.php';
                     while ($rowCustomField = mysqli_fetch_array($rsCustomFields, MYSQLI_BOTH)) {
                         extract($rowCustomField);
                         if (AuthenticationManager::getCurrentUser()->isEnabledSecurity($aSecurityType[$custom_FieldSec])) {
-                            echo '<div class="row"><div class="mb-3 col-md-6"><label for="' . $custom_Field . '">' . $custom_Name . '</label>';
+                            echo '<div class="row"><div class="mb-3 col-12 col-md-6"><label for="' . $custom_Field . '">' . $custom_Name . '</label>';
 
                             if (array_key_exists($custom_Field, $aCustomData)) {
                                 $currentFieldData = trim($aCustomData[$custom_Field]);

--- a/src/PersonEditor.php
+++ b/src/PersonEditor.php
@@ -604,7 +604,7 @@ require_once __DIR__ . '/Include/Header.php';
         </div>
         <div class="card-body">
             <div class="row">
-                <div class="mb-3 col-6 col-md-2">
+                <div class="mb-3 col-12 col-sm-6 col-md-2">
                     <label for="Title"><?= gettext('Title') ?>:</label>
                     <input type="text" name="Title" id="Title"
                            value="<?= InputUtils::escapeAttribute(stripslashes($sTitle)) ?>"
@@ -619,7 +619,7 @@ require_once __DIR__ . '/Include/Header.php';
                         <span class="text-danger small"><?= $sFirstNameError ?></span>
                     <?php } ?>
                 </div>
-                <div class="mb-3 col-6 col-md-2">
+                <div class="mb-3 col-12 col-sm-6 col-md-2">
                     <label for="MiddleName"><?= gettext('Middle') ?>:</label>
                     <input type="text" name="MiddleName" id="MiddleName"
                            value="<?= InputUtils::escapeAttribute(stripslashes($sMiddleName)) ?>"
@@ -637,13 +637,13 @@ require_once __DIR__ . '/Include/Header.php';
                         <span class="text-danger small"><?= $sLastNameError ?></span>
                     <?php } ?>
                 </div>
-                <div class="mb-3 col-4 col-md-1">
+                <div class="mb-3 col-6 col-sm-4 col-md-1">
                     <label for="Suffix"><?= gettext('Suffix') ?>:</label>
                     <input type="text" name="Suffix" id="Suffix"
                            value="<?= InputUtils::escapeAttribute(stripslashes($sSuffix)) ?>"
                            placeholder="<?= gettext('Jr., Sr.') ?>" class="form-control">
                 </div>
-                <div class="mb-3 col-4 col-md-1">
+                <div class="mb-3 col-6 col-sm-4 col-md-1">
                     <label for="Gender"><?= gettext('Gender') ?>:</label>
                     <select id="Gender" name="Gender" class="form-select">
                         <option value="0">-</option>
@@ -662,7 +662,7 @@ require_once __DIR__ . '/Include/Header.php';
         </div>
         <div class="card-body">
             <div class="row">
-                <div class="mb-3 col-6 col-md-2">
+                <div class="mb-3 col-12 col-sm-6 col-md-2">
                     <label for="BirthMonth"><?= gettext('Birth Month') ?>:</label>
                     <select id="BirthMonth" name="BirthMonth" class="form-select">
                         <option value="0" <?= $iBirthMonth === 0 ? 'selected' : '' ?>>-</option>
@@ -680,7 +680,7 @@ require_once __DIR__ . '/Include/Header.php';
                         <option value="12" <?= $iBirthMonth === 12 ? 'selected' : '' ?>><?= gettext('Dec') ?></option>
                     </select>
                 </div>
-                <div class="mb-3 col-4 col-md-1">
+                <div class="mb-3 col-6 col-sm-4 col-md-1">
                     <label for="BirthDay"><?= gettext('Day') ?>:</label>
                     <select id="BirthDay" name="BirthDay" class="form-select">
                         <option value="0">-</option>
@@ -690,7 +690,7 @@ require_once __DIR__ . '/Include/Header.php';
                         <?php } ?>
                     </select>
                 </div>
-                <div class="mb-3 col-4 col-md-1">
+                <div class="mb-3 col-6 col-sm-4 col-md-1">
                     <label for="BirthYear"><?= gettext('Year') ?>:</label>
                     <input type="text" id="BirthYear" name="BirthYear" value="<?= $iBirthYear ?>"
                            maxlength="4" placeholder="YYYY" class="form-control">
@@ -701,7 +701,7 @@ require_once __DIR__ . '/Include/Header.php';
                         <span class="text-danger small"><?= $sBirthDateError ?></span>
                     <?php } ?>
                 </div>
-                <div class="mb-3 col-4 col-md-1">
+                <div class="mb-3 col-6 col-sm-4 col-md-1">
                     <label for="HideAge"><?= gettext('Hide Age') ?></label>
                     <div class="form-check mt-2">
                         <input type="checkbox" class="form-check-input" id="HideAge" name="HideAge" value="1" <?= $bHideAge ? 'checked' : '' ?>>
@@ -801,7 +801,7 @@ require_once __DIR__ . '/Include/Header.php';
                            value="<?= InputUtils::escapeAttribute(stripslashes($sState)) ?>"
                            maxlength="30" class="form-control">
                 </div>
-                <div class="mb-3 col-6 col-md-2">
+                <div class="mb-3 col-12 col-sm-6 col-md-2">
                     <label for="Zip">
                         <?= $bFamilyZip ? '<span class="text-danger">' : '' ?>
                         <?= gettext('Zip Code') ?>:

--- a/src/external/templates/registration/family-register.php
+++ b/src/external/templates/registration/family-register.php
@@ -22,7 +22,7 @@ require(SystemURLs::getDocumentRoot() ."/Include/HeaderNotLoggedIn.php");
         }
     };
 </script>
-<div class="register-box" style="width: 90%; max-width: 900px;">
+<div class="register-box" style="max-width: 900px;">
     <div class="register-logo text-center mb-4">
         <a href="<?= SystemURLs::getRootPath() ?>/" class="h2"><?= ChurchMetaData::getChurchName() ?></a>
         <p class="text-muted mt-2"><?= gettext("We're so glad you're here! Register your family in just 3 easy steps.") ?></p>

--- a/src/groups/views/dashboard.php
+++ b/src/groups/views/dashboard.php
@@ -143,7 +143,9 @@ $totalMemberships = Person2group2roleP2g2rQuery::create()->count();
                     </h5>
                 </div>
                 <div class="card-body" style="overflow: visible;">
-                    <table class="table" id="groupsTable"></table>
+                    <div class="table-responsive">
+                        <table class="table" id="groupsTable"></table>
+                    </div>
                 </div>
             </div>
 

--- a/src/groups/views/sundayschool/dashboard.php
+++ b/src/groups/views/sundayschool/dashboard.php
@@ -10,8 +10,8 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
 ?>
 
 <!-- Stat Cards Row -->
-<div class="row mb-3">
-    <div class="col-6 col-lg-2">
+<div class="row row-cards mb-3 g-2">
+    <div class="col-6 col-md-4 col-lg-2">
         <div class="card card-sm">
             <div class="card-body">
                 <div class="row align-items-center">
@@ -28,7 +28,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
             </div>
         </div>
     </div>
-    <div class="col-6 col-lg-2">
+    <div class="col-6 col-md-4 col-lg-2">
         <div class="card card-sm">
             <div class="card-body">
                 <div class="row align-items-center">
@@ -45,7 +45,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
             </div>
         </div>
     </div>
-    <div class="col-6 col-lg-2">
+    <div class="col-6 col-md-4 col-lg-2">
         <div class="card card-sm">
             <div class="card-body">
                 <div class="row align-items-center">
@@ -62,7 +62,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
             </div>
         </div>
     </div>
-    <div class="col-6 col-lg-2">
+    <div class="col-6 col-md-4 col-lg-2">
         <div class="card card-sm">
             <div class="card-body">
                 <div class="row align-items-center">
@@ -79,7 +79,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
             </div>
         </div>
     </div>
-    <div class="col-6 col-lg-2">
+    <div class="col-6 col-md-4 col-lg-2">
         <div class="card card-sm">
             <div class="card-body">
                 <div class="row align-items-center">
@@ -96,7 +96,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
             </div>
         </div>
     </div>
-    <div class="col-6 col-lg-2">
+    <div class="col-6 col-md-4 col-lg-2">
         <div class="card card-sm">
             <div class="card-body">
                 <div class="row align-items-center">

--- a/src/skin/scss/_authentication-pages.scss
+++ b/src/skin/scss/_authentication-pages.scss
@@ -283,6 +283,8 @@ body.page-auth .mb-3 {
   text-align: center !important;
   font-weight: 300 !important;
   font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Courier New', monospace;
+  max-width: 100%;
+  box-sizing: border-box;
 }
 
 // Form footer with links
@@ -588,6 +590,7 @@ body.page-auth .alert {
   z-index: 3;
   margin-top: auto;
   padding: 40px 20px 20px;
+  padding-bottom: max(20px, env(safe-area-inset-bottom));
   text-align: center;
   color: rgba(255, 255, 255, 0.8);
   font-size: 13px;
@@ -606,13 +609,18 @@ body.page-auth .alert {
 
 .auth-footer-social {
   margin-top: 15px;
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 10px;
 
   a {
-    display: inline-block;
-    margin: 0 8px;
-    width: 32px;
-    height: 32px;
-    line-height: 32px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    // 44px minimum touch target per Apple/Google guidelines
+    width: 44px;
+    height: 44px;
     border-radius: 50%;
     background: rgba(255, 255, 255, 0.15);
     transition: all 0.2s;
@@ -624,7 +632,7 @@ body.page-auth .alert {
     }
 
     i {
-      font-size: 14px;
+      font-size: 16px;
     }
   }
 }
@@ -850,6 +858,20 @@ body.page-auth .btn {
   }
 
   .register-benefits li {
+    font-size: 12px;
+  }
+
+  // 2FA code input — reduce size to prevent overflow on narrow screens
+  #TwoFACode {
+    font-size: 1.5em !important;
+    letter-spacing: 0.2em !important;
+    padding: 10px 8px !important;
+  }
+
+  // Footer — reduce top padding on mobile, keep touch targets
+  .auth-footer {
+    padding: 24px 16px 16px;
+    padding-bottom: max(16px, env(safe-area-inset-bottom));
     font-size: 12px;
   }
 }

--- a/src/v2/templates/people/family-view.php
+++ b/src/v2/templates/people/family-view.php
@@ -44,7 +44,7 @@ $otherPeople = $family->getOtherPeople();
 
 <div class="row">
     <!-- LEFT COLUMN: Actions, Members, Timeline -->
-    <div class="col-lg-8">
+    <div class="col-12 col-lg-8">
         <!-- Family Action Toolbar -->
         <div class="d-flex align-items-center mb-3 gap-2 flex-wrap d-print-none">
             <?php if (AuthenticationManager::getCurrentUser()->isEditRecordsEnabled()) { ?>
@@ -144,7 +144,7 @@ $otherPeople = $family->getOtherPeople();
             if (empty($members)) { return; } ?>
             <div class="mb-1">
                 <?php renderSectionHeader($label, $icon, $color, count($members)); ?>
-                <div style="overflow: visible;">
+                <div class="table-responsive">
                     <table class="table table-vcenter card-table mb-0">
                         <thead>
                             <tr>
@@ -218,7 +218,7 @@ $otherPeople = $family->getOtherPeople();
         ?>
             <div class="mb-1">
                 <?php renderSectionHeader($label, $icon, $color, count($members)); ?>
-                <div style="overflow: visible;">
+                <div class="table-responsive">
                     <table class="table table-vcenter card-table mb-0">
                         <thead>
                             <tr>
@@ -353,7 +353,7 @@ $otherPeople = $family->getOtherPeople();
     </div>
 
     <!-- RIGHT COLUMN: Navigation, Photo, Address, Contact, Properties -->
-    <div class="col-lg-4">
+    <div class="col-12 col-lg-4">
         <!-- Family Navigation -->
         <div class="d-flex justify-content-between align-items-center mb-3">
             <a href="<?= SystemURLs::getRootPath()?>/v2/family" class="btn btn-outline-secondary btn-sm">
@@ -569,7 +569,7 @@ if (AuthenticationManager::getCurrentUser()->isFinanceEnabled()) { ?>
                     </ul>
                 </div>
             </div>
-            <div class="table-responsive" style="overflow: visible;">
+            <div class="table-responsive">
                 <table id="pledge-payment-v2-table" class="table table-vcenter card-table" style="width: 100%;">
                     <tbody></tbody>
                 </table>

--- a/src/v2/templates/root/dashboard.php
+++ b/src/v2/templates/root/dashboard.php
@@ -7,8 +7,8 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
 ?>
 
 <!-- Stat Cards Row -->
-<div class="row mb-3">
-    <div class="col-6 col-lg">
+<div class="row row-cards mb-3 g-2">
+    <div class="col-6 col-md-4 col-lg">
         <div class="card card-sm">
             <div class="card-body">
                 <div class="row align-items-center">
@@ -25,7 +25,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
             </div>
         </div>
     </div>
-    <div class="col-6 col-lg">
+    <div class="col-6 col-md-4 col-lg">
         <div class="card card-sm">
             <div class="card-body">
                 <div class="row align-items-center">
@@ -42,7 +42,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
             </div>
         </div>
     </div>
-    <div class="col-6 col-lg">
+    <div class="col-6 col-md-4 col-lg">
         <div class="card card-sm">
             <div class="card-body">
                 <div class="row align-items-center">
@@ -59,7 +59,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
             </div>
         </div>
     </div>
-    <div class="col-6 col-lg">
+    <div class="col-6 col-md-4 col-lg">
         <div class="card card-sm<?= $sundaySchoolEnabled ? '' : ' opacity-50' ?>">
             <div class="card-body">
                 <div class="row align-items-center">
@@ -81,7 +81,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
             </div>
         </div>
     </div>
-    <div class="col-6 col-lg">
+    <div class="col-6 col-md-4 col-lg">
         <div class="card card-sm<?= $eventsEnabled ? '' : ' opacity-50' ?>">
             <div class="card-body">
                 <div class="row align-items-center">
@@ -141,16 +141,24 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
             <div class="card-body p-0">
                 <div class="tab-content" id="people-tabs-content">
                     <div class="tab-pane fade show active" id="latest-fam-pane" role="tabpanel" aria-labelledby="latest-fam-tab">
-                        <table class="table table-vcenter table-hover card-table mb-0" width="100%" id="latestFamiliesDashboardItem"></table>
+                        <div class="table-responsive">
+                            <table class="table table-vcenter table-hover card-table mb-0" width="100%" id="latestFamiliesDashboardItem"></table>
+                        </div>
                     </div>
                     <div class="tab-pane fade" id="updated-fam-pane" role="tabpanel" aria-labelledby="updated-fam-tab">
-                        <table class="table table-vcenter table-hover card-table mb-0" width="100%" id="updatedFamiliesDashboardItem"></table>
+                        <div class="table-responsive">
+                            <table class="table table-vcenter table-hover card-table mb-0" width="100%" id="updatedFamiliesDashboardItem"></table>
+                        </div>
                     </div>
                     <div class="tab-pane fade" id="latest-ppl-pane" role="tabpanel" aria-labelledby="latest-ppl-tab">
-                        <table class="table table-vcenter table-hover card-table mb-0" width="100%" id="latestPersonDashboardItem"></table>
+                        <div class="table-responsive">
+                            <table class="table table-vcenter table-hover card-table mb-0" width="100%" id="latestPersonDashboardItem"></table>
+                        </div>
                     </div>
                     <div class="tab-pane fade" id="updated-ppl-pane" role="tabpanel" aria-labelledby="updated-ppl-tab">
-                        <table class="table table-vcenter table-hover card-table mb-0" width="100%" id="updatedPersonDashboardItem"></table>
+                        <div class="table-responsive">
+                            <table class="table table-vcenter table-hover card-table mb-0" width="100%" id="updatedPersonDashboardItem"></table>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -165,7 +173,9 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
             </div>
             <div class="card-body p-0">
                 <p class="text-muted small px-3 pt-3 mb-2"><?= gettext('Past & next 7 days') ?></p>
-                <table class="table table-hover mb-0" width="100%" id="PersonBirthdayDashboardItem"></table>
+                <div class="table-responsive">
+                    <table class="table table-hover mb-0" width="100%" id="PersonBirthdayDashboardItem"></table>
+                </div>
             </div>
         </div>
         <div class="card mb-3" id="anniversaryCard">
@@ -174,7 +184,9 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
             </div>
             <div class="card-body p-0">
                 <p class="text-muted small px-3 pt-3 mb-2"><?= gettext('Past & next 7 days') ?></p>
-                <table class="table table-hover mb-0" width="100%" id="FamiliesWithAnniversariesDashboardItem"></table>
+                <div class="table-responsive">
+                    <table class="table table-hover mb-0" width="100%" id="FamiliesWithAnniversariesDashboardItem"></table>
+                </div>
             </div>
         </div>
     </div>

--- a/webpack/family-register.css
+++ b/webpack/family-register.css
@@ -1,6 +1,7 @@
 /* ChurchCRM Family Registration Styles */
 
 .register-box {
+  width: 90%;
   margin: 30px auto;
   position: relative;
   z-index: 2;
@@ -21,6 +22,13 @@
   color: white;
   padding: 20px;
   margin: 0 -30px 30px -30px;
+}
+
+/* Stepper label: hide text on very small screens, show only circle */
+@media (max-width: 400px) {
+  .bs-stepper-label {
+    display: none;
+  }
 }
 
 .step-header h4 {
@@ -109,37 +117,36 @@
 .member-card .row {
   display: flex;
   flex-wrap: wrap;
-  margin-right: -15px;
-  margin-left: -15px;
 }
 
 .member-card .mb-3 {
   margin-bottom: 1rem;
 }
 
-.member-card .row > [class*="col-"] {
-  padding-right: 15px;
-  padding-left: 15px;
+/* Column widths — only enforce at md breakpoint and above so they stack on mobile */
+@media (min-width: 768px) {
+  .member-card .row .col-md-6 {
+    flex: 0 0 50%;
+    max-width: 50%;
+  }
+
+  .member-card .row .col-md-7 {
+    flex: 0 0 58.333333%;
+    max-width: 58.333333%;
+  }
+
+  .member-card .row .col-md-5 {
+    flex: 0 0 41.666667%;
+    max-width: 41.666667%;
+  }
 }
 
-.member-card .row .col-md-6 {
-  flex: 0 0 50%;
-  max-width: 50%;
-}
-
-.member-card .row .col-md-7 {
-  flex: 0 0 58.333333%;
-  max-width: 58.333333%;
-}
-
-.member-card .row .col-md-5 {
-  flex: 0 0 41.666667%;
-  max-width: 41.666667%;
-}
-
-.member-card .row .col-md-12 {
-  flex: 0 0 100%;
-  max-width: 100%;
+/* Below md: stack all columns full-width */
+@media (max-width: 767.98px) {
+  .member-card .row > [class*="col-"] {
+    flex: 0 0 100%;
+    max-width: 100%;
+  }
 }
 
 /* Form control styling for member cards */
@@ -398,4 +405,92 @@
 .registration-error p {
   color: #666;
   margin-bottom: 20px;
+}
+
+/* ── Mobile Responsive Overrides ───────────────────────────────── */
+@media (max-width: 767.98px) {
+  .register-box {
+    width: 100% !important;
+    max-width: 100% !important;
+    padding: 0 12px;
+    margin: 16px auto;
+  }
+
+  .bs-stepper .content {
+    padding: 16px;
+  }
+
+  .step-header {
+    margin: 0 -16px 20px -16px;
+    padding: 16px;
+  }
+
+  .step-header h4 {
+    font-size: 1rem;
+  }
+
+  .step-header p {
+    font-size: 0.8rem;
+  }
+
+  /* Prevent iOS auto-zoom on input focus */
+  .member-card .form-control,
+  .member-card .form-select,
+  .register-box .form-control,
+  .register-box .form-select {
+    font-size: 16px;
+  }
+
+  /* Member card spacing */
+  .member-card .card-header {
+    padding: 10px 14px;
+  }
+
+  .member-card .card-body {
+    padding: 14px;
+  }
+
+  .member-card h5 {
+    font-size: 0.9rem;
+  }
+
+  /* Phone input: stack "No format" checkbox below on mobile */
+  .member-card .input-group > .input-group-text:last-child {
+    border-top: 1px solid #ced4da;
+    border-left: 1px solid #ced4da;
+    font-size: 0.8rem;
+  }
+
+  /* Nav buttons: full-width stacked on mobile */
+  .bs-stepper .content > .mb-3:last-child {
+    display: flex;
+    flex-direction: column-reverse;
+    gap: 10px;
+  }
+
+  .bs-stepper .content > .mb-3:last-child .btn {
+    width: 100%;
+    margin-right: 0 !important;
+  }
+
+  /* Family count badge */
+  .family-count-badge {
+    padding: 4px 10px;
+    font-size: 12px;
+  }
+
+  /* Review cards */
+  .register-box .card-body {
+    padding: 16px;
+  }
+
+  /* Register logo */
+  .register-logo {
+    margin-bottom: 12px !important;
+  }
+
+  .register-logo .h2,
+  .register-logo a {
+    font-size: 1.25rem;
+  }
 }

--- a/webpack/family-register.css
+++ b/webpack/family-register.css
@@ -24,10 +24,19 @@
   margin: 0 -30px 30px -30px;
 }
 
-/* Stepper label: hide text on very small screens, show only circle */
+/* Stepper label: visually hide text on very small screens while keeping it
+   in the accessibility tree for screen readers */
 @media (max-width: 400px) {
   .bs-stepper-label {
-    display: none;
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 }
 
@@ -454,10 +463,18 @@
     font-size: 0.9rem;
   }
 
-  /* Phone input: stack "No format" checkbox below on mobile */
+  /* Phone input: stack "No format" checkbox on its own row below the input */
+  .member-card .input-group {
+    flex-wrap: wrap;
+  }
+
   .member-card .input-group > .input-group-text:last-child {
+    flex: 0 0 100%;
+    width: 100%;
     border-top: 1px solid #ced4da;
     border-left: 1px solid #ced4da;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
     font-size: 0.8rem;
   }
 


### PR DESCRIPTION
## Summary

Comprehensive mobile UX cleanup across logged-out pages, family registration, dashboards, profile views, and Person/Family editors.

## Logged-out pages (`_authentication-pages.scss`)

- **Touch targets:** Footer social icons 32px → **44px** (Apple/Google minimum)
- **Notched phones:** `safe-area-inset-bottom` for iPhone X+
- **2FA input:** `max-width: 100%` + `box-sizing` to prevent overflow; reduced size on mobile
- **Footer:** Reduced padding on small screens (40px → 24px top)

## Family registration (`family-register.css` + template)

- **Critical fix:** `.member-card .row .col-md-*` was forcing 50% width at all sizes — now only enforced at `min-width: 768px`. Below that, columns stack full-width.
- **Container:** Moved inline `width: 90%` to CSS; mobile: `width: 100%` + `12px` padding
- **Stepper:** Content padding 30px → 16px on mobile; labels hidden below 400px (circles only)
- **iOS zoom prevention:** Form inputs set to `16px` font-size
- **Nav buttons:** Stack full-width on mobile (column-reverse → primary on top)
- Scaled down member card, badge, logo, step-header font sizes on mobile

## Dashboards

- **Root dashboard:** 5 stat cards get `col-md-4` tablet breakpoint (was `col-6 col-lg` only); 4 people tables + 2 sidebar tables wrapped in `table-responsive`
- **Groups dashboard:** groups table wrapped in `table-responsive`
- **Sunday School dashboard:** 6 stat cards get `col-md-4` (was cramped `col-lg-2` only)

## Family view (`family-view.php`)

- `col-lg-8` / `col-lg-4` split gets `col-12` fallback so sidebar stacks on mobile
- Member tables wrapped in `table-responsive` (previously `overflow: visible`)
- Removed `style="overflow: visible"` override on pledges/payments table-responsive

## Person / Family editors

All `col-md-*` grids get consistent mobile fallbacks so form fields stack full-width on phones instead of compressing:

| Original | New |
|----------|-----|
| `col-md-1` (Suffix, Gender, Day, Year, HideAge) | `col-6 col-sm-4 col-md-1` |
| `col-md-2` (Title, Middle, Month, Zip) | `col-12 col-sm-6 col-md-2` |
| `col-md-3/4` (Name, Address, Dates) | `col-12 col-sm-6 col-md-3/4` |
| `col-md-6` (Wide fields, columns) | `col-12 col-md-6` |

Also applies to dynamic custom field output in both editors.

## Cypress tests (`cypress/e2e/ui/mobile/mobile-ux.spec.js`)

New mobile regression suite tests at 375×812 (iPhone X):

- Login, password reset, error pages — no horizontal overflow, 16px inputs (iOS-zoom prevention), 44px touch targets
- Family registration — overflow check, font-size, stacked nav buttons
- Root + groups dashboards — overflow + `table-responsive` wrappers
- Family view — column stacking
- Person/Family editors — form fields stack full-width

## Test plan

- [ ] Run `npx cypress run --spec cypress/e2e/ui/mobile/mobile-ux.spec.js`
- [ ] Manual check on iPhone SE (375px): login, register, dashboard, person editor
- [ ] iPhone X+ notch: auth footer respects safe area
- [ ] iOS Safari: no auto-zoom on input focus
- [ ] Screen < 400px: family register stepper shows only circles

## Known limitation (follow-up PR)

FamilyEditor has a 10-column family members table (lines 783-917) with hardcoded `width:60px`/`70px` inputs. Making it fully mobile-friendly requires a larger refactor to a card-based layout — left as a follow-up.

https://claude.ai/code/session_018wpgjQEhtz8wPVZeP8uhVS