### PR TITLE
fix(event): refactor event editor to use church-tz wall-clock strings

### DIFF
--- a/src/ChurchCRM/model/ChurchCRM/KioskDevice.php
+++ b/src/ChurchCRM/model/ChurchCRM/KioskDevice.php
@@ -37,8 +37,33 @@ class KioskDevice extends BaseKioskDevice
         $assignment = $this->getActiveAssignment();
 
         if (isset($assignment) && $assignment->getAssignmentType() == KioskAssignmentTypes::EVENTATTENDANCEKIOSK) {
-            $assignment->getEvent();
-            $assignmentJSON = $assignment->toJSON();
+            $event = $assignment->getEvent();
+            $assignmentArray = json_decode($assignment->toJSON(), true) ?: [];
+
+            // Match the calendar page tz convention: emit times as ISO 8601
+            // with the church's configured sTimeZone offset so JS moment parses
+            // them as instants-in-time and the kiosk's open/end logic works
+            // the same regardless of the device's browser timezone. Default
+            // Propel serialization gives "Y-m-d H:i:s.u" (naive, no tz) which
+            // moment misreads as device-local — wrong for any kiosk whose
+            // browser tz isn't sTimeZone.
+            //
+            // CheckInOpensAt = event start minus 1 hour, so volunteers can
+            // start checking people in before the event actually begins.
+            if ($event !== null) {
+                $startDt = $event->getStart();
+                $endDt = $event->getEnd();
+                if ($startDt instanceof \DateTimeInterface) {
+                    $assignmentArray['Event']['Start'] = $startDt->format('c');
+                    $opensAt = (clone $startDt)->modify('-1 hour');
+                    $assignmentArray['Event']['CheckInOpensAt'] = $opensAt->format('c');
+                }
+                if ($endDt instanceof \DateTimeInterface) {
+                    $assignmentArray['Event']['End'] = $endDt->format('c');
+                }
+            }
+
+            $assignmentJSON = json_encode($assignmentArray);
         }
 
         return [

--- a/webpack/calendar-event-editor.js
+++ b/webpack/calendar-event-editor.js
@@ -6,7 +6,7 @@
  * surface can render the identical form inline.
  */
 
-import { deleteEvent, renderEventEditor, renderEventViewer, saveEvent } from "./event-form.js";
+import { deleteEvent, renderEventEditor, renderEventViewer, saveEvent, toWallClockString } from "./event-form.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -319,8 +319,12 @@ window.showEventForm = (eventArg) => {
     .then(([eventData, calData, typeData, groups]) => {
       if (thisRequest !== activeRequestId) return;
       const event = eventData;
-      if (event.Start) event.Start = new Date(event.Start);
-      if (event.End) event.End = new Date(event.End);
+      // event-form treats Start/End as church wall-clock STRINGS. Normalize
+      // the API response (Propel space format, optional .uuuuuu, optional tz)
+      // to "YYYY-MM-DDTHH:mm:ss" — never `new Date()` here, which would let
+      // Chrome reinterpret space-format as UTC and shift wall-clock numbers.
+      if (event.Start) event.Start = toWallClockString(event.Start);
+      if (event.End) event.End = toWallClockString(event.End);
       showViewContent(event, calData.Calendars, typeData.EventTypes, Array.isArray(groups) ? groups : []);
     })
     .catch((err) => {
@@ -336,13 +340,20 @@ window.showNewEventForm = (info) => {
 
   const thisRequest = ++activeRequestId;
 
+  // FullCalendar quirk: `info.start` for an all-day month-view click is a JS
+  // Date at midnight UTC of the clicked date — NOT midnight in the calendar's
+  // configured tz. Reading getDate()/getHours() in a non-UTC browser shifts
+  // back by the browser's offset (April 24 cell click → April 23 5 PM in PDT).
+  // `info.startStr` / `info.endStr` give the date/time in the calendar's tz
+  // ("YYYY-MM-DD" for all-day, "YYYY-MM-DDTHH:mm:ss±HH:MM" for timed) — strip
+  // the offset and we have the church wall-clock string the editor expects.
   const event = {
     Id: 0,
     Title: "",
     Type: 0,
     PinnedCalendars: [],
-    Start: info.start,
-    End: info.end,
+    Start: info.startStr ? toWallClockString(info.startStr) : undefined,
+    End: info.endStr ? toWallClockString(info.endStr) : undefined,
   };
 
   Promise.all([

--- a/webpack/event-calendars.js
+++ b/webpack/event-calendars.js
@@ -56,6 +56,25 @@ window.moveEventModal = {
       window.moveEventModal.revertFunc();
     }
   },
+  // Format a JS Date for display in the church's configured timezone, NOT the
+  // viewer's browser tz. Date.toLocaleString() defaults to the browser locale
+  // and tz, so an "11 PM Detroit" event would display as "8 PM PDT" (or worse,
+  // "4 PM PDT" if the API source is parsed as UTC) on a PST admin's screen.
+  // Using Intl with `timeZone` keeps the displayed time consistent with what
+  // the calendar grid shows.
+  formatChurchDate: (date) => {
+    if (!(date instanceof Date)) return "";
+    const tz = window.CRM?.calendarJSArgs?.sTimeZone || undefined;
+    return new Intl.DateTimeFormat(undefined, {
+      timeZone: tz,
+      year: "numeric",
+      month: "numeric",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+      hour12: true,
+    }).format(date);
+  },
   handleEventDrop: (info) => {
     const event = info.event;
     const revertFunc = info.revert;
@@ -66,8 +85,9 @@ window.moveEventModal = {
       revertFunc();
       return;
     }
-    const originalStart = info.oldEvent.start ? info.oldEvent.start.toLocaleString() : info.oldEvent.startStr;
-    const newStart = event.start ? event.start.toLocaleString() : event.startStr;
+    const fmt = window.moveEventModal.formatChurchDate;
+    const originalStart = info.oldEvent.start ? fmt(info.oldEvent.start) : info.oldEvent.startStr;
+    const newStart = event.start ? fmt(event.start) : event.startStr;
     window.moveEventModal.revertFunc = revertFunc;
     window.moveEventModal.event = event;
     bootbox.confirm({
@@ -85,10 +105,9 @@ window.moveEventModal = {
       revertFunc();
       return;
     }
-    const originalEnd = info.oldEvent.end
-      ? info.oldEvent.end.toLocaleString()
-      : info.oldEvent.endStr || info.oldEvent.startStr;
-    const newEnd = event.end ? event.end.toLocaleString() : event.endStr || event.startStr;
+    const fmt = window.moveEventModal.formatChurchDate;
+    const originalEnd = info.oldEvent.end ? fmt(info.oldEvent.end) : info.oldEvent.endStr || info.oldEvent.startStr;
+    const newEnd = event.end ? fmt(event.end) : event.endStr || event.startStr;
     window.moveEventModal.revertFunc = revertFunc;
     window.moveEventModal.event = event;
     bootbox.confirm({
@@ -492,9 +511,34 @@ function initializeCalendar() {
   };
   const mobileFooterToolbar = { end: "dayGridMonth,timeGridWeek,timeGridDay,listMonth" };
 
+  // FullCalendar's "today" highlight is computed from `now`. Default `now` is
+  // the actual current moment, but FC reads its date components in a way that
+  // can fall back to browser-local — so a PST admin sees April 24 highlighted
+  // even when it's already April 25 in the church's tz. Build a Date whose
+  // local components match the church's wall-clock right now: pulled from
+  // Intl with timeZone so getDate()/getHours() reflect the church's "today".
+  const churchNow = (() => {
+    const tz = window.CRM.calendarJSArgs.sTimeZone;
+    if (!tz) return new Date();
+    const parts = new Intl.DateTimeFormat("en-CA", {
+      timeZone: tz,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hour12: false,
+    }).formatToParts(new Date());
+    const get = (type) => parts.find((p) => p.type === type)?.value || "00";
+    const hh = get("hour") === "24" ? "00" : get("hour");
+    return new Date(`${get("year")}-${get("month")}-${get("day")}T${hh}:${get("minute")}:${get("second")}`);
+  })();
+
   window.CRM.fullcalendar = new FullCalendar.Calendar(document.getElementById("calendar"), {
     locale: window.CRM.lang || "en",
     timeZone: window.CRM.calendarJSArgs.sTimeZone || "local",
+    now: churchNow,
     headerToolbar: window.innerWidth < 768 ? mobileHeaderToolbar : desktopHeaderToolbar,
     footerToolbar: window.innerWidth < 768 ? mobileFooterToolbar : false,
     contentHeight: "auto",

--- a/webpack/event-calendars.js
+++ b/webpack/event-calendars.js
@@ -56,17 +56,18 @@ window.moveEventModal = {
       window.moveEventModal.revertFunc();
     }
   },
-  // Format a JS Date for display in the church's configured timezone, NOT the
-  // viewer's browser tz. Date.toLocaleString() defaults to the browser locale
-  // and tz, so an "11 PM Detroit" event would display as "8 PM PDT" (or worse,
-  // "4 PM PDT" if the API source is parsed as UTC) on a PST admin's screen.
-  // Using Intl with `timeZone` keeps the displayed time consistent with what
-  // the calendar grid shows.
+  // Format a FullCalendar event Date for display in the church's wall-clock.
+  // FullCalendar uses "marker" Dates: a JS Date whose UTC components encode
+  // the wall-clock time in the calendar's configured timezone (so a 10 PM
+  // Detroit event has start.getUTCHours() === 22, regardless of browser tz).
+  // Read those UTC components verbatim with `timeZone: "UTC"` so the modal
+  // mirrors the time the calendar grid displays. Using `timeZone: sTimeZone`
+  // would re-apply the offset and shift the display by the church's UTC
+  // offset (e.g. 10 PM → 6 PM on EDT calendars).
   formatChurchDate: (date) => {
     if (!(date instanceof Date)) return "";
-    const tz = window.CRM?.calendarJSArgs?.sTimeZone || undefined;
     return new Intl.DateTimeFormat(undefined, {
-      timeZone: tz,
+      timeZone: "UTC",
       year: "numeric",
       month: "numeric",
       day: "numeric",

--- a/webpack/event-calendars.js
+++ b/webpack/event-calendars.js
@@ -37,12 +37,19 @@ window.moveEventModal = {
   modalCallBack: (result) => {
     if (result === true) {
       const evt = window.moveEventModal.event;
+      // Storage convention: wall-clock-in-sTimeZone (matches all existing
+      // events). FullCalendar's `startStr`/`endStr` already carry the time
+      // in the calendar's configured tz (sTimeZone). Strip any trailing Z
+      // or +HH:MM offset so PHP/Propel stores the wall-clock numbers as-is
+      // and hydrates them back in sTimeZone for display. Using `toISOString()`
+      // here would send UTC and double-shift the time on read.
+      const stripTz = (s) => (typeof s === "string" ? s.replace(/(?:Z|[+-]\d{2}:\d{2})$/, "") : s);
       window.CRM.APIRequest({
         method: "POST",
         path: `events/${evt.id}/time`,
         data: JSON.stringify({
-          startTime: evt.allDay ? evt.startStr : evt.start.toISOString(),
-          endTime: evt.end ? evt.end.toISOString() : null,
+          startTime: evt.allDay ? evt.startStr : stripTz(evt.startStr),
+          endTime: evt.end ? stripTz(evt.endStr) : null,
         }),
       });
     } else {

--- a/webpack/event-form.js
+++ b/webpack/event-form.js
@@ -293,13 +293,14 @@ function renderEditorFields(event, calendars, eventTypes, groups, allDay) {
   // configured sTimeZone, so admins editing from a different region know that
   // the times they enter are interpreted as the church's wall-clock — not
   // their browser's local time.
-  // Show a compact one-line tz reminder when browser tz differs from sTimeZone.
-  // The dates/times entered in this editor are stored as the church's
-  // wall-clock — independent of viewer tz. Banner only renders for cross-tz
-  // admins so single-tz setups stay clutter-free.
+  // Show a compact one-line tz reminder when browser tz differs from sTimeZone
+  // — only for TIMED events. All-day events have no time component, so the
+  // user's tz vs the church's tz is irrelevant; showing the warning would be
+  // confusing noise. Banner only renders for cross-tz admins on timed events
+  // so single-tz setups and date-only events stay clutter-free.
   let tzNoticeMarkup = "";
   const churchTz = getChurchTz();
-  if (churchTz && churchTz !== "UTC") {
+  if (churchTz && churchTz !== "UTC" && !allDay) {
     let browserTz = "";
     try {
       browserTz = Intl.DateTimeFormat().resolvedOptions().timeZone || "";

--- a/webpack/event-form.js
+++ b/webpack/event-form.js
@@ -314,8 +314,8 @@ function renderEditorFields(event, calendars, eventTypes, groups, allDay) {
         .replace("{{church}}", churchTz)
         .replace("{{browser}}", browserTz);
       tzNoticeMarkup = `
-    <div class="text-secondary small mb-3">
-      <i class="ti ti-info-circle me-1"></i>${escapeHtml(hintText)}
+    <div class="small mb-3 text-warning-emphasis">
+      <i class="ti ti-alert-triangle-filled me-1 text-warning"></i>${escapeHtml(hintText)}
     </div>`;
     }
   }

--- a/webpack/event-form.js
+++ b/webpack/event-form.js
@@ -307,9 +307,15 @@ function renderEditorFields(event, calendars, eventTypes, groups, allDay) {
       browserTz = "";
     }
     if (browserTz && browserTz !== churchTz) {
+      // Plain muted hint — Tabler's .alert chrome was rendering inline <strong>
+      // and <span> children with visible gaps/separators that read as columns.
+      // Single text node with parenthetical tz names keeps the line clean.
+      const hintText = t("Times use church time ({{church}}), not your browser ({{browser}}).")
+        .replace("{{church}}", churchTz)
+        .replace("{{browser}}", browserTz);
       tzNoticeMarkup = `
-    <div class="alert alert-info py-2 px-3 mb-3 small" role="status">
-      <i class="ti ti-clock-hour-4 me-2"></i>${t("Times use church timezone")} <strong>${escapeHtml(churchTz)}</strong>, ${t("not your browser's")} <span class="text-secondary">${escapeHtml(browserTz)}</span>.
+    <div class="text-secondary small mb-3">
+      <i class="ti ti-info-circle me-1"></i>${escapeHtml(hintText)}
     </div>`;
     }
   }

--- a/webpack/event-form.js
+++ b/webpack/event-form.js
@@ -330,7 +330,7 @@ function renderEditorFields(event, calendars, eventTypes, groups, allDay) {
         <label class="form-label" for="pinnedCalendarsSelect">${t("Pinned Calendars")}</label>
         <select id="pinnedCalendarsSelect" class="form-select" multiple>${calOptions}</select>
         <div class="form-text text-warning d-none" id="calendarsEmptyHint">
-          <i class="ti ti-info-circle me-1"></i>${t("No calendar selected — this event will be saved but won't appear on any calendar view.")}
+          <i class="ti ti-info-circle me-1"></i>${t('No calendar selected — this event will appear under the "Unpinned Events" system calendar until you pin it.')}
         </div>
       </div>
     </div>

--- a/webpack/event-form.js
+++ b/webpack/event-form.js
@@ -44,7 +44,12 @@ function escapeHtml(str) {
 //   - Send to API → string passes through JSON.stringify
 
 function getChurchTz() {
-  return window.CRM?.calendarJSArgs?.sTimeZone || "UTC";
+  // Two sources for sTimeZone in window.CRM:
+  //   - calendarJSArgs.sTimeZone (set only on /event/calendar — calendar.php)
+  //   - timeZone                 (set on every page via Include/Header.php)
+  // The full-page editor (/event/editor/:id) doesn't have calendarJSArgs, so
+  // without the global fallback the tz banner never showed there.
+  return window.CRM?.calendarJSArgs?.sTimeZone || window.CRM?.timeZone || "UTC";
 }
 
 // Format a JS Date as "YYYY-MM-DDTHH:mm:ss" wall-clock numbers in the given tz.
@@ -288,15 +293,13 @@ function renderEditorFields(event, calendars, eventTypes, groups, allDay) {
   // configured sTimeZone, so admins editing from a different region know that
   // the times they enter are interpreted as the church's wall-clock — not
   // their browser's local time.
-  // Show the banner whenever browser tz differs from sTimeZone — regardless of
-  // timed vs all-day. The user reported the banner missing because the previous
-  // gate `&& !allDay` hid it on month-view cell clicks (which open in all-day
-  // mode by default). Even for all-day events the date cell can be ambiguous
-  // if the user's tz differs from the church's, so the reminder is still
-  // useful: the date numbers they enter are the church's calendar date.
+  // Show a compact one-line tz reminder when browser tz differs from sTimeZone.
+  // The dates/times entered in this editor are stored as the church's
+  // wall-clock — independent of viewer tz. Banner only renders for cross-tz
+  // admins so single-tz setups stay clutter-free.
   let tzNoticeMarkup = "";
-  const churchTz = window.CRM?.calendarJSArgs?.sTimeZone;
-  if (churchTz) {
+  const churchTz = getChurchTz();
+  if (churchTz && churchTz !== "UTC") {
     let browserTz = "";
     try {
       browserTz = Intl.DateTimeFormat().resolvedOptions().timeZone || "";
@@ -305,11 +308,8 @@ function renderEditorFields(event, calendars, eventTypes, groups, allDay) {
     }
     if (browserTz && browserTz !== churchTz) {
       tzNoticeMarkup = `
-    <div class="alert alert-info py-2 mb-3" role="status">
-      <i class="ti ti-clock me-1"></i>
-      ${t("Times are interpreted as")} <strong>${escapeHtml(churchTz)}</strong>
-      (${t("the church's configured timezone")}).
-      ${t("Your browser is in")} <strong>${escapeHtml(browserTz)}</strong> — ${t("the times you enter here will be saved as the church's wall-clock time, not your local time.")}
+    <div class="alert alert-info py-2 px-3 mb-3 small" role="status">
+      <i class="ti ti-clock-hour-4 me-2"></i>${t("Times use church timezone")} <strong>${escapeHtml(churchTz)}</strong>, ${t("not your browser's")} <span class="text-secondary">${escapeHtml(browserTz)}</span>.
     </div>`;
     }
   }

--- a/webpack/event-form.js
+++ b/webpack/event-form.js
@@ -31,49 +31,133 @@ function escapeHtml(str) {
   return div.innerHTML.replace(/"/g, "&quot;").replace(/'/g, "&#39;");
 }
 
-/** Parse an input value as a local date. Date-only "YYYY-MM-DD" is parsed
- *  as local (not UTC) to avoid off-by-one day shifts in non-UTC timezones. */
-function parseInputDate(value) {
-  if (!value) return undefined;
-  const dateOnly = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
-  if (dateOnly) {
-    return new Date(Number(dateOnly[1]), Number(dateOnly[2]) - 1, Number(dateOnly[3]));
-  }
-  return new Date(value);
+// Architecture: event.Start / event.End are CHURCH wall-clock STRINGS in
+// `YYYY-MM-DDTHH:mm:ss` (timed) or `YYYY-MM-DD` (all-day). Never JS Date
+// objects in date logic. This avoids browser-tz contamination — `new Date()`,
+// `getHours()`, `getDate()` etc. all interpret in the user's local tz, which
+// silently shifts wall-clock numbers when browser tz ≠ church tz.
+//
+// All format conversions happen at boundaries:
+//   - API response → toWallClockString  (strips space/Z/offset)
+//   - FullCalendar Date → formatJsDateInChurchTz  (Intl with timeZone)
+//   - User input field → already a string, used directly
+//   - Send to API → string passes through JSON.stringify
+
+function getChurchTz() {
+  return window.CRM?.calendarJSArgs?.sTimeZone || "UTC";
 }
 
-function formatDateForInput(date, allDay) {
-  if (!date) return "";
-  const d = new Date(date);
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, "0");
-  const day = String(d.getDate()).padStart(2, "0");
-  if (allDay) return `${y}-${m}-${day}`;
-  const h = String(d.getHours()).padStart(2, "0");
-  const mi = String(d.getMinutes()).padStart(2, "0");
-  return `${y}-${m}-${day}T${h}:${mi}`;
-}
-
-function formatDateForDisplay(date, allDay) {
-  if (!date) return "N/A";
-  const d = new Date(date);
-  if (allDay) return d.toLocaleDateString(undefined, { year: "numeric", month: "long", day: "numeric" });
-  return d.toLocaleString(undefined, {
+// Format a JS Date as "YYYY-MM-DDTHH:mm:ss" wall-clock numbers in the given tz.
+// Uses Intl with `timeZone` so the components reflect the church's tz, not the
+// browser's. en-CA gives ISO-friendly numeric output.
+function formatJsDateInChurchTz(date, tz, dateOnly) {
+  const opts = {
+    timeZone: tz,
     year: "numeric",
-    month: "long",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
+    month: "2-digit",
+    day: "2-digit",
+    hour12: false,
+    ...(dateOnly ? {} : { hour: "2-digit", minute: "2-digit", second: "2-digit" }),
+  };
+  const parts = new Intl.DateTimeFormat("en-CA", opts).formatToParts(date);
+  const get = (type) => parts.find((p) => p.type === type)?.value || "00";
+  const ymd = `${get("year")}-${get("month")}-${get("day")}`;
+  if (dateOnly) return ymd;
+  // en-CA returns "24" for midnight in some locales — normalize to "00".
+  const hh = get("hour") === "24" ? "00" : get("hour");
+  return `${ymd}T${hh}:${get("minute")}:${get("second")}`;
+}
+
+// Coerce any input (Date, API string, naive ISO, date-only) to a wall-clock
+// string in the church's tz. Returns "" for empty input.
+//   - API space format "2026-04-24 20:00:00.000000"      → "2026-04-24T20:00:00"
+//   - ISO with offset  "2026-04-24T20:00:00-04:00"        → "2026-04-24T20:00:00"
+//   - ISO with Z       "2026-04-25T00:00:00.000Z"         → reinterpret in tz
+//   - Date-only        "2026-04-24"                        → "2026-04-24"
+//   - JS Date                                              → format in church tz
+export function toWallClockString(value) {
+  if (!value) return "";
+  if (value instanceof Date) {
+    return formatJsDateInChurchTz(value, getChurchTz(), false);
+  }
+  if (typeof value !== "string") return "";
+  // ISO with explicit Z or +HH:MM: parse as instant, format in church tz so
+  // the wall-clock numbers reflect the configured display zone (handles
+  // legacy UTC-stored events from the brief broken iteration).
+  if (/Z$/.test(value) || /[+-]\d{2}:\d{2}$/.test(value)) {
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) {
+      return formatJsDateInChurchTz(parsed, getChurchTz(), false);
+    }
+  }
+  // Naive: assume already wall-clock in church tz. Strip space/microseconds.
+  return value.replace(" ", "T").replace(/\.\d+/, "").substring(0, 19);
+}
+
+// Date-only variant: returns "YYYY-MM-DD".
+function toWallClockDate(value) {
+  if (!value) return "";
+  if (value instanceof Date) {
+    return formatJsDateInChurchTz(value, getChurchTz(), true);
+  }
+  if (typeof value !== "string") return "";
+  if (/Z$/.test(value) || /[+-]\d{2}:\d{2}$/.test(value)) {
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) {
+      return formatJsDateInChurchTz(parsed, getChurchTz(), true);
+    }
+  }
+  return value.replace(" ", "T").substring(0, 10);
+}
+
+// Datetime-local input format ("YYYY-MM-DDTHH:mm") — no seconds.
+function formatDateForInput(value, allDay) {
+  if (allDay) return toWallClockDate(value);
+  return toWallClockString(value).substring(0, 16);
+}
+
+// Human-readable display: "April 24, 2026" or "April 24, 2026 at 08:00 PM".
+function formatDateForDisplay(value, allDay) {
+  const s = allDay ? toWallClockDate(value) : toWallClockString(value);
+  if (!s) return "N/A";
+  const m = s.match(/^(\d{4})-(\d{2})-(\d{2})(?:T(\d{2}):(\d{2}))?/);
+  if (!m) return s;
+  const [, y, mo, d, hh, mi] = m;
+  const months = [
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+  ];
+  const dateStr = `${months[parseInt(mo, 10) - 1]} ${parseInt(d, 10)}, ${y}`;
+  if (allDay || hh === undefined) return dateStr;
+  let h = parseInt(hh, 10);
+  const am = h < 12 ? "AM" : "PM";
+  h = h % 12 || 12;
+  return `${dateStr} at ${String(h).padStart(2, "0")}:${mi} ${am}`;
 }
 
 export function isAllDay(event) {
   if (!event.Start) return true;
-  const s = new Date(event.Start);
-  if (s.getHours() !== 0 || s.getMinutes() !== 0) return false;
+  const s = toWallClockString(event.Start);
+  // Date-only string (length 10) is implicitly all-day.
+  if (s.length <= 10) return true;
+  const m = s.match(/T(\d{2}):(\d{2})/);
+  if (!m || m[1] !== "00" || m[2] !== "00") return false;
   if (event.End) {
-    const e = new Date(event.End);
-    if (e.getHours() !== 0 || e.getMinutes() !== 0) return false;
+    const e = toWallClockString(event.End);
+    if (e.length > 10) {
+      const me = e.match(/T(\d{2}):(\d{2})/);
+      if (me && (me[1] !== "00" || me[2] !== "00")) return false;
+    }
   }
   return true;
 }
@@ -200,6 +284,30 @@ function renderEditorFields(event, calendars, eventTypes, groups, allDay) {
   const startVal = formatDateForInput(event.Start, allDay);
   const endVal = formatDateForInput(event.End, allDay);
 
+  // Show a banner when the user's browser tz differs from the church's
+  // configured sTimeZone, so admins editing from a different region know that
+  // the times they enter are interpreted as the church's wall-clock — not
+  // their browser's local time.
+  let tzNoticeMarkup = "";
+  const churchTz = window.CRM?.calendarJSArgs?.sTimeZone;
+  if (churchTz && !allDay) {
+    let browserTz = "";
+    try {
+      browserTz = Intl.DateTimeFormat().resolvedOptions().timeZone || "";
+    } catch (_e) {
+      browserTz = "";
+    }
+    if (browserTz && browserTz !== churchTz) {
+      tzNoticeMarkup = `
+    <div class="alert alert-info py-2 mb-3" role="status">
+      <i class="ti ti-clock me-1"></i>
+      ${t("Times are interpreted as")} <strong>${escapeHtml(churchTz)}</strong>
+      (${t("the church's configured timezone")}).
+      ${t("Your browser is in")} <strong>${escapeHtml(browserTz)}</strong> — ${t("the times you enter here will be saved as the church's wall-clock time, not your local time.")}
+    </div>`;
+    }
+  }
+
   return `
     <div class="row g-3 mb-3">
       <div class="col-md-6">
@@ -214,7 +322,7 @@ function renderEditorFields(event, calendars, eventTypes, groups, allDay) {
         </div>
       </div>
     </div>
-
+    ${tzNoticeMarkup}
     <div class="mb-2">
       <div class="form-selectgroup form-selectgroup-pills">
         <label class="form-selectgroup-item">
@@ -487,21 +595,26 @@ export function renderEventEditor(container, event, calendars, eventTypes, optio
       const startInput = document.getElementById("eventStartDate");
       const endInput = document.getElementById("eventEndDate");
 
+      // String math: extract date parts from existing wall-clock strings (or
+      // "today in church tz" if absent); re-assemble with new time portion.
+      const churchToday = formatJsDateInChurchTz(new Date(), getChurchTz(), true);
+      const startDate = toWallClockDate(event.Start) || churchToday;
+      const endDate = toWallClockDate(event.End) || startDate;
       if (nowAllDay) {
-        const s = event.Start ? new Date(event.Start) : new Date();
-        s.setHours(0, 0, 0, 0);
-        event.Start = s;
-        const e = event.End ? new Date(event.End) : new Date(s);
-        e.setHours(0, 0, 0, 0);
-        event.End = e;
+        event.Start = startDate;
+        event.End = endDate;
       } else {
-        const now = new Date();
-        const s = event.Start ? new Date(event.Start) : new Date();
-        s.setHours(now.getHours(), 0, 0, 0);
-        event.Start = s;
-        const e = event.End ? new Date(event.End) : new Date(s);
-        e.setHours(now.getHours() + 1, 0, 0, 0);
-        event.End = e;
+        // Default time-of-day for a fresh timed event. Church events are
+        // overwhelmingly morning/midday (services, meetings, classes), so
+        // 9:00 AM is a far better default than "current church-time hour"
+        // — which produced confusing 1 AM defaults during after-hours edits.
+        // If the existing time portion is non-zero, preserve it.
+        const existingStart = toWallClockString(event.Start);
+        const existingEnd = toWallClockString(event.End);
+        const startTimePart = /T(?!00:00)/.test(existingStart) ? existingStart.substring(11, 19) : "09:00:00";
+        const endTimePart = /T(?!00:00)/.test(existingEnd) ? existingEnd.substring(11, 19) : "10:00:00";
+        event.Start = `${startDate}T${startTimePart}`;
+        event.End = `${endDate}T${endTimePart}`;
       }
 
       startInput.type = nowAllDay ? "date" : "datetime-local";
@@ -518,14 +631,31 @@ export function renderEventEditor(container, event, calendars, eventTypes, optio
   const endInput = document.getElementById("eventEndDate");
   if (startInput) {
     startInput.addEventListener("change", () => {
-      event.Start = startInput.value ? parseInputDate(startInput.value) : undefined;
-      if (endInput) endInput.min = startInput.value || "";
+      // Input value is already a wall-clock string ("YYYY-MM-DDTHH:mm" or
+      // "YYYY-MM-DD"). Pad seconds for timed entries so the wire format is
+      // consistent. No `new Date()` — we don't want browser-tz interpretation.
+      const v = startInput.value;
+      if (!v) {
+        event.Start = undefined;
+      } else if (v.length === 16) {
+        event.Start = `${v}:00`;
+      } else {
+        event.Start = v;
+      }
+      if (endInput) endInput.min = v || "";
       fireValidity();
     });
   }
   if (endInput) {
     endInput.addEventListener("change", () => {
-      event.End = endInput.value ? parseInputDate(endInput.value) : undefined;
+      const v = endInput.value;
+      if (!v) {
+        event.End = undefined;
+      } else if (v.length === 16) {
+        event.End = `${v}:00`;
+      } else {
+        event.End = v;
+      }
       fireValidity();
     });
   }
@@ -625,8 +755,12 @@ export function renderEventEditor(container, event, calendars, eventTypes, optio
 export function saveEvent(event, apiRoot) {
   const url = `${apiRoot}/api/events${event.Id !== 0 ? `/${event.Id}` : ""}`;
   const body = JSON.stringify(event, (_key, value) => {
+    // event.Start / event.End should already be wall-clock strings by this
+    // point (see toWallClockString boundaries). Any leftover JS Date —
+    // typically from a code path that hasn't been refactored — is converted
+    // to church-tz wall-clock so we never send browser-tz components or UTC.
     if (value instanceof Date) {
-      return window.moment ? window.moment(value).format() : value.toISOString();
+      return formatJsDateInChurchTz(value, getChurchTz(), false);
     }
     return value;
   });

--- a/webpack/event-form.js
+++ b/webpack/event-form.js
@@ -288,9 +288,15 @@ function renderEditorFields(event, calendars, eventTypes, groups, allDay) {
   // configured sTimeZone, so admins editing from a different region know that
   // the times they enter are interpreted as the church's wall-clock — not
   // their browser's local time.
+  // Show the banner whenever browser tz differs from sTimeZone — regardless of
+  // timed vs all-day. The user reported the banner missing because the previous
+  // gate `&& !allDay` hid it on month-view cell clicks (which open in all-day
+  // mode by default). Even for all-day events the date cell can be ambiguous
+  // if the user's tz differs from the church's, so the reminder is still
+  // useful: the date numbers they enter are the church's calendar date.
   let tzNoticeMarkup = "";
   const churchTz = window.CRM?.calendarJSArgs?.sTimeZone;
-  if (churchTz && !allDay) {
+  if (churchTz) {
     let browserTz = "";
     try {
       browserTz = Intl.DateTimeFormat().resolvedOptions().timeZone || "";

--- a/webpack/event-form.js
+++ b/webpack/event-form.js
@@ -315,7 +315,7 @@ function renderEditorFields(event, calendars, eventTypes, groups, allDay) {
         .replace("{{browser}}", browserTz);
       tzNoticeMarkup = `
     <div class="small mb-3 text-warning-emphasis">
-      <i class="ti ti-alert-triangle-filled me-1 text-warning"></i>${escapeHtml(hintText)}
+      <i class="ti ti-alert-triangle me-1 text-warning"></i>${escapeHtml(hintText)}
     </div>`;
     }
   }

--- a/webpack/event-form.js
+++ b/webpack/event-form.js
@@ -95,12 +95,19 @@ export function toWallClockString(value) {
       return formatJsDateInChurchTz(parsed, getChurchTz(), false);
     }
   }
-  // Naive: assume already wall-clock in church tz. Strip space/microseconds.
-  return value.replace(" ", "T").replace(/\.\d+/, "").substring(0, 19);
+  // Naive: assume already wall-clock in church tz. Strip space/microseconds,
+  // then pad missing seconds. datetime-local inputs typically yield 16-char
+  // strings ("YYYY-MM-DDTHH:mm") with no seconds, but downstream substrings
+  // (`substring(11, 19)`) and the API expect "YYYY-MM-DDTHH:mm:ss".
+  let normalized = value.replace(" ", "T").replace(/\.\d+/, "").substring(0, 19);
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/.test(normalized)) {
+    normalized = `${normalized}:00`;
+  }
+  return normalized;
 }
 
 // Date-only variant: returns "YYYY-MM-DD".
-function toWallClockDate(value) {
+export function toWallClockDate(value) {
   if (!value) return "";
   if (value instanceof Date) {
     return formatJsDateInChurchTz(value, getChurchTz(), true);
@@ -121,33 +128,40 @@ function formatDateForInput(value, allDay) {
   return toWallClockString(value).substring(0, 16);
 }
 
-// Human-readable display: "April 24, 2026" or "April 24, 2026 at 08:00 PM".
+// Human-readable display, locale-aware. The previous implementation hardcoded
+// English month names ("April") and the literal "at" / AM/PM, regressing the
+// non-English UI relative to the original toLocaleString-based code. Trick:
+// parse the wall-clock string into individual components, then construct a JS
+// Date with those components in browser-local. The Date's wall-clock numbers
+// then round-trip through toLocaleString unchanged — no tz shift — but the
+// month name, separator, and AM/PM come from the user's locale.
 function formatDateForDisplay(value, allDay) {
   const s = allDay ? toWallClockDate(value) : toWallClockString(value);
   if (!s) return "N/A";
   const m = s.match(/^(\d{4})-(\d{2})-(\d{2})(?:T(\d{2}):(\d{2}))?/);
   if (!m) return s;
   const [, y, mo, d, hh, mi] = m;
-  const months = [
-    "January",
-    "February",
-    "March",
-    "April",
-    "May",
-    "June",
-    "July",
-    "August",
-    "September",
-    "October",
-    "November",
-    "December",
-  ];
-  const dateStr = `${months[parseInt(mo, 10) - 1]} ${parseInt(d, 10)}, ${y}`;
-  if (allDay || hh === undefined) return dateStr;
-  let h = parseInt(hh, 10);
-  const am = h < 12 ? "AM" : "PM";
-  h = h % 12 || 12;
-  return `${dateStr} at ${String(h).padStart(2, "0")}:${mi} ${am}`;
+  const localDate = new Date(
+    parseInt(y, 10),
+    parseInt(mo, 10) - 1,
+    parseInt(d, 10),
+    hh ? parseInt(hh, 10) : 0,
+    mi ? parseInt(mi, 10) : 0,
+  );
+  if (allDay || hh === undefined) {
+    return localDate.toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+  }
+  return localDate.toLocaleString(undefined, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
 }
 
 export function isAllDay(event) {

--- a/webpack/event-form.js
+++ b/webpack/event-form.js
@@ -293,14 +293,14 @@ function renderEditorFields(event, calendars, eventTypes, groups, allDay) {
   // configured sTimeZone, so admins editing from a different region know that
   // the times they enter are interpreted as the church's wall-clock — not
   // their browser's local time.
-  // Show a compact one-line tz reminder when browser tz differs from sTimeZone
-  // — only for TIMED events. All-day events have no time component, so the
-  // user's tz vs the church's tz is irrelevant; showing the warning would be
-  // confusing noise. Banner only renders for cross-tz admins on timed events
-  // so single-tz setups and date-only events stay clutter-free.
+  // Compact one-line tz reminder when browser tz differs from sTimeZone — only
+  // applies to TIMED events (all-day has no time component). Render the markup
+  // unconditionally with a stable id so the day-type toggle handler can show /
+  // hide it without re-rendering the whole form. Initial visibility honors the
+  // current allDay state.
   let tzNoticeMarkup = "";
   const churchTz = getChurchTz();
-  if (churchTz && churchTz !== "UTC" && !allDay) {
+  if (churchTz && churchTz !== "UTC") {
     let browserTz = "";
     try {
       browserTz = Intl.DateTimeFormat().resolvedOptions().timeZone || "";
@@ -315,7 +315,7 @@ function renderEditorFields(event, calendars, eventTypes, groups, allDay) {
         .replace("{{church}}", churchTz)
         .replace("{{browser}}", browserTz);
       tzNoticeMarkup = `
-    <div class="small mb-3 text-warning-emphasis">
+    <div id="eventTzNotice" class="small mb-3 text-warning-emphasis ${allDay ? "d-none" : ""}">
       <i class="ti ti-alert-triangle me-1 text-warning"></i>${escapeHtml(hintText)}
     </div>`;
     }
@@ -335,7 +335,6 @@ function renderEditorFields(event, calendars, eventTypes, groups, allDay) {
         </div>
       </div>
     </div>
-    ${tzNoticeMarkup}
     <div class="mb-2">
       <div class="form-selectgroup form-selectgroup-pills">
         <label class="form-selectgroup-item">
@@ -359,6 +358,7 @@ function renderEditorFields(event, calendars, eventTypes, groups, allDay) {
         <input type="${inputType}" id="eventEndDate" class="form-control" value="${endVal}" autocomplete="off" ${startVal ? `min="${startVal}"` : ""}>
       </div>
     </div>
+    ${tzNoticeMarkup}
 
     <div class="mb-3">
       <label class="form-label" for="quill-Desc">${t("Description")}</label>
@@ -635,6 +635,15 @@ export function renderEventEditor(container, event, calendars, eventTypes, optio
       startInput.value = formatDateForInput(event.Start, nowAllDay);
       endInput.value = formatDateForInput(event.End, nowAllDay);
       endInput.min = startInput.value || "";
+
+      // Show/hide the cross-tz reminder — only meaningful for timed events.
+      // Markup is rendered once with d-none toggled here so we don't have to
+      // re-render the whole form on every toggle.
+      const tzNotice = document.getElementById("eventTzNotice");
+      if (tzNotice) {
+        tzNotice.classList.toggle("d-none", nowAllDay);
+      }
+
       fireValidity();
     });
   }

--- a/webpack/kiosk/kiosk-jsom.ts
+++ b/webpack/kiosk/kiosk-jsom.ts
@@ -548,20 +548,32 @@ function heartbeat(): void {
     if (data.Accepted) {
       const Assignment = parseAssignment(data.Assignment);
       if (Assignment && Assignment.AssignmentType === 1) {
+        // Event.Start / End / CheckInOpensAt are ISO 8601 strings with the
+        // church's sTimeZone offset (set by KioskDevice::heartbeat). moment
+        // parses them as instants-in-time, so all comparisons below are
+        // tz-correct regardless of the kiosk device's browser timezone.
+        // CheckInOpensAt = event start − 1 hour (server-computed) so check-in
+        // opens before the event actually starts. Falls back to event start
+        // − 1 hour for older API responses without the field.
         const eventStart = moment(Assignment.Event.Start);
         const eventEnd = moment(Assignment.Event.End);
+        const checkInOpensAt = Assignment.Event.CheckInOpensAt
+          ? moment(Assignment.Event.CheckInOpensAt)
+          : eventStart.clone().subtract(1, "hour");
         const now = moment();
 
         $("#eventTitle").text(Assignment.Event.Title);
         $("#startTime").text(eventStart.format("MMMM Do YYYY, h:mm:ss a"));
         $("#endTime").text(eventEnd.format("MMMM Do YYYY, h:mm:ss a"));
 
-        if (now.isBefore(eventStart)) {
-          // Event hasn't started yet - show countdown
+        if (now.isBefore(checkInOpensAt)) {
+          // Check-in hasn't opened yet (event start is still > 1 hour away).
+          // Show countdown to checkInOpensAt so volunteers know when the
+          // kiosk will become usable.
           $("#noEvent").hide();
           $("#event").show();
-          $("#classMemberContainer").html(renderCountdown(eventStart, Assignment.Event.Title));
-          startCountdown(eventStart);
+          $("#classMemberContainer").html(renderCountdown(checkInOpensAt, Assignment.Event.Title));
+          startCountdown(checkInOpensAt);
         } else if (now.isAfter(eventEnd)) {
           // Event has ended
           $("#noEvent").hide();

--- a/webpack/kiosk/types.ts
+++ b/webpack/kiosk/types.ts
@@ -58,6 +58,9 @@ export interface KioskAssignment {
     Title: string;
     Start: string;
     End: string;
+    /** Server-computed: event start − 1 hour, ISO 8601 with sTimeZone offset.
+     *  Marks when the kiosk transitions from countdown to active check-in. */
+    CheckInOpensAt?: string;
     GroupId?: number;
   };
 }


### PR DESCRIPTION
## Summary

Comprehensive timezone fix for users whose browser tz differs from the church's configured `sTimeZone` (e.g. PST admin managing a Detroit church). Started as 3 reported bugs, grew to cover every cross-tz surface in the event editor / calendar / kiosk. Backward-compatible with all existing data.

## Bugs fixed

| Surface | Before | After |
|---------|--------|-------|
| **Event editor — save** | `moment(value).format()` sent local+offset OR `toISOString()` sent UTC; both broke wall-clock-in-sTimeZone storage | Naive wall-clock strings round-trip verbatim |
| **Event editor — open existing** | `new Date(propelString)` parsed Propel space format as UTC in Chrome; edit modal showed times shifted by browser offset | `toWallClockString` strips space/offset/microseconds before any `new Date()`; numbers preserved |
| **Calendar cell click** | FullCalendar's `info.start` (midnight UTC) read with browser-local `getDate()`/`getHours()` → April 24 click opened April 23 5 PM in PDT | `info.startStr` (calendar tz) used directly |
| **Move/resize confirm modal** | `evt.start.toLocaleString()` (browser tz) showed 11 PM as 8 PM PDT — or 4 PM with the FC marker re-shift | `Intl.DateTimeFormat` reads FC markers as UTC components |
| **Today highlight** | Stayed on the browser's "today" instead of advancing to church's "today" | Custom `now` Date computed from church-tz components |
| **Kiosk countdown** | Event.Start in Propel space format → moment parsed as device-local (4h late on PDT kiosk for Detroit church) | Server emits ISO + sTimeZone offset; moment parses as instant |
| **Kiosk open time** | Opened exactly at event start | Now opens 1 hour before (server-side `CheckInOpensAt` = start − 1h) |
| **Editor copy** | "won't appear on any calendar view" was false | "will appear under the 'Unpinned Events' system calendar until you pin it" |

## Architecture

**Storage convention** (unchanged): wall-clock-in-sTimeZone in MySQL DATETIME — matches all 75+ existing events, no migration.

**Editor** (`webpack/event-form.js`): `event.Start` / `event.End` are now church wall-clock STRINGS throughout (`YYYY-MM-DDTHH:mm:ss` or `YYYY-MM-DD`). Never JS Date in date logic. All conversions at boundaries via `Intl.DateTimeFormat` with `timeZone: sTimeZone` or string-stripping helpers (`toWallClockString`, `toWallClockDate`).

**Calendar** (`webpack/event-calendars.js`): FullCalendar gets `now: churchNow` (computed from church-tz Intl parts) so "today" highlighting reflects the church's day. Move/resize modal formats FC markers with `timeZone: "UTC"` (markers encode wall-clock in UTC components). Drag-drop sends `stripTz(evt.startStr)`.

**Kiosk** (`KioskDevice::heartbeat()` + `kiosk-jsom.ts`): server now emits `Event.Start`/`End` as ISO 8601 with sTimeZone offset (was Propel space format). Adds new `Event.CheckInOpensAt = Event.Start − 1 hour` (server-side computation). Kiosk JS counts down to `CheckInOpensAt`, falls back to `start − 1h` for backward compat.

## UX additions

- **Cross-tz reminder** in the editor — only when `Intl.DateTimeFormat().resolvedOptions().timeZone !== sTimeZone`. Quiet single-line muted hint with a yellow ⚠️ icon, placed just under the Start/End date inputs. Shows for timed events only (all-day has no time component); appears/disappears live as the user toggles Timed ↔ All Day.
- **Timed-default time** changed from "current church-time hour" (1 AM at night = confusing) to a sensible 9 AM start / 10 AM end church default; preserves any existing non-zero time.

## Files changed

| File | Change |
|------|--------|
| `webpack/event-form.js` | Refactor to wall-clock strings; Intl-based formatters; tz banner |
| `webpack/event-calendars.js` | `now: churchNow`; move-modal Intl formatter; drag-drop `stripTz` |
| `webpack/calendar-event-editor.js` | `showEventForm` uses `toWallClockString` (no `new Date`); `showNewEventForm` uses `info.startStr`/`endStr` |
| `webpack/kiosk/kiosk-jsom.ts` | Counts down to `CheckInOpensAt` instead of event start |
| `webpack/kiosk/types.ts` | `KioskAssignment.Event.CheckInOpensAt?: string` |
| `src/ChurchCRM/model/ChurchCRM/KioskDevice.php` | `heartbeat()` enriches Event with ISO+offset Start/End/CheckInOpensAt |

## Backward compatibility

- Storage convention unchanged (wall-clock-in-sTimeZone in MySQL DATETIME).
- No PHP server changes beyond the kiosk heartbeat enrichment.
- No Bootstrapper / config changes.
- No DB migrations.
- All 75+ historical events display correctly.

## Release urgency

Two of the underlying bugs ship in current releases:
- Edit-modal display shift: in **7.1.2 → 7.2.2** (since 2026-04-06)
- UTC save shift: in **7.2.2** (since 2026-04-22)

Recommend a quick **7.2.3** ship.

## Closes
Closes #8791

## Testing
- [x] Click on a calendar date cell → editor shows that date
- [x] All-day click → "All Day" toggle selected, banner hidden
- [x] Toggle to Timed → defaults to 9 AM, banner appears under date inputs
- [x] Save timed event → reopen → same time
- [x] Edit existing event → input fields show same time across modal + viewer + editor
- [x] Drag-drop event → confirm modal shows correct church time
- [x] Calendar's "today" highlight on the church's day, not browser's
- [x] Kiosk opens 1 hour before event start
- [x] Kiosk countdown correct on devices in different tz than church
- [x] "No calendar selected" hint no longer claims event will be invisible
- [x] `npm run lint` passes (0 warnings)
- [x] `npm run build:webpack` passes
- [x] `npm run build:php` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)