### PR TITLE
fix(dashboard): hide deposit widget from non-finance users

### DIFF
--- a/cypress/e2e/api/private/finance/finance-deposits.spec.js
+++ b/cypress/e2e/api/private/finance/finance-deposits.spec.js
@@ -220,6 +220,21 @@ describe("API Private Deposit Operations", () => {
                 [401, 403]
             );
         });
+
+        // Regression for PR #8562: the main dashboard JS used to hit
+        // /api/deposits/dashboard unconditionally, producing a bootbox error
+        // for non-finance users. The JS fix prevents the call client-side,
+        // but we also assert the server-side FinanceRoleAuthMiddleware
+        // (applied to the /deposits route group) denies the request so the
+        // fix is defense-in-depth, not the only line of defense.
+        it("Non-finance user denied getting deposit dashboard data", () => {
+            cy.makePrivateNoFinanceAPICall(
+                "GET",
+                `/api/deposits/dashboard`,
+                null,
+                [401, 403]
+            );
+        });
     });
 
     describe("Middleware Validation Tests", () => {

--- a/cypress/e2e/ui/main.dashboard.spec.js
+++ b/cypress/e2e/ui/main.dashboard.spec.js
@@ -12,29 +12,46 @@ describe("Main Dashboard", () => {
 });
 
 /**
- * Regression tests for PR #8562
+ * Regression tests for the deposits widget authorization fix on
+ * /v2/dashboard.
  *
- * The /v2/dashboard used to unconditionally call /api/deposits/dashboard
- * whenever the #depositChartRow card was visible. That card is rendered
- * for every user, so non-finance users triggered the endpoint and received
- * an "Admin or Finance permission required" error popup.
+ * The bug: non-finance users visiting /v2/dashboard received an "Admin or
+ * Finance permission required" bootbox popup because the JS unconditionally
+ * called /api/deposits/dashboard whenever #depositChartRow was visible —
+ * which it always was, even when the card only showed a "no permissions"
+ * empty state.
  *
- * The fix switches the JS guard in src/skin/js/MainDashboard.js to check
- * for #deposit-lineGraph, which the PHP template (src/v2/templates/root/dashboard.php)
- * only injects for users who pass AuthenticationManager::getCurrentUser()->isFinanceEnabled().
+ * The fix consists of two coordinated changes:
+ *
+ *   1. src/skin/js/MainDashboard.js — guard the deposits API call on
+ *      #deposit-lineGraph presence instead of #depositChartRow visibility.
+ *      This is defense-in-depth at the JS layer so a stale finance UI
+ *      can never leak a finance API call.
+ *
+ *   2. src/v2/templates/root/dashboard.php — only render the deposit
+ *      tracking row at all when $depositEnabled = isFinanceEnabled() is
+ *      true. This removes the noisy "No Deposit Tracking / You do not
+ *      have finance permissions" empty state from every non-finance
+ *      user's home screen, and is the root-cause fix at the PHP layer.
+ *
+ * These tests enforce the full contract: a non-finance user must NOT
+ * see any finance UI, must NOT trigger any finance API call, and must
+ * NOT receive any permission-error popup. A finance user must still
+ * see the deposit chart and trigger the backing API call.
  */
-describe("Main Dashboard - Deposits widget authorization (PR #8562)", () => {
+describe("Main Dashboard - Deposits widget authorization", () => {
     describe("Finance-enabled user (admin)", () => {
         beforeEach(() => cy.setupAdminSession());
 
-        it("renders the deposit line graph container and calls the deposits API", () => {
+        it("renders the deposit chart and calls the deposits API", () => {
             cy.intercept("GET", "**/api/deposits/dashboard").as("depositsApi");
 
             cy.visit("v2/dashboard");
 
-            // The finance-only container must exist for finance users.
+            // The finance-only row must exist for finance users.
             cy.get("#depositChartRow").should("exist");
             cy.get("#deposit-lineGraph").should("exist");
+            cy.contains("Deposit Tracking").should("be.visible");
 
             // The JS guard should trigger the deposits API call.
             cy.wait("@depositsApi").its("response.statusCode").should("eq", 200);
@@ -44,17 +61,29 @@ describe("Main Dashboard - Deposits widget authorization (PR #8562)", () => {
     describe("User without finance permission", () => {
         beforeEach(() => cy.setupNoFinanceSession());
 
-        it("does not render the deposit line graph container", () => {
+        it("hides the entire deposit tracking card from non-finance users", () => {
             cy.visit("v2/dashboard");
 
-            // The deposit card header is still rendered (it shows an empty
-            // state), but the inner #deposit-lineGraph element is gated on
-            // $depositEnabled = isFinanceEnabled() in dashboard.php.
-            cy.get("#depositChartRow").should("exist");
+            // Wait for the dashboard to fully render before asserting
+            // absence — page content loads incrementally.
+            cy.contains("Families");
+            cy.contains("People");
+
+            // Root-cause fix (PHP): the entire deposit tracking row
+            // must be absent from the DOM, not just hidden.
+            cy.get("#depositChartRow").should("not.exist");
             cy.get("#deposit-lineGraph").should("not.exist");
+
+            // No noisy empty-state text advertising a feature the user
+            // cannot access.
+            cy.contains("Deposit Tracking").should("not.exist");
+            cy.contains("No Deposit Tracking").should("not.exist");
+            cy.contains(
+                "You do not have finance permissions to view deposits.",
+            ).should("not.exist");
         });
 
-        it("does not call /api/deposits/dashboard for a non-finance user", () => {
+        it("does not call /api/deposits/dashboard and shows no permission popup", () => {
             // Register the intercept BEFORE cy.visit so every matching
             // request gets captured against the alias.
             cy.intercept("GET", "**/api/deposits/dashboard").as("depositsApi");
@@ -67,12 +96,12 @@ describe("Main Dashboard - Deposits widget authorization (PR #8562)", () => {
             cy.contains("People");
             cy.contains("Sunday School");
 
-            // The bootbox error popup ("User must be an Admin or have Finance
-            // permission.") used to appear here before PR #8562 — it must not.
+            // The bootbox error popup ("User must be an Admin or have
+            // Finance permission.") used to appear here — it must not.
             cy.get(".bootbox").should("not.exist");
 
             // And the deposits endpoint must never have been called.
-            // This is the exact regression PR #8562 fixes.
+            // This is the exact regression being fixed.
             cy.get("@depositsApi.all").should("have.length", 0);
         });
     });

--- a/cypress/e2e/ui/main.dashboard.spec.js
+++ b/cypress/e2e/ui/main.dashboard.spec.js
@@ -2,11 +2,78 @@
 
 describe("Main Dashboard", () => {
     beforeEach(() => cy.setupStandardSession());
-    
+
     it("Loads all", () => {
         cy.visit("v2/dashboard");
         cy.contains("Families");
         cy.contains("People");
         cy.contains("Sunday School");
+    });
+});
+
+/**
+ * Regression tests for PR #8562
+ *
+ * The /v2/dashboard used to unconditionally call /api/deposits/dashboard
+ * whenever the #depositChartRow card was visible. That card is rendered
+ * for every user, so non-finance users triggered the endpoint and received
+ * an "Admin or Finance permission required" error popup.
+ *
+ * The fix switches the JS guard in src/skin/js/MainDashboard.js to check
+ * for #deposit-lineGraph, which the PHP template (src/v2/templates/root/dashboard.php)
+ * only injects for users who pass AuthenticationManager::getCurrentUser()->isFinanceEnabled().
+ */
+describe("Main Dashboard - Deposits widget authorization (PR #8562)", () => {
+    describe("Finance-enabled user (admin)", () => {
+        beforeEach(() => cy.setupAdminSession());
+
+        it("renders the deposit line graph container and calls the deposits API", () => {
+            cy.intercept("GET", "**/api/deposits/dashboard").as("depositsApi");
+
+            cy.visit("v2/dashboard");
+
+            // The finance-only container must exist for finance users.
+            cy.get("#depositChartRow").should("exist");
+            cy.get("#deposit-lineGraph").should("exist");
+
+            // The JS guard should trigger the deposits API call.
+            cy.wait("@depositsApi").its("response.statusCode").should("eq", 200);
+        });
+    });
+
+    describe("User without finance permission", () => {
+        beforeEach(() => cy.setupNoFinanceSession());
+
+        it("does not render the deposit line graph container", () => {
+            cy.visit("v2/dashboard");
+
+            // The deposit card header is still rendered (it shows an empty
+            // state), but the inner #deposit-lineGraph element is gated on
+            // $depositEnabled = isFinanceEnabled() in dashboard.php.
+            cy.get("#depositChartRow").should("exist");
+            cy.get("#deposit-lineGraph").should("not.exist");
+        });
+
+        it("does not call /api/deposits/dashboard for a non-finance user", () => {
+            // Register the intercept BEFORE cy.visit so every matching
+            // request gets captured against the alias.
+            cy.intercept("GET", "**/api/deposits/dashboard").as("depositsApi");
+
+            cy.visit("v2/dashboard");
+
+            // Wait for the dashboard to fully render before asserting the
+            // API was NOT hit — widgets fire requests during page load.
+            cy.contains("Families");
+            cy.contains("People");
+            cy.contains("Sunday School");
+
+            // The bootbox error popup ("User must be an Admin or have Finance
+            // permission.") used to appear here before PR #8562 — it must not.
+            cy.get(".bootbox").should("not.exist");
+
+            // And the deposits endpoint must never have been called.
+            // This is the exact regression PR #8562 fixes.
+            cy.get("@depositsApi.all").should("have.length", 0);
+        });
     });
 });

--- a/src/skin/js/MainDashboard.js
+++ b/src/skin/js/MainDashboard.js
@@ -653,7 +653,7 @@ export function initializeMainDashboard() {
     $("#todayEventsDashboardItem").DataTable(todayEventsConfig);
   }
 
-  if ($("#depositChartRow").is(":visible")) {
+  if ($("#deposit-lineGraph").length > 0) {
     window.CRM.APIRequest({
       method: "GET",
       path: "deposits/dashboard",

--- a/src/v2/templates/root/dashboard.php
+++ b/src/v2/templates/root/dashboard.php
@@ -200,30 +200,20 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
     </div>
 </div>
 
+<?php if ($depositEnabled) { ?>
 <div class="row">
     <div class="col-12">
         <div class="card mb-3" id="depositChartRow">
             <div class="card-header d-flex align-items-center">
                 <h3 class="card-title"><i class="fa-solid fa-circle-dollar-to-slot me-2"></i> <?= gettext('Deposit Tracking') ?></h3>
             </div>
-            <?php if ($depositEnabled) { ?>
-                <div class="card-body">
-                    <div id="deposit-lineGraph" style="min-height: 300px;"></div>
-                </div>
-            <?php } else { ?>
-                <div class="card-body">
-                    <div class="empty">
-                        <div class="empty-icon">
-                            <i class="fa-solid fa-circle-dollar-to-slot fa-3x text-muted"></i>
-                        </div>
-                        <p class="empty-title"><?= gettext('No Deposit Tracking') ?></p>
-                        <p class="empty-subtitle text-muted"><?= gettext('You do not have finance permissions to view deposits.') ?></p>
-                    </div>
-                </div>
-            <?php } ?>
+            <div class="card-body">
+                <div id="deposit-lineGraph" style="min-height: 300px;"></div>
+            </div>
         </div>
     </div>
 </div>
+<?php } ?>
 
 <script src="<?= SystemURLs::assetVersioned('/skin/v2/root-dashboard.min.js') ?>"></script>
 <?php


### PR DESCRIPTION
## Summary

Consolidates the deposits-widget authorization fixes (previously split across #8562 and #8566) and their regression coverage into a single branch.

**The bug:** Non-finance users visiting `/v2/dashboard` received an "Admin or Finance permission required" bootbox popup because `MainDashboard.js` unconditionally called `/api/deposits/dashboard` whenever `#depositChartRow` was visible — which it always was, even when the card only showed a "no permissions" empty state.

## Changes

### 1. Root-cause fix — `src/v2/templates/root/dashboard.php`
Only render the deposit tracking row when `$depositEnabled = isFinanceEnabled()` is true. Drops the noisy *"No Deposit Tracking / You do not have finance permissions to view deposits."* empty state that advertised a feature non-finance users cannot access.

### 2. Defense-in-depth — `src/skin/js/MainDashboard.js`
```diff
- if ($("#depositChartRow").is(":visible")) {
+ if ($("#deposit-lineGraph").length > 0) {
```
Guard the deposits API call on `#deposit-lineGraph` presence instead of the outer card visibility so a stale finance UI can never leak a finance API call.

### 3. UI regression tests — `cypress/e2e/ui/main.dashboard.spec.js`
Full contract coverage:
- **Finance user** sees `#depositChartRow` + `#deposit-lineGraph`, "Deposit Tracking" header is visible, and `/api/deposits/dashboard` is called and returns 200.
- **Non-finance user** sees no `#depositChartRow`, no `#deposit-lineGraph`, no "Deposit Tracking" / "No Deposit Tracking" text, no "You do not have finance permissions..." empty-state, no `.bootbox` popup, and `/api/deposits/dashboard` is never called.

### 4. API regression test — `cypress/e2e/api/private/finance/finance-deposits.spec.js`
New non-finance denial test for `GET /api/deposits/dashboard`, asserting `FinanceRoleAuthMiddleware` (applied at the `/deposits` route group level) rejects the request server-side. The JS fix prevents the call client-side; the server check is the authoritative safeguard.

## Supersedes

- #8562 (JS-only fix — subset of this PR)
- #8566 (template-only fix — subset of this PR)

## Test plan

- [x] `npm run lint` passes
- [x] `npm run build:webpack` passes
- [x] `php -l` clean on modified template
- [ ] Cypress `cypress/e2e/ui/main.dashboard.spec.js` passes in CI
- [ ] Cypress `cypress/e2e/api/private/finance/finance-deposits.spec.js` passes in CI
- [ ] Manual: log in as `judith.matthews@example.com` (no finance) → `/v2/dashboard` shows no deposit card and no popup
- [ ] Manual: log in as admin → deposit chart renders as before

https://claude.ai/code/session_01PuMALYGzU8q5roa5pydZYz