### PR TITLE
fix(upgrade): read composer.json fresh after in-place code deploy

### DIFF
--- a/src/ChurchCRM/utils/VersionUtils.php
+++ b/src/ChurchCRM/utils/VersionUtils.php
@@ -11,15 +11,22 @@ class VersionUtils
 {
     private const COMPOSER_NAME = 'churchcrm/crm';
     private static ?string $cachedVersion = null;
+    private static bool $forceReload = false;
 
     /**
-     * Reset the in-process static version cache.
-     * Call this after a code upgrade so that the next call to getInstalledVersion()
-     * re-reads from the Composer autoloader with the newly-deployed package data.
+     * Reset the in-process static version cache and force the next
+     * getInstalledVersion() call to re-read from composer.json on disk.
+     *
+     * Composer's InstalledVersions class has its own static cache populated from
+     * vendor/composer/installed.php at request start — after an in-place upgrade
+     * that static still returns the pre-upgrade version, even once the files on
+     * disk are the new release. Calling this signals that the on-disk code has
+     * changed and the next read must skip that stale static.
      */
     public static function resetCache(): void
     {
         self::$cachedVersion = null;
+        self::$forceReload = true;
     }
 
     public static function getInstalledVersion(): string
@@ -29,6 +36,18 @@ class VersionUtils
             return self::$cachedVersion;
         }
 
+        // After resetCache(), bypass Composer\InstalledVersions (its static cache
+        // is stale after an in-place upgrade) and read composer.json fresh from disk.
+        if (self::$forceReload) {
+            self::$forceReload = false;
+            $version = self::readVersionFromComposerJson();
+            if ($version !== null) {
+                self::$cachedVersion = $version;
+                return $version;
+            }
+            // fall through to InstalledVersions if composer.json couldn't be read
+        }
+
         $version = InstalledVersions::getPrettyVersion(self::COMPOSER_NAME);
         if ($version) {
             self::$cachedVersion = $version;
@@ -36,11 +55,18 @@ class VersionUtils
         }
 
         LoggerUtils::getAppLogger()->warning('could not determine version from composer autoloader, falling back to legacy composer.json parsing');
-        $composerFile = file_get_contents(SystemURLs::getDocumentRoot() . '/composer.json');
-        $composerJson = json_decode($composerFile, true, 512, JSON_THROW_ON_ERROR);
-
-        self::$cachedVersion = $composerJson['version'];
+        self::$cachedVersion = self::readVersionFromComposerJson();
         return self::$cachedVersion;
+    }
+
+    private static function readVersionFromComposerJson(): ?string
+    {
+        $composerFile = @file_get_contents(SystemURLs::getDocumentRoot() . '/composer.json');
+        if ($composerFile === false) {
+            return null;
+        }
+        $composerJson = json_decode($composerFile, true, 512, JSON_THROW_ON_ERROR);
+        return $composerJson['version'] ?? null;
     }
 
     public static function getDBVersion()

--- a/src/ChurchCRM/utils/VersionUtils.php
+++ b/src/ChurchCRM/utils/VersionUtils.php
@@ -55,8 +55,13 @@ class VersionUtils
         }
 
         LoggerUtils::getAppLogger()->warning('could not determine version from composer autoloader, falling back to legacy composer.json parsing');
-        self::$cachedVersion = self::readVersionFromComposerJson();
-        return self::$cachedVersion;
+        $version = self::readVersionFromComposerJson();
+        if ($version === null) {
+            throw new \RuntimeException('Unable to determine installed version from Composer metadata or composer.json');
+        }
+
+        self::$cachedVersion = $version;
+        return $version;
     }
 
     private static function readVersionFromComposerJson(): ?string
@@ -65,8 +70,22 @@ class VersionUtils
         if ($composerFile === false) {
             return null;
         }
-        $composerJson = json_decode($composerFile, true, 512, JSON_THROW_ON_ERROR);
-        return $composerJson['version'] ?? null;
+
+        try {
+            $composerJson = json_decode($composerFile, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            // composer.json may be partial/invalid mid-deploy; let callers fall back.
+            return null;
+        }
+
+        $version = $composerJson['version'] ?? null;
+        if (!is_string($version)) {
+            return null;
+        }
+
+        $version = trim($version);
+
+        return $version !== '' ? $version : null;
     }
 
     public static function getDBVersion()


### PR DESCRIPTION
## Summary

- `UpgradeService::upgradeDatabaseVersion()` runs right after the new release's files are moved into place. It reads the installed version via `VersionUtils::getInstalledVersion()`, which delegates to `Composer\InstalledVersions::getPrettyVersion()`.
- `Composer\InstalledVersions` has its **own** static cache, populated from `vendor/composer/installed.php` at request start. Even after we replace the files on disk, that static still reports the **pre-upgrade** version within the same PHP request.
- Result: the post-deploy DB check compares `db=7.2.0` to `installed=7.2.0` (instead of 7.2.1), logs "Database is already at current version, no upgrade needed", and skips the migration. The DB only gets upgraded later, on the next request, via the `Bootstrapper` fallback — leaving a window during which new code runs against the old schema.
- Fix: make `VersionUtils::resetCache()` also set a one-shot `$forceReload` flag. On the next `getInstalledVersion()` call, bypass `InstalledVersions` and read `composer.json` fresh from disk. `resetCache()` is only called from the post-deploy path, so normal page loads still use the fast `InstalledVersions` path.

## Observed failure (real upgrade from 7.2.0 → 7.2.1)

```
13:29:44 Upgrade process complete
13:29:44 Attempting automatic database upgrade post code-deploy
13:29:44 Current Version: 7.2.0, Installed Version: 7.2.0
         {"dbVersion":"7.2.0","softwareInstalledVersion":"7.2.0"}
13:29:44 Database is already at current version, no upgrade needed   ← wrong
...
16:29:45 Auto-upgrading database from 7.2.0 to 7.2.1                 ← finally, 3h later
         {"dbVersion":"7.2.0","softwareInstalledVersion":"7.2.1"}
16:29:45 Database auto-upgrade completed successfully
```

After this fix, the second log line in the `do-upgrade` request reads `Installed Version: 7.2.1`, the equality check correctly fails, and the DB migration runs inline.

## Test plan

- [ ] Unit: add a test that calls `VersionUtils::resetCache()` then `getInstalledVersion()` and asserts it reads from `composer.json` on disk (not the `InstalledVersions` cache). *(No existing `VersionUtilsTest` in the repo — optional follow-up.)*
- [ ] Manual: on a staging install running 7.2.0 code, replace `composer.json`'s `version` with `7.2.2-dev`, call `VersionUtils::resetCache()` then `VersionUtils::getInstalledVersion()` — confirm it returns `7.2.2-dev` without restarting PHP.
- [ ] Manual end-to-end: stage a 7.2.x → 7.2.(x+1) release with a DB migration in `mysql/upgrade.json`, trigger the in-app upgrade, and confirm the `do-upgrade` request log now shows `softwareInstalledVersion` equal to the new release and the migration runs inline (no 3-hour gap waiting for bootstrap).
- [ ] Regression: normal page loads (outside the upgrade flow) still return the correct version — `resetCache()` is not called anywhere else, so `InstalledVersions` remains the primary source.

https://claude.ai/code/session_01RL66j5rBx9nUEMQsVHJSBo