### PR TITLE
docs: correct stale cypress.config.ts references across dev docs + code

### DIFF
--- a/.agents/skills/churchcrm/cypress-testing.md
+++ b/.agents/skills/churchcrm/cypress-testing.md
@@ -96,9 +96,18 @@ cy.setupNoFinanceSession();
 
 ### Configuration Location
 
-Credentials live in **two** config files that MUST be kept in sync:
-- `cypress.config.ts` — used for local `npm run test` / `npm run test:open`
-- `docker/cypress.config.ts` — used by the Docker / CI runner
+Credentials live in the Cypress config files under `cypress/configs/` that the
+`npm run test*` scripts pass via `--config-file`:
+
+- `cypress/configs/docker.config.ts` — used by `npm run test`, `test:open`,
+  `test:api`, `test:ui`, and the `test-root` / `test-subdir` CI matrix
+- `cypress/configs/new-system.config.ts` — used by `npm run test:new-system`
+  and the `test-new-system` CI job (has its own `env` block with an admin
+  account because this job boots from a fresh install)
+
+There is **no** root `cypress.config.ts` in this repo — don't add one and
+don't expect Cypress to auto-detect one. Every script passes an explicit
+`--config-file`.
 
 ```typescript
 env: {
@@ -116,20 +125,23 @@ env: {
 }
 ```
 
-> ⚠️ **CRITICAL: keep both configs in sync.** <!-- learned: 2026-04-13 -->
-> Any new test user credential has to be added to **both** `cypress.config.ts`
-> and `docker/cypress.config.ts`. If you update only one, tests will pass
-> locally but fail in CI (or vice-versa), and the failure message — usually
-> `Admin credentials not configured in cypress.config.ts env` thrown from
-> `setupLoginSession` — does not tell you which config file is missing the
-> key. Always grep both files when adding a new `*.username` / `*.password`
-> entry.
+> ⚠️ **CRITICAL: keep shared credentials in sync across configs.** <!-- learned: 2026-04-13 -->
+> If you add a new test user that the `test-new-system` job also needs, the
+> credential has to be added to **both** `cypress/configs/docker.config.ts`
+> and `cypress/configs/new-system.config.ts`. If you update only one,
+> tests will pass in one CI job but fail in the other, and the failure
+> message from `setupLoginSession` — usually
+> `Admin credentials not configured in cypress config env` — does not tell
+> you which config file is missing the key. Always grep both files when
+> adding a new `*.username` / `*.password` entry.
 
 **CRITICAL:**
 - ❌ DO NOT hardcode credentials in test files
 - ❌ DO NOT add commented-out tests or TODO comments
 - ✅ Configuration-driven approach prevents secrets leaking into git
-- ✅ Update `cypress.config.ts` AND `docker/cypress.config.ts` together
+- ✅ Update `cypress/configs/docker.config.ts` AND
+  `cypress/configs/new-system.config.ts` together when the credential is
+  used by both jobs
 
 ### cy.request() API Calls Reset PHP Sessions (CRITICAL) <!-- learned: 2026-03-27 -->
 
@@ -853,7 +865,7 @@ Config files live in `cypress/configs/` (NOT `docker/`):
 - `cypress/configs/new-system.config.ts` — setup wizard / fresh install tests
 - `cypress/configs/base.config.ts` + `_shared.ts` — shared base configuration
 
-**NOTE:** The root `cypress.config.ts` is auto-detected by Cypress, so `--config-file` is only required when using a non-default config (e.g., `cypress/configs/new-system.config.ts`). For standard runs, `npx cypress run --spec "..."` works without `--config-file`.
+**NOTE:** There is **no** root `cypress.config.ts` in this repo. Cypress can still run without `--config-file`, but it will fall back to defaults and will **not** pick up ChurchCRM's required `env` / `baseUrl` / `specPattern` settings. The `npm run test*` scripts already pass `--config-file cypress/configs/docker.config.ts` (or `new-system.config.ts`) — see `package.json`. If you invoke ChurchCRM's Cypress suite yourself, always pass the appropriate config file, e.g. `npx cypress run --config-file cypress/configs/docker.config.ts --spec "..."`.
 
 **CRITICAL: Always install Cypress via `npm install`** <!-- learned: 2026-03-07 -->
 - Never use `npx cypress install` — it can produce a corrupt binary with wrong permissions.
