### PR TITLE
Fix #8570: cart empty-to-group sends groupID without groupRoleID

### DIFF
--- a/.agents/skills/churchcrm/frontend-development.md
+++ b/.agents/skills/churchcrm/frontend-development.md
@@ -638,6 +638,17 @@ TomSelect hides options with `value=""` (treats them as placeholder/clear state)
 
 When TomSelect is inside a card with `table-responsive` or constrained overflow, dropdowns get clipped. Fix: pass `dropdownParent: 'body'` to TomSelect init and add a `body > .ts-dropdown` SCSS rule in `_tabler-bridge.scss` to preserve Tabler styling.
 
+### Reading TomSelect values: never use jQuery `option:selected` <!-- learned: 2026-04-09 -->
+
+TomSelect does **not** reliably mirror its current selection back onto the underlying `<option selected>` attribute — `$("#mySelect option:selected").val()` may return `undefined` even when the user has clearly picked an item. Always read the value via the TomSelect instance API:
+
+```js
+const el = document.getElementById("targetRoleSelection");
+const value = el.tomselect ? el.tomselect.getValue() : window.jQuery(el).val();
+```
+
+This bit `promptSelection` in `CRMJSOM.js` (issue #8570 — "Cart empty to group" sent `groupID` only because `RoleID` was undefined and `JSON.stringify` silently dropped it, yielding a confusing `Invalid request data` 400). When forwarding select values into a payload, **also validate before sending** — `JSON.stringify({ a: undefined })` becomes `"{}"`, so missing values become silent server-side errors.
+
 ### marked.parse() XSS Prevention <!-- learned: 2026-03-30 -->
 
 When rendering user-supplied markdown (e.g., GitHub release notes) with `marked`, strip raw HTML to prevent XSS:

--- a/cypress/e2e/api/private/standard/private.cart.empty-to-group.spec.js
+++ b/cypress/e2e/api/private/standard/private.cart.empty-to-group.spec.js
@@ -1,0 +1,145 @@
+/// <reference types="cypress" />
+
+/**
+ * Regression coverage for ChurchCRM/CRM#8570 — `POST /api/cart/emptyToGroup`
+ * was returning a confusing 400 ("Invalid request data") whenever the JS
+ * caller forgot to send `groupRoleID`. The frontend bug was that
+ * `JSON.stringify` silently drops keys whose value is `undefined`, so a
+ * missing TomSelect read produced the same payload as deliberately omitting
+ * the field. The API contract is that BOTH parameters are required and
+ * must be numeric — these tests pin that contract down so a future
+ * refactor cannot regress it without noticing.
+ */
+describe("API Private Cart - emptyToGroup", () => {
+    // Test fixture group: "Clergy" (grp_ID = 11) — has role list 23 with
+    // option_id 1 = "Member". See cypress/data/seed.sql.
+    const TARGET_GROUP_ID = 11;
+    const TARGET_ROLE_ID = 1;
+
+    // Persons we move into the group during the happy-path test. These come
+    // from family 6 (already used by private.people.family.cart.spec.js).
+    const TEST_PERSON_IDS = [28, 30];
+
+    beforeEach(() => {
+        cy.setupStandardSession();
+
+        // Make sure the cart starts empty so each test owns its own state.
+        cy.makePrivateAdminAPICall(
+            "DELETE",
+            "/api/cart/",
+            null,
+            200,
+        );
+
+        cy.on("uncaught:exception", () => false);
+    });
+
+    afterEach(() => {
+        // Clean up: remove the test persons from the target group so the
+        // happy-path test can be re-run safely. removeperson is idempotent
+        // (the route loops membership rows and only deletes matches), so a
+        // 200 is expected even if the person was never added.
+        TEST_PERSON_IDS.forEach((personId) => {
+            cy.makePrivateAdminAPICall(
+                "DELETE",
+                `/api/groups/${TARGET_GROUP_ID}/removeperson/${personId}`,
+                null,
+                200,
+            );
+        });
+    });
+
+    it("returns 400 when groupRoleID is missing (regression for #8570)", () => {
+        // This is exactly the broken payload the JS was sending: groupID
+        // present, groupRoleID dropped by JSON.stringify because the
+        // TomSelect read returned `undefined`.
+        cy.makePrivateAdminAPICall(
+            "POST",
+            "/api/cart/emptyToGroup",
+            JSON.stringify({ groupID: TARGET_GROUP_ID }),
+            400,
+        );
+    });
+
+    it("returns 400 when groupID is missing", () => {
+        cy.makePrivateAdminAPICall(
+            "POST",
+            "/api/cart/emptyToGroup",
+            JSON.stringify({ groupRoleID: TARGET_ROLE_ID }),
+            400,
+        );
+    });
+
+    it("returns 400 when both fields are missing", () => {
+        cy.makePrivateAdminAPICall(
+            "POST",
+            "/api/cart/emptyToGroup",
+            JSON.stringify({}),
+            400,
+        );
+    });
+
+    it("returns 400 when groupID is non-numeric", () => {
+        cy.makePrivateAdminAPICall(
+            "POST",
+            "/api/cart/emptyToGroup",
+            JSON.stringify({ groupID: "not-a-number", groupRoleID: TARGET_ROLE_ID }),
+            400,
+        );
+    });
+
+    it("returns 400 when groupRoleID is non-numeric", () => {
+        cy.makePrivateAdminAPICall(
+            "POST",
+            "/api/cart/emptyToGroup",
+            JSON.stringify({ groupID: TARGET_GROUP_ID, groupRoleID: "not-a-number" }),
+            400,
+        );
+    });
+
+    it("moves cart contents into the target group and empties the cart", () => {
+        // Seed the cart with two people.
+        cy.makePrivateAdminAPICall(
+            "POST",
+            "/api/cart/",
+            JSON.stringify({ Persons: TEST_PERSON_IDS }),
+            200,
+        );
+
+        // Sanity-check the cart actually got populated.
+        cy.makePrivateAdminAPICall("GET", "/api/cart/", null, 200).then((resp) => {
+            expect(resp.body.PeopleCart).to.include.members(TEST_PERSON_IDS);
+        });
+
+        // Happy path — both required fields present.
+        cy.makePrivateAdminAPICall(
+            "POST",
+            "/api/cart/emptyToGroup",
+            JSON.stringify({
+                groupID: TARGET_GROUP_ID,
+                groupRoleID: TARGET_ROLE_ID,
+            }),
+            200,
+        ).then((resp) => {
+            expect(resp.body).to.have.property("status", "success");
+        });
+
+        // The cart should now be empty.
+        cy.makePrivateAdminAPICall("GET", "/api/cart/", null, 200).then((resp) => {
+            expect(resp.body.PeopleCart).to.be.an("array").that.has.lengthOf(0);
+        });
+
+        // Both persons should now be members of the target group.
+        cy.makePrivateAdminAPICall(
+            "GET",
+            `/api/groups/${TARGET_GROUP_ID}/members`,
+            null,
+            200,
+        ).then((resp) => {
+            const memberIds = resp.body.Person2group2roleP2g2rs.map((m) => m.PersonId);
+            TEST_PERSON_IDS.forEach((id) => {
+                expect(memberIds).to.include(id);
+            });
+        });
+    });
+});

--- a/src/skin/js/CRMJSOM.js
+++ b/src/skin/js/CRMJSOM.js
@@ -243,6 +243,22 @@ window.CRM.groups = {
     };
     let initFunction = function () {};
 
+    // Read a value from a TomSelect-wrapped (or plain) select. TomSelect does
+    // not always mirror its current selection back onto the underlying
+    // <option selected> attribute, so `option:selected` is unreliable here —
+    // always prefer the TomSelect instance API when available. Returns "" if
+    // nothing is selected.
+    const readSelectValue = (id) => {
+      const el = document.getElementById(id);
+      if (!el) return "";
+      if (el.tomselect) {
+        const v = el.tomselect.getValue();
+        return v == null ? "" : String(v);
+      }
+      const jqVal = window.jQuery(el).val();
+      return jqVal == null ? "" : String(jqVal);
+    };
+
     if (selectOptions.Type & window.CRM.groups.selectTypes.Group) {
       options.title = i18next.t("Select Group");
       options.message +=
@@ -251,9 +267,12 @@ window.CRM.groups = {
         ':</span>\
                   <select name="targetGroupSelection" id="targetGroupSelection" class="form-control"></select>';
       options.buttons.confirm.callback = function () {
-        selectionCallback({
-          GroupID: window.jQuery("#targetGroupSelection option:selected").val(),
-        });
+        var groupId = readSelectValue("targetGroupSelection");
+        if (!groupId) {
+          bootbox.alert(i18next.t("Please select a group."));
+          return false;
+        }
+        selectionCallback({ GroupID: groupId });
       };
     }
     if (selectOptions.Type & window.CRM.groups.selectTypes.Role) {
@@ -264,9 +283,12 @@ window.CRM.groups = {
         ':</span>\
                   <select name="targetRoleSelection" id="targetRoleSelection" class="form-control"></select>';
       options.buttons.confirm.callback = function () {
-        selectionCallback({
-          RoleID: window.jQuery("#targetRoleSelection option:selected").val(),
-        });
+        var roleId = readSelectValue("targetRoleSelection");
+        if (!roleId) {
+          bootbox.alert(i18next.t("Please select a role."));
+          return false;
+        }
+        selectionCallback({ RoleID: roleId });
       };
     }
 
@@ -299,11 +321,13 @@ window.CRM.groups = {
     if (selectOptions.Type === (window.CRM.groups.selectTypes.Group | window.CRM.groups.selectTypes.Role)) {
       options.title = i18next.t("Select Group and Role");
       options.buttons.confirm.callback = function () {
-        selection = {
-          RoleID: window.jQuery("#targetRoleSelection option:selected").val(),
-          GroupID: window.jQuery("#targetGroupSelection option:selected").val(),
-        };
-        selectionCallback(selection);
+        var groupId = readSelectValue("targetGroupSelection");
+        var roleId = readSelectValue("targetRoleSelection");
+        if (!groupId || !roleId) {
+          bootbox.alert(i18next.t("Please select both a group and a role."));
+          return false;
+        }
+        selectionCallback({ GroupID: groupId, RoleID: roleId });
       };
     }
     options.message += "</div>";

--- a/src/skin/js/cart.js
+++ b/src/skin/js/cart.js
@@ -436,6 +436,13 @@ export class CartManager {
         Type: window.CRM.groups.selectTypes.Group | window.CRM.groups.selectTypes.Role,
       },
       (selectedRole) => {
+        // Defensive — promptSelection should already validate, but the API
+        // requires both fields and JSON.stringify silently drops `undefined`,
+        // so a missing value would otherwise yield a confusing 400.
+        if (!selectedRole?.GroupID || !selectedRole?.RoleID) {
+          this.showNotification("danger", i18next.t("Please select both a group and a role."));
+          return;
+        }
         window.CRM.APIRequest({
           method: "POST",
           path: "cart/emptyToGroup",


### PR DESCRIPTION
## Summary

Fixes ChurchCRM/CRM#8570 — "Cart empty to group" was failing with a confusing `Invalid request data` 400 from `POST /api/cart/emptyToGroup`. The server log showed `Missing required parameters: groupID=set, groupRoleID=missing`.

**Root cause:** `promptSelection()` in `CRMJSOM.js` reads the selected group/role via `$("#targetRoleSelection option:selected").val()`, but TomSelect does not reliably mirror its current selection back onto the underlying `<option selected>` attribute. So `.val()` returned `undefined`, and `JSON.stringify({ groupID, groupRoleID: undefined })` silently dropped the key — the API saw only `groupID` and rejected the request.

## Changes

- **`src/skin/js/CRMJSOM.js`** — Added a `readSelectValue()` helper that prefers `el.tomselect.getValue()` and falls back to `$(el).val()`. All three callback variants in `promptSelection` (Group / Role / Group+Role) now read via the TomSelect API, validate the required field(s) are populated, and `return false` from the bootbox callback (which keeps the dialog open) with a clear `bootbox.alert` when something is missing — instead of silently passing `undefined` through.
- **`src/skin/js/cart.js`** — Defensive guard in `CartManager.emptyToGroup()` so a future caller of `promptSelection` cannot regress this with a confusing 400.
- **`cypress/e2e/api/private/standard/private.cart.empty-to-group.spec.js`** *(new)* — Pins the API contract with 6 tests:
  - Regression for #8570: `{ groupID }` only → 400
  - `{ groupRoleID }` only → 400
  - `{}` → 400
  - Non-numeric `groupID` → 400
  - Non-numeric `groupRoleID` → 400
  - Happy path: cart with persons 28+30 → POST `{ groupID: 11, groupRoleID: 1 }` → 200, then assert cart is empty and both persons appear in `GET /api/groups/11/members`.
- **`.agents/skills/churchcrm/frontend-development.md`** — Documents the TomSelect / `option:selected` / `JSON.stringify(undefined)` trap so this doesn't bite again.

## Why

The user-facing symptom was a "Failed to empty cart to group" notification with no actionable information. The underlying class of bug — `JSON.stringify` silently dropping `undefined` values — is one of the easiest ways to convert a frontend validation gap into a confusing server-side 400, so the fix both validates upstream (in the bootbox callback, where the user can immediately correct it) and downstream (in the cart caller).

## Files Changed

| File | Type | Purpose |
|---|---|---|
| `src/skin/js/CRMJSOM.js` | Fix | Use TomSelect API + validate before invoking selection callback |
| `src/skin/js/cart.js` | Fix (defensive) | Guard against missing GroupID/RoleID before POSTing |
| `cypress/e2e/api/private/standard/private.cart.empty-to-group.spec.js` | Test (new) | API regression coverage |
| `.agents/skills/churchcrm/frontend-development.md` | Docs | TomSelect value-read pattern |

## Test plan

- [x] `npm run lint` — no new diagnostics (3 errors / 101 warnings / 20 infos, identical to baseline)
- [x] `npm run build:webpack` — compiles successfully
- [ ] `npx cypress run --spec "cypress/e2e/api/private/standard/private.cart.empty-to-group.spec.js" --headless` — all 6 tests pass
- [ ] Manual: select people → "Empty Cart to Group" → choose group + role → cart empties, members added
- [ ] Manual: "Empty Cart to Group" → click OK without selecting role → bootbox alert appears, dialog stays open

## Related Issues

Fixes ChurchCRM/CRM#8570

🤖 Generated with [Claude Code](https://claude.com/claude-code)