### PR TITLE
fix: exempt password change + 2FA enrollment from limited-permission block (#8680)

### DIFF
--- a/src/ChurchCRM/Slim/Middleware/AuthMiddleware.php
+++ b/src/ChurchCRM/Slim/Middleware/AuthMiddleware.php
@@ -66,7 +66,7 @@ class AuthMiddleware implements MiddlewareInterface
                 // BUT allow them through if they need to change their password — blocking
                 // the change-password page locks new users out permanently. See #8680.
                 $sessionUser = AuthenticationManager::getCurrentUser();
-                if ($sessionUser->hasNoAdminPermissions() && !$this->isPasswordChangePath($request)) {
+                if ($sessionUser->hasNoAdminPermissions() && !$this->isAuthFlowExemptPath($request)) {
                     if ($this->isBrowserRequest($request)) {
                         $rootPath = SystemURLs::getRootPath();
                         return (new Response())->withStatus(302)->withHeader('Location', $rootPath . '/external/limited-access');
@@ -109,13 +109,24 @@ class AuthMiddleware implements MiddlewareInterface
     }
 
     /**
-     * Check whether the current request targets the forced-password-change page.
-     * Users who must change their password on first login should always be able
-     * to reach this page, even if they have no other admin permissions. See #8680.
+     * Check whether the current request targets a page that must remain
+     * accessible even when the user has no admin permissions. Without these
+     * exemptions, limited-permission users get stuck in a redirect loop
+     * because AuthMiddleware blocks the page the auth system is sending
+     * them to. See #8680.
+     *
+     * Exempt paths:
+     *  - /user/current/changepassword  — forced password change on first login
+     *  - /user/current/manage2fa       — forced 2FA enrollment when bRequire2FA is on
+     *  - /user/current/enroll2fa       — backward-compat alias for manage2fa
      */
-    private function isPasswordChangePath(ServerRequestInterface $request): bool
+    private function isAuthFlowExemptPath(ServerRequestInterface $request): bool
     {
-        return str_contains($request->getUri()->getPath(), '/user/current/changepassword');
+        $path = $request->getUri()->getPath();
+
+        return str_contains($path, '/user/current/changepassword')
+            || str_contains($path, '/user/current/manage2fa')
+            || str_contains($path, '/user/current/enroll2fa');
     }
 
     private function isPath(ServerRequestInterface $request, string $pathPart): bool

--- a/src/ChurchCRM/Slim/Middleware/AuthMiddleware.php
+++ b/src/ChurchCRM/Slim/Middleware/AuthMiddleware.php
@@ -63,8 +63,10 @@ class AuthMiddleware implements MiddlewareInterface
                 // since /background operations do not connotate user activity.
 
                 // Block users with no admin permissions from MVC/API access (GHSA-5w59-32c8-933v)
+                // BUT allow them through if they need to change their password — blocking
+                // the change-password page locks new users out permanently. See #8680.
                 $sessionUser = AuthenticationManager::getCurrentUser();
-                if ($sessionUser->hasNoAdminPermissions()) {
+                if ($sessionUser->hasNoAdminPermissions() && !$this->isPasswordChangePath($request)) {
                     if ($this->isBrowserRequest($request)) {
                         $rootPath = SystemURLs::getRootPath();
                         return (new Response())->withStatus(302)->withHeader('Location', $rootPath . '/external/limited-access');
@@ -104,6 +106,16 @@ class AuthMiddleware implements MiddlewareInterface
         }
 
         return $handler->handle($request);
+    }
+
+    /**
+     * Check whether the current request targets the forced-password-change page.
+     * Users who must change their password on first login should always be able
+     * to reach this page, even if they have no other admin permissions. See #8680.
+     */
+    private function isPasswordChangePath(ServerRequestInterface $request): bool
+    {
+        return str_contains($request->getUri()->getPath(), '/user/current/changepassword');
     }
 
     private function isPath(ServerRequestInterface $request, string $pathPart): bool

--- a/src/ChurchCRM/Slim/Middleware/ChurchInfoRequiredMiddleware.php
+++ b/src/ChurchCRM/Slim/Middleware/ChurchInfoRequiredMiddleware.php
@@ -39,6 +39,8 @@ class ChurchInfoRequiredMiddleware implements MiddlewareInterface
     private const EXEMPT_PATHS = [
         self::CHURCH_INFO_PATH,
         '/v2/user/current/changepassword',
+        '/v2/user/current/manage2fa',
+        '/v2/user/current/enroll2fa',
     ];
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface


### PR DESCRIPTION
## Summary

`AuthMiddleware`'s `hasNoAdminPermissions()` check (from security advisory GHSA-5w59-32c8-933v) blocks users without any core admin permissions and redirects them to `/external/limited-access`. This creates a dead-end for freshly created non-admin users whose first login requires a password change or 2FA enrollment:

1. User logs in → `needPasswordChange = true` → auth system redirects to `/v2/user/current/changepassword`
2. `AuthMiddleware` runs BEFORE the page loads → `hasNoAdminPermissions() = true` → redirects to `/external/limited-access`
3. User can never reach the change-password page → stuck, reports "403 permission denied"

Same issue applies when `bRequire2FA = true` — users forced to enroll in 2FA are redirected away from `/v2/user/current/manage2fa`.

## Fix

### AuthMiddleware (commit 1 + 2)
Exempt auth-flow pages from the `hasNoAdminPermissions` block:

```php
if ($sessionUser->hasNoAdminPermissions() && !$this->isAuthFlowExemptPath($request)) {
    // block...
}
```

`isAuthFlowExemptPath()` covers:
- `/user/current/changepassword` — forced password change on first login
- `/user/current/manage2fa` — forced 2FA enrollment when bRequire2FA is on
- `/user/current/enroll2fa` — backward-compat alias

### ChurchInfoRequiredMiddleware (commit 2)
Added 2FA paths to `EXEMPT_PATHS` so admins on fresh installs can complete forced 2FA enrollment before setting church name.

## Test plan
- [x] `npm run build:php` — 548 files pass
- [ ] CI green
- [ ] Manual: create a non-admin user with EditSelf only → first login should reach the password change page
- [ ] Manual: with bRequire2FA=true, limited user → should reach 2FA enrollment page
- [ ] Manual: admin user first login still works normally

Closes #8680

https://claude.ai/code/session_01KVFkMYhe7PA3fqUV4AbCmp