### PR TITLE
fix: admin users bypass module feature-flag checks (#8667)

### DIFF
--- a/src/ChurchCRM/model/ChurchCRM/User.php
+++ b/src/ChurchCRM/model/ChurchCRM/User.php
@@ -72,11 +72,11 @@ class User extends BaseUser
 
     public function isFinanceEnabled(): bool
     {
-        if (SystemConfig::getBooleanValue('bEnabledFinance')) {
-            return $this->isAdmin() || $this->isFinance();
+        if ($this->isAdmin()) {
+            return true;
         }
 
-        return false;
+        return SystemConfig::getBooleanValue('bEnabledFinance') && $this->isFinance();
     }
 
     public function isNotesEnabled(): bool
@@ -223,21 +223,20 @@ class User extends BaseUser
 
     /**
      * Whether this user can manage events: events module is enabled
-     * AND user has the AddEvent permission. Use this for buttons,
-     * routes, and UI gates that should hide when either condition fails.
+     * AND user has the AddEvent permission. Admins always pass.
      */
     public function canManageEvents(): bool
     {
-        return self::isEventsEnabled() && $this->isAddEvent();
+        return $this->isAdmin() || (self::isEventsEnabled() && $this->isAddEvent());
     }
 
     /**
-     * Whether this user can view events: events module is enabled.
-     * Anyone with login access can view events, so no per-user gate.
+     * Whether this user can view events. Admins always pass; other users
+     * require the Events module to be enabled system-wide.
      */
     public function canViewEvents(): bool
     {
-        return self::isEventsEnabled();
+        return $this->isAdmin() || self::isEventsEnabled();
     }
 
     public function isEmailEnabled(): bool


### PR DESCRIPTION
## Summary

Three `User` permission methods gated even admin users behind system-wide feature flags (`bEnabledEvents`, `bEnabledFinance`). This is the **root cause** of #8667: the reporting admin had all permissions but still got bounced to `/v2/access-denied?role=ViewEvents` because `canViewEvents()` only checked the system flag, not admin status.

## Root cause (from issue comments)

The user [confirmed they're an admin with all permissions](https://github.com/ChurchCRM/CRM/issues/8667#issuecomment-4255868449), yet the Calendar/Events pages return 403. This means `bEnabledEvents` must be `false` in their `system_config` table — and the current code treats that as an absolute gate, even for admins.

The established pattern in `User.php` is:
```php
return $this->isAdmin() || <specific_check>;
```

Three methods deviated from this pattern:

| Method | Before | After |
|---|---|---|
| `canViewEvents()` | `return self::isEventsEnabled()` | `return $this->isAdmin() \|\| self::isEventsEnabled()` |
| `canManageEvents()` | `return self::isEventsEnabled() && $this->isAddEvent()` | `return $this->isAdmin() \|\| (self::isEventsEnabled() && $this->isAddEvent())` |
| `isFinanceEnabled()` | `if (bEnabledFinance) { ... } return false` | `if ($this->isAdmin()) return true; return flag && perm;` |

## Companion PR

churchcrm/crm#8678 separately gates the Calendar **menu** visibility on `bEnabledEvents` so non-admin users don't see a dead-end link when events are off. That's still correct and complementary — this PR ensures admins can always access everything.

## Test plan
- [x] `npm run build:php` — 548 PHP files pass syntax validation
- [ ] CI green
- [ ] Manual: admin user with `bEnabledEvents = 0` can access `/event/dashboard` and `/event/calendars`
- [ ] Manual: non-admin user with `bEnabledEvents = 0` still gets 403 on event pages
- [ ] Manual: admin user with `bEnabledFinance = 0` can access finance pages
- [ ] Manual: non-admin user with `bEnabledFinance = 0` still gets 403 on finance pages

Fixes #8667

https://claude.ai/code/session_01KVFkMYhe7PA3fqUV4AbCmp