### PR TITLE
refactor(dashboard): hide deposit card entirely for non-finance users

### DIFF
--- a/src/v2/templates/root/dashboard.php
+++ b/src/v2/templates/root/dashboard.php
@@ -200,30 +200,20 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
     </div>
 </div>
 
+<?php if ($depositEnabled) { ?>
 <div class="row">
     <div class="col-12">
         <div class="card mb-3" id="depositChartRow">
             <div class="card-header d-flex align-items-center">
                 <h3 class="card-title"><i class="fa-solid fa-circle-dollar-to-slot me-2"></i> <?= gettext('Deposit Tracking') ?></h3>
             </div>
-            <?php if ($depositEnabled) { ?>
-                <div class="card-body">
-                    <div id="deposit-lineGraph" style="min-height: 300px;"></div>
-                </div>
-            <?php } else { ?>
-                <div class="card-body">
-                    <div class="empty">
-                        <div class="empty-icon">
-                            <i class="fa-solid fa-circle-dollar-to-slot fa-3x text-muted"></i>
-                        </div>
-                        <p class="empty-title"><?= gettext('No Deposit Tracking') ?></p>
-                        <p class="empty-subtitle text-muted"><?= gettext('You do not have finance permissions to view deposits.') ?></p>
-                    </div>
-                </div>
-            <?php } ?>
+            <div class="card-body">
+                <div id="deposit-lineGraph" style="min-height: 300px;"></div>
+            </div>
         </div>
     </div>
 </div>
+<?php } ?>
 
 <script src="<?= SystemURLs::assetVersioned('/skin/v2/root-dashboard.min.js') ?>"></script>
 <?php


### PR DESCRIPTION
## Summary

Follow-up to #8562. That PR correctly stopped the JS from calling `/api/deposits/dashboard` for non-finance users, but the underlying UX noise is still there: every non-finance user sees a full-width empty card saying:

> **No Deposit Tracking**
> You do not have finance permissions to view deposits.

This advertises a feature users can't access and eats vertical space on the main dashboard. This PR removes that card entirely for non-finance users.

## Change

**`src/v2/templates/root/dashboard.php`** — wrap the entire deposit row in `<?php if ($depositEnabled) { ?>` and drop the `else` empty-state branch.

```diff
+<?php if ($depositEnabled) { ?>
 <div class="row">
     <div class="col-12">
         <div class="card mb-3" id="depositChartRow">
             <div class="card-header d-flex align-items-center">
                 <h3 class="card-title"><i class="fa-solid fa-circle-dollar-to-slot me-2"></i> <?= gettext('Deposit Tracking') ?></h3>
             </div>
-            <?php if ($depositEnabled) { ?>
-                <div class="card-body">
-                    <div id="deposit-lineGraph" style="min-height: 300px;"></div>
-                </div>
-            <?php } else { ?>
-                <div class="card-body">
-                    <div class="empty">
-                        <div class="empty-icon">
-                            <i class="fa-solid fa-circle-dollar-to-slot fa-3x text-muted"></i>
-                        </div>
-                        <p class="empty-title"><?= gettext('No Deposit Tracking') ?></p>
-                        <p class="empty-subtitle text-muted"><?= gettext('You do not have finance permissions to view deposits.') ?></p>
-                    </div>
-                </div>
-            <?php } ?>
+            <div class="card-body">
+                <div id="deposit-lineGraph" style="min-height: 300px;"></div>
+            </div>
         </div>
     </div>
 </div>
+<?php } ?>
```

`$depositEnabled` is set in `src/v2/routes/root.php:123` from `AuthenticationManager::getCurrentUser()->isFinanceEnabled()`, so the card now matches the exact same visibility semantics as the data it displays.

## Why this pattern

The file already uses this exact idiom for the Today's Events card at lines 108/126 (`<?php if ($eventsEnabled) { ?>` wrapping `<div class="row">`). This PR brings the deposit card into consistency.

## Interactions with #8562 and #8565

- **#8562** (the JS fix): still correct and still needed — server-side API enforcement means a finance-less user who somehow triggered the JS guard would still get a 403. Keep it.
- **#8565** (the Cypress tests): the non-finance tests there assert `cy.get("#depositChartRow").should("exist")`. Once this PR lands, `#depositChartRow` will no longer exist for non-finance users, so the assertion needs to flip to `should("not.exist")`. I'll push a follow-up commit to #8565 (or update this PR) to flip that assertion, depending on merge order:
  - If this PR merges first → update #8565 assertion before merge
  - If #8562 + #8565 merge first → update the test in a follow-up commit to this PR's branch

Both are trivial one-line changes. Happy to coordinate on whichever merge order the team prefers.

## Test plan

- [ ] Log in as admin → main dashboard shows the Deposit Tracking card with the chart (unchanged)
- [ ] Log in as `tony.wade@example.com` (has Finance=1) → main dashboard shows the chart (unchanged)
- [ ] Log in as `judith.matthews@example.com` (Finance=0, Admin=0) → main dashboard does **not** render a Deposit Tracking card at all (no empty state, no header, no DOM element)
- [ ] No visual regressions to the rows above the deposit card (People / Birthdays / Anniversaries layout unchanged)

## Related

- Opens from the follow-up note in ChurchCRM/CRM#8562 (issuecomment-4216039696)
- Companion test PR: #8565

https://claude.ai/code/session_01PuMALYGzU8q5roa5pydZYz