### PR TITLE
security(config): data/code separation for Config.php (GHSA-mp2w-4q3r-ppx7)

### DIFF
--- a/.agents/skills/churchcrm/security-best-practices.md
+++ b/.agents/skills/churchcrm/security-best-practices.md
@@ -262,6 +262,43 @@ $userId = $_GET['userId'];  // Could be "1 OR 1=1"
 
 ---
 
+## Config & Secrets: Data/Code Separation <!-- learned: 2026-04-22 -->
+
+**Never render user-supplied values into an executable PHP file.** Templating untrusted input into a `.php` file reopens the pre-auth RCE class regardless of how carefully you sanitize at write time — one missed field, one future placeholder, and a quote-breaking payload becomes PHP code (GHSA-mp2w-4q3r-ppx7 / CVE-2026-39337 was exactly this pattern: `$sPASSWORD = '||DB_PASSWORD||';` with a raw password).
+
+**Correct architecture**: values live in data, `Config.php` is a static bootstrap.
+
+```php
+// src/Include/Config.php.example (static — shipped in the repo, copied verbatim on install)
+$values = \ChurchCRM\Config\ConfigLoader::load(__DIR__ . '/config-values.json');
+$sSERVERNAME = $values['DB_SERVER_NAME'];
+$sPASSWORD   = $values['DB_PASSWORD'];
+// ...
+```
+
+```php
+// src/setup/routes/setup.php — POST handler writes data, never code
+file_put_contents($tmp, json_encode($userInput, JSON_THROW_ON_ERROR), LOCK_EX);
+rename($tmp, $valuesFile);          // atomic data write
+copy($examplePath, $configFile);    // verbatim bootstrap — no substitution
+```
+
+```php
+// src/ChurchCRM/Config/ConfigLoader.php — validation happens ON READ
+if (!preg_match('/^[0-9]{1,5}$/', $data['DB_SERVER_PORT'])) {
+    throw new RuntimeException('Invalid DB_SERVER_PORT');
+}
+```
+
+### Rules
+
+- **Write JSON, not PHP.** `json_encode()` quoting is airtight for arbitrary bytes.
+- **Validate at read time, not write time.** The boundary to defend is where data becomes code — which is `Config.php` → `require_once`, not the wizard. The loader rejects malformed fields regardless of how the file got there (attacker with filesystem access, misconfigured migration, hand-edited typo, etc.).
+- **Block web access to the config file.** `src/Include/.htaccess` denies all (matching `src/logs/.htaccess`); `docker/nginx/default.conf` and `docker/frankenphp/Caddyfile` have matching `location ~ ^/Include` deny rules. A JSON secrets file served over HTTP is an instant credential leak.
+- **Upgrade migration for existing installs.** A PHP migration under `src/mysql/upgrade.json:current.scripts` captures the legacy `$GLOBALS` variables, writes JSON, preserves the old file as `Config.php.legacy-backup`, and swaps in the new bootstrap. Idempotent.
+
+---
+
 ## Authorization & Access Control
 
 ### Block Users With No Admin Permissions <!-- learned: 2026-04-12 -->

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ src/skin/external
 
 # Configuration files with passwords
 src/Include/Config.php
+src/Include/config-values.json
+src/Include/config-values.json.tmp
+src/Include/Config.php.legacy-backup
 orm/propel.php
 
 # Perpl/Propel generated config

--- a/docker/README.md
+++ b/docker/README.md
@@ -191,7 +191,7 @@ Visit `http://localhost/` — you will see the setup wizard on first run.
 2. Replace `php-fpm:9000` with your PHP-FPM container hostname/port.
 3. Set `root` to the path where ChurchCRM's `src/` contents are served from.
 4. For a **subdirectory install** (e.g. `http://example.com/churchcrm/`):
