### PR TITLE
fix: bust browser cache on profile photo after upload (#8662)

### DIFF
--- a/src/ChurchCRM/dto/Photo.php
+++ b/src/ChurchCRM/dto/Photo.php
@@ -146,6 +146,22 @@ class Photo
     }
 
     /**
+     * Return the last-modified timestamp of the uploaded photo file, or 0 if
+     * no photo exists. Useful as a cache-busting version token for <img src>
+     * so that re-uploading the same file URL produces a fresh browser fetch.
+     * See #8662.
+     */
+    public function getPhotoModifiedTime(): int
+    {
+        if (!$this->hasUploadedPhoto || !$this->photoURI || !is_file($this->photoURI)) {
+            return 0;
+        }
+
+        $mtime = @filemtime($this->photoURI);
+        return $mtime === false ? 0 : $mtime;
+    }
+
+    /**
      * Save an uploaded image from base64 data
      */
     public function setImageFromBase64(string $base64): void

--- a/src/v2/templates/user/user.php
+++ b/src/v2/templates/user/user.php
@@ -12,7 +12,13 @@ $isOwnProfile = (AuthenticationManager::getCurrentUser()->getId() === $user->get
 $personId = $user->getPersonId();
 $photo = new Photo('Person', $personId);
 $hasUploadedPhoto = $photo->hasUploadedPhoto();
-$avatarApiUrl = SystemURLs::getRootPath() . '/api/person/' . $personId . '/photo';
+// Append the photo file mtime as a cache-busting version token. The
+// /api/person/{id}/photo endpoint sends a 2-hour public Cache-Control
+// header, so without this the browser shows the stale image after an
+// upload + page reload. See #8662.
+$photoVersion = $photo->getPhotoModifiedTime();
+$avatarApiUrl = SystemURLs::getRootPath() . '/api/person/' . $personId . '/photo'
+    . ($photoVersion > 0 ? ('?v=' . $photoVersion) : '');
 $localeInfo = Bootstrapper::getCurrentLocale();
 
 // Read user settings server-side so controls are pre-populated without JS API calls


### PR DESCRIPTION
## Summary

The `/api/person/{id}/photo` endpoint sends a 2-hour public Cache-Control header (`Photo::CACHE_DURATION_SECONDS = 7200s`) for performance. The user settings page renders the avatar as:

```html
<img src="/api/person/2/photo">
```

After the photo uploader completes, it calls `window.location.reload()`, which re-parses the HTML, sees the same `<img src>` URL, and the browser serves the previously-cached response — which, on a fresh upload, is either a 404 or the old avatar. Result: the user reports "the upload succeeds but the photo doesn't show up." (matches the user's screenshot in #8662 showing initials where the avatar should be).

## Fix

Append the photo file's mtime as a `?v=` query parameter to the `<img src>`. Each upload writes a new file, so mtime changes, so the URL changes, so the browser fetches fresh bytes. The API response is still cached for re-renders of the same version — no throughput regression.

- `Photo::getPhotoModifiedTime()` returns the file mtime (or `0` if no photo exists), so templates can use it as a version token.
- `user.php` appends `?v={mtime}` to the avatar `<img src>`.

```php
$photoVersion = $photo->getPhotoModifiedTime();
$avatarApiUrl = SystemURLs::getRootPath() . '/api/person/' . $personId . '/photo'
    . ($photoVersion > 0 ? ('?v=' . $photoVersion) : '');
```

## Scope

Only the `/v2/user/{id}` page is fixed — that's the one reported in the issue. Other places that embed `/api/person/{id}/photo` in an `<img>` can adopt the same pattern later; keeping blast radius tight for 7.2.1. `PersonView.php` uses the URL only as an upload endpoint, not a display URL, so it's unaffected.

## Test plan
- [x] `npm run build:php` — all 548 files pass syntax validation
- [ ] CI green
- [ ] Manual: visit `/v2/user/{id}`, upload a new photo, verify it appears immediately after the automatic page reload without needing a hard refresh

Closes #8662

https://claude.ai/code/session_01KVFkMYhe7PA3fqUV4AbCmp