### PR TITLE
Fix #8793: events dashboard sort order (Jan→Dec) + auto-scroll to current month

### DIFF
--- a/src/event/routes/list-events.php
+++ b/src/event/routes/list-events.php
@@ -81,7 +81,7 @@ $app->get('/dashboard', function (Request $request, Response $response) {
         ->toArray();
 
     // --- Build monthly event data (all Propel ORM — replaces 6 RunQuery calls) ---
-    $allMonths = [12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1];
+    $allMonths = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
     $monthlyData = [];
 
     foreach ($allMonths as $mVal) {

--- a/src/event/views/list-events.php
+++ b/src/event/views/list-events.php
@@ -154,7 +154,7 @@ foreach ($monthlyData as $monthData):
     $monthName = $monthData['monthName'];
     $averages = $monthData['averages'];
 ?>
-<div class="card mb-3">
+<div class="card mb-3" id="month-<?= (int) $monthData['month'] ?>">
   <div class="card-header d-flex align-items-center">
     <h3 class="card-title mb-0">
       <i class="ti ti-calendar me-2 text-muted"></i>
@@ -270,6 +270,15 @@ foreach ($monthlyData as $monthData):
   </div>
 </div>
 <?php endforeach; ?>
+
+<?php if ($hasEvents && $EventYear === (int) date('Y')): ?>
+<script nonce="<?= SystemURLs::getCSPNonce() ?>">
+  document.addEventListener('DOMContentLoaded', function () {
+    var m = document.getElementById('month-<?= (int) date('n') ?>');
+    if (m) m.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  });
+</script>
+<?php endif; ?>
 
 <?php if (!$hasEvents): ?>
 <div class="card">


### PR DESCRIPTION
## Summary

Fixes the events dashboard rendering months in reverse order (December first), requiring users to scroll past the entire year to reach the current month.

## Changes

- `src/event/routes/list-events.php` — render months ascending Jan→Dec instead of Dec→Jan
- `src/event/views/list-events.php` — add `id="month-N"` anchors to each month card; auto-scroll to current month on page load (only when viewing the current year)

## Why

The `$allMonths` array was hardcoded in descending order `[12, 11, ..., 1]`. Reversed to `[1, 2, ..., 12]`. Added scroll-to-current-month so the page opens at the relevant section rather than January of a past year.

## Testing

- `npm run build:php` ✅
- `npm run lint` ✅

## Related Issues

Closes #8793

🤖 Generated with [Claude Code](https://claude.com/claude-code)