### PR TITLE
feat(ui): breadcrumbs, auth pages, dashboards, event types nav cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Release notes are stored in the [`changelog/`](./changelog/) folder — one file
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| [7.2.2](./changelog/7.2.2.md) | April 2026 | CSRF hardening (GHSA-3xq9-c86x-cwpp), person delete fix, orphaned images cleanup, 41 locales |
+| [7.2.1](./changelog/7.2.1.md) | April 2026 | Permission consolidation, admin menu bypass fix, photo cache bust, FrankenPHP redirect fix |
 | [7.2.0](./changelog/7.2.0.md) | April 2026 | Event MVC epic, responsive design guidelines, 27 locales translated, GA4 tracking, mobile UX |
 | [7.1.2](./changelog/7.1.2.md) | April 2026 | User settings redesign, CSV import fields, MvcAppFactory, React removal |
 | [7.1.1](./changelog/7.1.1.md) | April 2026 | Stored XSS fix, CSP hardening, notification system redesign, CSS cleanup |

--- a/changelog/7.2.1.md
+++ b/changelog/7.2.1.md
@@ -1,0 +1,53 @@
+# ChurchCRM 7.2.1 — Refinement & Reliability
+
+**Release Date**: April 16, 2026  
+**Theme**: Polishing the Foundation  
+**Previous Release**: [7.2.0](./7.2.0.md)
+
+---
+
+Hot on the heels of our major 7.2.0 release, **Version 7.2.1** arrives as a focused maintenance update. This release is all about "smoothness"—fixing those small friction points in the login process, security settings, and photo management to ensure your experience is as seamless as possible.
+
+## 🛡️ Smarter Security & Access
+
+We've refined how the system handles permissions to make sure the "gates" are always locked for the right people, but open for you when you need them.
+
+- **Fixing the "Password Loop"**: We resolved a specific issue that caused some users to get stuck in a "redirect loop" when trying to change their passwords. You can now update your credentials without any technical hiccups. (#8405, #8676)
+- **Streamlined Permissions**: We've overhauled how the system checks your access levels. This ensures that even if you have "limited permissions," you are always allowed to access essential security features like changing your password or setting up Two-Factor Authentication (2FA). (#8680, #8683, #8684)
+- **Cleaner Logins**: We've blocked browsers from trying to "autofill" your 2FA security codes. This prevents your browser from accidentally putting a saved password into the security code box, making your login much faster. (#5143, #8664)
+
+## 🖼️ Instant Photo Updates
+
+Have you ever uploaded a new profile photo only to see the old one still staring back at you?
+
+- **Cache Busting**: We've fixed a bug where the browser would "remember" your old photo too well. Now, the moment you upload a new profile picture, it will update across the entire system instantly. No more manual page refreshing required! (#8662, #8677)
+
+## 🌍 Global & Technical Stability
+
+While you might not see these changes on the surface, they make ChurchCRM faster and more reliable for your church:
+
+- **Speedy Testing**: Our developers have optimized our automated testing suite, making it much faster to verify that new updates are safe to release. (#8652, #8655)
+- **Cleaning House**: We've removed "dead code" (old files that were no longer used), which keeps the system lean and efficient. (#8159, #8673)
+- **Library Updates**: We've updated our security "cleaning" tools (like DOMPurify) to the latest versions to keep your data safe from modern web threats. (#8686)
+
+## 🌟 Legacy of the 7.2.0 Series
+
+If you are just joining us for the 7.2.x series, don't forget these recent major milestones:
+
+- **Mabuhay!** Filipino is now an officially supported language.
+- **Events Overhaul**: A faster, more responsive calendar and a brand-new Events Dashboard.
+- **Fortress Security**: Deep database protections and human-readable 2FA recovery codes.
+
+## ⚠️ Important Notes
+
+- **Server Requirement**: This version continues to **require PHP 8.4**.
+- **Guided Upgrade**: Use our built-in update wizard to move safely from 7.2.0 to 7.2.1.
+
+## 📊 Release Statistics
+
+- **14 commits** since 7.2.0
+- **3 security / permission fixes**
+- **1 photo cache fix**
+- **2 testing & housekeeping improvements**
+
+**Download**: [GitHub Release](https://github.com/ChurchCRM/CRM/releases/tag/7.2.1)

--- a/changelog/7.2.2.md
+++ b/changelog/7.2.2.md
@@ -1,0 +1,64 @@
+# ChurchCRM 7.2.2 — Polishing the Experience
+
+**Release Date**: April 23, 2026  
+**Theme**: Better Communication & Cleaner Profiles  
+**Previous Release**: [7.2.1](./7.2.1.md)
+
+---
+
+**Version 7.2.2** is a significant refinement release that focuses on making your church data more organized and your communications more reliable. We've touched almost every corner of the app—from how you import members to how your profile pages look—ensuring ChurchCRM remains the most intuitive tool for your ministry.
+
+## 👤 Unified Member & Family Profiles
+
+We've redesigned our profile cards so that information is consistent whether you are looking at a single person or an entire family.
+
+- **Timeline Cleanup**: We've removed "duplicate" notes that used to clutter the activity timeline, giving you a much clearer history of member engagement.
+- **Property Management**: Managing member properties (like "Volunteer" or "Staff") is now faster and more consistent across the system.
+- **Automatic Cleanup**: When you delete a person or family, the system now automatically removes their old profile images from your server, keeping your storage lean and organized. (#8765)
+
+## 📧 Reliable Email & Communication
+
+We've performed a complete "top-to-bottom" cleanup of the internal email system.
+
+- **Spam-Safe Templates**: Our email templates have been modernized to follow current security standards, helping ensure your church's messages land in inboxes rather than spam folders.
+- **Smart Gating**: The system is now smarter about only showing email options when your email service is properly configured, preventing confusing "failed to send" errors.
+- **Rich Text Editing**: Our note and email editor (Quill) has been updated to match our new modern design. It now also supports **Right-to-Left (RTL)** typing for our global users.
+
+## 📅 Calendar & Event Refinements
+
+Planning your church calendar just got a little easier:
+
+- **Time Zone Awareness**: We've added time zone indicators to the calendar, which is a lifesaver for churches coordinating across different regions.
+- **Unified Event Editor**: Whether you are creating an event from a small pop-up window or the full event page, the form is now exactly the same. No more hunting for missing fields!
+- **Friendly Error Pages**: If someone clicks an old or private calendar link, they'll now see a friendly, helpful "Page Not Found" screen instead of a technical error message.
+
+## 📤 Smarter Member Imports
+
+Our **Member Import** tool continues to evolve. In this release:
+
+- **Custom Field Support**: You can now import "Custom Fields" and "Properties" directly from your spreadsheets. This means you can bring in specialized data—like "T-Shirt Size" or "Background Check Date"—in one single upload.
+
+## 🌍 Massive Global Update
+
+Our translation community has been incredibly busy!
+
+- **Over 3,500 Terms Updated**: We have performed a massive translation refresh across **41 active languages**. This ensures that even the newest features from the 7.2 series are accurately translated for your local team. (#8771, #8773, #8774, #8776, #8778, #8781, #8782)
+
+## 🛡️ Security Hardening
+
+- **Anti-Forgery Protection**: We've added extra layers of "CSRF" protection to our older delete pages, making it even harder for malicious websites to trick the system into performing unauthorized actions. (GHSA-3xq9-c86x-cwpp, #8755)
+- **Modern Diagnostics**: For church tech teams, we have overhauled our "Debug" pages to make it easier to troubleshoot email or system issues with a clean, modern interface.
+
+## ⚠️ Important Notes
+
+- **Server Requirement**: This version continues to **require PHP 8.4**.
+- **Guided Upgrade**: Our built-in update wizard is ready to guide you safely from 7.2.1 to 7.2.2.
+
+## 📊 Release Statistics
+
+- **56 commits** since 7.2.1
+- **1 security fix** (CSRF hardening, CVE-level)
+- **3+ profile & communication improvements**
+- **41 languages refreshed, 3,500+ terms translated**
+
+**Download**: [GitHub Release](https://github.com/ChurchCRM/CRM/releases/tag/7.2.2)

--- a/src/ChurchCRM/Config/Menu/Menu.php
+++ b/src/ChurchCRM/Config/Menu/Menu.php
@@ -249,7 +249,12 @@ class Menu
         $eventsMenu->addSubMenu(new MenuItem(gettext('Events Dashboard'), 'event/dashboard', true, 'fa-gauge'));
         $eventsMenu->addSubMenu(new MenuItem(gettext('Add Church Event'), 'event/editor', $isAddEventEnabled, 'fa-circle-plus'));
         $eventsMenu->addSubMenu(new MenuItem(gettext('Check-in and Check-out'), 'event/checkin', true, 'fa-user-check'));
-        $eventsMenu->addSubMenu(new MenuItem(gettext('List Event Types'), 'event/types', $isAddEventEnabled, 'fa-tags'));
+
+        if ($isAddEventEnabled) {
+            $adminMenu = new MenuItem(gettext('Admin'), '', true);
+            $adminMenu->addSubMenu(new MenuItem(gettext('Event Types'), 'event/types', true, 'fa-tags'));
+            $eventsMenu->addSubMenu($adminMenu);
+        }
 
         return $eventsMenu;
     }

--- a/src/PropertyList.php
+++ b/src/PropertyList.php
@@ -64,9 +64,15 @@ $canManage = AuthenticationManager::getCurrentUser()->isMenuOptionsEnabled();
 $colCount = $canManage ? 4 : 3;
 
 $sPageSubtitle = gettext('Define custom properties that can be assigned to') . ' ' . strtolower(InputUtils::escapeHTML($sTypeName)) . ' ' . gettext('records');
-$aBreadcrumbs = PageHeader::breadcrumbs([
+$breadcrumbParent = match ($sType) {
+    'g' => [gettext('Groups'), '/groups/dashboard'],
+    'p', 'f' => [gettext('People'), '/people/dashboard'],
+    default => null,
+};
+$aBreadcrumbs = PageHeader::breadcrumbs(array_values(array_filter([
+    $breadcrumbParent,
     [$sTypeName . ' ' . gettext('Properties')],
-]);
+])));
 require_once __DIR__ . '/Include/Header.php';
 ?>
 

--- a/src/admin/routes/system.php
+++ b/src/admin/routes/system.php
@@ -126,12 +126,18 @@ $app->group('/system', function (RouteCollectorProxy $group): void {
             }
         }
 
+        $breadcrumbParent = match ($mode) {
+            'grptypes', 'grproles', 'groupcustom' => [gettext('Groups'), '/groups/dashboard'],
+            'famroles', 'famcustom' => [gettext('People'), '/people/dashboard'],
+            'classes', 'custom' => [gettext('People'), '/people/dashboard'],
+            default => [gettext('Admin'), '/admin/'],
+        };
         $pageArgs = [
             'sRootPath' => SystemURLs::getRootPath(),
             'sPageTitle' => $listConfig['title'],
             'sPageSubtitle' => sprintf(gettext('Manage %s options'), $listConfig['noun']),
             'aBreadcrumbs' => PageHeader::breadcrumbs([
-                [gettext('Admin'), '/admin/'],
+                $breadcrumbParent,
                 [$listConfig['title']],
             ]),
             'mode' => $mode,

--- a/src/people/views/dashboard.php
+++ b/src/people/views/dashboard.php
@@ -13,7 +13,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
     <!-- Stat Cards Row -->
     <div class="row mb-3">
         <div class="col-6 col-lg-3">
-            <div class="card card-sm">
+            <a href="<?= $sRootPath ?>/people/family" class="card card-sm text-decoration-none">
                 <div class="card-body">
                     <div class="row align-items-center">
                         <div class="col-auto">
@@ -22,15 +22,15 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
                             </span>
                         </div>
                         <div class="col">
-                            <div class="fw-medium"><?= $familyCount['familyCount'] ?></div>
+                            <div class="fw-medium text-body"><?= $familyCount['familyCount'] ?></div>
                             <div class="text-muted"><?= gettext('Families') ?></div>
                         </div>
                     </div>
                 </div>
-            </div>
+            </a>
         </div>
         <div class="col-6 col-lg-3">
-            <div class="card card-sm">
+            <a href="<?= $sRootPath ?>/people/list" class="card card-sm text-decoration-none">
                 <div class="card-body">
                     <div class="row align-items-center">
                         <div class="col-auto">
@@ -39,16 +39,16 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
                             </span>
                         </div>
                         <div class="col">
-                            <div class="fw-medium"><?= $personCount ?></div>
+                            <div class="fw-medium text-body"><?= $personCount ?></div>
                             <div class="text-muted"><?= gettext('People') ?></div>
                         </div>
                     </div>
                 </div>
-            </div>
+            </a>
         </div>
         <?php if (SystemConfig::getValue('bEnabledSundaySchool')) { ?>
         <div class="col-6 col-lg-3">
-            <div class="card card-sm">
+            <a href="<?= $sRootPath ?>/groups/sundayschool" class="card card-sm text-decoration-none">
                 <div class="card-body">
                     <div class="row align-items-center">
                         <div class="col-auto">
@@ -57,16 +57,16 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
                             </span>
                         </div>
                         <div class="col">
-                            <div class="fw-medium"><?= $groupStats['sundaySchoolkids'] ?></div>
+                            <div class="fw-medium text-body"><?= $groupStats['sundaySchoolkids'] ?></div>
                             <div class="text-muted"><?= gettext('Sunday School Kids') ?></div>
                         </div>
                     </div>
                 </div>
-            </div>
+            </a>
         </div>
         <?php } ?>
         <div class="col-6 col-lg-3">
-            <div class="card card-sm">
+            <a href="<?= $sRootPath ?>/groups/dashboard" class="card card-sm text-decoration-none">
                 <div class="card-body">
                     <div class="row align-items-center">
                         <div class="col-auto">
@@ -75,12 +75,12 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
                             </span>
                         </div>
                         <div class="col">
-                            <div class="fw-medium"><?= $groupStats['groups'] ?></div>
+                            <div class="fw-medium text-body"><?= $groupStats['groups'] ?></div>
                             <div class="text-muted"><?= gettext('Groups') ?></div>
                         </div>
                     </div>
                 </div>
-            </div>
+            </a>
         </div>
     </div>
 
@@ -247,8 +247,42 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
 
         </div>
 
-        <!-- Right column: Gender Demographics + Age Histogram + Reports -->
+        <!-- Right column: Reports + Gender Demographics + Age Histogram -->
         <div class="col-lg-6">
+
+            <!-- Reports -->
+            <div class="card mb-3">
+                <div class="card-header">
+                    <h3 class="card-title"><i class="fa-solid fa-file-lines me-2"></i><?= gettext('Reports') ?></h3>
+                </div>
+                <div class="list-group list-group-flush">
+                    <a href="<?= $sRootPath ?>/members/self-register.php" class="list-group-item list-group-item-action d-flex align-items-center">
+                        <i class="fa-solid fa-user-clock fa-fw text-muted me-3"></i>
+                        <div>
+                            <div class="fw-medium"><?= gettext('Self Registration Report') ?></div>
+                            <div class="text-muted small"><?= gettext('List families created via self registration') ?></div>
+                        </div>
+                        <i class="fa-solid fa-chevron-right ms-auto text-muted"></i>
+                    </a>
+
+                    <a href="<?= $sRootPath ?>/DirectoryReports.php" class="list-group-item list-group-item-action d-flex align-items-center">
+                        <i class="fa-solid fa-address-book fa-fw text-muted me-3"></i>
+                        <div>
+                            <div class="fw-medium"><?= gettext('People Directory') ?></div>
+                            <div class="text-muted small"><?= gettext('Printable directory of all people, grouped by family') ?></div>
+                        </div>
+                        <i class="fa-solid fa-chevron-right ms-auto text-muted"></i>
+                    </a>
+                    <a href="<?= $sRootPath ?>/LettersAndLabels.php" class="list-group-item list-group-item-action d-flex align-items-center">
+                        <i class="fa-solid fa-envelope-open-text fa-fw text-muted me-3"></i>
+                        <div>
+                            <div class="fw-medium"><?= gettext('Letters & Mailing Labels') ?></div>
+                            <div class="text-muted small"><?= gettext('Generate letters and mailing labels') ?></div>
+                        </div>
+                        <i class="fa-solid fa-chevron-right ms-auto text-muted"></i>
+                    </a>
+                </div>
+            </div>
 
             <!-- Gender Demographics -->
             <div class="card mb-3">
@@ -300,40 +334,6 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
                 </div>
                 <div class="card-body">
                     <div id="age-stats-bar" style="min-height:300px;"></div>
-                </div>
-            </div>
-
-            <!-- Reports -->
-            <div class="card mb-3">
-                <div class="card-header">
-                    <h3 class="card-title"><i class="fa-solid fa-file-lines me-2"></i><?= gettext('Reports') ?></h3>
-                </div>
-                <div class="list-group list-group-flush">
-                    <a href="<?= $sRootPath ?>/members/self-register.php" class="list-group-item list-group-item-action d-flex align-items-center">
-                        <i class="fa-solid fa-user-clock fa-fw text-muted me-3"></i>
-                        <div>
-                            <div class="fw-medium"><?= gettext('Self Registration Report') ?></div>
-                            <div class="text-muted small"><?= gettext('List families created via self registration') ?></div>
-                        </div>
-                        <i class="fa-solid fa-chevron-right ms-auto text-muted"></i>
-                    </a>
-
-                    <a href="<?= $sRootPath ?>/DirectoryReports.php" class="list-group-item list-group-item-action d-flex align-items-center">
-                        <i class="fa-solid fa-address-book fa-fw text-muted me-3"></i>
-                        <div>
-                            <div class="fw-medium"><?= gettext('People Directory') ?></div>
-                            <div class="text-muted small"><?= gettext('Printable directory of all people, grouped by family') ?></div>
-                        </div>
-                        <i class="fa-solid fa-chevron-right ms-auto text-muted"></i>
-                    </a>
-                    <a href="<?= $sRootPath ?>/LettersAndLabels.php" class="list-group-item list-group-item-action d-flex align-items-center">
-                        <i class="fa-solid fa-envelope-open-text fa-fw text-muted me-3"></i>
-                        <div>
-                            <div class="fw-medium"><?= gettext('Letters & Mailing Labels') ?></div>
-                            <div class="text-muted small"><?= gettext('Generate letters and mailing labels') ?></div>
-                        </div>
-                        <i class="fa-solid fa-chevron-right ms-auto text-muted"></i>
-                    </a>
                 </div>
             </div>
 

--- a/src/session/templates/begin-session.php
+++ b/src/session/templates/begin-session.php
@@ -14,10 +14,10 @@ require SystemURLs::getDocumentRoot() . '/Include/HeaderNotLoggedIn.php';
 $hasSelfReg = SystemConfig::getBooleanValue('bEnableSelfRegistration');
 ?>
 
-<div class="login-container <?php if ($hasSelfReg) echo 'login-container-split'; ?>">
-  <div class="login-wrapper <?php if ($hasSelfReg) echo 'login-wrapper-split'; ?>">
+<div class="login-container login-container-split">
+  <div class="login-wrapper login-wrapper-split">
     <!-- Login Form Section -->
-    <div class="<?php if ($hasSelfReg) echo 'login-form-column'; else echo 'login-form-section'; ?>">
+    <div class="login-form-column">
       <div class="login-form-inner">
         <!-- Header with Logo and Church Name -->
         <div class="login-form-header">
@@ -69,16 +69,11 @@ $hasSelfReg = SystemConfig::getBooleanValue('bEnableSelfRegistration');
           <button type="submit" class="btn-sign-in"><?= gettext('Sign in') ?></button>
         </form>
 
-        <?php if (!SystemConfig::getBooleanValue('bEnableSelfRegistration')) { ?>
-          <div class="signup-link">
-            <p><?= gettext('Need help?') ?> <a href="<?= SystemURLs::getRootPath() ?>/external/register/"><?= gettext('Contact us') ?></a></p>
-          </div>
-        <?php } ?>
       </div>
-    </div><!-- end login-form-column / login-form-section -->
+    </div><!-- end login-form-column -->
 
-    <!-- Right Column: Registration Info (sibling of login-form-column) -->
-    <?php if (SystemConfig::getBooleanValue('bEnableSelfRegistration')) { ?>
+    <!-- Right Column -->
+    <?php if ($hasSelfReg): ?>
       <div class="login-register-column">
         <div class="register-content">
           <div class="register-icon">
@@ -98,7 +93,43 @@ $hasSelfReg = SystemConfig::getBooleanValue('bEnableSelfRegistration');
           </a>
         </div>
       </div>
-    <?php } ?>
+    <?php else: ?>
+      <div class="login-info-column">
+        <div class="login-info-content">
+          <div class="login-info-icon">
+            <i class="fa-solid fa-church"></i>
+          </div>
+          <h2 class="login-info-name"><?= ChurchMetaData::getChurchName() ?></h2>
+          <p class="login-info-tagline"><?= gettext('Welcome — sign in to manage your community') ?></p>
+
+          <?php $address = ChurchMetaData::getChurchFullAddress(); ?>
+          <?php $phone   = ChurchMetaData::getChurchPhone(); ?>
+          <?php $email   = ChurchMetaData::getChurchEmail(); ?>
+          <?php $website = ChurchMetaData::getChurchWebSite(); ?>
+
+          <?php if ($address || $phone || $email || $website): ?>
+            <ul class="login-info-details">
+              <?php if ($address): ?>
+                <li><i class="fa-solid fa-location-dot"></i> <?= htmlspecialchars($address) ?></li>
+              <?php endif; ?>
+              <?php if ($phone): ?>
+                <li><i class="fa-solid fa-phone"></i> <?= htmlspecialchars($phone) ?></li>
+              <?php endif; ?>
+              <?php if ($email): ?>
+                <li><i class="fa-solid fa-envelope"></i> <a href="mailto:<?= htmlspecialchars($email) ?>"><?= htmlspecialchars($email) ?></a></li>
+              <?php endif; ?>
+              <?php if ($website): ?>
+                <li><i class="fa-solid fa-globe"></i> <a href="<?= htmlspecialchars($website) ?>" target="_blank" rel="noopener"><?= htmlspecialchars($website) ?></a></li>
+              <?php endif; ?>
+            </ul>
+          <?php endif; ?>
+
+          <a href="<?= SystemURLs::getRootPath() ?>/external/register/" class="login-info-contact">
+            <i class="fa-solid fa-circle-question me-2"></i><?= gettext('Need help? Contact us') ?>
+          </a>
+        </div>
+      </div>
+    <?php endif; ?>
   </div><!-- end login-wrapper -->
 </div><!-- end login-container -->
 <?php

--- a/src/skin/scss/_authentication-pages.scss
+++ b/src/skin/scss/_authentication-pages.scss
@@ -166,7 +166,97 @@ body.page-login {
   }
 }
 
-// Form section
+// Church info panel — shown on the right when self-registration is disabled.
+// Provides visual balance and useful contact details.
+.login-info-column {
+  flex: 1 1 0;
+  padding: 50px 45px;
+  background: linear-gradient(160deg, #1e293b 0%, #0f172a 100%);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  border-left: 1px solid rgba(255, 255, 255, 0.08);
+  color: #e2e8f0;
+
+  .login-info-content {
+    text-align: center;
+    max-width: 100%;
+  }
+
+  .login-info-icon {
+    font-size: 56px;
+    color: rgba(255, 255, 255, 0.25);
+    margin-bottom: 24px;
+  }
+
+  .login-info-name {
+    font-size: 24px;
+    font-weight: 700;
+    color: #fff;
+    margin-bottom: 10px;
+    line-height: 1.3;
+  }
+
+  .login-info-tagline {
+    color: rgba(255, 255, 255, 0.55);
+    font-size: 13px;
+    line-height: 1.6;
+    margin-bottom: 32px;
+  }
+
+  .login-info-details {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 32px 0;
+    text-align: left;
+    display: inline-block;
+
+    li {
+      padding: 7px 0;
+      color: rgba(255, 255, 255, 0.65);
+      font-size: 13px;
+      line-height: 1.5;
+
+      i {
+        color: rgba(255, 255, 255, 0.35);
+        width: 16px;
+        margin-right: 10px;
+        text-align: center;
+      }
+
+      a {
+        color: rgba(255, 255, 255, 0.75);
+        text-decoration: none;
+
+        &:hover {
+          color: #fff;
+          text-decoration: underline;
+        }
+      }
+    }
+  }
+
+  .login-info-contact {
+    display: inline-flex;
+    align-items: center;
+    padding: 10px 20px;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 8px;
+    color: rgba(255, 255, 255, 0.7);
+    font-size: 13px;
+    text-decoration: none;
+    transition: all 0.2s;
+
+    &:hover {
+      border-color: rgba(255, 255, 255, 0.5);
+      color: #fff;
+      background: rgba(255, 255, 255, 0.06);
+    }
+  }
+}
+
+// Form section (legacy — kept for non-split auth pages)
 .login-form-section {
   padding: 45px 40px;
   display: flex;
@@ -785,6 +875,17 @@ body.page-auth .btn {
     border-left: none;
     border-top: 1px solid #f0f0f0;
     padding: 30px 30px;
+  }
+
+  // Info column stacks below form on tablet; hide decorative icon to save space
+  .login-info-column {
+    border-left: none;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    padding: 28px 30px;
+
+    .login-info-icon {
+      display: none;
+    }
   }
 
   .btn-register {

--- a/src/v2/templates/root/dashboard.php
+++ b/src/v2/templates/root/dashboard.php
@@ -9,7 +9,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
 <!-- Stat Cards Row -->
 <div class="row row-cards mb-3 g-2">
     <div class="col-6 col-md-4 col-lg">
-        <div class="card card-sm">
+        <a href="<?= $sRootPath ?>/people/family" class="card card-sm text-decoration-none">
             <div class="card-body">
                 <div class="row align-items-center">
                     <div class="col-auto">
@@ -18,15 +18,15 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
                         </span>
                     </div>
                     <div class="col">
-                        <div class="fw-medium" id="familyCountDashboard"><?= $dashboardCounts["families"] ?></div>
+                        <div class="fw-medium text-body" id="familyCountDashboard"><?= $dashboardCounts["families"] ?></div>
                         <div class="text-muted"><?= gettext('Families') ?></div>
                     </div>
                 </div>
             </div>
-        </div>
+        </a>
     </div>
     <div class="col-6 col-md-4 col-lg">
-        <div class="card card-sm">
+        <a href="<?= $sRootPath ?>/people/list" class="card card-sm text-decoration-none">
             <div class="card-body">
                 <div class="row align-items-center">
                     <div class="col-auto">
@@ -35,15 +35,15 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
                         </span>
                     </div>
                     <div class="col">
-                        <div class="fw-medium" id="peopleStatsDashboard"><?= $dashboardCounts["People"] ?></div>
+                        <div class="fw-medium text-body" id="peopleStatsDashboard"><?= $dashboardCounts["People"] ?></div>
                         <div class="text-muted"><?= gettext('People') ?></div>
                     </div>
                 </div>
             </div>
-        </div>
+        </a>
     </div>
     <div class="col-6 col-md-4 col-lg">
-        <div class="card card-sm">
+        <a href="<?= $sRootPath ?>/groups/dashboard" class="card card-sm text-decoration-none">
             <div class="card-body">
                 <div class="row align-items-center">
                     <div class="col-auto">
@@ -52,15 +52,16 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
                         </span>
                     </div>
                     <div class="col">
-                        <div class="fw-medium" id="groupsCountDashboard"><?= $dashboardCounts["Groups"] ?></div>
+                        <div class="fw-medium text-body" id="groupsCountDashboard"><?= $dashboardCounts["Groups"] ?></div>
                         <div class="text-muted"><?= gettext('Groups') ?></div>
                     </div>
                 </div>
             </div>
-        </div>
+        </a>
     </div>
     <div class="col-6 col-md-4 col-lg">
-        <div class="card card-sm<?= $sundaySchoolEnabled ? '' : ' opacity-50' ?>">
+        <?php if ($sundaySchoolEnabled): ?>
+        <a href="<?= $sRootPath ?>/groups/sundayschool" class="card card-sm text-decoration-none">
             <div class="card-body">
                 <div class="row align-items-center">
                     <div class="col-auto">
@@ -69,20 +70,33 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
                         </span>
                     </div>
                     <div class="col">
-                        <?php if ($sundaySchoolEnabled) { ?>
-                            <div class="fw-medium" id="groupStatsSundaySchool"><?= $dashboardCounts["SundaySchool"] ?></div>
-                            <div class="text-muted"><?= gettext('Sunday School') ?></div>
-                        <?php } else { ?>
-                            <div class="fw-medium text-muted"><?= gettext('No Sunday School') ?></div>
-                            <div class="text-muted small"><?= gettext('Disabled in settings') ?></div>
-                        <?php } ?>
+                        <div class="fw-medium text-body" id="groupStatsSundaySchool"><?= $dashboardCounts["SundaySchool"] ?></div>
+                        <div class="text-muted"><?= gettext('Sunday School') ?></div>
+                    </div>
+                </div>
+            </div>
+        </a>
+        <?php else: ?>
+        <div class="card card-sm opacity-50">
+            <div class="card-body">
+                <div class="row align-items-center">
+                    <div class="col-auto">
+                        <span class="bg-warning text-white avatar rounded-circle">
+                            <i class="fa-solid fa-child icon"></i>
+                        </span>
+                    </div>
+                    <div class="col">
+                        <div class="fw-medium text-muted"><?= gettext('No Sunday School') ?></div>
+                        <div class="text-muted small"><?= gettext('Disabled in settings') ?></div>
                     </div>
                 </div>
             </div>
         </div>
+        <?php endif; ?>
     </div>
     <div class="col-6 col-md-4 col-lg">
-        <div class="card card-sm<?= $eventsEnabled ? '' : ' opacity-50' ?>">
+        <?php if ($eventsEnabled): ?>
+        <a href="<?= $sRootPath ?>/event/dashboard" class="card card-sm text-decoration-none">
             <div class="card-body">
                 <div class="row align-items-center">
                     <div class="col-auto">
@@ -91,17 +105,29 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
                         </span>
                     </div>
                     <div class="col">
-                        <?php if ($eventsEnabled) { ?>
-                            <div class="fw-medium"><?= $dashboardCounts["events"] ?></div>
-                            <div class="text-muted"><?= gettext('Check-ins') ?></div>
-                        <?php } else { ?>
-                            <div class="fw-medium text-muted"><?= gettext('No Check-ins') ?></div>
-                            <div class="text-muted small"><?= gettext('Disabled in settings') ?></div>
-                        <?php } ?>
+                        <div class="fw-medium text-body"><?= $dashboardCounts["events"] ?></div>
+                        <div class="text-muted"><?= gettext('Check-ins') ?></div>
+                    </div>
+                </div>
+            </div>
+        </a>
+        <?php else: ?>
+        <div class="card card-sm opacity-50">
+            <div class="card-body">
+                <div class="row align-items-center">
+                    <div class="col-auto">
+                        <span class="bg-info text-white avatar rounded-circle">
+                            <i class="fa-regular fa-calendar-check icon"></i>
+                        </span>
+                    </div>
+                    <div class="col">
+                        <div class="fw-medium text-muted"><?= gettext('No Check-ins') ?></div>
+                        <div class="text-muted small"><?= gettext('Disabled in settings') ?></div>
                     </div>
                 </div>
             </div>
         </div>
+        <?php endif; ?>
     </div>
 </div>
 


### PR DESCRIPTION
## Summary
- Move Event Types link under Events → Admin submenu (was cluttering top-level nav)
- Fix breadcrumbs: Group-type/role/custom options now show Groups as parent; Property List respects type context (Groups vs People)
- Tabler UI refresh for People dashboard, root dashboard, and login/begin-session page
- Auth page SCSS improvements

## Changes
| File | Change |
|------|--------|
| `src/ChurchCRM/Config/Menu/Menu.php` | Event Types nested under Events → Admin submenu |
| `src/PropertyList.php` | Breadcrumb parent = Groups for `?Type=g`, People for p/f |
| `src/admin/routes/system.php` | grptypes/grproles/groupcustom breadcrumbs → Groups dashboard |
| `src/people/views/dashboard.php` | Tabler layout cleanup |
| `src/v2/templates/root/dashboard.php` | Tabler layout cleanup |
| `src/session/templates/begin-session.php` | Login page improvements |
| `src/skin/scss/_authentication-pages.scss` | Auth page styling |

## Testing
- [ ] Navigate Events menu — Event Types appears under Admin submenu
- [ ] Visit `PropertyList.php?Type=g` — breadcrumb shows Groups → Group Properties
- [ ] Visit `admin/system/options?mode=grptypes` — breadcrumb shows Groups → Group Types
- [ ] Login page renders correctly
- [ ] People and root dashboards render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)