### PR TITLE
fix: prevent browser autofill on 2FA TOTP input (#5143)

### DIFF
--- a/src/session/templates/two-factor.php
+++ b/src/session/templates/two-factor.php
@@ -86,7 +86,7 @@ require SystemURLs::getDocumentRoot() . '/Include/HeaderNotLoggedIn.php';
           <form method="post" name="TwoFAForm" action="<?= SystemURLs::getRootPath()?>/session/two-factor">
             <div class="mb-3">
               <label for="TwoFACode"><?= gettext('Authentication Code') ?></label>
-              <input type="text" id="TwoFACode" name="TwoFACode" placeholder="000000" maxlength="6" inputmode="numeric" required autofocus>
+              <input type="text" id="TwoFACode" name="TwoFACode" placeholder="000000" maxlength="6" inputmode="numeric" autocomplete="one-time-code" required autofocus>
             </div>
 
             <button type="submit" class="btn-sign-in">


### PR DESCRIPTION
## Summary

- Adds `autocomplete="one-time-code"` to the TOTP code input in `src/session/templates/two-factor.php`
- Fixes #5143 — browsers were offering saved-form suggestions on the 2FA authentication code field
- `one-time-code` is the standard WHATWG value for TOTP/SMS codes: it suppresses stale form autofill and on iOS Safari / modern Chrome enables native OTP autofill from authenticator apps
- Recovery-code input already had `autocomplete="off"` and is unchanged

## Test plan

- [ ] Load `/session/two-factor` in a browser that has previously saved a form value and confirm no suggestions are offered
- [ ] On iOS Safari, confirm the OS keyboard still offers the native OTP autofill pill when a code arrives
- [ ] Existing Cypress 2FA login flow still passes

https://claude.ai/code/session_01BP6Lu9ay6kaeVL6Bx1PSNh