### PR TITLE
fix(2fa): restore recovery code entropy and add tests

### DIFF
--- a/cypress/e2e/ui/session/session.two-factor-recovery.spec.js
+++ b/cypress/e2e/ui/session/session.two-factor-recovery.spec.js
@@ -1,0 +1,49 @@
+/// <reference types="cypress" />
+
+describe("2FA Recovery Code Generation", () => {
+    beforeEach(() => cy.setupStandardSession());
+
+    it("generates 12 unique codes in xxxxxxxx-xxxxxxxx lowercase hex format", () => {
+        cy.makePrivateUserAPICall(
+            "POST",
+            "/api/user/current/refresh2farecoverycodes",
+            null,
+            200,
+        ).then((resp) => {
+            expect(resp.body).to.have.property("TwoFARecoveryCodes");
+            const codes = resp.body.TwoFARecoveryCodes;
+            expect(codes).to.have.length(12);
+            const format = /^[a-f0-9]{8}-[a-f0-9]{8}$/;
+            codes.forEach((code) => expect(code).to.match(format));
+            expect(new Set(codes).size).to.equal(12);
+        });
+    });
+});
+
+describe("2FA Login Template", () => {
+    beforeEach(() => cy.setupStandardSession());
+
+    it("renders TOTP mode by default with toggle to recovery mode", () => {
+        cy.visit("session/two-factor");
+        cy.get("#TwoFACode")
+            .should("have.attr", "maxlength", "6")
+            .should("have.attr", "inputmode", "numeric")
+            .should("have.attr", "placeholder", "000000");
+        cy.contains("a", "Use a recovery code instead")
+            .should("have.attr", "href")
+            .and("include", "/session/two-factor?recovery");
+        cy.contains("a", "Use a different account");
+    });
+
+    it("renders recovery mode when ?recovery is present", () => {
+        cy.visit("session/two-factor?recovery");
+        cy.get("#TwoFACode")
+            .should("have.attr", "maxlength", "20")
+            .should("have.attr", "placeholder", "xxxxxxxx-xxxxxxxx")
+            .should("not.have.attr", "inputmode", "numeric");
+        cy.contains("a", "Use authenticator app instead")
+            .should("have.attr", "href")
+            .and("match", /\/session\/two-factor$/);
+        cy.contains("a", "Use a different account");
+    });
+});