-   - Set `$sRootPath = '/churchcrm'` in `Include/Config.php`.
+   - Set `ROOT_PATH` to `"/churchcrm"` in `Include/config-values.json` (or re-run the setup wizard after deleting `Include/Config.php` + `Include/config-values.json`).
    - Prefix all `location` paths in the nginx config with `/churchcrm`.
    - See the commented example at the bottom of `nginx/default.conf`.
 
@@ -261,7 +261,7 @@ Visit `http://localhost/` — you will see the setup wizard on first run.
 1. Copy `frankenphp/Caddyfile` to your deployment.
 2. Update `root` to the path where ChurchCRM's `src/` contents are served from.
 3. For a **subdirectory install** (e.g. `http://example.com/churchcrm/`):
-   - Set `$sRootPath = '/churchcrm'` in `Include/Config.php`.
+   - Set `ROOT_PATH` to `"/churchcrm"` in `Include/config-values.json` (or re-run the setup wizard after deleting `Include/Config.php` + `Include/config-values.json`).
    - Prefix all `handle` paths in the Caddyfile with `/churchcrm`.
    - See the commented example at the bottom of `frankenphp/Caddyfile`.
 4. To enable **automatic HTTPS**, replace `:80` with your domain name (Caddy

--- a/docker/frankenphp/Caddyfile
+++ b/docker/frankenphp/Caddyfile
@@ -52,6 +52,12 @@
     @tmp_attach path /tmp_attach/*
     respond @tmp_attach 404
 
+    # Block access to install-time configuration (Config.php, config-values.json,
+    # bootstrap scripts). Nothing under Include/ should ever be served directly.
+    # See GHSA-mp2w-4q3r-ppx7.
+    @include path /Include/*
+    respond @include 404
+
     # ── Slim sub-application routing ──────────────────────────────────────
     #
     # Each block below handles one of ChurchCRM's Slim 4 sub-applications.
@@ -143,6 +149,8 @@
 #     respond @logs 404
 #     @tmp_attach path /churchcrm/tmp_attach/*
 #     respond @tmp_attach 404
+#     @include path /churchcrm/Include/*
+#     respond @include 404
 #
 #     handle /churchcrm/session/* {
 #         try_files {path} /churchcrm/session/index.php

--- a/docker/frankenphp/Caddyfile
+++ b/docker/frankenphp/Caddyfile
@@ -136,7 +136,7 @@
 # ── SUBDIRECTORY INSTALLATION ─────────────────────────────────────────────────
 #
 # If ChurchCRM is installed at a subdirectory (e.g., http://example.com/churchcrm/),
-# set $sRootPath = '/churchcrm' in Include/Config.php and replace the server block
+# set ROOT_PATH to "/churchcrm" in Include/config-values.json and replace the server block
 # above with the following (prefix all handle paths with /churchcrm):
 #
 # :80 {

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -209,7 +209,7 @@ server {
 # ── SUBDIRECTORY INSTALLATION ─────────────────────────────────────────────────
 #
 # If ChurchCRM is installed at a subdirectory (e.g., http://example.com/churchcrm/),
-# set $sRootPath = '/churchcrm' in Include/Config.php and replace the server block
+# set ROOT_PATH to "/churchcrm" in Include/config-values.json and replace the server block
 # above with the following (prefix all location paths with /churchcrm):
 #
 # server {

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -53,6 +53,14 @@ server {
         return 404;
     }
 
+    # Block access to install-time configuration (Config.php, config-values.json,
+    # bootstrap scripts). Nothing under Include/ should ever be served directly.
+    # See GHSA-mp2w-4q3r-ppx7.
+    location ~ ^/Include(/|$) {
+        deny all;
+        return 404;
+    }
+
     # ── Slim sub-application routing ──────────────────────────────────────
     #
     # Each block below handles one of ChurchCRM's Slim 4 sub-applications.
@@ -214,6 +222,7 @@ server {
 #     location ~ /\. { deny all; return 404; }
 #     location ~ ^/churchcrm/logs(/|$) { deny all; return 404; }
 #     location ~ ^/churchcrm/tmp_attach(/|$) { deny all; return 404; }
+#     location ~ ^/churchcrm/Include(/|$) { deny all; return 404; }
 #
 #     location ^~ /churchcrm/session {
 #         try_files $uri /churchcrm/session/index.php$is_args$args;

--- a/src/ChurchCRM/Config/ConfigLoader.php
+++ b/src/ChurchCRM/Config/ConfigLoader.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace ChurchCRM\Config;
+
+use RuntimeException;
+
+/**
+ * Loads ChurchCRM configuration from a JSON values file and validates every
+ * field at read time.
+ *
+ * Security note (GHSA-mp2w-4q3r-ppx7 / CVE-2026-39337):
+ * The setup wizard previously substituted user-supplied DB credentials into
+ * a PHP template, which allowed quote-breaking payloads in DB_PASSWORD to
+ * inject executable PHP. Configuration values are now stored in JSON and
+ * loaded through this class, so user input cannot reach the PHP grammar.
+ * Validation is enforced on read — the loader rejects anything that does
+ * not match the expected shape regardless of how it was written to disk.
+ */
+final class ConfigLoader
+{
+    public const REQUIRED_KEYS = [
+        'DB_SERVER_NAME',
+        'DB_SERVER_PORT',
+        'DB_NAME',
+        'DB_USER',
+        'DB_PASSWORD',
+        'ROOT_PATH',
+        'URL',
+    ];
+
+    /**
+     * Load and validate config values from a JSON file.
+     *
+     * @return array<string, string> validated values keyed by REQUIRED_KEYS
+     * @throws RuntimeException on any validation failure
+     */
+    public static function load(string $path): array
+    {
+        if (!is_file($path) || !is_readable($path)) {
+            throw new RuntimeException("Config values file not found or not readable: {$path}");
+        }
+
+        $raw = file_get_contents($path);
+        if ($raw === false) {
+            throw new RuntimeException("Unable to read config values file: {$path}");
+        }
+
+        $data = json_decode($raw, true);
+        if (!is_array($data)) {
+            throw new RuntimeException("Config values file is not a valid JSON object: {$path}");
+        }
+
+        foreach (self::REQUIRED_KEYS as $key) {
+            if (!array_key_exists($key, $data)) {
+                throw new RuntimeException("Missing required config key: {$key}");
+            }
+            if (!is_string($data[$key])) {
+                throw new RuntimeException("Config key must be a string: {$key}");
+            }
+        }
+
+        self::validateHostname($data['DB_SERVER_NAME']);
+        self::validatePort($data['DB_SERVER_PORT']);
+        self::validateDbName($data['DB_NAME']);
+        self::validateDbUser($data['DB_USER']);
+        self::validateDbPassword($data['DB_PASSWORD']);
+        self::validateRootPath($data['ROOT_PATH']);
+        self::validateUrl($data['URL']);
+
+        return [
+            'DB_SERVER_NAME' => $data['DB_SERVER_NAME'],
+            'DB_SERVER_PORT' => $data['DB_SERVER_PORT'],
+            'DB_NAME'        => $data['DB_NAME'],
+            'DB_USER'        => $data['DB_USER'],
+            'DB_PASSWORD'    => $data['DB_PASSWORD'],
+            'ROOT_PATH'      => $data['ROOT_PATH'],
+            'URL'            => $data['URL'],
+        ];
+    }
+
+    private static function validateHostname(string $value): void
+    {
+        // RFC 1123 hostname — letters, digits, dash, dot; no @ or :
+        if (!preg_match('/^(?=.{1,253}$)([a-zA-Z0-9\-]{1,63}\.)*[a-zA-Z0-9\-]{1,63}$/', $value)) {
+            throw new RuntimeException('Invalid DB_SERVER_NAME');
+        }
+    }
+
+    private static function validatePort(string $value): void
+    {
+        if (!preg_match('/^[0-9]{1,5}$/', $value)) {
+            throw new RuntimeException('Invalid DB_SERVER_PORT');
+        }
+        $port = (int) $value;
+        if ($port < 1 || $port > 65535) {
+            throw new RuntimeException('Invalid DB_SERVER_PORT');
+        }
+    }
+
+    private static function validateDbName(string $value): void
+    {
+        if (!preg_match('/^[a-zA-Z0-9_\-\.]+$/', $value)) {
+            throw new RuntimeException('Invalid DB_NAME');
+        }
+    }
+
+    private static function validateDbUser(string $value): void
+    {
+        if (!preg_match('/^[a-zA-Z0-9_\-\.@]+$/', $value)) {
+            throw new RuntimeException('Invalid DB_USER');
+        }
+    }
+
+    private static function validateDbPassword(string $value): void
+    {
+        // Passwords are opaque and may contain arbitrary bytes. The JSON
+        // storage layer prevents grammar injection, so the only invariant
+        // enforced at read time is non-empty.
+        if ($value === '') {
+            throw new RuntimeException('Invalid DB_PASSWORD');
+        }
+    }
+
+    private static function validateRootPath(string $value): void
+    {
+        // Empty, or starts with "/" — letters, digits, underscore, dash, dot, slash only.
+        if (!preg_match('#^(|\/[a-zA-Z0-9_\-\.\/]*)$#', $value)) {
+            throw new RuntimeException('Invalid ROOT_PATH');
+        }
+    }
+
+    private static function validateUrl(string $value): void
+    {
+        if (!filter_var($value, FILTER_VALIDATE_URL) || !preg_match('#^https?://[^\s]+/$#i', $value)) {
+            throw new RuntimeException('Invalid URL');
+        }
+    }
+}

--- a/src/Include/.htaccess
+++ b/src/Include/.htaccess
@@ -1,0 +1,16 @@
+# Deny all direct web access to the Include/ directory.
+#
+# This directory holds install-time configuration (Config.php and the
+# JSON values file that feeds ConfigLoader), plus other bootstrap
+# scripts. None of it should ever be served directly — the files are
+# only consumed by PHP includes from the application's entry points.
+#
+# See GHSA-mp2w-4q3r-ppx7 for the motivating security context.
+
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+<IfModule !mod_authz_core.c>
+    Order deny,allow
+    Deny from all
+</IfModule>

--- a/src/Include/Config.php.example
+++ b/src/Include/Config.php.example
@@ -3,16 +3,31 @@
  *
  *  filename    : Include/Config.php
  *  website     : https://churchcrm.io
- *  description : global configuration
+ *  description : global configuration bootstrap
+ *
+ *  Install-time values (DB credentials, root path, primary URL) live in
+ *  Include/config-values.json and are validated at read time by
+ *  ChurchCRM\Config\ConfigLoader. This file is a static bootstrap — do not
+ *  edit user data here. To change DB credentials or paths, edit the JSON
+ *  file or re-run the setup wizard after removing Config.php.
+ *
+ *  Security: GHSA-mp2w-4q3r-ppx7 / CVE-2026-39337 — configuration values
+ *  MUST NOT be rendered into this file via string substitution. Doing so
+ *  re-opens the pre-auth RCE class where a quote-breaking DB_PASSWORD
+ *  injected executable PHP.
  *
  ******************************************************************************/
 
-// Database connection constants
-$sSERVERNAME = '||DB_SERVER_NAME||';
-$dbPort = '||DB_SERVER_PORT||';
-$sUSER = '||DB_USER||';
-$sPASSWORD = '||DB_PASSWORD||';
-$sDATABASE = '||DB_NAME||';
+require_once __DIR__ . '/../vendor/autoload.php';
+
+$churchCrmConfigValues = \ChurchCRM\Config\ConfigLoader::load(__DIR__ . '/config-values.json');
+
+// Database connection constants (read from validated JSON — never templated from user input).
+$sSERVERNAME = $churchCrmConfigValues['DB_SERVER_NAME'];
+$dbPort      = $churchCrmConfigValues['DB_SERVER_PORT'];
+$sUSER       = $churchCrmConfigValues['DB_USER'];
+$sPASSWORD   = $churchCrmConfigValues['DB_PASSWORD'];
+$sDATABASE   = $churchCrmConfigValues['DB_NAME'];
 
 // Root path of your ChurchCRM installation ( THIS MUST BE SET CORRECTLY! )
 //
@@ -24,7 +39,7 @@ $sDATABASE = '||DB_NAME||';
 // - the path SHOULD Start with slash, if not ''.
 // - the path SHOULD NOT end with slash.
 // - the path is case sensitive.
-$sRootPath = '||ROOT_PATH||';
+$sRootPath = $churchCrmConfigValues['ROOT_PATH'];
 
 // Set $bLockURL=TRUE to enforce https access by specifying exactly
 // which URL's your users may use to log into ChurchCRM.
@@ -32,7 +47,8 @@ $bLockURL = FALSE;
 
 // URL[0] is the URL that you prefer most users use when they
 // log in.  These are case sensitive.
-$URL[0] = '||URL||';
+$URL    = [];
+$URL[0] = $churchCrmConfigValues['URL'];
 // List as many other URL's as may be needed. Number them sequentially.
 //$URL[1] = 'https://www.mychurch.org/churchcrm/';
 //$URL[2] = 'https://www.mychurch.org:8080/churchcrm/';
@@ -50,6 +66,8 @@ $URL[0] = '||URL||';
 // When using a shared SSL certificate provided by your webhost for https access
 // you may need to add the shared SSL server name as well as your host name to
 // the URL.  See example $URL[4]
+
+unset($churchCrmConfigValues);
 
 // Sets which PHP errors are reported see https://www.php.net/manual/en/errorfunc.constants.php
 error_reporting(E_ERROR);

--- a/src/mysql/upgrade.json
+++ b/src/mysql/upgrade.json
@@ -265,9 +265,7 @@
   },
   "current": {
     "versions": ["7.2.0", "7.2.1"],
-    "scripts": [
-      "/mysql/upgrade/migrate-config-to-json.php"
-    ],
+    "scripts": ["/mysql/upgrade/migrate-config-to-json.php"],
     "dbVersion": "7.2.2"
   }
 }

