### PR TITLE
Fix #8528: expose lat/long fields on Church Information page

### DIFF
--- a/cypress/e2e/ui/admin/admin.church-info.spec.js
+++ b/cypress/e2e/ui/admin/admin.church-info.spec.js
@@ -237,4 +237,129 @@ describe("Admin - Church Information Page", () => {
 
         cy.get("#sChurchAddress").should("have.attr", "required");
     });
+
+    // Map coordinates / GPS-pin regression — issue #8528
+    // Auto-geocoding via Nominatim fails for many international addresses
+    // and for users who only have GPS coordinates. The form must let admins
+    // enter latitude/longitude manually as a fallback (or override).
+    describe("Map Coordinates (#8528)", () => {
+        // Helper: fill the always-required text fields so submission can succeed
+        function fillRequiredFields(suffix = "") {
+            cy.get("#sChurchName").clear().type("Coord Test Church" + suffix);
+            cy.get("#sChurchPhone").clear().type("(555) 123-4567");
+            cy.get("#sChurchEmail").clear().type("coord-test@example.com");
+            cy.get("#sChurchAddress").clear().type("123 Main St");
+            cy.get("#sChurchCity").clear().type("Springfield");
+            cy.get("#sChurchState", { timeout: 10000 }).siblings(".ts-wrapper").should("exist");
+            cy.tomSelectByValue("#sChurchState", "IL");
+            cy.get("#sChurchZip").clear().type("62701");
+        }
+
+        it("should expose latitude and longitude input fields", () => {
+            cy.visit("admin/system/church-info");
+
+            cy.get("#iChurchLatitude").should("exist").and("have.attr", "type", "number");
+            cy.get("#iChurchLongitude").should("exist").and("have.attr", "type", "number");
+            cy.contains("Map Coordinates").should("be.visible");
+        });
+
+        it("should accept manually entered GPS coordinates and persist them", () => {
+            cy.visit("admin/system/church-info");
+
+            cy.get("#sChurchCountry", { timeout: 10000 }).siblings(".ts-wrapper").should("exist");
+            fillRequiredFields(" Manual");
+
+            // The reporter's exact case: GPS coordinates from Davao City, Philippines
+            cy.get("#iChurchLatitude").clear().type("7.0933301");
+            cy.get("#iChurchLongitude").clear().type("125.5818270");
+
+            cy.wait(500);
+            cy.get("#church-info-form").submit();
+
+            cy.url({ timeout: 10000 }).should("include", "church-info");
+            cy.contains("Church information saved successfully", { timeout: 10000 }).should("be.visible");
+
+            // Coordinates should round-trip back into the form on the redirect
+            cy.get("#iChurchLatitude").should("have.value", "7.0933301");
+            cy.get("#iChurchLongitude").should("have.value", "125.581827");
+        });
+
+        it("should reject latitude outside the valid -90..90 range", () => {
+            cy.visit("admin/system/church-info");
+
+            cy.get("#sChurchCountry", { timeout: 10000 }).siblings(".ts-wrapper").should("exist");
+            fillRequiredFields(" BadLat");
+
+            // 91 is out of range
+            cy.get("#iChurchLatitude").clear().type("91");
+            cy.get("#iChurchLongitude").clear().type("0");
+
+            cy.wait(500);
+            cy.get("#church-info-form").submit();
+
+            cy.contains("Latitude must be a number between -90 and 90", { timeout: 10000 }).should("be.visible");
+            // The user's bad input should still be in the field so they can correct it
+            cy.get("#iChurchLatitude").should("have.value", "91");
+        });
+
+        it("should reject longitude outside the valid -180..180 range", () => {
+            cy.visit("admin/system/church-info");
+
+            cy.get("#sChurchCountry", { timeout: 10000 }).siblings(".ts-wrapper").should("exist");
+            fillRequiredFields(" BadLng");
+
+            cy.get("#iChurchLatitude").clear().type("0");
+            cy.get("#iChurchLongitude").clear().type("181");
+
+            cy.wait(500);
+            cy.get("#church-info-form").submit();
+
+            cy.contains("Longitude must be a number between -180 and 180", { timeout: 10000 }).should("be.visible");
+            cy.get("#iChurchLongitude").should("have.value", "181");
+        });
+
+        it("should reject lat without lng (and vice versa)", () => {
+            cy.visit("admin/system/church-info");
+
+            cy.get("#sChurchCountry", { timeout: 10000 }).siblings(".ts-wrapper").should("exist");
+            fillRequiredFields(" OnlyLat");
+
+            cy.get("#iChurchLatitude").clear().type("40.7128");
+            cy.get("#iChurchLongitude").clear();
+
+            cy.wait(500);
+            cy.get("#church-info-form").submit();
+
+            cy.contains("Both latitude and longitude must be provided together", { timeout: 10000 }).should("be.visible");
+        });
+
+        it("should fall back to auto-geocoding when both coordinate fields are blank", () => {
+            cy.visit("admin/system/church-info");
+
+            cy.get("#sChurchCountry", { timeout: 10000 }).siblings(".ts-wrapper").should("exist");
+            fillRequiredFields(" Auto");
+
+            // Explicitly blank both lat and lng — POST handler should fall back
+            // to GeoUtils::getLatLong() with the address. We don't assert on
+            // the resulting coordinates (Nominatim is external) — only that
+            // the save itself succeeds.
+            cy.get("#iChurchLatitude").clear();
+            cy.get("#iChurchLongitude").clear();
+
+            cy.wait(500);
+            cy.get("#church-info-form").submit();
+
+            cy.url({ timeout: 10000 }).should("include", "church-info");
+            // Either success (Nominatim found the address) OR a warning that
+            // it couldn't auto-locate — both are valid outcomes depending on
+            // network and OSM coverage.
+            cy.get("body", { timeout: 10000 }).should(($body) => {
+                const text = $body.text();
+                expect(
+                    text.includes("Church information saved successfully") ||
+                        text.includes("could not be auto-located"),
+                ).to.equal(true);
+            });
+        });
+    });
 });

