### PR TITLE
fix(event-checkin): roster avatars, badge contrast, clickable names

### DIFF
--- a/src/event/views/checkin.php
+++ b/src/event/views/checkin.php
@@ -100,7 +100,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
                     <span id="rosterGroupName" class="text-secondary"></span>
                 </h3>
                 <div class="d-flex align-items-center gap-2">
-                    <span class="badge bg-primary" id="rosterStats"></span>
+                    <span class="badge bg-primary-lt text-primary" id="rosterStats"></span>
                     <button type="button" class="btn btn-sm btn-success" id="checkinAllBtn">
                         <i class="ti ti-checks me-1"></i><?= gettext('Check In All') ?>
                     </button>

--- a/src/event/views/checkin.php
+++ b/src/event/views/checkin.php
@@ -118,7 +118,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
                 <div class="col-md-6 pe-md-2">
                     <h4 class="text-secondary mb-2">
                         <i class="ti ti-clock me-1"></i><?= gettext('Waiting to Check In') ?>
-                        <span class="badge bg-secondary ms-1" id="notCheckedInCount">0</span>
+                        <span class="badge bg-secondary text-white ms-1" id="notCheckedInCount">0</span>
                     </h4>
                     <div id="notCheckedInList" class="d-flex flex-column gap-1"></div>
                     <div id="notCheckedInEmpty" class="text-center text-success py-3 d-none">
@@ -128,7 +128,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
                 <div class="col-md-6 ps-md-2 mt-3 mt-md-0">
                     <h4 class="text-secondary mb-2">
                         <i class="ti ti-circle-check me-1"></i><?= gettext('Checked In') ?>
-                        <span class="badge bg-success ms-1" id="checkedInCount">0</span>
+                        <span class="badge bg-success text-white ms-1" id="checkedInCount">0</span>
                     </h4>
                     <div id="checkedInList" class="d-flex flex-column gap-1"></div>
                     <div id="checkedInEmpty" class="text-center text-secondary py-3 d-none">

