### PR TITLE
fix: disable browser cache on API GETs to stop stale Family Properties dropdown (#7165)

### DIFF
--- a/src/skin/js/CRMJSOM.js
+++ b/src/skin/js/CRMJSOM.js
@@ -35,6 +35,13 @@ window.CRM.APIRequest = function (options) {
   options.dataType = "json";
   options.url = window.CRM.root + "/api/" + options.path;
   options.contentType = "application/json";
+  // Disable browser caching of GET API responses. Without this, the browser
+  // can serve stale data after the user modifies a related record elsewhere
+  // in the app — e.g. deleting a Family Property in the admin page and then
+  // re-visiting the Family View shows the deleted option in the dropdown
+  // until a hard refresh. jQuery only applies `cache: false` to GET/HEAD, so
+  // setting this unconditionally is safe for POST/PUT/DELETE. See #7165.
+  options.cache = false;
   options.beforeSend = function (jqXHR, settings) {
     jqXHR.url = settings.url;
   };


### PR DESCRIPTION
## Summary

`window.CRM.APIRequest` wraps `jQuery.ajax` without `cache: false`, so `GET` responses from `/api/*` were being served from the browser cache. This surfaces as the symptom reported in #7165: after the admin deletes a Family Property, re-visiting `/v2/family/{id}` still shows the deleted option in the "Assign a New Property" dropdown until a hard refresh.

## Fix

Set `options.cache = false` in the `APIRequest` wrapper. jQuery's `cache: false` only affects GET/HEAD (it adds a `_=<timestamp>` cache-busting query param); POST/PUT/DELETE are unaffected, so no regression on mutations.

```js
window.CRM.APIRequest = function (options) {
  ...
  options.cache = false; // prevents browser cache of GET /api/* responses
  ...
};
```

## Why this is the right layer

The staleness is browser-level HTTP caching. Fixing it in the `APIRequest` wrapper:
- Zero blast radius — single file, single line change
- Applies uniformly to every JS consumer of the API
- Avoids having to decide cache headers per-endpoint on the server

## Test plan
- [x] `npm run lint` — exit 0
- [ ] CI green
- [ ] Manual reproduction from #7165:
  - Go to Family View → Properties pane → click +
  - Go to People → Admin → Family Properties → delete an option, add a new one
  - Go back to Family View → click + → new list should reflect the admin change immediately (not require a hard refresh)

Closes #7165

https://claude.ai/code/session_01KVFkMYhe7PA3fqUV4AbCmp