### PR TITLE
security: add CSRF protection to UserEditor.php

### DIFF
--- a/.agents/skills/churchcrm/cypress-testing.md
+++ b/.agents/skills/churchcrm/cypress-testing.md
@@ -432,6 +432,20 @@ cy.intercept("GET", "/api/people/properties/definition/*").as("getDef");
 
 **Note:** This does NOT apply to `cy.visit()` or `cy.request()` — those use `baseUrl` from config and handle the prefix automatically. Only `cy.intercept()` needs the `**` glob because it matches against the full request URL.
 
+## Editable Table Cells: Names Render in Input Values <!-- learned: 2026-04-12 -->
+
+When a table renders option/option names in `<input>` elements (like the OptionManager and many Tabler tables with inline editing), `cy.contains("Member")` does NOT find the value — `cy.contains` searches text content, not input value attributes.
+
+```javascript
+// ❌ WRONG — searches text content, won't find value attributes
+cy.get("#optionsTable tbody").should("contain", "Member");
+
+// ✅ CORRECT — query the input by its value attribute
+cy.get('#optionsTable tbody input.option-name-input[value="Member"]').should("exist");
+```
+
+This applies to any test that asserts data in a table where cells use `<input value="...">` for inline editing.
+
 ## Preventing Flaky Tests (Timing & State) <!-- learned: 2026-04-07 -->
 
 Flaky tests almost always come from one of four root causes. Each has a mandatory fix pattern.

--- a/.agents/skills/churchcrm/security-best-practices.md
+++ b/.agents/skills/churchcrm/security-best-practices.md
@@ -264,6 +264,40 @@ $userId = $_GET['userId'];  // Could be "1 OR 1=1"
 
 ## Authorization & Access Control
 
+### Block Users With No Admin Permissions <!-- learned: 2026-04-12 -->
+
+Users with `EditSelf=1` and **all other permissions at 0** can log in but have no functional admin access. They must NOT see the full admin UI — instead they should be redirected to a limited-access page.
+
+Use `User::hasNoAdminPermissions()` to detect this state. The check fires in two places:
+
+1. **`PageInit.php`** — for legacy `*.php` pages
+2. **`AuthMiddleware`** — for MVC routes (`/people/`, `/admin/`, `/v2/`) and API endpoints
+
+```php
+// In PageInit.php — runs for legacy pages
+if (AuthenticationManager::getCurrentUser()->hasNoAdminPermissions()) {
+    RedirectUtils::redirect(SystemURLs::getRootPath() . '/external/limited-access');
+}
+
+// In AuthMiddleware (session branch) — runs for MVC pages
+if ($sessionUser->hasNoAdminPermissions()) {
+    if ($this->isBrowserRequest($request)) {
+        return (new Response())->withStatus(302)->withHeader('Location', $rootPath . '/external/limited-access');
+    }
+    return $response->withStatus(403)->withHeader('Content-Type', 'application/json');
+}
+```
+
+The `/external/limited-access` page is in the external module (no auth required) and shows:
+- A "Verify Family Info" button (generates time-limited token bound to user's family)
+- A "Log Out" button
+
+**Reference**: GHSA-5w59-32c8-933v / PR #8616 / Issue #237
+
+### MVC vs Legacy Auth Enforcement Points <!-- learned: 2026-04-12 -->
+
+Permission checks must run in BOTH `AuthMiddleware` (MVC + API) AND `PageInit.php` (legacy). Adding a check in only one leaves a hole — the MVC modules `/people/`, `/admin/`, `/v2/`, `/event/`, `/groups/`, `/finance/` all use `AuthMiddleware`, while legacy `*.php` files in `src/` go through `PageInit.php`.
+
 ### Object-Level Authorization
 
 Check if user can edit SPECIFIC person:

--- a/src/UserEditor.php
+++ b/src/UserEditor.php
@@ -12,6 +12,7 @@ use ChurchCRM\model\ChurchCRM\User;
 use ChurchCRM\model\ChurchCRM\UserConfig;
 use ChurchCRM\model\ChurchCRM\UserConfigQuery;
 use ChurchCRM\model\ChurchCRM\UserQuery;
+use ChurchCRM\Utils\CSRFUtils;
 use ChurchCRM\Utils\FiscalYearUtils;
 use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
@@ -50,6 +51,11 @@ if (isset($_POST['NewUser'])) {
 
 // Has the form been submitted?
 if (isset($_POST['save']) && $iPersonID > 0) {
+    // Security: CSRF token validation (GHSA-3xq9-c86x-cwpp)
+    if (!CSRFUtils::verifyRequest($_POST, 'user_editor')) {
+        RedirectUtils::redirect('UserEditor.php?PersonID=' . $iPersonID . '&ErrorText=Invalid+security+token.+Please+try+again.');
+    }
+
     // Assign all variables locally
     $sAction = $_POST['Action'];
 
@@ -329,6 +335,7 @@ require_once __DIR__ . '/Include/Header.php';
 
 ?>
 <form method="post" action="UserEditor.php">
+<?= CSRFUtils::getTokenInputField('user_editor') ?>
 <input type="hidden" name="Action" value="<?= $sAction ?>">
 <input type="hidden" name="NewUser" value="<?= $vNewUser ?>">
 

--- a/src/UserEditor.php
+++ b/src/UserEditor.php
@@ -53,7 +53,9 @@ if (isset($_POST['NewUser'])) {
 if (isset($_POST['save']) && $iPersonID > 0) {
     // Security: CSRF token validation (GHSA-3xq9-c86x-cwpp)
     if (!CSRFUtils::verifyRequest($_POST, 'user_editor')) {
-        RedirectUtils::redirect('UserEditor.php?PersonID=' . $iPersonID . '&ErrorText=Invalid+security+token.+Please+try+again.');
+        // Preserve add-vs-edit context — NewUser is "true"/"false" string from form
+        $idParam = ($NewUser ?? 'false') === 'true' ? 'NewPersonID' : 'PersonID';
+        RedirectUtils::redirect('UserEditor.php?' . $idParam . '=' . $iPersonID . '&ErrorText=Invalid+security+token.+Please+try+again.');
     }
 
     // Assign all variables locally


### PR DESCRIPTION
## Summary
Add CSRF token validation to `UserEditor.php` form processing.

## Vulnerability
GHSA-3xq9-c86x-cwpp — Cross-Site Request Forgery (CSRF) Leading to Admin Privilege Escalation

`UserEditor.php` processed user account creation and permission updates entirely through `$_POST` parameters with no CSRF token validation. An attacker could craft a malicious page that, when visited by an authenticated administrator, silently elevated any low-privilege user to full administrator.

## Changes
- `src/UserEditor.php`:
  - Add `use ChurchCRM\Utils\CSRFUtils`
  - Call `CSRFUtils::verifyRequest($_POST, 'user_editor')` before processing the form — redirect with error on failure
  - Inject `CSRFUtils::getTokenInputField('user_editor')` hidden field in the form

## Test plan
- [ ] Edit a user via UserEditor → save → succeeds
- [ ] Create a new user → save → succeeds
- [ ] POST to `/UserEditor.php` without csrf_token → redirected with "Invalid security token" error
- [ ] No regression in existing user editor functionality

## Related
- Advisory: GHSA-3xq9-c86x-cwpp
- Closed duplicate: GHSA-xv5c-cggm-p25r

🤖 Generated with [Claude Code](https://claude.com/claude-code)