--- a/webpack/event-checkin.js
+++ b/webpack/event-checkin.js
@@ -280,6 +280,13 @@ function loadRoster(eventId) {
       // Show the grid, hide loading
       $("#rosterLoading").addClass("d-none");
       $("#rosterGrid").removeClass("d-none");
+
+      // avatar-loader's IntersectionObserver was wired up at DOMContentLoaded,
+      // so the <img data-image-entity-type> elements we just appended need to
+      // be re-observed. init() is idempotent (already-loaded images skip via
+      // the src-already-set guard) and does NOT clear the info cache, so it's
+      // cheaper than refresh() on repeat roster reloads.
+      window.CRM?.avatarLoader?.init();
     })
     .catch(() => {
       $("#rosterCheckin").addClass("d-none");

--- a/webpack/event-checkin.js
+++ b/webpack/event-checkin.js
@@ -299,20 +299,29 @@ function buildMemberCard(member, eventId) {
   const btnText = isCheckedIn ? i18next.t("Check Out") : i18next.t("Check In");
   const action = isCheckedIn ? "checkout" : "checkin";
 
-  const roleBadge = member.role ? `<span class="badge bg-blue-lt ms-2">${escapeHtml(member.role)}</span>` : "";
+  // bg-blue-lt with no companion text-blue fails WCAG AA contrast in Tabler.
+  // Pair the soft background with the matching text color for the same hue.
+  const roleBadge = member.role
+    ? `<span class="badge bg-blue-lt text-blue ms-2">${escapeHtml(member.role)}</span>`
+    : "";
 
-  const photoHtml = member.hasPhoto
-    ? '<span class="avatar avatar-sm me-2" style="background-image: url(' +
-      window.CRM.root +
-      "/api/person/" +
-      member.personId +
-      '/photo)"></span>'
-    : '<span class="avatar avatar-sm me-2 bg-primary-lt"><i class="ti ti-user"></i></span>';
+  // Use the standard avatar-loader contract (data-image-entity-type/-id) so
+  // the shared loader handles fallbacks (Gravatar, identicons, default
+  // placeholder) consistently with the rest of the app. The previous direct
+  // background-image hack bypassed the loader and produced empty squares.
+  const photoHtml =
+    '<img data-image-entity-type="person" data-image-entity-id="' +
+    member.personId +
+    '" class="avatar avatar-sm rounded-circle me-2" alt="" />';
 
   let timeInfo = "";
   if (isCheckedIn && member.checkinTime) {
     timeInfo = `<small class="text-secondary ms-2">${escapeHtml(member.checkinTime)}</small>`;
   }
+
+  // Make the name a link to PersonView, matching the bottom "People Checked In"
+  // table. text-reset + text-decoration-none keep the visual weight unchanged.
+  const personUrl = `${window.CRM.root}/PersonView.php?PersonID=${member.personId}`;
 
   const html =
     '<div class="d-flex align-items-center justify-content-between p-2 border rounded roster-member" data-person-id="' +
@@ -320,9 +329,11 @@ function buildMemberCard(member, eventId) {
     '">' +
     '<div class="d-flex align-items-center">' +
     photoHtml +
-    '<span class="fw-medium">' +
+    '<a class="fw-medium text-reset text-decoration-none" href="' +
+    personUrl +
+    '">' +
     escapeHtml(`${member.firstName} ${member.lastName}`) +
-    "</span>" +
+    "</a>" +
     roleBadge +
     timeInfo +
     "</div>" +


### PR DESCRIPTION
## Summary

Five small UX bugs in the Group Roster section of the event check-in page (`/event/checkin/{id}`):

1. **Broken avatars (raw photo URL)** — empty squares instead of person photos
2. **Avatar fallbacks not loading** — switching to the avatar-loader contract didn't trigger the loader on dynamically appended cards (caught by Copilot review)
3. **Role badge contrast** — "Member" / "Student" / "Teacher" badges fail WCAG AA
4. **Count badge contrast** — "Waiting to Check In" / "Checked In" count chips were `bg-secondary` / `bg-success` without `text-white`, leaving the number low-contrast against the colored chip
5. **Names not clickable** — should link to PersonView like the table below

Plus a bonus fix for the "X / Y checked in" stat badge that was visually clashing with the adjacent green "Check In All" button.

## Root causes

| Bug | Cause | Fix |
|-----|-------|-----|
| Empty avatars (raw photo URL) | `<span style="background-image: url(/api/person/N/photo)">` bypassed the shared `avatar-loader` and its Gravatar/identicon/default fallbacks | Use the standard `<img data-image-entity-type="person" data-image-entity-id="N">` contract |
| Empty avatars (loader not triggered) | `avatar-loader.init()` only observes images present at `DOMContentLoaded`. Roster cards are appended after a fetch in `loadRoster()`, so the new `<img>` elements were never observed and stayed unloaded | Call `window.CRM?.avatarLoader?.init()` at the end of `loadRoster()`. `init()` is idempotent and does not clear the avatar info cache (unlike `refresh()`), so repeat reloads don't burn extra round-trips |
| Role badge contrast | `bg-blue-lt` without companion `text-blue` (Tabler's soft-bg pattern requires both) | Added `text-blue` |
| Count badge contrast | `bg-secondary` / `bg-success` without `text-white` — the body color inherits, which lands dark-on-grey / dark-on-green and the number is barely legible | Added `text-white` to both. Matches MEMORY.md badge rule: counts need `text-white`, labels need `bg-{color}-lt text-{color}` |
| Names not clickable | Plain `<span class="fw-medium">` | Wrapped in `<a href="PersonView.php?PersonID=N" class="text-reset text-decoration-none">` matching the bottom "People Checked In" table |
| Stat badge clash | `bg-primary` (saturated blue + white text) competed with the adjacent green CTA | Switched to `bg-primary-lt text-primary` so it reads as a stat label |

## Files

| File | Change |
|------|--------|
| `webpack/event-checkin.js` | `buildMemberCard()` — avatar contract, role badge `text-blue`, name link. `loadRoster()` — re-init avatar-loader after appending cards |
| `src/event/views/checkin.php` | Stat badge: `bg-primary` → `bg-primary-lt text-primary`. Count badges: added `text-white` to `bg-secondary` / `bg-success` chips |

## Testing
- [x] Open `/event/checkin/{id}` for a group-linked event with rostered members
- [x] Avatars show person photos, Gravatars, or generated initials — never empty squares
- [x] Role badges ("Member", "Student", "Teacher") have readable contrast
- [x] "Waiting to Check In" / "Checked In" count chips have legible numbers
- [x] Clicking a member name opens their PersonView
- [x] "X / Y checked in" stat badge no longer clashes with the green CTA
- [x] After a check-in/check-out, roster re-renders and avatars still load (init() is idempotent, no cache clear)
- [x] `npm run lint` passes
- [x] `npm run build:webpack` passes
- [x] `npm run build:php` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
