### PR TITLE
test(new-system): fix Step 10b race by splitting post-reset verification

### DIFF
--- a/cypress/e2e/new-system/04-system-reset.spec.js
+++ b/cypress/e2e/new-system/04-system-reset.spec.js
@@ -96,7 +96,25 @@ describe('04 - System Reset', () => {
         it('should reset the database via API', () => {
             manualLogin();
 
-            // Perform reset via API
+            // Navigate to the reset page BEFORE firing the destructive API call.
+            // manualLogin() leaves the browser on /v2/dashboard (or church-info),
+            // which fires async widget XHRs (cart, familiesInCart,
+            // deposits/dashboard, calendar counters, ...). If any are still
+            // in-flight when /admin/api/database/reset invalidates the session
+            // and wipes tables, they reject with unexpected payloads and
+            // surface as "An unknown error has occurred: [object Object]"
+            // unhandled rejections that fail the test — a pure race condition.
+            //
+            // The reset page is simple (one confirmation form, no DataTable,
+            // no charts) — loading it replaces the dashboard, aborts any
+            // pending dashboard XHRs, and gives the header cart-count refresh
+            // time to complete before we fire the destructive call.
+            cy.visit('/admin/system/reset');
+            cy.contains('.alert-danger', 'Destructive Operation', { timeout: 15000 })
+                .should('be.visible');
+            cy.get('#resetBtn').should('be.disabled');
+
+            // Browser is now idle on a static page. Perform reset via API.
             cy.request({
                 method: 'DELETE',
                 url: '/admin/api/database/reset',
@@ -107,108 +125,15 @@ describe('04 - System Reset', () => {
                 expect(response.body).to.have.property('msg');
                 expect(response.body).to.have.property('defaultUsername', 'admin');
                 expect(response.body).to.have.property('defaultPassword', 'changeme');
-                
+
                 cy.log('Database reset successful');
             });
         });
     });
-
-    describe('Step 10c: Verify System Reset and Login', () => {
-        it('should redirect to login after reset', () => {
-            // Clear any cached sessions since we just reset the database
-            cy.clearCookies();
-            cy.clearLocalStorage();
-
-            // Visit homepage - should redirect to login after reset.
-            // A DB reset recreates the schema at the current version, so no version
-            // mismatch occurs and the db-upgrade page is never shown.
-            cy.visit('/');
-
-            cy.url({ timeout: 30000 }).should('satisfy', (url) => {
-                return url.includes('/session/begin') || url.includes('/login');
-            });
-        });
-
-        it('should login with default credentials after reset', () => {
-            // manualLogin() uses 'changeme', detects forced /changepassword redirect,
-            // and completes it — leaving password as 'Cypress@01!' with NeedPasswordChange=false.
-            manualLogin();
-
-            // Now change it back to 'changeme' so Steps 10d/10e can login cleanly.
-            // NeedPasswordChange=false so this shows the voluntary form (input[type=submit]).
-            cy.visit('/v2/user/current/changepassword');
-            cy.get('#OldPassword').type('Cypress@01!');
-            cy.get('#NewPassword1').type('changeme');
-            cy.get('#NewPassword2').type('changeme');
-            cy.get('input[type=submit]').click();
-            cy.contains('Password Change Successful', { timeout: 10000 }).should('be.visible');
-        });
-    });
-
-    describe('Step 10d: Verify System is Blank', () => {
-        beforeEach(() => {
-            manualLogin();
-        });
-
-        it('should verify no people exist (except admin)', () => {
-            cy.request({
-                method: 'GET',
-                url: '/api/persons/latest',
-                timeout: 30000
-            }).then((response) => {
-                expect(response.status).to.equal(200);
-                expect(response.body).to.have.property('people');
-                
-                // Should only have admin user (1 person max)
-                const people = response.body.people;
-                expect(people.length).to.be.lessThan(2);
-                cy.log(`Found ${people.length} people after reset (expected 0-1)`);
-            });
-        });
-
-        it('should verify no families exist', () => {
-            cy.request({
-                method: 'GET',
-                url: '/api/families/latest',
-                timeout: 30000
-            }).then((response) => {
-                expect(response.status).to.equal(200);
-                expect(response.body).to.have.property('families');
-                
-                // Should have no families
-                const families = response.body.families;
-                expect(families.length).to.equal(0);
-                cy.log('No families found after reset (as expected)');
-            });
-        });
-
-        it('should verify no groups exist', () => {
-            cy.request({
-                method: 'GET', 
-                url: '/api/groups/',
-                timeout: 30000,
-                failOnStatusCode: false
-            }).then((response) => {
-                if (response.status === 200) {
-                    // Groups API returns array directly
-                    const groups = response.body;
-                    expect(groups.length).to.equal(0);
-                    cy.log('No groups found after reset (as expected)');
-                }
-            });
-        });
-    });
-
-    describe('Step 10e: Final Verification', () => {
-        it('should have a clean system ready for use', () => {
-            manualLogin();
-            
-            // Verify admin dashboard is accessible
-            cy.visit('/admin/');
-            cy.contains('Admin Dashboard', { timeout: 15000 }).should('be.visible');
-            
-            // The system is now blank and ready for a fresh start
-            cy.log('System reset complete - clean installation verified');
-        });
-    });
 });
