### PR TITLE
security: convert FundRaiserEditor raw SQL to Propel ORM

### DIFF
--- a/src/FundRaiserEditor.php
+++ b/src/FundRaiserEditor.php
@@ -101,11 +101,33 @@ if (isset($_POST['FundRaiserSubmit'])) {
         $sDescription = $fundraiser->getDescription();
 
 
+        // Use addAscendingOrderByColumn with raw SQL to preserve natural sort
+        // (e.g., A2 before A10) matching the original ORDER BY
         $donatedItems = DonatedItemQuery::create()
             ->filterByFrId((int) $iFundRaiserID)
-            ->orderByMultibuy()
-            ->orderByItem()
+            ->addAscendingOrderByColumn('di_multibuy')
+            ->addAscendingOrderByColumn('SUBSTR(di_item,1,1)')
+            ->addAscendingOrderByColumn('cast(SUBSTR(di_item,2) as unsigned integer)')
+            ->addAscendingOrderByColumn('SUBSTR(di_item,4)')
             ->find();
+
+        // Preload all referenced person IDs to avoid N+1 queries
+        $personIds = [];
+        foreach ($donatedItems as $item) {
+            if ($item->getDonorId()) {
+                $personIds[] = (int) $item->getDonorId();
+            }
+            if ($item->getBuyerId()) {
+                $personIds[] = (int) $item->getBuyerId();
+            }
+        }
+        $personMap = [];
+        if (!empty($personIds)) {
+            $persons = PersonQuery::create()->findPks(array_unique($personIds));
+            foreach ($persons as $person) {
+                $personMap[$person->getId()] = $person;
+            }
+        }
         $_SESSION['iCurrentFundraiser'] = $iFundRaiserID;        // Probably redundant
 
     } else {
@@ -205,8 +227,8 @@ require_once __DIR__ . '/Include/Header.php';
         if ($donatedItems !== null && $donatedItems->count() > 0) {
             foreach ($donatedItems as $item) {
                 $itemName = $item->getItem() ?: '~';
-                $donor = $item->getDonorId() ? PersonQuery::create()->findPk((int) $item->getDonorId()) : null;
-                $buyer = $item->getBuyerId() ? PersonQuery::create()->findPk((int) $item->getBuyerId()) : null;
+                $donor = $item->getDonorId() ? ($personMap[(int) $item->getDonorId()] ?? null) : null;
+                $buyer = $item->getBuyerId() ? ($personMap[(int) $item->getBuyerId()] ?? null) : null;
                 $donorFirstName = $donor ? $donor->getFirstName() : '';
                 $donorLastName = $donor ? $donor->getLastName() : '';
                 $buyerFirstName = $buyer ? $buyer->getFirstName() : '';

--- a/src/FundRaiserEditor.php
+++ b/src/FundRaiserEditor.php
@@ -4,8 +4,10 @@ require_once __DIR__ . '/Include/Config.php';
 require_once __DIR__ . '/Include/PageInit.php';
 
 use ChurchCRM\Authentication\AuthenticationManager;
+use ChurchCRM\model\ChurchCRM\DonatedItemQuery;
 use ChurchCRM\model\ChurchCRM\FundRaiser;
 use ChurchCRM\model\ChurchCRM\FundRaiserQuery;
+use ChurchCRM\model\ChurchCRM\PersonQuery;
 use ChurchCRM\Utils\DateTimeUtils;
 use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
@@ -99,22 +101,18 @@ if (isset($_POST['FundRaiserSubmit'])) {
         $sDescription = $fundraiser->getDescription();
 
 
-        $sSQL ="SELECT di_ID, di_Item, di_multibuy,
-        a.per_FirstName as donorFirstName, a.per_LastName as donorLastName,
-        b.per_FirstName as buyerFirstName, b.per_LastName as buyerLastName,
-        di_title, di_sellprice, di_estprice, di_materialvalue, di_minimum
-        FROM donateditem_di
-        LEFT JOIN person_per a ON di_donor_ID=a.per_ID
-        LEFT JOIN person_per b ON di_buyer_ID=b.per_ID
-        WHERE di_FR_ID = '" . $iFundRaiserID ."' ORDER BY di_multibuy,SUBSTR(di_item,1,1),cast(SUBSTR(di_item,2) as unsigned integer),SUBSTR(di_item,4)";
-        $rsDonatedItems = RunQuery($sSQL);
+        $donatedItems = DonatedItemQuery::create()
+            ->filterByFrId((int) $iFundRaiserID)
+            ->orderByMultibuy()
+            ->orderByItem()
+            ->find();
         $_SESSION['iCurrentFundraiser'] = $iFundRaiserID;        // Probably redundant
 
     } else {
         $dDate = date_create('now');    // Set default date to today
         $sTitle = '';
         $sDescription = '';
-        $rsDonatedItems = 0;
+        $donatedItems = null;
     }
 }
 
@@ -204,42 +202,44 @@ require_once __DIR__ . '/Include/Header.php';
         <tbody>
         <?php
         //Loop through all donated items
-        if ($rsDonatedItems instanceof \mysqli_result) {
-            while ($aRow = mysqli_fetch_array($rsDonatedItems)) {
-                extract($aRow);
-
-                if ($di_Item === '') {
-                    $di_Item = '~';
-                }
+        if ($donatedItems !== null && $donatedItems->count() > 0) {
+            foreach ($donatedItems as $item) {
+                $itemName = $item->getItem() ?: '~';
+                $donor = $item->getDonorId() ? PersonQuery::create()->findPk((int) $item->getDonorId()) : null;
+                $buyer = $item->getBuyerId() ? PersonQuery::create()->findPk((int) $item->getBuyerId()) : null;
+                $donorFirstName = $donor ? $donor->getFirstName() : '';
+                $donorLastName = $donor ? $donor->getLastName() : '';
+                $buyerFirstName = $buyer ? $buyer->getFirstName() : '';
+                $buyerLastName = $buyer ? $buyer->getLastName() : '';
 
                 ?>
                 <tr>
-                    <td><?= InputUtils::escapeHTML($di_Item) ?></td>
-                    <td><?= $di_multibuy ? '<span class="badge bg-info">X</span>' : '' ?></td>
+                    <td><?= InputUtils::escapeHTML($itemName) ?></td>
+                    <td><?= $item->getMultibuy() ? '<span class="badge bg-info">X</span>' : '' ?></td>
                     <td><?= InputUtils::escapeHTML($donorFirstName) . ' ' . InputUtils::escapeHTML($donorLastName) ?></td>
                     <td>
-                        <?php if ($di_multibuy) {
+                        <?php if ($item->getMultibuy()) {
                             echo '<span class="text-muted">' . gettext('Multiple') . '</span>';
                         } else {
                             echo InputUtils::escapeHTML($buyerFirstName) . ' ' . InputUtils::escapeHTML($buyerLastName);
                         } ?>
                     </td>
-                    <td><?= InputUtils::escapeHTML($di_title) ?></td>
-                    <td class="text-end"><?= InputUtils::escapeHTML($di_sellprice) ?></td>
-                    <td class="text-end"><?= InputUtils::escapeHTML($di_estprice) ?></td>
-                    <td class="text-end"><?= InputUtils::escapeHTML($di_materialvalue) ?></td>
-                    <td class="text-end"><?= InputUtils::escapeHTML($di_minimum) ?></td>
+                    <td><?= InputUtils::escapeHTML($item->getTitle()) ?></td>
+                    <td class="text-end"><?= InputUtils::escapeHTML($item->getSellprice()) ?></td>
+                    <td class="text-end"><?= InputUtils::escapeHTML($item->getEstprice()) ?></td>
+                    <td class="text-end"><?= InputUtils::escapeHTML($item->getMaterialValue()) ?></td>
+                    <td class="text-end"><?= InputUtils::escapeHTML($item->getMinimum()) ?></td>
                     <td class="w-1">
                         <div class="dropdown">
                             <button class="btn btn-sm btn-ghost-secondary" type="button" data-bs-toggle="dropdown" data-bs-display="static" aria-expanded="false">
                                 <i class="ti ti-dots-vertical"></i>
                             </button>
                             <div class="dropdown-menu dropdown-menu-end">
-                                <a class="dropdown-item" href="DonatedItemEditor.php?DonatedItemID=<?= (int)$di_ID ?>&linkBack=FundRaiserEditor.php?FundRaiserID=<?= (int)$iFundRaiserID ?>">
+                                <a class="dropdown-item" href="DonatedItemEditor.php?DonatedItemID=<?= (int) $item->getId() ?>&linkBack=FundRaiserEditor.php?FundRaiserID=<?= (int)$iFundRaiserID ?>">
                                     <i class="ti ti-pencil me-2"></i><?= gettext('Edit') ?>
                                 </a>
                                 <div class="dropdown-divider"></div>
-                                <a class="dropdown-item text-danger" href="DonatedItemDelete.php?DonatedItemID=<?= (int)$di_ID ?>&linkBack=FundRaiserEditor.php?FundRaiserID=<?= (int)$iFundRaiserID ?>">
+                                <a class="dropdown-item text-danger" href="DonatedItemDelete.php?DonatedItemID=<?= (int) $item->getId() ?>&linkBack=FundRaiserEditor.php?FundRaiserID=<?= (int)$iFundRaiserID ?>">
                                     <i class="ti ti-trash me-2"></i><?= gettext('Delete') ?>
                                 </a>
                             </div>
@@ -247,7 +247,7 @@ require_once __DIR__ . '/Include/Header.php';
                     </td>
                 </tr>
                 <?php
-            } // while
+            } // foreach
         } // if
         ?>
         </tbody>


### PR DESCRIPTION
## Summary
- Replace raw SQL query for donated items with `DonatedItemQuery::create()->filterByFrId()`
- Replace `mysqli_fetch_array` loop with Propel foreach using getters
- Donor/buyer names loaded via `PersonQuery::findPk()` per row

## Changes
- `src/FundRaiserEditor.php` — ORM conversion for donated items query

## Why
Addresses GHSA-vg4m-hc29-jgqj (2nd-order SQL injection). The `$iFundRaiserID` variable was concatenated directly into the SQL string. While it was filtered as int, the pattern is inconsistent with the codebase ORM standard.

## Test plan
- [ ] View a fundraiser with donated items → items display correctly
- [ ] Donor/buyer names render properly
- [ ] Run `npx cypress run --spec cypress/e2e/ui/finance/standard.fundraiser.spec.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)