--- a/src/mysql/upgrade.json
+++ b/src/mysql/upgrade.json
@@ -265,7 +265,9 @@
   },
   "current": {
     "versions": ["7.2.0", "7.2.1"],
-    "scripts": [],
+    "scripts": [
+      "/mysql/upgrade/migrate-config-to-json.php"
+    ],
     "dbVersion": "7.2.2"
   }
 }

--- a/src/mysql/upgrade/migrate-config-to-json.php
+++ b/src/mysql/upgrade/migrate-config-to-json.php
@@ -1,0 +1,78 @@
+<?php
+/*
+ * GHSA-mp2w-4q3r-ppx7 — migrate legacy Config.php to JSON values file.
+ *
+ * Installs that were created by the pre-fix setup wizard have an
+ * Include/Config.php rendered via string substitution, with DB credentials
+ * baked into PHP literals. This migration moves the install-time values
+ * out of executable PHP into Include/config-values.json and replaces
+ * Config.php with the static bootstrap that reads and validates the JSON
+ * at runtime via ChurchCRM\Config\ConfigLoader.
+ *
+ * The script is idempotent — re-running on an already-migrated install is
+ * a no-op. It is registered in upgrade.json under the "current" block so
+ * it runs as the terminal step of every upgrade path.
+ *
+ * Running context: this file is `require_once`'d by
+ * ChurchCRM\Service\UpgradeService::upgradeDatabaseVersion() from the
+ * admin's web request, at which point Include/Config.php has already been
+ * loaded and the legacy $sSERVERNAME / $dbPort / $sUSER / $sPASSWORD /
+ * $sDATABASE / $sRootPath / $URL globals are in scope.
+ */
+
+$includeDir = realpath(__DIR__ . '/../../Include');
+if ($includeDir === false) {
+    throw new RuntimeException('Unable to resolve Include directory path during config migration');
+}
+
+$configPath  = $includeDir . '/Config.php';
+$examplePath = $includeDir . '/Config.php.example';
+$valuesPath  = $includeDir . '/config-values.json';
+$backupPath  = $includeDir . '/Config.php.legacy-backup';
+
+// Already migrated — skip silently. This also covers fresh installs that
+// were created by the new JSON-based wizard.
+if (file_exists($valuesPath)) {
+    return;
+}
+
+// Legacy Config.php was required earlier in the request chain, so the
+// install-time variables are in the global scope.
+$required = ['sSERVERNAME', 'dbPort', 'sUSER', 'sPASSWORD', 'sDATABASE', 'sRootPath', 'URL'];
+foreach ($required as $var) {
+    if (!array_key_exists($var, $GLOBALS)) {
+        throw new RuntimeException("Legacy config variable not available for migration: \${$var}");
+    }
+}
+
+$values = [
+    'DB_SERVER_NAME' => (string) $GLOBALS['sSERVERNAME'],
+    'DB_SERVER_PORT' => (string) $GLOBALS['dbPort'],
+    'DB_NAME'        => (string) $GLOBALS['sDATABASE'],
+    'DB_USER'        => (string) $GLOBALS['sUSER'],
+    'DB_PASSWORD'    => (string) $GLOBALS['sPASSWORD'],
+    'ROOT_PATH'      => (string) $GLOBALS['sRootPath'],
+    'URL'            => (string) ($GLOBALS['URL'][0] ?? ''),
+];
+
+$json = json_encode($values, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+$tmp  = $valuesPath . '.tmp';
+if (file_put_contents($tmp, $json, LOCK_EX) === false) {
+    throw new RuntimeException('Failed to write config values file during upgrade migration');
+}
+@chmod($tmp, 0640);
+if (!rename($tmp, $valuesPath)) {
+    @unlink($tmp);
+    throw new RuntimeException('Failed to finalize config values file during upgrade migration');
+}
+
+// Preserve the legacy Config.php so admins can recover any custom lines
+// (extra $URL[N] entries, $bLockURL=TRUE, custom error_reporting, etc.).
+if (file_exists($configPath) && !copy($configPath, $backupPath)) {
+    throw new RuntimeException('Failed to back up legacy Config.php during upgrade migration');
+}
+
+// Replace Config.php with the static bootstrap that reads the JSON file.
+if (!copy($examplePath, $configPath)) {
+    throw new RuntimeException('Failed to install new Config.php bootstrap during upgrade migration');
+}

--- a/src/setup/routes/setup.php
+++ b/src/setup/routes/setup.php
@@ -105,25 +105,41 @@ $app->group('/', function (RouteCollectorProxy $group): void {
             return SlimUtils::renderJSON($response->withStatus(400), ['errors' => $errors]);
         }
 
-        // Use sanitized values
-        $dbServerName = sanitize_db_field($setupData['DB_SERVER_NAME']);
-        $dbServerPort = preg_replace('/[^0-9]/', '', $setupData['DB_SERVER_PORT']);
-        $dbName      = sanitize_db_field($setupData['DB_NAME']);
-        $dbUser      = sanitize_db_field($setupData['DB_USER']);
-        $dbPassword  = $setupData['DB_PASSWORD'];
-        $rootPath    = $setupData['ROOT_PATH'];
-        $url         = $setupData['URL'];
+        // Persist values as JSON data (never as PHP code). ConfigLoader
+        // validates every field on read — the wizard does not need to
+        // sanitize here beyond the front-end UX checks above.
+        // See GHSA-mp2w-4q3r-ppx7.
+        $configValues = [
+            'DB_SERVER_NAME' => (string) $setupData['DB_SERVER_NAME'],
+            'DB_SERVER_PORT' => (string) preg_replace('/[^0-9]/', '', $setupData['DB_SERVER_PORT']),
+            'DB_NAME'        => (string) $setupData['DB_NAME'],
+            'DB_USER'        => (string) $setupData['DB_USER'],
+            'DB_PASSWORD'    => (string) $setupData['DB_PASSWORD'],
+            'ROOT_PATH'      => (string) $setupData['ROOT_PATH'],
+            'URL'            => (string) $setupData['URL'],
+        ];
 
-        $template = file_get_contents($docRoot . '/Include/Config.php.example');
-        $template = str_replace('||DB_SERVER_NAME||', $dbServerName, $template);
-        $template = str_replace('||DB_SERVER_PORT||', $dbServerPort, $template);
-        $template = str_replace('||DB_NAME||', $dbName, $template);
-        $template = str_replace('||DB_USER||', $dbUser, $template);
-        $template = str_replace('||DB_PASSWORD||', $dbPassword, $template);
-        $template = str_replace('||ROOT_PATH||', $rootPath, $template);
-        $template = str_replace('||URL||', $url, $template);
+        $valuesFile = $docRoot . '/Include/config-values.json';
+        $json = json_encode($configValues, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
 
-        file_put_contents($configFile, $template);
+        // Write the JSON atomically so a crashed write cannot leave a
+        // partial file that ConfigLoader would refuse to parse.
+        $tmpFile = $valuesFile . '.tmp';
+        if (file_put_contents($tmpFile, $json, LOCK_EX) === false) {
+            return SlimUtils::renderJSON($response->withStatus(500), ['error' => 'Failed to write config values file']);
+        }
+        @chmod($tmpFile, 0640);
+        if (!rename($tmpFile, $valuesFile)) {
+            @unlink($tmpFile);
+            return SlimUtils::renderJSON($response->withStatus(500), ['error' => 'Failed to finalize config values file']);
+        }
+
+        // Copy the static Config.php bootstrap into place — verbatim, no
+        // string substitution. The bootstrap calls ConfigLoader::load()
+        // which reads the JSON above.
+        if (!copy($docRoot . '/Include/Config.php.example', $configFile)) {
+            return SlimUtils::renderJSON($response->withStatus(500), ['error' => 'Failed to create Config.php']);
+        }
 
         return $response->withStatus(200);
     };


### PR DESCRIPTION
## Summary

Closes **GHSA-mp2w-4q3r-ppx7 / CVE-2026-39337** — unauthenticated pre-auth RCE via the setup wizard. The previous fix (CVE-2025-62521 / GHSA-m8jq-j3p9-2xf3) only sanitized `DB_SERVER_NAME/PORT/NAME/USER`; `DB_PASSWORD` was still rendered raw into a PHP string literal in `Config.php.example`. A password like `'; shell_exec($_GET['c']); //` broke the quote and produced executable PHP on the next `require_once Config.php` — full OS command execution as `www-data` from a single unauthenticated POST.

Rather than escape at write time (fragile — re-opens the same class the moment any future field gets templated), this PR **eliminates the class**: configuration values stop being PHP code and become data. The boundary to defend moves from "wizard write" to "Config.php read," which is where data becomes code.

## Architecture

1. **Values live in `Include/config-values.json`** — plain JSON written by the wizard. `json_encode` quoting means no user input reaches PHP grammar.
2. **`ChurchCRM\Config\ConfigLoader`** reads the JSON at request time and validates every field (hostname, port, db name/user, password non-empty, root path, URL). Invalid values throw `RuntimeException` — **check and reject at read time**, independent of how the file was written.
3. **`Config.php.example`** is now a static bootstrap that calls `ConfigLoader::load()` and exposes the legacy `$sSERVERNAME / $dbPort / $sUSER / $sPASSWORD / $sDATABASE / $sRootPath / $URL[0]` variables the ~98 `require_once Config.php` call-sites depend on. Zero placeholders, zero user data.
4. **Setup wizard** writes `config-values.json` atomically (tmp → rename, mode 0640) and `copy()`s the static example verbatim to `Config.php`. No `str_replace`, no templating.
5. **Upgrade migration** (`src/mysql/upgrade/migrate-config-to-json.php`, registered in `upgrade.json:current.scripts`) captures legacy globals on existing installs, writes JSON, preserves old Config.php as `Config.php.legacy-backup`, and swaps in the bootstrap. Idempotent.
6. **Web access to `Include/` blocked** across apache (`.htaccess`), nginx, and frankenphp/Caddy (root + subdir snippets) — the JSON file is only safe if it's not served as a URL.

## Commits (landed in chunks)

1. `security(include): deny direct web access to Include/ directory` — `.htaccess` + nginx + Caddyfile, root + subdir.
2. `feat(config): add ConfigLoader with read-time validation` — pure class, no wiring.
3. `feat(config): switch Config.php to JSON-driven bootstrap` — cut the example, rewrite setup POST handler, gitignore JSON.
4. `feat(upgrade): migrate legacy Config.php to JSON on upgrade` — the migration script + upgrade.json wiring.
5. `docs(config): update subdir-install instructions for JSON values file` — docker README, nginx/caddy comments, skill update.

## End-to-end sweep

- **Current installs**: templated Config.php keeps running until the upgrade migration runs; the 98 `require Config.php` call-sites are untouched. On `admin/system/upgrade`, the migration captures existing globals, writes JSON, backs up the old file as `Config.php.legacy-backup`, and swaps in the bootstrap. Idempotent — safe to re-run.
- **New installs**: setup wizard writes JSON + copies static bootstrap. No executable PHP ever receives user input.
- **CI** (`.github/workflows/build-test-package.yml`): root + subdir fresh-install specs exercise the new wizard path. The docker CI fixtures (`docker/Config.{root,parallel.subdir}.php`) remain direct-variable-assignment Config.php files — still valid PHP, still define the expected globals, still work. No CI changes required.
- **Upgrade test** (line 611): still a placeholder TODO in CI — cannot validate the migration in CI today; manual verification recommended pre-release.
- **Docs**: docker/README.md + nginx/caddy comments updated to point at `config-values.json` for `ROOT_PATH` edits.

## Testing plan

- [x] `npm run build:php` — 722 files pass
- [x] `npm run lint` — clean for touched files (pre-push hook enforces)
- [x] `php -l` on new PHP files
- [ ] Fresh install via wizard (docker root + subdir) — happy path still works
- [ ] Manual CSRF/RCE probe: `curl -d 'DB_PASSWORD='"'"'; phpinfo(); //'` against `/setup` on a fresh install → assert `Config.php` does NOT contain `phpinfo` as code; assert subsequent `/` request does not execute injected PHP
- [ ] Upgrade-from-7.1.x: seed a legacy templated Config.php, run `admin/system/upgrade`, assert `config-values.json` appears, `Config.php.legacy-backup` exists, new `Config.php` is byte-identical to `Config.php.example`
- [ ] Web-access probe: `curl -I /Include/config-values.json` + `curl -I /Include/.htaccess` + `curl -I /Include/Config.php` → all must be 403/404
- [ ] Re-run the upgrade migration on an already-migrated install → no-op (idempotent)

## Files changed

- **New**: `src/Include/.htaccess`, `src/ChurchCRM/Config/ConfigLoader.php`, `src/mysql/upgrade/migrate-config-to-json.php`
- **Modified**: `src/Include/Config.php.example`, `src/setup/routes/setup.php`, `src/mysql/upgrade.json`, `.gitignore`, `docker/nginx/default.conf`, `docker/frankenphp/Caddyfile`, `docker/README.md`, `.agents/skills/churchcrm/security-best-practices.md`

## Related

- Advisory: GHSA-mp2w-4q3r-ppx7
- Superseded fix: CVE-2026-39337 / GHSA-pm2v-ggh4-mp7p (incomplete — didn't cover `DB_PASSWORD`)
- Original CVE: CVE-2025-62521 / GHSA-m8jq-j3p9-2xf3

🤖 Generated with [Claude Code](https://claude.com/claude-code)