+
+// Post-reset verification (Steps 10c / 10d / 10e) lives in
+// 05-post-reset-verification.spec.js so Cypress tears down the browser context
+// between the destructive reset and the verification steps. This eliminates
+// any possibility of lingering XHRs from the pre-reset session interacting
+// with the freshly-wiped database.

--- a/cypress/e2e/new-system/05-post-reset-verification.spec.js
+++ b/cypress/e2e/new-system/05-post-reset-verification.spec.js
@@ -26,8 +26,7 @@ describe('05 - Post-Reset Verification', () => {
     };
 
     // Helper to manually login, handling forced password-change redirect after a DB reset.
-    // Duplicated from 04-system-reset.spec.js — Cypress specs cannot share helpers directly
-    // without a shared module, and this helper is tightly coupled to the new-system flow.
+    // Kept local to this spec because it is tightly coupled to the new-system reset flow.
     const manualLogin = () => {
         cy.clearCookies();
         cy.clearLocalStorage();
@@ -76,9 +75,7 @@ describe('05 - Post-Reset Verification', () => {
             // mismatch occurs and the db-upgrade page is never shown.
             cy.visit('/');
 
-            cy.url({ timeout: 30000 }).should('satisfy', (url) => {
-                return url.includes('/session/begin') || url.includes('/login');
-            });
+            cy.url({ timeout: 30000 }).should('include', '/session/begin');
         });
 
         it('should login with default credentials after reset', () => {
@@ -137,14 +134,12 @@ describe('05 - Post-Reset Verification', () => {
             cy.request({
                 method: 'GET',
                 url: '/api/groups/',
-                timeout: 30000,
-                failOnStatusCode: false
+                timeout: 30000
             }).then((response) => {
-                if (response.status === 200) {
-                    const groups = response.body;
-                    expect(groups.length).to.equal(0);
-                    cy.log('No groups found after reset (as expected)');
-                }
+                expect(response.status).to.equal(200);
+                const groups = response.body;
+                expect(groups.length).to.equal(0);
+                cy.log('No groups found after reset (as expected)');
             });
         });
     });

--- a/cypress/e2e/new-system/05-post-reset-verification.spec.js
+++ b/cypress/e2e/new-system/05-post-reset-verification.spec.js
@@ -1,0 +1,162 @@
+/// <reference types="cypress" />
+
+/**
+ * Post-Reset Verification Tests (Steps 10c / 10d / 10e)
+ *
+ * Runs AFTER 04-system-reset.spec.js has wiped the database.
+ *
+ * Why this lives in its own spec file: Cypress tears down the browser context
+ * between spec files. Splitting here guarantees no in-flight XHRs from the
+ * pre-reset session (dashboard widgets, cart-count refresh, etc.) can race
+ * with the verification requests on the freshly-wiped database — a race that
+ * previously surfaced as "An unknown error has occurred: [object Object]"
+ * unhandled rejections.
+ *
+ * Preconditions (left by 04-system-reset.spec.js):
+ * - DB has just been reset
+ * - admin / changeme credentials are valid again
+ * - NeedPasswordChange=true on admin (forced flow)
+ * - sChurchName is empty (ChurchInfoRequiredMiddleware will redirect)
+ */
+
+describe('05 - Post-Reset Verification', () => {
+    const adminCredentials = {
+        username: 'admin',
+        password: 'changeme'
+    };
+
+    // Helper to manually login, handling forced password-change redirect after a DB reset.
+    // Duplicated from 04-system-reset.spec.js — Cypress specs cannot share helpers directly
+    // without a shared module, and this helper is tightly coupled to the new-system flow.
+    const manualLogin = () => {
+        cy.clearCookies();
+        cy.clearLocalStorage();
+        const password = adminCredentials.password;
+        cy.visit('/login');
+        cy.get('input[name=User]', { timeout: 15000 }).type(adminCredentials.username);
+        cy.get('input[name=Password]').type(password);
+        cy.get('input[name=Password]').type('{enter}');
+        cy.url({ timeout: 30000 }).should('not.include', '/session/begin');
+
+        cy.url().then((url) => {
+            if (url.includes('/changepassword')) {
+                cy.get('#OldPassword').type(password);
+                cy.get('#NewPassword1').type('Cypress@01!');
+                cy.get('#NewPassword2').type('Cypress@01!');
+                cy.get('button[type=submit]').click();
+                cy.url({ timeout: 15000 }).should('include', '/admin/system/church-info');
+            }
+        });
+
+        cy.url().then((url) => {
+            if (url.includes('/admin/system/church-info')) {
+                cy.get('#sChurchCountry', { timeout: 10000 }).siblings('.ts-wrapper').should('exist');
+                cy.get('#sChurchName').clear().type('Test Community Church');
+                cy.get('#sChurchPhone').clear().type('(555) 123-4567');
+                cy.get('#sChurchEmail').clear().type('info@testchurch.org');
+                cy.get('#sChurchAddress').clear().type('123 Main Street');
+                cy.get('#sChurchCity').clear().type('Springfield');
+                cy.get('#sChurchState', { timeout: 10000 }).siblings('.ts-wrapper').should('exist');
+                cy.tomSelectByValue('#sChurchState', 'IL');
+                cy.get('#sChurchState').should('have.value', 'IL');
+                cy.get('#sChurchZip').clear().type('62701');
+                cy.get('#church-info-form').submit();
+                cy.url({ timeout: 10000 }).should('include', 'church-info');
+            }
+        });
+    };
+
+    describe('Step 10c: Verify System Reset and Login', () => {
+        it('should redirect to login after reset', () => {
+            // Clear any cached sessions since the database was just reset.
+            cy.clearCookies();
+            cy.clearLocalStorage();
+
+            // A DB reset recreates the schema at the current version, so no version
+            // mismatch occurs and the db-upgrade page is never shown.
+            cy.visit('/');
+
+            cy.url({ timeout: 30000 }).should('satisfy', (url) => {
+                return url.includes('/session/begin') || url.includes('/login');
+            });
+        });
+
+        it('should login with default credentials after reset', () => {
+            // manualLogin() uses 'changeme', detects forced /changepassword redirect,
+            // and completes it — leaving password as 'Cypress@01!' with NeedPasswordChange=false.
+            manualLogin();
+
+            // Change it back to 'changeme' so Steps 10d/10e can login cleanly.
+            // NeedPasswordChange=false so this shows the voluntary form (input[type=submit]).
+            cy.visit('/v2/user/current/changepassword');
+            cy.get('#OldPassword').type('Cypress@01!');
+            cy.get('#NewPassword1').type('changeme');
+            cy.get('#NewPassword2').type('changeme');
+            cy.get('input[type=submit]').click();
+            cy.contains('Password Change Successful', { timeout: 10000 }).should('be.visible');
+        });
+    });
+
+    describe('Step 10d: Verify System is Blank', () => {
+        beforeEach(() => {
+            manualLogin();
+        });
+
+        it('should verify no people exist (except admin)', () => {
+            cy.request({
+                method: 'GET',
+                url: '/api/persons/latest',
+                timeout: 30000
+            }).then((response) => {
+                expect(response.status).to.equal(200);
+                expect(response.body).to.have.property('people');
+
+                // Should only have admin user (1 person max)
+                const people = response.body.people;
+                expect(people.length).to.be.lessThan(2);
+                cy.log(`Found ${people.length} people after reset (expected 0-1)`);
+            });
+        });
+
+        it('should verify no families exist', () => {
+            cy.request({
+                method: 'GET',
+                url: '/api/families/latest',
+                timeout: 30000
+            }).then((response) => {
+                expect(response.status).to.equal(200);
+                expect(response.body).to.have.property('families');
+
+                const families = response.body.families;
+                expect(families.length).to.equal(0);
+                cy.log('No families found after reset (as expected)');
+            });
+        });
+
+        it('should verify no groups exist', () => {
+            cy.request({
+                method: 'GET',
+                url: '/api/groups/',
+                timeout: 30000,
+                failOnStatusCode: false
+            }).then((response) => {
+                if (response.status === 200) {
+                    const groups = response.body;
+                    expect(groups.length).to.equal(0);
+                    cy.log('No groups found after reset (as expected)');
+                }
+            });
+        });
+    });
+
+    describe('Step 10e: Final Verification', () => {
+        it('should have a clean system ready for use', () => {
+            manualLogin();
+
+            cy.visit('/admin/');
+            cy.contains('Admin Dashboard', { timeout: 15000 }).should('be.visible');
+
+            cy.log('System reset complete - clean installation verified');
+        });
+    });
+});

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -51,46 +51,6 @@ Cypress.on('uncaught:exception', (err) => {
   if (/^An unknown error has occurred:\s*\[object Object\]$/.test(message)) {
     return false;
   }
-
-  // When the app does `Promise.reject(jqXHR)` Cypress passes the raw XHR
-  // object as `err`, so err.message is undefined. Serialize once so the
-  // endpoint+status checks below can match against JSON or the .message text.
-  let serialized = '';
-  if (err && typeof err === 'object') {
-    try {
-      serialized = JSON.stringify(err);
-    } catch {
-      serialized = '';
-    }
-  }
-  const haystack = `${message}\n${serialized}`;
-
-  // Dashboard widget API calls (cart, familiesInCart, deposits/dashboard) fire
-  // immediately on page load and return 4xx/5xx when the PHP session is in a
-  // transitional state during system-reset tests. These do not affect real
-  // assertions — the test still runs its own cy.request() assertions.
-  if (
-    /"status"\s*:\s*(?:4\d{2}|5\d{2})|\bstatus["'\s:=]+(?:4\d{2}|5\d{2})\b/.test(haystack) &&
-    /api\/cart\/?|api\/families\/familiesInCart|api\/deposits\/dashboard/.test(haystack)
-  ) {
-    return false;
-  }
-
-  // After /admin/api/database/reset the PHP session is invalidated, so any
-  // in-flight dashboard widget API call surfaces as a bare jqXHR rejection
-  // with status >= 400 but no .message. Narrow by /api/ so we don't swallow
-  // real app errors.
-  if (
-    !message &&
-    err &&
-    typeof err === 'object' &&
-    typeof err.status === 'number' &&
-    err.status >= 400 &&
-    typeof err.responseURL === 'string' &&
-    /\/api\//.test(err.responseURL)
-  ) {
-    return false;
-  }
 });
 
 window.addEventListener('error', (event) => {


### PR DESCRIPTION
## Summary

Fix the intermittent `04-system-reset.spec.js` Step 10b failure:

```
Error: An unknown error has occurred: [object Object]
```

Root cause: classic race between `manualLogin()`'s dashboard load and `cy.request(DELETE /admin/api/database/reset)`. Dashboard widgets (cart, familiesInCart, deposits/dashboard, calendar counters) fire async XHRs on page load — if any is still in-flight when the reset invalidates the session and wipes tables, it rejects with an unexpected payload that Cypress wraps into the generic noise error.

## Why the previous filter didn't work

The filter in `cypress/support/e2e.js` tried to swallow these errors by regex-matching on `err.message` / `JSON.stringify(err)`. Doesn't fire — by the time our handler sees `err`, Cypress has already wrapped the original jqXHR into a synthetic Error. `JSON.stringify(new Error(…)) === '{}'`, so the haystack is empty and the regex never matches. Those 40+ lines are dead code.

## Structural fix (3 parts)

1. **Step 10b navigates to `/admin/system/reset` before the destructive call**. That page is static (one confirmation form, no charts/DataTables), so loading it aborts pending dashboard XHRs and lets the header cart refresh finish before we hit the reset endpoint.

2. **Steps 10c/10d/10e moved to a new `05-post-reset-verification.spec.js`**. Cypress tears down the browser context between spec files, so any lingering XHRs from the pre-reset session can't race with verification requests on the freshly-wiped database.

3. **Reverted the broadened `uncaught:exception` filter** in `cypress/support/e2e.js` (commit `93beb7046`). Keeps the narrow PR #8738 anchored filter for its unrelated signature; drops the `JSON.stringify(err)` / `err.responseURL` branches that never matched.

## Verification

- [x] Webpack build still passes (no webpack changes).
- [x] Glob `cypress/e2e/new-system/**/*.spec.js` auto-discovers the new `05-*` file — no CI workflow changes needed (`cypress/configs/new-system.config.ts:24`).
- [ ] Wait for CI matrix: `test-new-system (8.5)`, `test-new-system-subdir (8.5)`, `test-new-system (8.4)`, `test-new-system-subdir (8.4)` — expect all four green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)