--- a/src/admin/routes/system.php
+++ b/src/admin/routes/system.php
@@ -290,6 +290,16 @@ $app->group('/system', function (RouteCollectorProxy $group): void {
             unset($_SESSION['sGlobalMessage'], $_SESSION['sGlobalMessageClass']);
         }
 
+        // iChurchLatitude / iChurchLongitude are stored as strings in
+        // config_cfg but are semantically floats. Cast on read so the view
+        // can compare numerically without "0.0 vs '0' string" surprises, and
+        // emit empty string when unset so the form input renders blank
+        // instead of "0".
+        $rawLat = (string) SystemConfig::getValue('iChurchLatitude');
+        $rawLng = (string) SystemConfig::getValue('iChurchLongitude');
+        $latFloat = $rawLat === '' ? 0.0 : (float) $rawLat;
+        $lngFloat = $rawLng === '' ? 0.0 : (float) $rawLng;
+
         $churchInfo = [
             'sChurchName'      => SystemConfig::getValue('sChurchName'),
             'sChurchAddress'   => SystemConfig::getValue('sChurchAddress'),
@@ -299,8 +309,8 @@ $app->group('/system', function (RouteCollectorProxy $group): void {
             'sChurchCountry'   => SystemConfig::getValue('sChurchCountry') ?: 'US',
             'sChurchPhone'     => SystemConfig::getValue('sChurchPhone'),
             'sChurchEmail'     => SystemConfig::getValue('sChurchEmail'),
-            'iChurchLatitude'  => SystemConfig::getValue('iChurchLatitude'),
-            'iChurchLongitude' => SystemConfig::getValue('iChurchLongitude'),
+            'iChurchLatitude'  => ($latFloat !== 0.0 || $lngFloat !== 0.0) ? (string) $latFloat : '',
+            'iChurchLongitude' => ($latFloat !== 0.0 || $lngFloat !== 0.0) ? (string) $lngFloat : '',
             'sTimeZone'        => SystemConfig::getValue('sTimeZone'),
             'sChurchWebSite'   => SystemConfig::getValue('sChurchWebSite'),
             'sLanguage'        => SystemConfig::getValue('sLanguage'),
@@ -342,6 +352,12 @@ $app->group('/system', function (RouteCollectorProxy $group): void {
         $churchPhone   = trim($body['sChurchPhone'] ?? '');
         $churchEmail   = trim($body['sChurchEmail'] ?? '');
 
+        // Lat/long are not in the sanitization allow-list — they're numeric.
+        // Validate via filter_var below before saving. Empty string is allowed
+        // and means "let me geocode from the address" (fallback path).
+        $rawLatInput = trim((string) ($body['iChurchLatitude'] ?? ''));
+        $rawLngInput = trim((string) ($body['iChurchLongitude'] ?? ''));
+
         // Validation: Required fields
         $validationError = '';
         if (empty($churchName)) {
@@ -362,8 +378,32 @@ $app->group('/system', function (RouteCollectorProxy $group): void {
             $validationError = gettext('Email address is required.');
         }
 
+        // Coordinate validation — only if the user provided one or both fields.
+        // Both must be present together (you can't have lat without lng), and
+        // both must parse as floats in valid earth ranges.
+        $manualLat = null;
+        $manualLng = null;
+        if ($validationError === '' && ($rawLatInput !== '' || $rawLngInput !== '')) {
+            if ($rawLatInput === '' || $rawLngInput === '') {
+                $validationError = gettext('Both latitude and longitude must be provided together (or both left blank for automatic detection).');
+            } else {
+                $parsedLat = filter_var($rawLatInput, FILTER_VALIDATE_FLOAT);
+                $parsedLng = filter_var($rawLngInput, FILTER_VALIDATE_FLOAT);
+                if ($parsedLat === false || $parsedLat < -90.0 || $parsedLat > 90.0) {
+                    $validationError = gettext('Latitude must be a number between -90 and 90.');
+                } elseif ($parsedLng === false || $parsedLng < -180.0 || $parsedLng > 180.0) {
+                    $validationError = gettext('Longitude must be a number between -180 and 180.');
+                } else {
+                    $manualLat = $parsedLat;
+                    $manualLng = $parsedLng;
+                }
+            }
+        }
+
         if (!empty($validationError)) {
-            // Re-render with validation error via the system-wide notify
+            // Re-render with validation error via the system-wide notify.
+            // Echo the user's lat/long input so they can correct it (rather
+            // than wiping their entry and showing the previously-saved value).
             $renderer = new PhpRenderer(__DIR__ . '/../views/');
 
             $churchInfo = [
@@ -375,8 +415,8 @@ $app->group('/system', function (RouteCollectorProxy $group): void {
                 'sChurchCountry'   => $churchCountry,
                 'sChurchPhone'     => $churchPhone,
                 'sChurchEmail'     => $churchEmail,
-                'iChurchLatitude'  => SystemConfig::getValue('iChurchLatitude'),
-                'iChurchLongitude' => SystemConfig::getValue('iChurchLongitude'),
+                'iChurchLatitude'  => $rawLatInput !== '' ? $rawLatInput : (string) (float) SystemConfig::getValue('iChurchLatitude'),
+                'iChurchLongitude' => $rawLngInput !== '' ? $rawLngInput : (string) (float) SystemConfig::getValue('iChurchLongitude'),
                 'sTimeZone'        => $body['sTimeZone'] ?? '',
                 'sChurchWebSite'   => $body['sChurchWebSite'] ?? '',
                 'sLanguage'        => $body['sLanguage'] ?? '',
@@ -412,16 +452,32 @@ $app->group('/system', function (RouteCollectorProxy $group): void {
         $zip     = $churchZip;
         $country = $churchCountry;
 
-        // Always re-geocode from address using GeoUtils (Nominatim / OpenStreetMap,
-        // no API key required). Coordinates are not exposed in the form — they are
-        // derived from the address automatically on every save.
+        // Coordinate resolution — manual entry always wins over auto-detection.
+        // 1. If admin entered both lat AND lng manually → use those, skip Nominatim
+        // 2. Otherwise → try to geocode from the address via GeoUtils (Nominatim)
+        // 3. If geocoding fails (returns 0,0 for a non-empty address) → surface a
+        //    warning flash so the admin knows to enter coordinates manually
         $latitude  = '';
         $longitude = '';
-        if ($address !== '') {
+        $geocodingFailed = false;
+
+        if ($manualLat !== null && $manualLng !== null) {
+            $latitude  = (string) $manualLat;
+            $longitude = (string) $manualLng;
+        } elseif ($address !== '') {
             $coords = GeoUtils::getLatLong($address, $city, $state, $zip, $country);
             if ($coords['Latitude'] !== 0.0 || $coords['Longitude'] !== 0.0) {
                 $latitude  = (string) $coords['Latitude'];
                 $longitude = (string) $coords['Longitude'];
+            } else {
+                // Geocoding silently returned no result — preserve any
+                // previously-saved coordinates (don't wipe them) and tell
+                // the admin to enter coordinates manually.
+                $previousLat = (float) SystemConfig::getValue('iChurchLatitude');
+                $previousLng = (float) SystemConfig::getValue('iChurchLongitude');
+                $latitude  = $previousLat !== 0.0 ? (string) $previousLat : '';
+                $longitude = $previousLng !== 0.0 ? (string) $previousLng : '';
+                $geocodingFailed = true;
             }
         }
 
@@ -445,9 +501,17 @@ $app->group('/system', function (RouteCollectorProxy $group): void {
         SystemConfig::setValue('sDefaultZip', $body['sDefaultZip'] ?? '');
         SystemConfig::setValue('sDefaultCountry', $body['sDefaultCountry'] ?? '');
 
-        // Flash success via the system-wide notify
-        $_SESSION['sGlobalMessage']     = gettext('Church information saved successfully');
-        $_SESSION['sGlobalMessageClass'] = 'success';
+        // Flash success via the system-wide notify. If geocoding silently
+        // failed (Nominatim returned no result for a non-empty address) we
+        // still saved the rest of the form, but warn the admin so they know
+        // to enter coordinates manually.
+        if ($geocodingFailed) {
+            $_SESSION['sGlobalMessage']      = gettext('Church information saved, but the address could not be auto-located. Please enter the latitude and longitude manually under Map Coordinates.');
+            $_SESSION['sGlobalMessageClass'] = 'warning';
+        } else {
+            $_SESSION['sGlobalMessage']      = gettext('Church information saved successfully');
+            $_SESSION['sGlobalMessageClass'] = 'success';
+        }
 
         return $response
             ->withHeader('Location', SystemURLs::getRootPath() . '/admin/system/church-info')

--- a/src/admin/views/church-info.php
+++ b/src/admin/views/church-info.php
@@ -165,30 +165,57 @@ $validationError     = $validationError ?? '';
                         </div>
                     </div>
 
+                    <hr class="my-3">
+                    <h5 class="mb-3"><?= gettext('Map Coordinates') ?></h5>
+                    <p class="text-muted small mb-3">
+                        <i class="fa-solid fa-circle-info me-1"></i>
+                        <?= gettext('Coordinates are auto-detected from your address on save (via OpenStreetMap). You can also enter them manually below — manual values always take precedence over auto-detection. Leave both blank to let the system geocode from the address.') ?>
+                    </p>
+                    <div class="row">
+                        <div class="mb-3 col-md-4">
+                            <label for="iChurchLatitude"><?= gettext('Latitude') ?></label>
+                            <input type="number"
+                                   step="any"
+                                   min="-90"
+                                   max="90"
+                                   class="form-control"
+                                   id="iChurchLatitude"
+                                   name="iChurchLatitude"
+                                   value="<?= InputUtils::escapeHTML((string) $churchInfo['iChurchLatitude']) ?>"
+                                   placeholder="<?= gettext('e.g., 40.7128') ?>">
+                            <small class="form-text text-muted"><?= gettext('Range: -90 to 90.') ?></small>
+                        </div>
+                        <div class="mb-3 col-md-4">
+                            <label for="iChurchLongitude"><?= gettext('Longitude') ?></label>
+                            <input type="number"
+                                   step="any"
+                                   min="-180"
+                                   max="180"
+                                   class="form-control"
+                                   id="iChurchLongitude"
+                                   name="iChurchLongitude"
+                                   value="<?= InputUtils::escapeHTML((string) $churchInfo['iChurchLongitude']) ?>"
+                                   placeholder="<?= gettext('e.g., -74.0060') ?>">
+                            <small class="form-text text-muted"><?= gettext('Range: -180 to 180.') ?></small>
+                        </div>
+                    </div>
+
                     <?php
-                    $hasCoords = !empty($churchInfo['iChurchLatitude'])
-                        && !empty($churchInfo['iChurchLongitude'])
-                        && ((float) $churchInfo['iChurchLatitude'] !== 0.0
-                            || (float) $churchInfo['iChurchLongitude'] !== 0.0);
+                    $latFloat  = (float) $churchInfo['iChurchLatitude'];
+                    $lngFloat  = (float) $churchInfo['iChurchLongitude'];
+                    $hasCoords = ($latFloat !== 0.0 || $lngFloat !== 0.0)
+                        && $latFloat >= -90.0 && $latFloat <= 90.0
+                        && $lngFloat >= -180.0 && $lngFloat <= 180.0;
                     ?>
 
                     <?php if ($hasCoords): ?>
-                    <hr class="my-3">
-                    <h5 class="mb-3"><?= gettext('Map') ?></h5>
                     <link rel="stylesheet" href="<?= SystemURLs::assetVersioned('/skin/external/leaflet/leaflet.css') ?>">
                     <div id="church-location-map" class="mb-2 rounded border" style="height:280px;"></div>
-                    <p class="text-muted small mb-0">
-                        <i class="fa-solid fa-location-dot me-1"></i>
-                        <?= gettext('Geocoded coordinates:') ?>
-                        <?= InputUtils::escapeHTML($churchInfo['iChurchLatitude']) ?>,
-                        <?= InputUtils::escapeHTML($churchInfo['iChurchLongitude']) ?>
-                        &mdash; <?= gettext('Updated automatically on every save.') ?>
-                    </p>
                     <script nonce="<?= SystemURLs::getCSPNonce() ?>">
                         window.CRM = window.CRM || {};
                         window.CRM.churchMapConfig = <?= json_encode([
-                            'lat'  => (float) $churchInfo['iChurchLatitude'],
-                            'lng'  => (float) $churchInfo['iChurchLongitude'],
+                            'lat'  => $latFloat,
+                            'lng'  => $lngFloat,
                             'name' => $churchInfo['sChurchName'],
                         ]) ?>;
                     </script>
@@ -196,7 +223,7 @@ $validationError     = $validationError ?? '';
                     <?php else: ?>
                     <div class="alert alert-info mt-3 mb-0">
                         <i class="fa-solid fa-location-dot me-2"></i>
-                        <?= gettext('A map will appear here once a street address is saved. Coordinates are detected automatically — no manual entry required.') ?>
+                        <?= gettext('A map will appear here once coordinates are saved — either auto-detected from your address or entered manually above.') ?>
                     </div>
                     <?php endif; ?>
                 </div>


### PR DESCRIPTION
## Summary

Fixes #8528 — restores the ability to set church map coordinates manually after the 7.1.x consolidation removed the lat/long inputs in favor of automatic Nominatim geocoding only.

The reporter (in Davao City, Philippines) was using the v7.0.x trick of pasting raw GPS coordinates (`7.0933301, 125.5818270`) into the address field — which used to work because the old form had explicit lat/long inputs. After the 7.1.x consolidation, Nominatim silently fails to parse coordinates as an address, no error surfaces, and the church map pin never appears.

This affects more than the reporter:
- Anyone in less-mapped regions (most of Asia / Africa / rural areas)
- New construction not yet indexed by OpenStreetMap
- Users behind firewalls blocking `nominatim.openstreetmap.org`
- Anyone hitting Nominatim's rate limit during rapid test-saving
- All downstream features that depend on populated coordinates: [MAPS-12 radius search](https://github.com/ChurchCRM/CRM/issues/8055), FamilyView distance, congregation map

## Changes

**`src/admin/views/church-info.php`** — adds Latitude / Longitude inputs to the Location card with help text explaining the precedence rule. Map block now uses validated float comparisons instead of the old `!empty() + !== 0.0` mishmash. Removes the misleading "auto-detected, no manual entry required" alert.

**`src/admin/routes/system.php`**
- **GET handler** — defensive `(float)` cast on `iChurchLatitude` / `iChurchLongitude` (the latent inconsistency where the view cast and the route didn't)
- **POST handler — coordinate validation**: both fields must be present together; both must parse as `FILTER_VALIDATE_FLOAT`; both must be in the legal earth ranges. Specific error message per failure mode. User's bad input is preserved on validation re-render
- **POST handler — coordinate resolution priority**:
  1. Manual lat AND lng both provided → use those, **skip Nominatim entirely**
  2. Otherwise → call `GeoUtils::getLatLong()` (existing behavior)
  3. Geocoding silently failed? → preserve previously-saved coordinates (don't wipe them) + flash a warning telling the admin to enter coordinates manually

**`cypress/e2e/ui/admin/admin.church-info.spec.js`** — new `Map Coordinates (#8528)` describe block with 6 tests:
- Field visibility
- Reporter's exact GPS case (7.0933301, 125.5818270) round-trips correctly
- Latitude range validation (`91` rejected, bad input preserved)
- Longitude range validation (`181` rejected, bad input preserved)
- Pair requirement (lat without lng rejected)
- Empty fields fall back to auto-geocoding

## Files Changed

- `src/admin/views/church-info.php` (+39, −12)
- `src/admin/routes/system.php` (+76, −16)
- `cypress/e2e/ui/admin/admin.church-info.spec.js` (+125, 0)

## Why

The 7.1.x consolidation ([commit d9e6954bc](https://github.com/ChurchCRM/CRM/commit/d9e6954bc), PR #8383) removed manual lat/long inputs without a fallback. Auto-geocoding via Nominatim works for the majority of US / EU street addresses but silently fails for many international, rural, and new-construction addresses, and there's no escape hatch when it does. This is a documented regression from the 7.0.x behavior.

This is a 7.1.x regression and belongs in 7.2.0 as a fix.

## Validation

- ✅ `npm run lint` — exit 0
- ✅ `npm run build:php` — 701 PHP files validated
- ✅ `npm run build:webpack` — compiled successfully
- ✅ Pre-push Biome hook passed

## Test plan

- [ ] Visit `/admin/system/church-info`
- [ ] Verify the Map Coordinates section renders with both inputs
- [ ] Enter the reporter's coordinates (`7.0933301` / `125.5818270`) → save → map should appear pointing to Davao City
- [ ] Clear both fields → save → Nominatim should geocode from the existing address (or surface a warning if it fails)
- [ ] Enter `91` in latitude → save → should reject with "Latitude must be a number between -90 and 90", input preserved
- [ ] Enter only latitude with empty longitude → save → should reject with "Both ... together"
- [ ] Run the 6 new Cypress tests in `admin.church-info.spec.js` (plus the 13 existing tests for regression)

## Related Issues

- Closes #8528
- Latent fix for the cast inconsistency referenced in `MEMORY.md` → "iChurchLatitude/iChurchLongitude are floats — use (float) getValue()"
- Unblocks downstream map features that depend on populated coordinates

## Out of Scope

Considered and deferred:
- ❌ Auto-detection of `lat,lng` patterns inside the address field (too magical, easy to confuse with a street address)
- ❌ "Re-geocode now" button (empty fields + Save accomplishes the same thing)
- ❌ New `bChurchCoordinatesManual` flag (the simpler "presence wins" rule means user-entered values always survive subsequent saves unless explicitly cleared)
- ❌ Changes to `webpack/church-info.js` (map init reads `window.CRM.churchMapConfig` which is still emitted by the view; nothing to change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)