--- a/src/ChurchCRM/model/ChurchCRM/User.php
+++ b/src/ChurchCRM/model/ChurchCRM/User.php
@@ -513,13 +513,13 @@ class User extends BaseUser
 
     public function getNewTwoFARecoveryCodes(): array
     {
-        // generate an array of 2FA recovery codes formatted as XXXXX-XXXXX (lowercase hex),
+        // generate 12 human-readable recovery codes formatted as xxxxxxxx-xxxxxxxx (lowercase hex, 64 bits of entropy each)
         // and store as an encrypted, comma-separated list
         $recoveryCodes = [];
         for ($i = 0; $i < 12; $i++) {
-            // random_bytes(5) yields 10 hex characters; split into two 5-char segments for XXXXX-XXXXX format
-            $hex = bin2hex(random_bytes(5));
-            $recoveryCodes[$i] = substr($hex, 0, 5) . '-' . substr($hex, 5, 5);
+            // random_bytes(8) yields 16 hex characters; split into two 8-char segments for xxxxxxxx-xxxxxxxx format
+            $hex = bin2hex(random_bytes(8));
+            $recoveryCodes[$i] = substr($hex, 0, 8) . '-' . substr($hex, 8, 8);
         }
         $recoveryCodesString = implode(',', $recoveryCodes);
         $this->setTwoFactorAuthRecoveryCodes(Crypto::encryptWithPassword($recoveryCodesString, KeyManagerUtils::getTwoFASecretKey()));

--- a/src/session/templates/two-factor.php
+++ b/src/session/templates/two-factor.php
@@ -47,7 +47,7 @@ require SystemURLs::getDocumentRoot() . '/Include/HeaderNotLoggedIn.php';
           <form method="post" name="TwoFAForm" action="<?= SystemURLs::getRootPath()?>/session/two-factor?recovery">
             <div class="mb-3">
               <label for="TwoFACode"><?= gettext('Recovery Code') ?></label>
-              <input type="text" id="TwoFACode" name="TwoFACode" placeholder="xxxxx-xxxxx" maxlength="20" autocomplete="off" required autofocus>
+              <input type="text" id="TwoFACode" name="TwoFACode" placeholder="xxxxxxxx-xxxxxxxx" maxlength="20" autocomplete="off" required autofocus>
             </div>
 
             <button type="submit" class="btn-sign-in">
@@ -57,6 +57,10 @@ require SystemURLs::getDocumentRoot() . '/Include/HeaderNotLoggedIn.php';
 
           <div class="back-link">
             <a href="<?= SystemURLs::getRootPath() ?>/session/two-factor"><?= gettext('Use authenticator app instead') ?></a>
+          </div>
+
+          <div class="back-link">
+            <a href="<?= SystemURLs::getRootPath() ?>/session/begin"><?= gettext('Use a different account') ?></a>
           </div>
 
         <?php else : ?>


### PR DESCRIPTION
Follow-up to #8634 addressing two concerns surfaced during review: a meaningful entropy reduction in the new recovery code format, and the absence of any test coverage for the changes.

> ⚠️ **Base is #8634**, not master. If #8634 merges first, this PR needs to be rebased onto master (the changes will still apply cleanly — the entropy fix modifies lines #8634 introduces).

## Summary

### 1. Entropy fix — `User.php`
#8634 changed `random_bytes(10)` (80 bits) → `random_bytes(5)` (**40 bits**) to produce `xxxxx-xxxxx` codes. That's a 2⁴⁰ reduction per code. This PR bumps to `random_bytes(8)` → 16 hex chars → `xxxxxxxx-xxxxxxxx` format, restoring **64 bits** of entropy per code while keeping the readable two-segment format.

```diff
-            $hex = bin2hex(random_bytes(5));
-            $recoveryCodes[$i] = substr($hex, 0, 5) . '-' . substr($hex, 5, 5);
+            $hex = bin2hex(random_bytes(8));
+            $recoveryCodes[$i] = substr($hex, 0, 8) . '-' . substr($hex, 8, 8);
```

The existing `maxlength="20"` on the recovery input already accommodates 17 chars; no other code changes needed.

### 2. Recovery mode UX parity — `two-factor.php`
- Placeholder updated `xxxxx-xxxxx` → `xxxxxxxx-xxxxxxxx` to match the new format
- Added "Use a different account" back-link to recovery mode (parity with TOTP mode, which already had it)

### 3. Tests — new `session.two-factor-recovery.spec.js`
Three Cypress specs covering the parts of the change that are testable without a seeded 2FA-enrolled user:

- **Generation format**: POSTs `/api/user/current/refresh2farecoverycodes` and asserts 12 unique codes matching `/^[a-f0-9]{8}-[a-f0-9]{8}$/`
- **TOTP mode render**: `GET /session/two-factor` renders the TOTP form (maxlength=6, inputmode=numeric, correct placeholder, toggle links present)
- **Recovery mode render**: `GET /session/two-factor?recovery` renders the recovery form (maxlength=20, placeholder=`xxxxxxxx-xxxxxxxx`, not numeric-only, toggle links present)

## What's still not covered

These require a 2FA-pre-enrolled seed user (with a known TOTP secret and known pre-encrypted recovery codes in `cypress/data/seed.sql`), which is a larger change that should be tackled separately:

- End-to-end recovery code login (valid code completes auth)
- Invalid recovery code preserves `?recovery` in redirect
- Hyphen-stripped and uppercase normalization paths in `isTwoFaRecoveryCodeValid()`
- One-time-use: recovery code is consumed and cannot be reused

Recommend filing a follow-up issue to plumb seeded 2FA user data and land the end-to-end coverage.

## Test plan

- [ ] `npx cypress run --config-file cypress/configs/docker.config.ts --spec 'cypress/e2e/ui/session/session.two-factor-recovery.spec.js'` passes in the Docker stack
- [ ] Manual: trigger new recovery code generation from the 2FA enrollment UI and confirm codes render in `xxxxxxxx-xxxxxxxx` format
- [ ] Manual: in recovery mode, confirm "Use a different account" link is present and navigates to `/session/begin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)