@@ -1153,7 +1165,7 @@ const password = Cypress.env('newSystemAdminPassword');  // ❌ NULL/undefined -
 
 ### ✅ CORRECT - Use stable config source
 ```typescript
-// cypress.config.ts
+// cypress/configs/docker.config.ts
 env: {
     'admin.password': 'changeme',
     'admin.new.password': 'AdminP@ss1234!',  // Define stable password upfront
@@ -1174,7 +1186,7 @@ it('should store password', () => {
     cy.task('setPassword', newPassword);
 });
 
-// cypress.config.ts - register task
+// cypress/configs/docker.config.ts - register task
 on('task', {
     setPassword: (pwd) => {
         require('fs').writeFileSync('.temp/test-pwd', pwd);

--- a/.agents/skills/churchcrm/development-workflows.md
+++ b/.agents/skills/churchcrm/development-workflows.md
@@ -315,7 +315,7 @@ git add -A
 
 - **Build**: `webpack.config.js`, `Gruntfile.js`, `package.json`
 - **Docker**: `docker-compose.yaml`, `docker/docker-compose.*.yaml`
-- **Cypress**: `cypress.config.ts`, `docker/cypress.config.ts`
+- **Cypress**: `cypress/configs/docker.config.ts`, `cypress/configs/new-system.config.ts`, `cypress/configs/base.config.ts`, `cypress/configs/_shared.ts`
 - **PHP**: `composer.json`, `orm/propel.php.dist`
 - **ORM**: `orm/schema.xml`
 

--- a/.agents/skills/churchcrm/testing.md
+++ b/.agents/skills/churchcrm/testing.md
@@ -15,7 +15,7 @@ This skill covers writing and running Cypress tests for API endpoints and UI wor
 
 - **API Tests**: `cypress/e2e/api/private/[feature]/[endpoint].spec.js`
 - **UI Tests**: `cypress/e2e/ui/[feature]/`
-- **Configuration**: `cypress.config.ts` (dev) and `docker/cypress.config.ts` (CI)
+- **Configuration**: `cypress/configs/docker.config.ts` (standard runner used by `npm run test` / `test:open` / `test:api` / `test:ui` / the `test-root` + `test-subdir` CI jobs) and `cypress/configs/new-system.config.ts` (setup-wizard / fresh-install runner used by `npm run test:new-system` and the `test-new-system` CI job)
 
 ## Cypress Configuration & Logging
 
@@ -132,7 +132,14 @@ describe('Feature X', () => {
 
 ### Credentials Configuration
 
-Credentials are stored in `cypress.config.ts` and `docker/cypress.config.ts`:
+Credentials live in the Cypress config files under `cypress/configs/` that
+`npm run test*` passes via `--config-file`:
+
+- `cypress/configs/docker.config.ts` — standard CI/dev runner
+- `cypress/configs/new-system.config.ts` — setup-wizard / fresh-install runner
+
+There is **no** root `cypress.config.ts` and no `docker/cypress.config.ts` —
+don't add one; every script passes `--config-file` explicitly.
 
 ```typescript
 env: {
@@ -148,7 +155,9 @@ env: {
 **DO NOT:**
 - ❌ Hardcode credentials in test files
 - ❌ Add commented-out tests or TODO comments - remove them
-- ❌ Add new users without updating both config files
+- ❌ Add new users to only one config — if the user is needed by both
+  runners, add the credential to BOTH `cypress/configs/docker.config.ts`
+  and `cypress/configs/new-system.config.ts`
 
 ### Other Available Commands
 
@@ -382,6 +391,6 @@ Four patterns cause most timing-related flaky failures. Full detail and code exa
 
 **API Tests:** `cypress/e2e/api/`
 **UI Tests:** `cypress/e2e/ui/`
-**Config:** `cypress.config.ts`, `docker/cypress.config.ts`
+**Config:** `cypress/configs/docker.config.ts`, `cypress/configs/new-system.config.ts`
 **Support:** `cypress/support/commands.js`
 **Logs:** `src/logs/`

--- a/cypress/README.md
+++ b/cypress/README.md
@@ -25,8 +25,7 @@ Running tests (recommended)
 
 Quick migration notes
 - Move `cypress/data/` → `cypress/fixtures/` and update usages of `cy.fixture()` accordingly.
-- Consolidate Docker/CI variants under `cypress/configs/` (use `--config-file` to point to them).
-- Remove the legacy `cypress.json` file in favor of `cypress.config.ts` (Cypress v10+).
+- Docker/CI variants already live under `cypress/configs/` — every `npm run test*` script passes `--config-file cypress/configs/<name>.config.ts`. Do NOT add a root `cypress.config.ts`; Cypress is never asked to auto-detect one here.
 
 Best practices
 - Group specs by feature and add tags (e.g., `@smoke`) to allow fast subset runs.

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -24,7 +24,7 @@ import "./api-commands";
 // require('./commands')
 
 // Note: cypress-terminal-report installLogsCollector disabled due to Cypress 15.x compatibility
-// Logging handled by installLogsPrinter in cypress.config.ts
+// Logging handled by installLogsPrinter in cypress/configs/_shared.ts (setupCommonNodeEvents)
 
 // Capture unhandled rejections and errors for terminal reporter
 window.addEventListener('unhandledrejection', (event) => {

--- a/cypress/support/ui-commands.js
+++ b/cypress/support/ui-commands.js
@@ -45,10 +45,13 @@ Cypress.Commands.add('setupLoginSession', (sessionName, username, password, opti
 
 /**
  * Sets up a cached admin login session for Cypress UI tests.
- * Reads credentials from cypress.config.ts env configuration.
+ * Reads credentials from the Cypress config env (cypress/configs/docker.config.ts
+ * for the standard CI/dev runner, cypress/configs/new-system.config.ts for
+ * the new-system job). See `.agents/skills/churchcrm/cypress-testing.md`
+ * for the full rationale.
  * Usage in test files:
  *   beforeEach(() => cy.setupAdminSession());
- * 
+ *
  * Note: Uses cy.session() with explicit validation to cache login across test runs.
  * If validation fails, the session is cleared and login is re-attempted.
  */
@@ -56,17 +59,18 @@ Cypress.Commands.add('setupAdminSession', (options = {}) => {
     const username = Cypress.env('admin.username');
     const password = Cypress.env('admin.password');
     if (!username || !password) {
-        throw new Error('Admin credentials not configured in cypress.config.ts env: admin.username and admin.password required');
+        throw new Error('Admin credentials not configured in cypress/configs/docker.config.ts (or cypress/configs/new-system.config.ts) env: admin.username and admin.password required');
     }
     cy.setupLoginSession('admin-session', username, password, options);
 });
 
 /**
  * Sets up a cached standard user login session for Cypress UI tests.
- * Reads credentials from cypress.config.ts env configuration.
+ * Reads credentials from the Cypress config env
+ * (cypress/configs/docker.config.ts for the standard CI/dev runner).
  * Usage in test files:
  *   beforeEach(() => cy.setupStandardSession());
- * 
+ *
  * Note: Uses cy.session() with explicit validation to cache login across test runs.
  * If validation fails, the session is cleared and login is re-attempted.
  */
@@ -74,7 +78,7 @@ Cypress.Commands.add('setupStandardSession', (options = {}) => {
     const username = Cypress.env('standard.username');
     const password = Cypress.env('standard.password');
     if (!username || !password) {
-        throw new Error('Standard user credentials not configured in cypress.config.ts env: standard.username and standard.password required');
+        throw new Error('Standard user credentials not configured in cypress/configs/docker.config.ts env: standard.username and standard.password required');
     }
     cy.setupLoginSession('standard-session', username, password, options);
 });
@@ -82,7 +86,8 @@ Cypress.Commands.add('setupStandardSession', (options = {}) => {
 /**
  * Sets up a cached session for a user WITHOUT finance permissions.
  * Used to test that finance pages correctly deny access to non-finance users.
- * Reads credentials from cypress.config.ts env configuration.
+ * Reads credentials from the Cypress config env
+ * (cypress/configs/docker.config.ts for the standard CI/dev runner).
  * Usage in test files:
  *   beforeEach(() => cy.setupNoFinanceSession());
  */
@@ -90,7 +95,7 @@ Cypress.Commands.add('setupNoFinanceSession', (options = {}) => {
     const username = Cypress.env('nofinance.username');
     const password = Cypress.env('nofinance.password');
     if (!username || !password) {
-        throw new Error('No-finance user credentials not configured in cypress.config.ts env: nofinance.username and nofinance.password required');
+        throw new Error('No-finance user credentials not configured in cypress/configs/docker.config.ts env: nofinance.username and nofinance.password required');
     }
     cy.setupLoginSession('nofinance-session', username, password, options);
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,8 +15,6 @@
     "node_modules",
     "src/vendor",
     "tests/vendor",
-    "cypress.config.ts",
-    "docker/cypress.config.ts",
     "cypress/configs/*"
   ]
 }


### PR DESCRIPTION
## Summary

The repo referenced `cypress.config.ts` (root) and `docker/cypress.config.ts` in **seven files** across dev docs, skill docs, and real runtime code, but **neither file exists in this repo**. The actual Cypress config files live under `cypress/configs/` and every `npm run test*` script passes them via `--config-file`:

```
package.json:
"test":            "npx cypress run --config-file cypress/configs/docker.config.ts",
"test:open":       "npx cypress open --e2e --config-file cypress/configs/docker.config.ts ...",
"test:api":        "npx cypress run --config-file cypress/configs/docker.config.ts --spec ...",
"test:ui":         "npx cypress run --config-file cypress/configs/docker.config.ts --spec ...",
"test:new-system": "npx cypress run --config-file cypress/configs/new-system.config.ts"
```

There is **no** root `cypress.config.ts` in this repo and Cypress is never asked to auto-detect one.

## ⚠️ Rebased onto master after #8655 merged

This branch was originally based on master before #8655 landed. After #8655 merged with the (also bad) boxed warning in cypress-testing.md, this branch rebased cleanly onto current master. The merge conflict in the `Configuration Location` section L97-132 (where both branches touched the same lines) was resolved by **keeping the `cypress/configs/*` version**, and the boxed warning that landed via #8655 was also rewritten in this commit so it points at the correct files.

The L774 NOTE wording was improved by an in-branch commit (`6ed0b21 Update cypress-testing.md`, co-authored by Copilot via @DawoudIO's review). That improvement is preserved in this rebase — Cypress *will* run without `--config-file`, but it falls back to defaults that don't carry ChurchCRM's `env` / `baseUrl` / `specPattern`.

## The most damaging version of this bug

`cypress/support/ui-commands.js` throws three runtime errors when credentials are missing:

```js
throw new Error('Admin credentials not configured in cypress.config.ts env: ...');
throw new Error('Standard user credentials not configured in cypress.config.ts env: ...');
throw new Error('No-finance user credentials not configured in cypress.config.ts env: ...');
```

**Contributors hitting these errors would grep for a file that was never there.** Fixing these error messages is the biggest single contributor-experience win in this PR.

## Files fixed (7)

| # | File | Fix |
|---|---|---|
| 1 | `cypress/support/ui-commands.js` | 3 thrown error messages in `setupAdminSession` / `setupStandardSession` / `setupNoFinanceSession` + 3 corresponding JSDoc blocks now point at `cypress/configs/docker.config.ts` |
| 2 | `cypress/support/e2e.js` | Comment about `installLogsPrinter` location corrected to `cypress/configs/_shared.ts` (`setupCommonNodeEvents`) — verified that's where it's actually registered |
| 3 | `.agents/skills/churchcrm/cypress-testing.md` | 5 locations: `Configuration Location` rewritten, the boxed warning that landed via #8655 also rewritten, `Cypress Config Files` NOTE flipped (with @DawoudIO's improved Copilot-co-authored wording preserved), 2 code-example comments (`cy.task()` registration + cross-spec env example) updated |
| 4 | `.agents/skills/churchcrm/testing.md` | 3 locations: Test Structure list, Credentials Configuration section, Files summary |
| 5 | `.agents/skills/churchcrm/development-workflows.md` | Cypress files list updated to the real `cypress/configs/` set |
| 6 | `cypress/README.md` | Stale migration TODO ("remove `cypress.json` in favor of `cypress.config.ts`") replaced with a factual note that configs already live under `cypress/configs/` and scripts pass `--config-file` |
| 7 | `tsconfig.json` | Drop `exclude` entries for the non-existent `cypress.config.ts` and `docker/cypress.config.ts`. The existing `cypress/configs/*` exclude is the only one that was ever doing anything. |

## Verification

- `grep -rn 'cypress\.config\.ts\|docker/cypress\.config' .agents/skills/churchcrm/ cypress/support/ cypress/README.md tsconfig.json` → only **negative** mentions remain (e.g. "there is no root `cypress.config.ts`"); no stale positive references
- `npm run lint` — exit 0 (pre-existing webpack warnings only, none introduced)
- `npm run build:webpack` — compiled successfully
- `node --check cypress/support/ui-commands.js` / `cypress/support/e2e.js` — both parse clean
- `tsconfig.json` JSON still parses
- Pre-push Biome hook passed
- Post-rebase: 1 commit ahead of master, 0 behind

## Test plan

- [ ] CI green on the full matrix (this is a docs + safe-message-string + tsconfig-exclude-cleanup change; no logic changes)
- [ ] Confirm that the three new thrown error messages in `ui-commands.js` render correctly if you temporarily unset a credential
- [ ] Spot-check the rendered markdown in the agent skills index for all three skill docs

https://claude.ai/code/session_015s8Ga53a7aE7f3mC8c8gaM