### PR TITLE
security: CSRF hardening on legacy delete pages (GHSA-3xq9-c86x-cwpp)

### DIFF
--- a/.agents/skills/churchcrm/cypress-testing.md
+++ b/.agents/skills/churchcrm/cypress-testing.md
@@ -665,6 +665,92 @@ cy.contains("Settings");
 
 ---
 
+### 5. Scoped `uncaught:exception` Filter for Cross-Test Noise <!-- learned: 2026-04-21 -->
+
+Unhandled promise rejections from **app JS or third-party libs** — ones we can't grep the source of — can fail *any* test that happens to visit the offending page. Symptom seen in `04-system-reset.spec.js` and observed to fail unrelated `.github/`-only PRs:
+
+```
+An unknown error has occurred: [object Object]
+```
+
+The `[object Object]` tail is the tell that an `Error`-like object was stringified into a template literal somewhere. Cypress treats the rejection as a test failure by default.
+
+**Rule:** when the root cause isn't grep-able in `src/**` or `webpack/**`, add a **tight, signature-matching** filter in `cypress/support/e2e.js` — not a blanket `return false`. Real test failures must still surface.
+
+```javascript
+// cypress/support/e2e.js
+Cypress.on('uncaught:exception', (err) => {
+    if (err && /An unknown error has occurred:\s*\[object Object\]/.test(err.message || '')) {
+        return false;   // filter only this exact signature
+    }
+    // any other uncaught exception still fails the test
+});
+```
+
+**Do NOT** add a project-wide `Cypress.on('uncaught:exception', () => false)` — that masks real regressions. Every filter needs a regex narrow enough that a different error would still fail.
+
+When adding such a filter, include a code-comment with a TODO + PR link so the root cause gets chased later.
+
+See PR [#8738](https://github.com/ChurchCRM/CRM/pull/8738) for the reference implementation.
+
+---
+
+### 6. API-Only Tests Should Skip UI Login <!-- learned: 2026-04-21 -->
+
+If a test *only* asserts against `cy.request()` responses, do **not** also drive the UI login form — doing so exposes the test to any JS error on the login / forced-password-change / church-info flow (which has caught out `04-system-reset.spec.js` more than once).
+
+```javascript
+// ✅ CORRECT — no browser JS executed, no page-init promise rejections
+const apiLogin = () => {
+    cy.clearCookies();
+    cy.request({
+        method: 'POST',
+        url: '/session/begin',
+        form: true,
+        body: { User: 'admin', Password: 'changeme' },
+        followRedirect: false,
+    });
+};
+
+it('should reset the database via API', () => {
+    apiLogin();  // session cookie only
+    cy.request({ method: 'DELETE', url: '/admin/api/database/reset' }).then(/* ... */);
+});
+
+// ❌ WRONG — full UI login just to get a cookie for a pure API call
+it('should reset the database via API', () => {
+    manualLogin();  // visits /login → maybe /changepassword → maybe /admin/system/church-info
+    cy.request({ method: 'DELETE', url: '/admin/api/database/reset' });
+});
+```
+
+UI login is only required when the test actually asserts against page content. For pure API tests, establish the session via API and skip the browser entirely.
+
+---
+
+### 7. Avoid Tautological `cy.url().should('include', ...)` After Form Submit <!-- learned: 2026-04-21 -->
+
+After submitting a form on page `/admin/system/church-info`, asserting `cy.url().should('include', 'church-info')` passes whether the submit succeeded, failed with validation errors, or never navigated at all — the URL substring is already present. The assertion is a no-op and, worse, is not a synchronization barrier, so the next command races any in-flight XHR.
+
+```javascript
+// ❌ WRONG — tautology; passes even if form submission failed silently
+cy.get('#church-info-form').submit();
+cy.url({ timeout: 10000 }).should('include', 'church-info');
+
+// ✅ CORRECT — wait for the actual save to complete via intercept
+cy.intercept('POST', '/admin/system/church-info').as('saveChurchInfo');
+cy.get('#church-info-form').submit();
+cy.wait('@saveChurchInfo').its('response.statusCode').should('be.oneOf', [200, 302]);
+
+// ✅ CORRECT — assert a visible success signal
+cy.get('#church-info-form').submit();
+cy.contains('.alert-success', /saved|updated/i, { timeout: 10000 }).should('be.visible');
+```
+
+Rule of thumb: if the URL substring you are asserting was **already** in the URL before the action, the assertion is not verifying anything.
+
+---
+
 ### Flakiness Prevention Checklist (for every new test that saves/loads state)
 
 Before marking a test complete, verify:
@@ -674,6 +760,8 @@ Before marking a test complete, verify:
 - [ ] Tests that reset a value after the assertion also `cy.wait()` on the reset call
 - [ ] `select()` tests ensure the starting value differs from the target value
 - [ ] `cy.contains()` is scoped to a container, not used globally
+- [ ] API-only tests (those that only assert against `cy.request()`) establish the session via `POST /session/begin` — not UI login
+- [ ] No `cy.url().should('include', ...)` assertions where the substring is already present pre-action (tautology)
 
 ---
 
@@ -1013,6 +1101,33 @@ cy.get("#sChurchState").find("option").should("have.length.greaterThan", 50);
 - [ ] Run tests again — all pass?
 - [ ] Review **both** code AND test changes in git diff
 - [ ] Commit together: code + test updates
+
+### Page Title Renames: Grep ALL spec Files, Not Just the Obvious One <!-- learned: 2026-04-21 -->
+
+When you rename a user-visible string (page title, card header, button
+label), **grep the entire `cypress/e2e` tree** for the old string before
+committing. Sibling spec files that happen to exercise the same route often
+assert the same title and will silently break in CI.
+
+Real example: the admin-debug refactor renamed `/admin/system/debug/email`'s
+page title from "Debug Email Connection" → "Email Debug".
+`admin.email.spec.js` was updated in the same PR, but `admin.debug.spec.js`
+had an `it("View email debug")` that still asserted the old string. The PR
+looked clean; CI failed on the first run.
+
+```bash
+# BEFORE renaming a title / label / card header, always run:
+rg -l "Debug Email Connection" cypress/e2e
+
+# Any spec that matches needs to be updated in the same commit.
+```
+
+**Rule of thumb for pages with variable state:** on pages that render
+different cards depending on environment (config error / success /
+failure), assert on **structural elements present in every state** — e.g.
+the new title plus a card header like "SMTP Configuration" — rather than a
+state-specific message. See `cypress/e2e/ui/admin/admin.email.spec.js` for
+the pattern.
 
 ## Test File Best Practices
 
@@ -1536,3 +1651,162 @@ cheapest way to catch the #8712 class of bugs without setting up a non-UTC CI
 environment. See `cypress/e2e/api/private/standard/private.calendar.timezone.spec.js`
 for the pattern — extract HH:MM:SS with a regex so the check works for both
 Propel's `Y-m-d H:i:s` output and FullCalendar's ISO 8601 feed.
+
+### Also Assert the ISO-8601 Offset for Calendar-Feed Endpoints <!-- learned: 2026-04-22 -->
+
+Wall-clock-only assertions miss a specific flavor of the #8712 regression:
+the feed emits the **correct HH:MM:SS** but stamps it with the **server's
+default offset** (e.g. `+00:00`) instead of the configured `sTimeZone` offset.
+FullCalendar then reinterprets the time against the browser zone and renders
+it shifted by hours — wall-clock looks right, UI is wrong.
+
+For any route that returns ISO 8601 strings (`/api/calendars/{id}/fullcalendar`,
+iCal exports, JSON-LD, etc.), assert both wall-clock AND that an offset is
+present and well-formed:
+
+```js
+const offsetOf = (dt) => {
+    if (typeof dt !== "string") return null;
+    const m = dt.match(/(Z|[+-]\d{2}:\d{2})$/);
+    return m ? m[1] : null;
+};
+
+// wall-clock preserved
+expect(timeOf(mine.start)).to.equal("11:15:00");
+
+// AND offset is present (not a naive datetime)
+expect(
+    offsetOf(mine.start),
+    "start must carry an ISO-8601 offset (not a naive datetime)",
+).to.match(/^(Z|[+-]\d{2}:\d{2})$/);
+```
+
+Don't pin to a specific offset value (e.g. `"+02:00"`) unless the test
+fixture also pins `sTimeZone` — CI may run in any zone. "Offset exists and is
+well-formed" is enough to catch the regression.
+
+### Admin Config Toggle in Tests — path is `/admin/api/system/config/{name}` <!-- learned: 2026-04-22 -->
+
+The `POST /api/system/config/{configName}` route is mounted under the **admin**
+Slim app (`MvcAppFactory::create('/admin', ...)` in `src/admin/index.php`),
+so the full path is `/admin/api/system/config/{configName}` — NOT
+`/api/system/config/...`. Using the wrong path returns 404 and every test
+that depends on the toggle breaks silently.
+
+```js
+function setExternalCalendarApi(enabled) {
+    cy.setupAdminSession();
+    cy.request({
+        method: "POST",
+        url: "/admin/api/system/config/bEnableExternalCalendarAPI",
+        body: { value: enabled ? "1" : "0" },
+        headers: { "Content-Type": "application/json" },
+    });
+}
+```
+
+Always reset the config back to its seed default in an `after()` hook so
+later specs aren't affected. Pattern used in
+`cypress/e2e/ui/events/external.calendar.spec.js`.
+
+### Tabler `.form-selectgroup-input` Visibility — target the label, not the input <!-- learned: 2026-04-22 -->
+
+Tabler pill-style `form-selectgroup` widgets hide the underlying radio
+input with `opacity: 0` and render the visible `.form-selectgroup-label`
+as the clickable surface. `cy.get('input[name="..."]').should("be.visible")`
+fails because the input itself is invisible by design. Assert visibility
+on the wrapping `<label>`, and click the label to change the value.
+
+```js
+// ❌ fails with "opacity: 0"
+cy.get('input[name="eventInActive"][value="1"]').should("be.visible");
+
+// ✅ assert + click the wrapping label
+cy.get('input[name="eventInActive"][value="1"]').parent("label").should("be.visible");
+cy.get('input[name="eventInActive"][value="1"]').parent("label").click();
+```
+
+Same fix applies to `.btn-check` radios — the input has `display: none` and
+the `<label class="btn">` IS the visible widget.
+
+### Save-path Tests on Standard Calendar Need Admin Session <!-- learned: 2026-04-22 -->
+
+`POST /api/events` is gated by `AddEventsRoleAuthMiddleware`. Tests that
+use `cy.setupStandardSession()` in a top-level `beforeEach` get `403`
+when they click the Save button on the event modal. Move the save-path
+tests into their own nested `describe` block with
+`cy.setupAdminSession()`:
+
+```js
+describe("Standard Calendar — save (admin-session)", () => {
+    beforeEach(() => cy.setupAdminSession());
+
+    it("New event saves successfully with default Event Type", () => {
+        // ... fill form, click Save, assert 200
+    });
+});
+```
+
+Keep the view-only rendering tests under the standard session.
+
+### Don't `cy.request("POST", "/api/calendars")` without a Body — Returns 400 <!-- learned: 2026-04-22 -->
+
+`POST /api/calendars` requires `Name`, `ForegroundColor`, `BackgroundColor`
+in the body. Calling it with no body returns 400 and the test fails.
+For fixtures that just need "any calendar exists", use `GET /api/events`
+or `GET /api/calendars` to read existing seed data instead.
+
+```js
+// ❌ 400 Bad Request
+cy.request("POST", "/api/calendars");
+
+// ✅ read seed data
+cy.request("/api/events").then((r) => {
+    const events = r.body.Events || r.body;
+    const arr = Array.isArray(events) ? events : Object.values(events);
+    if (arr.length > 0) cy.visit(`/event/editor/${arr[0].Id}`);
+});
+```
+
+### Driving Modals via Global Functions Beats `.fc-event` Clicks <!-- learned: 2026-04-22 -->
+
+FullCalendar events render at unpredictable positions depending on month/week.
+Clicking `.fc-event` is flaky. The calendar modal exposes
+`window.showEventForm({ id })` and `window.showNewEventForm(info)` globals
+used by FullCalendar's own click handlers — drive the modal directly via
+those globals so tests aren't coupled to which month the calendar is rendering.
+
+```js
+cy.visit("event/calendars");
+cy.window().should("have.property", "showEventForm");
+cy.window().then((win) => win.showEventForm({ id: eventId }));
+cy.get("#eventEditorModal").should("be.visible");
+```
+
+### Asserting CSRF Protection on Legacy PHP Delete Pages <!-- learned: 2026-04-21 -->
+
+When a legacy page is hardened with `CSRFUtils`, add three assertions per page:
+
+1. Confirmation page renders a 64-hex-char `csrf_token` hidden input.
+2. The page does **not** delete on GET (URL still shows the confirm page).
+3. POST with an invalid token returns **HTTP 403**.
+
+```js
+it("renders confirmation form with a CSRF token", () => {
+    cy.visit("FooDelete.php?FooID=1&linkBack=bar");
+    cy.contains("Confirm Delete");
+    cy.get('input[name="csrf_token"]').should("have.attr", "value").and("match", /^[a-f0-9]{64}$/);
+});
+
+it("rejects POST without a valid CSRF token", () => {
+    cy.request({
+        method: "POST",
+        url: "FooDelete.php",
+        form: true,
+        body: { FooID: "1", Delete: "Delete", csrf_token: "bogus" },
+        failOnStatusCode: false,
+    }).its("status").should("eq", 403);
+});
+```
+
+The 403 assertion exercises the exact code path a CSRF attacker would hit, so it's the regression test that actually proves the fix. Use `cy.setupStandardSession()` (or `cy.setupAdminSession()`) in `beforeEach` so the session cookie is real; the CSRF check runs AFTER the role/auth check.

--- a/.agents/skills/churchcrm/security-best-practices.md
+++ b/.agents/skills/churchcrm/security-best-practices.md
@@ -266,18 +266,27 @@ $userId = $_GET['userId'];  // Could be "1 OR 1=1"
 
 ### Every POST/delete page must validate a CSRF token <!-- learned: 2026-04-21 -->
 
-Any legacy `*.php` page that performs a DB write (insert/update/delete) MUST validate a CSRF token before acting. Pattern (applied in `UserEditor.php`, `PledgeDelete.php`, `DonatedItemDelete.php`, `PaddleNumDelete.php` — GHSA-3xq9-c86x-cwpp):
+Any legacy `*.php` page that performs a DB write (insert/update/delete) MUST validate a CSRF token before acting. The required rule is **validate before any DB write** (GHSA-3xq9-c86x-cwpp). Two failure-response patterns are in use in the codebase — pick whichever fits the page:
 
 ```php
 use ChurchCRM\Utils\CSRFUtils;
+use ChurchCRM\Utils\RedirectUtils;
 
-// In the POST handler — BEFORE any DB write:
-if (!CSRFUtils::verifyRequest($_POST, 'user_editor')) {
+// Pattern A — confirmation / delete pages (PledgeDelete.php, DonatedItemDelete.php,
+// PaddleNumDelete.php). Short-circuit with 403 because there is no form state to
+// preserve.
+if (!CSRFUtils::verifyRequest($_POST, 'pledge_delete')) {
     http_response_code(403);
     exit(gettext('Invalid security token. Please try again.'));
 }
 
-// In the form HTML:
+// Pattern B — long editor forms (UserEditor.php). Redirect back to the editor
+// with an ErrorText so the user's context (which record, add vs edit) is kept.
+if (!CSRFUtils::verifyRequest($_POST, 'user_editor')) {
+    RedirectUtils::redirect('UserEditor.php?PersonID=' . $iPersonID . '&ErrorText=Invalid+security+token.+Please+try+again.');
+}
+
+// In the form HTML (same for both patterns):
 <form method="post" action="...">
     <?= CSRFUtils::getTokenInputField('user_editor') ?>
     <!-- other inputs -->

--- a/.agents/skills/churchcrm/security-best-practices.md
+++ b/.agents/skills/churchcrm/security-best-practices.md
@@ -262,6 +262,53 @@ $userId = $_GET['userId'];  // Could be "1 OR 1=1"
 
 ---
 
+## CSRF Protection on State-Changing Pages
+
+### Every POST/delete page must validate a CSRF token <!-- learned: 2026-04-21 -->
+
+Any legacy `*.php` page that performs a DB write (insert/update/delete) MUST validate a CSRF token before acting. Pattern (applied in `UserEditor.php`, `PledgeDelete.php`, `DonatedItemDelete.php`, `PaddleNumDelete.php` — GHSA-3xq9-c86x-cwpp):
+
+```php
+use ChurchCRM\Utils\CSRFUtils;
+
+// In the POST handler — BEFORE any DB write:
+if (!CSRFUtils::verifyRequest($_POST, 'user_editor')) {
+    http_response_code(403);
+    exit(gettext('Invalid security token. Please try again.'));
+}
+
+// In the form HTML:
+<form method="post" action="...">
+    <?= CSRFUtils::getTokenInputField('user_editor') ?>
+    <!-- other inputs -->
+</form>
+```
+
+- Pick a unique `$formId` per form (e.g. `'user_editor'`, `'pledge_delete'`). The ID must match between `getTokenInputField()` and `verifyRequest()`.
+- `getTokenInputField()` auto-renders `<input type="hidden" name="csrf_token" value="...">` with a fresh 64-hex-char token.
+- Tokens are stored in `$_SESSION['csrf_tokens'][$formId]` with a 2-hour TTL.
+- Tokens are NOT consumed by default (allows resubmission on validation error). Pass `$consume = true` to `validateToken()` only if you need one-time use.
+
+### Never delete on GET — always confirmation-page pattern <!-- learned: 2026-04-21 -->
+
+A GET-based delete endpoint (`<a href="Foo.php?id=X">Delete</a>`) is exploitable by any HTML with an `<img>` or `<link>` tag pointing at it — no form submission needed. Convert to a two-step confirmation:
+
+1. **GET** — renders a confirmation `<form method="post">` with the CSRF token and Delete/Cancel buttons.
+2. **POST** — validates the token, then performs the delete and redirects.
+
+The caller's link stays a plain GET (`<a href="FooDelete.php?id=X">`), but the landing page now shows the confirmation form instead of silently deleting. This is what `PledgeDelete.php` already did before the CSRF fix; `DonatedItemDelete.php` and `PaddleNumDelete.php` were migrated to this pattern in the GHSA-3xq9-c86x-cwpp fix.
+
+### Role checks belong on every delete page <!-- learned: 2026-04-21 -->
+
+Delete pages must also enforce the relevant role guards — a CSRF token alone doesn't gate the feature, it only proves the request came from a real logged-in session. Finance-scoped deletes need both:
+
+```php
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isDeleteRecordsEnabled(), 'DeleteRecords');
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isFinanceEnabled(), 'Finance');
+```
+
+---
+
 ## Authorization & Access Control
 
 ### Block Users With No Admin Permissions <!-- learned: 2026-04-12 -->
@@ -616,6 +663,60 @@ churchWebSite:<?= SystemConfig::getValueForJs('sChurchWebSite') ?>,
 - [src/ChurchCRM/utils/CustomFieldUtils.php](../../../src/ChurchCRM/utils/CustomFieldUtils.php) — `placeholder`, `data-phone-mask`
 - [src/DirectoryReports.php](../../../src/DirectoryReports.php) — form `value=`, textarea content
 - [src/external/templates/registration/family-register.php](../../../src/external/templates/registration/family-register.php) — JS literals, address/phone inputs
+
+### JSON_HEX flags for inline `<script>` JSON <!-- learned: 2026-04-21 -->
+
+When embedding PHP data into a JS literal inside a `<script>` tag, `json_encode()`
+alone does not escape `<`, `>`, `&`, `'`, `"` — a value containing `</script>`
+(or `</SCRIPT`, `--!>`, etc.) can break out of the script context and become
+XSS. Always pass the four HEX flags alongside `JSON_THROW_ON_ERROR`:
+
+```php
+// ❌ WRONG — </script> in the data closes the script tag
+<script>
+window.CRM.calendarArgs = <?= json_encode($args, JSON_THROW_ON_ERROR) ?>;
+</script>
+
+// ✅ CORRECT — hex-encodes </script> and friends
+<script>
+window.CRM.calendarArgs = <?= json_encode(
+    $args,
+    JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_THROW_ON_ERROR
+) ?>;
+</script>
+```
+
+Grep for lone `json_encode($x, JSON_THROW_ON_ERROR)` inside `<script>` tags when
+reviewing — **every** such call needs the HEX flags. `SystemConfig::getValueForJs()`
+already handles this internally; the HEX flags apply when you call `json_encode()`
+directly on arrays/objects. Example site: [src/event/views/calendar.php](../../../src/event/views/calendar.php).
+
+### Escape captured SMTP / debug output before rendering as HTML <!-- learned: 2026-04-21 -->
+
+PHPMailer's `Debugoutput='html'` and similar debug capture modes emit **untrusted
+server-originated HTML** — server banners, auth exchanges, error text. Dumping the
+captured buffer straight into a page — even an admin-only page — is an XSS vector
+because a remote SMTP server (or any downstream service an attacker controls) owns
+part of the string. Strip tags, escape, then re-introduce line breaks with
+`nl2br()`:
+
+```php
+// ❌ WRONG — raw HTML from the SMTP server
+<div><?= $sendResult['debugLog'] ?></div>
+
+// ✅ CORRECT — strip, decode entities, escape, re-add line breaks
+$plain = trim(html_entity_decode(
+    strip_tags((string) $sendResult['debugLog']),
+    ENT_QUOTES | ENT_HTML5,
+    'UTF-8'
+));
+echo nl2br(InputUtils::escapeHTML($plain), false);
+```
+
+Same pattern applies to any "capture stream, then render" flow: `ob_get_clean()`
+output, cURL verbose logs, library diagnostic dumps. "Admin-only" is not a
+mitigation — an admin viewing a compromised downstream service's output is the
+exact attack surface.
 
 ### sanitizeText() Is Not Sufficient for HTML Attributes <!-- learned: 2026-04-03 -->
 

