### PR TITLE
fix: persist consumed recovery codes + add Copy/Download buttons

### DIFF
--- a/src/ChurchCRM/model/ChurchCRM/User.php
+++ b/src/ChurchCRM/model/ChurchCRM/User.php
@@ -566,6 +566,7 @@ class User extends BaseUser
                 unset($codes[$key]);
                 $recoveryCodesString = implode(',', $codes);
                 $this->setTwoFactorAuthRecoveryCodes(Crypto::encryptWithPassword($recoveryCodesString, KeyManagerUtils::getTwoFASecretKey()));
+                $this->save();
 
                 return true;
             }

--- a/webpack/two-factor-enrollment.js
+++ b/webpack/two-factor-enrollment.js
@@ -209,10 +209,18 @@ function renderSuccess() {
             <div style="background-color:#f8f9fa;padding:16px;border-radius:4px;border:1px solid #dee2e6;font-family:monospace;font-size:0.9em;line-height:2">
               ${codesHtml}
             </div>
-            <div class="mt-4 d-flex justify-content-between">
-              <button type="button" class="btn btn-outline-secondary" id="printCodesBtn">
-                <i class="fa-solid fa-print me-1"></i>${t("Print")}
-              </button>
+            <div class="mt-4 d-flex justify-content-between align-items-center flex-wrap gap-2">
+              <div class="d-flex gap-2">
+                <button type="button" class="btn btn-outline-secondary" id="printCodesBtn">
+                  <i class="fa-solid fa-print me-1"></i>${t("Print")}
+                </button>
+                <button type="button" class="btn btn-outline-secondary" id="copyCodesBtn">
+                  <i class="fa-solid fa-copy me-1"></i>${t("Copy")}
+                </button>
+                <button type="button" class="btn btn-outline-secondary" id="downloadCodesBtn">
+                  <i class="fa-solid fa-download me-1"></i>${t("Download")}
+                </button>
+              </div>
               <a href="${CRMRoot}/v2/user/current/manage2fa" class="btn btn-primary">
                 <i class="fa-solid fa-check me-1"></i>${t("Done")}
               </a>
@@ -333,6 +341,35 @@ function bindEvents() {
   const printBtn = document.getElementById("printCodesBtn");
   if (printBtn) {
     printBtn.addEventListener("click", () => window.print());
+  }
+
+  // Success: copy button
+  const copyBtn = document.getElementById("copyCodesBtn");
+  if (copyBtn) {
+    copyBtn.addEventListener("click", () => {
+      const text = state.TwoFARecoveryCodes.map((c, i) => `${String(i + 1).padStart(2, "0")}. ${c}`).join("\n");
+      navigator.clipboard.writeText(text).then(() => {
+        copyBtn.innerHTML = `<i class="fa-solid fa-check me-1"></i>${t("Copied!")}`;
+        setTimeout(() => {
+          copyBtn.innerHTML = `<i class="fa-solid fa-copy me-1"></i>${t("Copy")}`;
+        }, 2000);
+      });
+    });
+  }
+
+  // Success: download button
+  const downloadBtn = document.getElementById("downloadCodesBtn");
+  if (downloadBtn) {
+    downloadBtn.addEventListener("click", () => {
+      const text = state.TwoFARecoveryCodes.map((c, i) => `${String(i + 1).padStart(2, "0")}. ${c}`).join("\n");
+      const blob = new Blob([text], { type: "text/plain" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "churchcrm-recovery-codes.txt";
+      a.click();
+      URL.revokeObjectURL(url);
+    });
   }
 
   // Status enabled: disable button

--- a/webpack/two-factor-enrollment.js
+++ b/webpack/two-factor-enrollment.js
@@ -214,10 +214,10 @@ function renderSuccess() {
                 <button type="button" class="btn btn-outline-secondary" id="printCodesBtn">
                   <i class="fa-solid fa-print me-1"></i>${t("Print")}
                 </button>
-                <button type="button" class="btn btn-outline-secondary" id="copyCodesBtn">
+                <button type="button" class="btn btn-outline-secondary" id="copyCodesBtn" ${state.TwoFARecoveryCodes.length === 0 ? "disabled" : ""}>
                   <i class="fa-solid fa-copy me-1"></i>${t("Copy")}
                 </button>
-                <button type="button" class="btn btn-outline-secondary" id="downloadCodesBtn">
+                <button type="button" class="btn btn-outline-secondary" id="downloadCodesBtn" ${state.TwoFARecoveryCodes.length === 0 ? "disabled" : ""}>
                   <i class="fa-solid fa-download me-1"></i>${t("Download")}
                 </button>
               </div>
@@ -348,12 +348,42 @@ function bindEvents() {
   if (copyBtn) {
     copyBtn.addEventListener("click", () => {
       const text = state.TwoFARecoveryCodes.map((c, i) => `${String(i + 1).padStart(2, "0")}. ${c}`).join("\n");
-      navigator.clipboard.writeText(text).then(() => {
+      const showCopied = () => {
         copyBtn.innerHTML = `<i class="fa-solid fa-check me-1"></i>${t("Copied!")}`;
         setTimeout(() => {
           copyBtn.innerHTML = `<i class="fa-solid fa-copy me-1"></i>${t("Copy")}`;
         }, 2000);
-      });
+      };
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        navigator.clipboard
+          .writeText(text)
+          .then(showCopied)
+          .catch(() => {
+            // Fallback for permission denied
+            const ta = document.createElement("textarea");
+            ta.value = text;
+            ta.setAttribute("readonly", "");
+            ta.style.position = "absolute";
+            ta.style.left = "-9999px";
+            document.body.appendChild(ta);
+            try {
+              ta.select();
+              document.execCommand("copy");
+              document.body.removeChild(ta);
+              showCopied();
+            } catch (_e) {
+              document.body.removeChild(ta);
+              if (typeof bootbox !== "undefined") {
+                bootbox.alert(t("Unable to copy to clipboard. Please copy the codes manually."));
+              }
+            }
+          });
+      } else {
+        // Non-secure context — clipboard API unavailable
+        if (typeof bootbox !== "undefined") {
+          bootbox.alert(t("Clipboard not available. Please use the Download button to save your codes."));
+        }
+      }
     });
   }
 


### PR DESCRIPTION
## Summary

- **Security fix**: `isTwoFaRecoveryCodeValid()` was missing `$this->save()` after removing a used code from the encrypted store. Used recovery codes were never actually invalidated, allowing the same code to be reused indefinitely.
- **UX**: Add **Copy** and **Download** buttons alongside the existing Print button on the recovery codes setup screen, so users have multiple convenient options to save their codes.

## Changes

- `src/ChurchCRM/model/ChurchCRM/User.php` — add `$this->save()` after consuming a recovery code
- `webpack/two-factor-enrollment.js` — add Copy (clipboard with 2s feedback) and Download (`churchcrm-recovery-codes.txt`) buttons

## Why

The missing `$this->save()` is a pre-existing bug introduced alongside the recovery code feature. Copy/Download are standard UX expectations for recovery code setup screens — users need an easy way to store codes in a password manager or secure note.

## Testing

- [ ] Enroll 2FA, verify Copy produces correct numbered list in clipboard
- [ ] Verify Download saves `churchcrm-recovery-codes.txt` with all 12 codes
- [ ] Use a recovery code to log in, verify it no longer works on second attempt

## Related

Builds on #8634 (human-readable recovery code format).

🤖 Generated with [Claude Code](https://claude.com/claude-code)