### PR TITLE
fix(kiosk): photo + family routes 403 every roster member (array_column trap)

### DIFF
--- a/src/kiosk/routes/device.php
+++ b/src/kiosk/routes/device.php
@@ -298,7 +298,14 @@ $app->group('/device', function (RouteCollectorProxy $group) use ($getKioskFromC
         }
 
         // Verify the person is in the active class roster
-        $rosterIds = array_map('intval', array_column($assignment->getActiveGroupMembers(), 'PersonId'));
+        // array_column() returns zeros on a Propel ObjectCollection (it reads
+        // public props/array keys, not ORM getters), which silently 403s every
+        // photo/family request with a confusing "not in roster" error. Iterate
+        // and call ->getId() instead. See PR #8706 history; same trap recurred.
+        $rosterIds = [];
+        foreach ($assignment->getActiveGroupMembers() as $member) {
+            $rosterIds[] = (int) $member->getId();
+        }
         if (!in_array($personId, $rosterIds, true)) {
             return SlimUtils::renderErrorJSON($response, gettext('Person not in active class roster'), [], 403);
         }
@@ -325,7 +332,14 @@ $app->group('/device', function (RouteCollectorProxy $group) use ($getKioskFromC
         // Verify the requested person is actually part of the kiosk's
         // active class roster — prevents enumeration outside the assigned
         // group's members.
-        $rosterIds = array_map('intval', array_column($assignment->getActiveGroupMembers(), 'PersonId'));
+        // array_column() returns zeros on a Propel ObjectCollection (it reads
+        // public props/array keys, not ORM getters), which silently 403s every
+        // photo/family request with a confusing "not in roster" error. Iterate
+        // and call ->getId() instead. See PR #8706 history; same trap recurred.
+        $rosterIds = [];
+        foreach ($assignment->getActiveGroupMembers() as $member) {
+            $rosterIds[] = (int) $member->getId();
+        }
         if (!in_array($personId, $rosterIds, true)) {
             return SlimUtils::renderErrorJSON($response, gettext('Person not in active class roster'), [], 403);
         }


### PR DESCRIPTION
## Summary

Kiosk shows broken images for every class member who has a stored photo. The kiosk's `/activeClassMember/{PersonId}/photo` and `/family` endpoints both 403 with \"Person not in active class roster\" — even when the person IS on the roster.

## Root cause

Both routes gate access via:

\`\`\`php
\$rosterIds = array_map('intval',
    array_column(\$assignment->getActiveGroupMembers(), 'PersonId'));
if (!in_array(\$personId, \$rosterIds, true)) { return 403; }
\`\`\`

\`getActiveGroupMembers()\` returns a Propel \`PersonCollection\` of **\`Person\` ORM objects** (verified). \`array_column()\` reads public props / array keys; on ORM objects (IDs are protected, accessed via \`getId()\`) it returns nothing useful, so \`\$rosterIds\` becomes \`[]\` and every membership check fails.

This is the **same trap PR #8706 fixed in the kiosk member-list endpoint** — these two routes were missed at the time.

## Fix

Iterate the collection and call \`->getId()\`:

\`\`\`php
\$rosterIds = [];
foreach (\$assignment->getActiveGroupMembers() as \$member) {
    \$rosterIds[] = (int) \$member->getId();
}
\`\`\`

Applied identically to both \`/photo\` (line ~301) and \`/family\` (line ~328) handlers.

## Files

| File | Change |
|------|--------|
| \`src/kiosk/routes/device.php\` | 2 occurrences: \`array_column()\` → \`foreach + ->getId()\` |

## Testing
- [x] Open the kiosk and verify class members with stored photos show their photos (not broken-image placeholders)
- [x] Verify class members without photos still show the FA fallback silhouette
- [x] Verify the family lookup endpoint still returns 403 for personIds NOT in the active class roster (security check still intact)
- [x] \`npm run build:php\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)