### PR TITLE
security: fix XSS in search dropdown and PledgeEditor

### DIFF
--- a/cypress/e2e/ui/security/xss-search-escaping.spec.js
+++ b/cypress/e2e/ui/security/xss-search-escaping.spec.js
@@ -1,7 +1,7 @@
 /// <reference types="cypress" />
 
 describe("XSS: Search dropdown escaping", () => {
-    before(() => {
+    beforeEach(() => {
         cy.setupAdminSession();
     });
 

--- a/cypress/e2e/ui/security/xss-search-escaping.spec.js
+++ b/cypress/e2e/ui/security/xss-search-escaping.spec.js
@@ -2,17 +2,13 @@
 
 describe("XSS: Search dropdown escaping", () => {
     before(() => {
-        cy.loginAsAdmin();
+        cy.setupAdminSession();
     });
 
     it("Search results escape HTML in person names", () => {
-        // Visit dashboard and interact with search
         cy.visit("/");
-        cy.get("#navbar-search-input").should("exist");
+        cy.get("#globalSearch").should("exist");
 
-        // Type a search term and verify the dropdown uses escapeHtml
-        // We can't easily inject XSS data without DB access, but we CAN verify
-        // that the search JS uses window.CRM.escapeHtml by checking the source
         cy.window().then((win) => {
             // Verify the escapeHtml utility exists on the CRM object
             expect(win.CRM).to.have.property("escapeHtml");
@@ -24,5 +20,36 @@ describe("XSS: Search dropdown escaping", () => {
             expect(escaped).to.not.contain("<script>");
             expect(escaped).to.contain("&lt;script&gt;");
         });
+    });
+
+    it("Search dropdown renders escaped content from API", () => {
+        cy.visit("/");
+
+        // Intercept search API and inject XSS payload
+        cy.intercept("GET", "**/api/search/**", {
+            statusCode: 200,
+            body: [
+                {
+                    text: "Persons (1)",
+                    children: [
+                        {
+                            text: '<img src=x onerror=alert(1)>',
+                            uri: '/test?a="><script>alert(2)</script>',
+                        },
+                    ],
+                },
+            ],
+        }).as("searchXSS");
+
+        cy.get("#globalSearch").type("test");
+        cy.wait("@searchXSS");
+
+        // Verify no script elements were injected into the dropdown
+        cy.get("#searchDropdown").should("exist");
+        cy.get("#searchDropdown script").should("not.exist");
+        cy.get("#searchDropdown img").should("not.exist");
+
+        // The escaped text should appear as literal text, not rendered HTML
+        cy.get("#searchDropdown").should("contain.text", "<img");
     });
 });

--- a/cypress/e2e/ui/security/xss-search-escaping.spec.js
+++ b/cypress/e2e/ui/security/xss-search-escaping.spec.js
@@ -1,0 +1,28 @@
+/// <reference types="cypress" />
+
+describe("XSS: Search dropdown escaping", () => {
+    before(() => {
+        cy.loginAsAdmin();
+    });
+
+    it("Search results escape HTML in person names", () => {
+        // Visit dashboard and interact with search
+        cy.visit("/");
+        cy.get("#navbar-search-input").should("exist");
+
+        // Type a search term and verify the dropdown uses escapeHtml
+        // We can't easily inject XSS data without DB access, but we CAN verify
+        // that the search JS uses window.CRM.escapeHtml by checking the source
+        cy.window().then((win) => {
+            // Verify the escapeHtml utility exists on the CRM object
+            expect(win.CRM).to.have.property("escapeHtml");
+            expect(win.CRM.escapeHtml).to.be.a("function");
+
+            // Verify it properly escapes dangerous characters
+            const dangerous = '<script>alert(1)</script>';
+            const escaped = win.CRM.escapeHtml(dangerous);
+            expect(escaped).to.not.contain("<script>");
+            expect(escaped).to.contain("&lt;script&gt;");
+        });
+    });
+});

--- a/cypress/e2e/ui/security/xss-search-escaping.spec.js
+++ b/cypress/e2e/ui/security/xss-search-escaping.spec.js
@@ -45,11 +45,11 @@ describe("XSS: Search dropdown escaping", () => {
         cy.wait("@searchXSS");
 
         // Verify no script elements were injected into the dropdown
-        cy.get("#searchDropdown").should("exist");
-        cy.get("#searchDropdown script").should("not.exist");
-        cy.get("#searchDropdown img").should("not.exist");
+        cy.get("#globalSearchDropdown").should("exist");
+        cy.get("#globalSearchDropdown script").should("not.exist");
+        cy.get("#globalSearchDropdown img").should("not.exist");
 
         // The escaped text should appear as literal text, not rendered HTML
-        cy.get("#searchDropdown").should("contain.text", "<img");
+        cy.get("#globalSearchDropdown").should("contain.text", "<img");
     });
 });

--- a/src/PledgeEditor.php
+++ b/src/PledgeEditor.php
@@ -705,7 +705,7 @@ require_once __DIR__ . '/Include/Header.php';
                                         <?php
                                     } ?>
                                     <td>
-                                        <input type="text" size=40 name="<?= $fun_id ?>_Comment" id="<?= $fun_id ?>_Comment" value="<?= $sComment[$fun_id] ?>">
+                                        <input type="text" size=40 name="<?= $fun_id ?>_Comment" id="<?= $fun_id ?>_Comment" value="<?= InputUtils::escapeAttribute($sComment[$fun_id]) ?>">
                                     </td>
                                 </tr>
                                 <?php

--- a/src/skin/js/Footer.js
+++ b/src/skin/js/Footer.js
@@ -78,12 +78,12 @@ function initializeApp() {
           '<i class="ti ' +
           icon +
           ' me-1"></i> ' +
-          group.text +
+          window.CRM.escapeHtml(group.text) +
           "</div>";
         (group.children || []).forEach((item) => {
           var idx = currentItems.length;
           currentItems.push(item);
-          html += '<a href="' + item.uri + '" class="dropdown-item" data-idx="' + idx + '">' + item.text + "</a>";
+          html += '<a href="' + window.CRM.escapeHtml(item.uri) + '" class="dropdown-item" data-idx="' + idx + '">' + window.CRM.escapeHtml(item.text) + "</a>";
         });
       });
 

--- a/src/skin/js/Footer.js
+++ b/src/skin/js/Footer.js
@@ -83,7 +83,14 @@ function initializeApp() {
         (group.children || []).forEach((item) => {
           var idx = currentItems.length;
           currentItems.push(item);
-          html += '<a href="' + window.CRM.escapeHtml(item.uri) + '" class="dropdown-item" data-idx="' + idx + '">' + window.CRM.escapeHtml(item.text) + "</a>";
+          html +=
+            '<a href="' +
+            window.CRM.escapeHtml(item.uri) +
+            '" class="dropdown-item" data-idx="' +
+            idx +
+            '">' +
+            window.CRM.escapeHtml(item.text) +
+            "</a>";
         });
       });
 


### PR DESCRIPTION
## Summary
- Escape search dropdown results with `window.CRM.escapeHtml()` in Footer.js
- Escape PledgeEditor comment field with `InputUtils::escapeAttribute()`

## Changes
- `src/skin/js/Footer.js` — escape `group.text`, `item.text`, `item.uri` before innerHTML
- `src/PledgeEditor.php` — line 708: `escapeAttribute()` on `$sComment[$fun_id]`
- New test: `cypress/e2e/ui/security/xss-search-escaping.spec.js`

## Why
Addresses GHSA-3ghg-qfqw-rcqf (reflected XSS in search) and GHSA-wjmf-w8gj-rx7g (stored XSS portion).

## Test plan
- [ ] Search for a person with `<script>alert(1)</script>` in name → no alert fires
- [ ] Edit a pledge with HTML in comment field → rendered safely
- [ ] Run `npx cypress run --spec cypress/e2e/ui/security/xss-search-escaping.spec.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)