### PR TITLE
security: fix SQLi in FinancialService + harden API login

### DIFF
--- a/cypress/e2e/api/public/public.user.spec.js
+++ b/cypress/e2e/api/public/public.user.spec.js
@@ -1,7 +1,7 @@
 /// <reference types="cypress" />
 
 describe("API Public User", () => {
-    it("Login", () => {
+    it("Login with valid credentials returns apiKey", () => {
         const user = {
             userName: "admin",
             password: "changeme",
@@ -16,6 +16,43 @@ describe("API Public User", () => {
             expect(resp.status).to.eq(200);
             expect(resp.body).to.have.property('apiKey');
             expect(resp.body.apiKey).to.eq(Cypress.env("admin.api.key"));
+        });
+    });
+
+    it("Login with non-existent user returns 401 (not 404)", () => {
+        cy.apiRequest({
+            method: "POST",
+            url: "/api/public/user/login",
+            headers: { "content-type": "application/json" },
+            body: { userName: "nonexistent_user_xyz", password: "anything" },
+            failOnStatusCode: false,
+        }).then((resp) => {
+            // Should return 401 (same as wrong password) to prevent username enumeration
+            expect(resp.status).to.eq(401);
+        });
+    });
+
+    it("Login with wrong password returns 401", () => {
+        cy.apiRequest({
+            method: "POST",
+            url: "/api/public/user/login",
+            headers: { "content-type": "application/json" },
+            body: { userName: "admin", password: "wrong_password" },
+            failOnStatusCode: false,
+        }).then((resp) => {
+            expect(resp.status).to.eq(401);
+        });
+    });
+
+    it("Login with empty userName returns 401", () => {
+        cy.apiRequest({
+            method: "POST",
+            url: "/api/public/user/login",
+            headers: { "content-type": "application/json" },
+            body: { userName: "", password: "anything" },
+            failOnStatusCode: false,
+        }).then((resp) => {
+            expect(resp.status).to.eq(401);
         });
     });
 

--- a/src/ChurchCRM/Service/FinancialService.php
+++ b/src/ChurchCRM/Service/FinancialService.php
@@ -84,17 +84,15 @@ class FinancialService
         if (!$routeAndAccount) {
             throw new \Exception('error in locating family');
         }
-        $sSQL = 'SELECT fam_ID, fam_Name FROM family_fam WHERE fam_scanCheck="' . $routeAndAccount . '"';
-        $rsFam = FunctionsUtils::runQuery($sSQL);
-        $row = mysqli_fetch_array($rsFam);
+        $family = FamilyQuery::create()->findOneByScanCheck($routeAndAccount);
         $iCheckNo = $micrObj->findCheckNo($tScanString);
 
         return [
             'ScanString'      => $tScanString,
             'RouteAndAccount' => $routeAndAccount,
             'CheckNumber'     => $iCheckNo,
-            'fam_ID'          => $row['fam_ID'],
-            'fam_Name'        => $row['fam_Name'],
+            'fam_ID'          => $family?->getId(),
+            'fam_Name'        => $family?->getName(),
         ];
     }
 

--- a/src/ChurchCRM/Slim/SlimUtils.php
+++ b/src/ChurchCRM/Slim/SlimUtils.php
@@ -7,8 +7,11 @@ use ChurchCRM\Utils\LoggerUtils;
 use Exception;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Exception\HttpBadRequestException;
+use Slim\Exception\HttpForbiddenException;
 use Slim\Exception\HttpMethodNotAllowedException;
 use Slim\Exception\HttpNotFoundException;
+use Slim\Exception\HttpUnauthorizedException;
 use Slim\Interfaces\RouteInterface;
 use Slim\Psr7\Response as Psr7Response;
 use Slim\Routing\RouteContext;
@@ -173,7 +176,7 @@ class SlimUtils
                 'user_agent' => $request->getHeaderLine('User-Agent')
             ];
             $logger->error('Uncaught exception: ' . $exception->getMessage(), $requestContext);
-            
+
             $response = new Psr7Response();
 
             // Determine appropriate HTTP status code based on exception type
@@ -182,6 +185,12 @@ class SlimUtils
                 $statusCode = 404;
             } elseif ($exception instanceof HttpMethodNotAllowedException) {
                 $statusCode = 405;
+            } elseif ($exception instanceof HttpUnauthorizedException) {
+                $statusCode = 401;
+            } elseif ($exception instanceof HttpForbiddenException) {
+                $statusCode = 403;
+            } elseif ($exception instanceof HttpBadRequestException) {
+                $statusCode = 400;
             }
 
             // Sanitize error message to prevent credential disclosure

--- a/src/api/routes/public/public-user.php
+++ b/src/api/routes/public/public-user.php
@@ -30,7 +30,8 @@ $app->group('/public/user', function (RouteCollectorProxy $group): void {
  *         @OA\JsonContent(
  *             required={"userName","password"},
  *             @OA\Property(property="userName", type="string", example="admin"),
- *             @OA\Property(property="password", type="string", format="password", example="secret")
+ *             @OA\Property(property="password", type="string", format="password", example="secret"),
+ *             @OA\Property(property="otp", type="string", description="One-time password or recovery code for 2FA (required when 202 is returned)", example="123456")
  *         )
  *     ),
  *     @OA\Response(
@@ -65,14 +66,15 @@ function userLogin(Request $request, Response $response, array $args): Response
     $user = UserQuery::create()->findOneByUserName($body['userName']);
     if ($user === null) {
         // Return same error as wrong password to prevent username enumeration
-        $logger->warning('API login attempt for non-existent user: ' . $body['userName']);
+        $logger->warning('API login attempt for non-existent user', ['username' => $body['userName']]);
         throw new HttpUnauthorizedException($request, $genericError);
     }
 
     // Check account lockout before attempting password validation
+    // Use same generic error to prevent username enumeration via locked-account message
     if ($user->isLocked()) {
-        $logger->warning('API login attempt for locked account: ' . $user->getUserName());
-        throw new HttpUnauthorizedException($request, gettext('Too many failed logins: your account has been locked. Please contact an administrator.'));
+        $logger->warning('API login attempt for locked account', ['username' => $user->getUserName()]);
+        throw new HttpUnauthorizedException($request, $genericError);
     }
 
     $password = $body['password'] ?? '';
@@ -83,34 +85,42 @@ function userLogin(Request $request, Response $response, array $args): Response
 
         // Send locked email if account just became locked
         if ($user->isLocked() && !empty($user->getEmail())) {
-            $logger->warning('API login: too many failed attempts, account locked: ' . $user->getUserName());
+            $logger->warning('API login: account locked after too many failures', ['username' => $user->getUserName()]);
             $lockedEmail = new LockedEmail($user);
             $lockedEmail->send();
         }
 
-        $logger->warning('API login: invalid password for user: ' . $user->getUserName());
+        $logger->warning('API login: invalid password', ['username' => $user->getUserName()]);
         throw new HttpUnauthorizedException($request, $genericError);
     }
 
-    // Password is valid — reset failed login counter
-    $user->setFailedLogins(0);
-    $user->save();
-
-    // Check 2FA enrollment
+    // Check 2FA enrollment BEFORE resetting failed logins (only reset on full auth)
     if ($user->is2FactorAuthEnabled()) {
         $otp = $body['otp'] ?? null;
 
         if (empty($otp)) {
-            // No OTP provided — tell client to prompt for it
+            // No OTP provided — tell client to prompt for it (don't reset failed logins yet)
             return SlimUtils::renderJSON($response, ['requiresOTP' => true], 202);
         }
 
         // Validate OTP or recovery code
-        if (!$user->isTwoFACodeValid($otp) && !$user->isTwoFaRecoveryCodeValid($otp)) {
-            $logger->warning('API login: invalid 2FA code for user: ' . $user->getUserName());
-            throw new HttpUnauthorizedException($request, gettext('Invalid verification code'));
+        $otpValid = $user->isTwoFACodeValid($otp);
+        $recoveryValid = !$otpValid && $user->isTwoFaRecoveryCodeValid($otp);
+
+        if (!$otpValid && !$recoveryValid) {
+            $logger->warning('API login: invalid 2FA code', ['username' => $user->getUserName()]);
+            throw new HttpUnauthorizedException($request, $genericError);
+        }
+
+        // Persist consumed recovery code if one was used
+        if ($recoveryValid) {
+            $user->save();
         }
     }
+
+    // Full authentication complete — reset failed login counter
+    $user->setFailedLogins(0);
+    $user->save();
 
     return SlimUtils::renderJSON($response, ['apiKey' => $user->getApiKey()]);
 }

--- a/src/api/routes/public/public-user.php
+++ b/src/api/routes/public/public-user.php
@@ -1,5 +1,6 @@
 <?php
 
+use ChurchCRM\Emails\users\LockedEmail;
 use ChurchCRM\Emails\users\ResetPasswordTokenEmail;
 use ChurchCRM\model\ChurchCRM\Token;
 use ChurchCRM\model\ChurchCRM\UserQuery;
@@ -8,7 +9,6 @@ use ChurchCRM\Utils\LoggerUtils;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Exception\HttpBadRequestException;
-use Slim\Exception\HttpNotFoundException;
 use Slim\Exception\HttpUnauthorizedException;
 use Slim\Routing\RouteCollectorProxy;
 
@@ -41,24 +41,75 @@ $app->group('/public/user', function (RouteCollectorProxy $group): void {
  *         )
  *     ),
  *     @OA\Response(response=401, description="Invalid username or password"),
- *     @OA\Response(response=404, description="User not found")
+ *     @OA\Response(
+ *         response=202,
+ *         description="Password valid but 2FA verification required",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="requiresOTP", type="boolean", example=true)
+ *         )
+ *     )
  * )
  */
 function userLogin(Request $request, Response $response, array $args): Response
 {
+    $logger = LoggerUtils::getAppLogger();
     $body = json_decode($request->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+    // Use a generic error message to prevent username enumeration
+    $genericError = gettext('Invalid login or password');
+
     if (empty($body['userName'])) {
-        throw new HttpNotFoundException($request);
+        throw new HttpUnauthorizedException($request, $genericError);
     }
 
     $user = UserQuery::create()->findOneByUserName($body['userName']);
-    if (empty($user)) {
-        throw new HttpNotFoundException($request);
+    if ($user === null) {
+        // Return same error as wrong password to prevent username enumeration
+        $logger->warning('API login attempt for non-existent user: ' . $body['userName']);
+        throw new HttpUnauthorizedException($request, $genericError);
     }
 
-    $password = $body['password'];
+    // Check account lockout before attempting password validation
+    if ($user->isLocked()) {
+        $logger->warning('API login attempt for locked account: ' . $user->getUserName());
+        throw new HttpUnauthorizedException($request, gettext('Too many failed logins: your account has been locked. Please contact an administrator.'));
+    }
+
+    $password = $body['password'] ?? '';
     if (!$user->isPasswordValid($password)) {
-        throw new HttpUnauthorizedException($request, gettext('Invalid User/Password'));
+        // Increment failed login counter
+        $user->setFailedLogins($user->getFailedLogins() + 1);
+        $user->save();
+
+        // Send locked email if account just became locked
+        if ($user->isLocked() && !empty($user->getEmail())) {
+            $logger->warning('API login: too many failed attempts, account locked: ' . $user->getUserName());
+            $lockedEmail = new LockedEmail($user);
+            $lockedEmail->send();
+        }
+
+        $logger->warning('API login: invalid password for user: ' . $user->getUserName());
+        throw new HttpUnauthorizedException($request, $genericError);
+    }
+
+    // Password is valid — reset failed login counter
+    $user->setFailedLogins(0);
+    $user->save();
+
+    // Check 2FA enrollment
+    if ($user->is2FactorAuthEnabled()) {
+        $otp = $body['otp'] ?? null;
+
+        if (empty($otp)) {
+            // No OTP provided — tell client to prompt for it
+            return SlimUtils::renderJSON($response, ['requiresOTP' => true], 202);
+        }
+
+        // Validate OTP or recovery code
+        if (!$user->isTwoFACodeValid($otp) && !$user->isTwoFaRecoveryCodeValid($otp)) {
+            $logger->warning('API login: invalid 2FA code for user: ' . $user->getUserName());
+            throw new HttpUnauthorizedException($request, gettext('Invalid verification code'));
+        }
     }
 
     return SlimUtils::renderJSON($response, ['apiKey' => $user->getApiKey()]);


### PR DESCRIPTION
## Summary
- Replace raw SQL in `FinancialService::getMemberByScanString()` with `FamilyQuery::findOneByScanCheck()` (SQL injection)
- Return 401 (not 404) for missing users to prevent username enumeration
- Check `isLocked()` + increment `setFailedLogins()` on failure to enforce account lockout
- Enforce 2FA via `is2FactorAuthEnabled()` — return 202 `requiresOTP` when OTP needed

## Changes
- `src/ChurchCRM/Service/FinancialService.php` — Propel ORM instead of raw SQL
- `src/api/routes/public/public-user.php` — lockout, 2FA, enum fix (mirrors `LocalAuthentication.php` pattern)
- `cypress/e2e/api/public/public.user.spec.js` — 3 new tests

## Why
Addresses GHSA-hc37-vx3w-34fg (SQL injection), GHSA-x2qh-xmhq-4jpx (username enumeration), GHSA-8cwr-x83m-mh9x (auth bypass / lockout / 2FA bypass).

## Test plan
- [ ] `POST /api/public/user/login` with non-existent user → 401 (not 404)
- [ ] `POST /api/public/user/login` with wrong password → 401 + incremented failed logins
- [ ] `POST /api/public/user/login` with locked account → 401
- [ ] `POST /api/public/user/login` with 2FA user (no OTP) → 202 `requiresOTP`
- [ ] `POST /api/public/user/login` with valid credentials → 200 + apiKey
- [ ] Run `npx cypress run --spec cypress/e2e/api/public/public.user.spec.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)