--- a/cypress/e2e/ui/finance/finance.pledge-operations.spec.js
+++ b/cypress/e2e/ui/finance/finance.pledge-operations.spec.js
@@ -17,4 +17,20 @@ describe("Pledge Operations", () => {
         cy.get('input[name="Cancel"]').click();
         cy.url().should("contain", "v2/dashboard");
     });
+
+    // GHSA-3xq9-c86x-cwpp — CSRF protection on delete
+    it("PledgeDelete renders a CSRF token input", () => {
+        cy.visit("PledgeDelete.php?GroupKey=test&linkBack=v2/dashboard");
+        cy.get('input[name="csrf_token"]').should("have.attr", "value").and("match", /^[a-f0-9]{64}$/);
+    });
+
+    it("PledgeDelete rejects POST without a valid CSRF token", () => {
+        cy.request({
+            method: "POST",
+            url: "PledgeDelete.php?GroupKey=test&linkBack=v2/dashboard",
+            form: true,
+            body: { Delete: "Delete", csrf_token: "bogus" },
+            failOnStatusCode: false,
+        }).its("status").should("eq", 403);
+    });
 });

--- a/cypress/e2e/ui/fundraiser/fundraiser.delete-operations.spec.js
+++ b/cypress/e2e/ui/fundraiser/fundraiser.delete-operations.spec.js
@@ -1,0 +1,66 @@
+/// <reference types="cypress" />
+
+// GHSA-3xq9-c86x-cwpp — confirmation + CSRF guard on fundraiser delete pages.
+describe("Fundraiser Delete Operations", () => {
+    beforeEach(() => cy.setupStandardSession());
+
+    describe("DonatedItemDelete.php", () => {
+        it("renders confirmation form with a CSRF token", () => {
+            cy.visit("DonatedItemDelete.php?DonatedItemID=1&linkBack=FindFundRaiser.php");
+            cy.contains("Confirm Delete");
+            cy.get('input[name="csrf_token"]').should("have.attr", "value").and("match", /^[a-f0-9]{64}$/);
+            cy.get('input[name="Delete"]').should("exist");
+            cy.get('input[name="Cancel"]').should("exist");
+        });
+
+        it("does not delete on GET", () => {
+            cy.visit("DonatedItemDelete.php?DonatedItemID=1&linkBack=FindFundRaiser.php");
+            cy.contains("Confirm Delete");
+            cy.url().should("contain", "DonatedItemDelete.php");
+        });
+
+        it("rejects POST without a valid CSRF token", () => {
+            cy.request({
+                method: "POST",
+                url: "DonatedItemDelete.php",
+                form: true,
+                body: {
+                    DonatedItemID: "1",
+                    Delete: "Delete",
+                    csrf_token: "bogus",
+                },
+                failOnStatusCode: false,
+            }).its("status").should("eq", 403);
+        });
+    });
+
+    describe("PaddleNumDelete.php", () => {
+        it("renders confirmation form with a CSRF token", () => {
+            cy.visit("PaddleNumDelete.php?PaddleNumID=1&linkBack=FindFundRaiser.php");
+            cy.contains("Confirm Delete");
+            cy.get('input[name="csrf_token"]').should("have.attr", "value").and("match", /^[a-f0-9]{64}$/);
+            cy.get('input[name="Delete"]').should("exist");
+            cy.get('input[name="Cancel"]').should("exist");
+        });
+
+        it("does not delete on GET", () => {
+            cy.visit("PaddleNumDelete.php?PaddleNumID=1&linkBack=FindFundRaiser.php");
+            cy.contains("Confirm Delete");
+            cy.url().should("contain", "PaddleNumDelete.php");
+        });
+
+        it("rejects POST without a valid CSRF token", () => {
+            cy.request({
+                method: "POST",
+                url: "PaddleNumDelete.php",
+                form: true,
+                body: {
+                    PaddleNumID: "1",
+                    Delete: "Delete",
+                    csrf_token: "bogus",
+                },
+                failOnStatusCode: false,
+            }).its("status").should("eq", 403);
+        });
+    });
+});

