### PR TITLE
chore(deps): pin Dependabot away from quill 2.0.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,11 @@ updates:
     commit-message:
       prefix: "chore(deps)"
     open-pull-requests-limit: 5
+    ignore:
+      # Pinned: quill 2.0.3 has regressions we don't want to pick up.
+      # Remove this entry when a newer 2.x release addresses them.
+      - dependency-name: "quill"
+        versions: ["2.0.3"]
     groups:
       # Group all minor/patch updates together
       npm-minor-patch:


### PR DESCRIPTION
## Summary

Stop Dependabot from re-proposing the `quill` `2.0.2` → `2.0.3` bump. The ignore is version-scoped, so any future `2.0.4`+ release will still generate a PR.

## Changes

- `.github/dependabot.yml` — add `ignore:` block under the npm `updates` entry pinning away from `quill@2.0.3`

## Why

`2.0.3` has regressions the maintainers don't want to pick up. A scoped ignore is more durable than `@dependabot ignore this version` PR comments (which live in Dependabot's internal state and can be lost when the config is rewritten).

## Testing

- YAML is valid (only adds a key under an existing `updates[]` entry)
- The next Dependabot run will pick this up on its next scheduled Monday poll; any pending quill@2.0.3 PR can be closed manually or with `@dependabot close`

## Files Changed

- `.github/dependabot.yml` (+5 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)