--- a/cypress/e2e/ui/fundraiser/fundraiser.delete-operations.spec.js
+++ b/cypress/e2e/ui/fundraiser/fundraiser.delete-operations.spec.js
@@ -6,7 +6,7 @@ describe("Fundraiser Delete Operations", () => {
 
     describe("DonatedItemDelete.php", () => {
         it("renders confirmation form with a CSRF token", () => {
-            cy.visit("DonatedItemDelete.php?DonatedItemID=1&linkBack=FindFundRaiser.php");
+            cy.visit("/DonatedItemDelete.php?DonatedItemID=1&linkBack=FindFundRaiser.php");
             cy.contains("Confirm Delete");
             cy.get('input[name="csrf_token"]').should("have.attr", "value").and("match", /^[a-f0-9]{64}$/);
             cy.get('input[name="Delete"]').should("exist");
@@ -14,7 +14,7 @@ describe("Fundraiser Delete Operations", () => {
         });
 
         it("does not delete on GET", () => {
-            cy.visit("DonatedItemDelete.php?DonatedItemID=1&linkBack=FindFundRaiser.php");
+            cy.visit("/DonatedItemDelete.php?DonatedItemID=1&linkBack=FindFundRaiser.php");
             cy.contains("Confirm Delete");
             cy.url().should("contain", "DonatedItemDelete.php");
         });
@@ -36,7 +36,7 @@ describe("Fundraiser Delete Operations", () => {
 
     describe("PaddleNumDelete.php", () => {
         it("renders confirmation form with a CSRF token", () => {
-            cy.visit("PaddleNumDelete.php?PaddleNumID=1&linkBack=FindFundRaiser.php");
+            cy.visit("/PaddleNumDelete.php?PaddleNumID=1&linkBack=FindFundRaiser.php");
             cy.contains("Confirm Delete");
             cy.get('input[name="csrf_token"]').should("have.attr", "value").and("match", /^[a-f0-9]{64}$/);
             cy.get('input[name="Delete"]').should("exist");
@@ -44,7 +44,7 @@ describe("Fundraiser Delete Operations", () => {
         });
 
         it("does not delete on GET", () => {
-            cy.visit("PaddleNumDelete.php?PaddleNumID=1&linkBack=FindFundRaiser.php");
+            cy.visit("/PaddleNumDelete.php?PaddleNumID=1&linkBack=FindFundRaiser.php");
             cy.contains("Confirm Delete");
             cy.url().should("contain", "PaddleNumDelete.php");
         });

--- a/src/DonatedItemDelete.php
+++ b/src/DonatedItemDelete.php
@@ -3,17 +3,57 @@
 require_once __DIR__ . '/Include/Config.php';
 require_once __DIR__ . '/Include/PageInit.php';
 
+use ChurchCRM\Authentication\AuthenticationManager;
 use ChurchCRM\model\ChurchCRM\DonatedItemQuery;
+use ChurchCRM\Utils\CSRFUtils;
 use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
+use ChurchCRM\view\PageHeader;
 
-$iDonatedItemID = InputUtils::legacyFilterInput($_GET['DonatedItemID'], 'int');
+// Security: require Delete Records + Finance permissions (GHSA-3xq9-c86x-cwpp)
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isDeleteRecordsEnabled(), 'DeleteRecords');
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isFinanceEnabled(), 'Finance');
+
+$iDonatedItemID = (int) InputUtils::legacyFilterInput($_REQUEST['DonatedItemID'] ?? 0, 'int');
 $linkBack = RedirectUtils::getLinkBackFromRequest('FindFundRaiser.php');
+$iFundRaiserID = (int) ($_SESSION['iCurrentFundraiser'] ?? 0);
 
-$iFundRaiserID = $_SESSION['iCurrentFundraiser'];
+// Confirmed deletion (second pass, POST with CSRF token)
+if (isset($_POST['Delete'])) {
+    // Security: CSRF token validation (GHSA-3xq9-c86x-cwpp)
+    if (!CSRFUtils::verifyRequest($_POST, 'donated_item_delete')) {
+        http_response_code(403);
+        exit(gettext('Invalid security token. Please try again.'));
+    }
 
-DonatedItemQuery::create()
-    ->filterById((int) $iDonatedItemID)
-    ->filterByFrId((int) $iFundRaiserID)
-    ->delete();
-RedirectUtils::redirect($linkBack);
+    if ($iDonatedItemID > 0 && $iFundRaiserID > 0) {
+        DonatedItemQuery::create()
+            ->filterById($iDonatedItemID)
+            ->filterByFrId($iFundRaiserID)
+            ->delete();
+    }
+    RedirectUtils::redirect($linkBack);
+} elseif (isset($_POST['Cancel'])) {
+    RedirectUtils::redirect($linkBack);
+}
+
+$sPageTitle = gettext('Confirm Delete');
+$aBreadcrumbs = PageHeader::breadcrumbs([
+    [gettext('Fundraiser'), 'FindFundRaiser.php'],
+    [gettext('Delete Donated Item')],
+]);
+require_once __DIR__ . '/Include/Header.php';
+
+?>
+
+<div class="card-body text-center">
+    <p class="lead mb-4"><?= gettext('Are you sure you want to permanently delete this donated item?') ?></p>
+    <form method="post" action="DonatedItemDelete.php?DonatedItemID=<?= $iDonatedItemID ?>&amp;linkBack=<?= InputUtils::escapeAttribute($linkBack) ?>" name="DonatedItemDelete">
+        <?= CSRFUtils::getTokenInputField('donated_item_delete') ?>
+        <input type="hidden" name="DonatedItemID" value="<?= $iDonatedItemID ?>">
+        <input type="submit" class="btn btn-danger" value="<?= gettext('Delete') ?>" name="Delete">
+        <input type="submit" class="btn btn-secondary ms-2" value="<?= gettext('Cancel') ?>" name="Cancel">
+    </form>
+</div>
+<?php
+require_once __DIR__ . '/Include/Footer.php';

--- a/src/DonatedItemDelete.php
+++ b/src/DonatedItemDelete.php
@@ -14,7 +14,11 @@ use ChurchCRM\view\PageHeader;
 AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isDeleteRecordsEnabled(), 'DeleteRecords');
 AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isFinanceEnabled(), 'Finance');
 
-$iDonatedItemID = (int) InputUtils::legacyFilterInput($_REQUEST['DonatedItemID'] ?? 0, 'int');
+// Read the ID from $_POST on the confirmed-delete submit, $_GET when rendering
+// the confirmation page. $_REQUEST depends on request_order and can include
+// cookies — unsafe for destructive operations.
+$idSource = isset($_POST['Delete']) ? $_POST : $_GET;
+$iDonatedItemID = (int) InputUtils::legacyFilterInput($idSource['DonatedItemID'] ?? 0, 'int');
 $linkBack = RedirectUtils::getLinkBackFromRequest('FindFundRaiser.php');
 $iFundRaiserID = (int) ($_SESSION['iCurrentFundraiser'] ?? 0);
 
@@ -48,7 +52,7 @@ require_once __DIR__ . '/Include/Header.php';
 
 <div class="card-body text-center">
     <p class="lead mb-4"><?= gettext('Are you sure you want to permanently delete this donated item?') ?></p>
-    <form method="post" action="DonatedItemDelete.php?DonatedItemID=<?= $iDonatedItemID ?>&amp;linkBack=<?= InputUtils::escapeAttribute($linkBack) ?>" name="DonatedItemDelete">
+    <form method="post" action="DonatedItemDelete.php?DonatedItemID=<?= $iDonatedItemID ?>&amp;linkBack=<?= urlencode($linkBack) ?>" name="DonatedItemDelete">
         <?= CSRFUtils::getTokenInputField('donated_item_delete') ?>
         <input type="hidden" name="DonatedItemID" value="<?= $iDonatedItemID ?>">
         <input type="submit" class="btn btn-danger" value="<?= gettext('Delete') ?>" name="Delete">

--- a/src/PaddleNumDelete.php
+++ b/src/PaddleNumDelete.php
@@ -3,14 +3,56 @@
 require_once __DIR__ . '/Include/Config.php';
 require_once __DIR__ . '/Include/PageInit.php';
 
+use ChurchCRM\Authentication\AuthenticationManager;
+use ChurchCRM\Utils\CSRFUtils;
 use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
+use ChurchCRM\view\PageHeader;
 
-$iPaddleNumID = InputUtils::legacyFilterInput($_GET['PaddleNumID'], 'int');
+// Security: require Delete Records + Finance permissions (GHSA-3xq9-c86x-cwpp)
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isDeleteRecordsEnabled(), 'DeleteRecords');
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isFinanceEnabled(), 'Finance');
+
+$iPaddleNumID = (int) InputUtils::legacyFilterInput($_REQUEST['PaddleNumID'] ?? 0, 'int');
 $linkBack = RedirectUtils::getLinkBackFromRequest('FindFundRaiser.php');
+$iFundRaiserID = (int) ($_SESSION['iCurrentFundraiser'] ?? 0);
 
-$iFundRaiserID = $_SESSION['iCurrentFundraiser'];
+// Confirmed deletion (second pass, POST with CSRF token)
+if (isset($_POST['Delete'])) {
+    // Security: CSRF token validation (GHSA-3xq9-c86x-cwpp)
+    if (!CSRFUtils::verifyRequest($_POST, 'paddle_num_delete')) {
+        http_response_code(403);
+        exit(gettext('Invalid security token. Please try again.'));
+    }
 
-$sSQL ="DELETE FROM paddlenum_pn WHERE pn_id=$iPaddleNumID AND pn_fr_id=$iFundRaiserID";
-RunQuery($sSQL);
-RedirectUtils::redirect($linkBack);
+    if ($iPaddleNumID > 0 && $iFundRaiserID > 0) {
+        // No Propel-generated model exists for paddlenum_pn; raw SQL is safe
+        // here because both IDs are hard-cast to int before interpolation.
+        $sSQL = 'DELETE FROM paddlenum_pn WHERE pn_id=' . $iPaddleNumID . ' AND pn_fr_id=' . $iFundRaiserID;
+        RunQuery($sSQL);
+    }
+    RedirectUtils::redirect($linkBack);
+} elseif (isset($_POST['Cancel'])) {
+    RedirectUtils::redirect($linkBack);
+}
+
+$sPageTitle = gettext('Confirm Delete');
+$aBreadcrumbs = PageHeader::breadcrumbs([
+    [gettext('Fundraiser'), 'FindFundRaiser.php'],
+    [gettext('Delete Paddle Number')],
+]);
+require_once __DIR__ . '/Include/Header.php';
+
+?>
+
+<div class="card-body text-center">
+    <p class="lead mb-4"><?= gettext('Are you sure you want to permanently delete this paddle number?') ?></p>
+    <form method="post" action="PaddleNumDelete.php?PaddleNumID=<?= $iPaddleNumID ?>&amp;linkBack=<?= InputUtils::escapeAttribute($linkBack) ?>" name="PaddleNumDelete">
+        <?= CSRFUtils::getTokenInputField('paddle_num_delete') ?>
+        <input type="hidden" name="PaddleNumID" value="<?= $iPaddleNumID ?>">
+        <input type="submit" class="btn btn-danger" value="<?= gettext('Delete') ?>" name="Delete">
+        <input type="submit" class="btn btn-secondary ms-2" value="<?= gettext('Cancel') ?>" name="Cancel">
+    </form>
+</div>
+<?php
+require_once __DIR__ . '/Include/Footer.php';

--- a/src/PaddleNumDelete.php
+++ b/src/PaddleNumDelete.php
@@ -13,7 +13,11 @@ use ChurchCRM\view\PageHeader;
 AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isDeleteRecordsEnabled(), 'DeleteRecords');
 AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isFinanceEnabled(), 'Finance');
 
-$iPaddleNumID = (int) InputUtils::legacyFilterInput($_REQUEST['PaddleNumID'] ?? 0, 'int');
+// Read the ID from $_POST on the confirmed-delete submit, $_GET when rendering
+// the confirmation page. $_REQUEST depends on request_order and can include
+// cookies — unsafe for destructive operations.
+$idSource = isset($_POST['Delete']) ? $_POST : $_GET;
+$iPaddleNumID = (int) InputUtils::legacyFilterInput($idSource['PaddleNumID'] ?? 0, 'int');
 $linkBack = RedirectUtils::getLinkBackFromRequest('FindFundRaiser.php');
 $iFundRaiserID = (int) ($_SESSION['iCurrentFundraiser'] ?? 0);
 
@@ -47,7 +51,7 @@ require_once __DIR__ . '/Include/Header.php';
 
 <div class="card-body text-center">
     <p class="lead mb-4"><?= gettext('Are you sure you want to permanently delete this paddle number?') ?></p>
-    <form method="post" action="PaddleNumDelete.php?PaddleNumID=<?= $iPaddleNumID ?>&amp;linkBack=<?= InputUtils::escapeAttribute($linkBack) ?>" name="PaddleNumDelete">
+    <form method="post" action="PaddleNumDelete.php?PaddleNumID=<?= $iPaddleNumID ?>&amp;linkBack=<?= urlencode($linkBack) ?>" name="PaddleNumDelete">
         <?= CSRFUtils::getTokenInputField('paddle_num_delete') ?>
         <input type="hidden" name="PaddleNumID" value="<?= $iPaddleNumID ?>">
         <input type="submit" class="btn btn-danger" value="<?= gettext('Delete') ?>" name="Delete">

--- a/src/PledgeDelete.php
+++ b/src/PledgeDelete.php
@@ -5,6 +5,7 @@ require_once __DIR__ . '/Include/PageInit.php';
 
 use ChurchCRM\Authentication\AuthenticationManager;
 use ChurchCRM\model\ChurchCRM\PledgeQuery;
+use ChurchCRM\Utils\CSRFUtils;
 use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 use ChurchCRM\view\PageHeader;
@@ -20,6 +21,12 @@ AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser
 
 // Is this the second pass?
 if (isset($_POST['Delete'])) {
+    // Security: CSRF token validation (GHSA-3xq9-c86x-cwpp)
+    if (!CSRFUtils::verifyRequest($_POST, 'pledge_delete')) {
+        http_response_code(403);
+        exit(gettext('Invalid security token. Please try again.'));
+    }
+
     PledgeQuery::create()->filterByGroupKey($sGroupKey)->delete();
 
     if ($linkBack !== '') {
@@ -39,7 +46,8 @@ require_once __DIR__ . '/Include/Header.php';
 
 <div class="card-body text-center">
     <p class="lead mb-4"><?= gettext('Are you sure you want to permanently delete this pledge record?') ?></p>
-    <form method="post" action="PledgeDelete.php?<?= 'GroupKey=' . $sGroupKey . '&linkBack=' . $linkBack ?>" name="PledgeDelete">
+    <form method="post" action="PledgeDelete.php?<?= 'GroupKey=' . InputUtils::escapeAttribute($sGroupKey) . '&linkBack=' . InputUtils::escapeAttribute($linkBack) ?>" name="PledgeDelete">
+        <?= CSRFUtils::getTokenInputField('pledge_delete') ?>
         <input type="submit" class="btn btn-danger" value="<?= gettext('Delete') ?>" name="Delete">
         <input type="submit" class="btn btn-secondary ms-2" value="<?= gettext('Cancel') ?>" name="Cancel">
     </form>

--- a/src/PledgeDelete.php
+++ b/src/PledgeDelete.php
@@ -46,7 +46,7 @@ require_once __DIR__ . '/Include/Header.php';
 
 <div class="card-body text-center">
     <p class="lead mb-4"><?= gettext('Are you sure you want to permanently delete this pledge record?') ?></p>
-    <form method="post" action="PledgeDelete.php?<?= 'GroupKey=' . InputUtils::escapeAttribute($sGroupKey) . '&linkBack=' . InputUtils::escapeAttribute($linkBack) ?>" name="PledgeDelete">
+    <form method="post" action="PledgeDelete.php?GroupKey=<?= urlencode($sGroupKey) ?>&amp;linkBack=<?= urlencode($linkBack) ?>" name="PledgeDelete">
         <?= CSRFUtils::getTokenInputField('pledge_delete') ?>
         <input type="submit" class="btn btn-danger" value="<?= gettext('Delete') ?>" name="Delete">
         <input type="submit" class="btn btn-secondary ms-2" value="<?= gettext('Cancel') ?>" name="Cancel">


### PR DESCRIPTION
## Summary

Fixes **GHSA-3xq9-c86x-cwpp** — CSRF on three legacy `*Delete.php` pages that could be exploited by a one-click attack from an attacker-controlled page, allowing unauthenticated attackers to trigger privileged deletes against an authenticated admin. `UserEditor.php` (the primary target of the advisory) was already fixed in #8626; this PR closes the remaining three pages the advisory named.

## Changes

### PHP — CSRF + role + confirmation-page pattern
- **`src/PledgeDelete.php`** — already had a POST confirmation form and a `DeleteRecords` role check; adds `csrf_token` input + `CSRFUtils::verifyRequest()` before the delete, and escapes `GroupKey` / `linkBack` in the form action.
- **`src/DonatedItemDelete.php`** — previously deleted silently on **GET** with **no role check**. Converted to the same confirmation-page pattern as `PledgeDelete`: GET renders the confirm form with the token, POST validates and deletes. Added `isDeleteRecordsEnabled` + `isFinanceEnabled` guards.
- **`src/PaddleNumDelete.php`** — same treatment as above. Raw SQL retained (no Propel-generated model for `paddlenum_pn`) but hardened with explicit `(int)` casts on both `pn_id` and `pn_fr_id` before interpolation.

### Cypress
- **`cypress/e2e/ui/finance/finance.pledge-operations.spec.js`** — two new tests: CSRF token input renders on GET, and POST with a bogus token returns 403.
- **`cypress/e2e/ui/fundraiser/fundraiser.delete-operations.spec.js`** (new) — six tests covering both `DonatedItemDelete` and `PaddleNumDelete`: confirmation renders, no GET-delete, and 403 on invalid-token POST.

### Skills
- `security-best-practices.md` — new CSRF section documenting the `CSRFUtils::getTokenInputField` + `verifyRequest` pattern, the GET-delete → confirmation-page rule, and why role checks still belong alongside CSRF.
- `cypress-testing.md` — recipe for asserting CSRF protection on legacy PHP delete pages.

## Why

A GET-based delete endpoint is exploitable by a simple `<img src=\"…/FooDelete.php?id=X\">` tag on any page an admin visits. A POST-only endpoint without a CSRF token is exploitable by an auto-submitting `<form>`. The `CSRFUtils` helper was already in the codebase — this PR just applies it where it was missing, matching the fix that #8626 already landed on `UserEditor.php`.

## Files Changed

- `src/PledgeDelete.php`
- `src/DonatedItemDelete.php`
- `src/PaddleNumDelete.php`
- `cypress/e2e/ui/finance/finance.pledge-operations.spec.js`
- `cypress/e2e/ui/fundraiser/fundraiser.delete-operations.spec.js` *(new)*
- `.agents/skills/churchcrm/security-best-practices.md`
- `.agents/skills/churchcrm/cypress-testing.md`

## Testing

- [x] `npm run lint` — clean for touched files
- [x] `npm run build:php` — 722 files validated
- [ ] `npx cypress run --spec "cypress/e2e/ui/finance/finance.pledge-operations.spec.js" --spec "cypress/e2e/ui/fundraiser/fundraiser.delete-operations.spec.js"` (run locally against a dev server)
- [ ] Manual: click **Delete** link on a pledge, donated item, and paddle number — verify confirmation page shows a hidden `csrf_token` input, Cancel redirects back, Delete performs the action
- [ ] Manual CSRF probe: `curl -X POST .../PledgeDelete.php?GroupKey=X` with a valid session cookie but no token → expect 403

## Related

- Security advisory: GHSA-3xq9-c86x-cwpp
- Companion PR for the same advisory: #8626 (UserEditor.php — already merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)