### PR TITLE
fix(calendar): hover tooltip on long event titles

### DIFF
--- a/webpack/event-calendars.js
+++ b/webpack/event-calendars.js
@@ -522,6 +522,16 @@ function initializeCalendar() {
         window.CRM.notify(parts.join(" · "), { type: "info", delay: 10000, close: true });
       }
     },
+    eventDidMount: (info) => {
+      // Long event titles get clipped by FullCalendar's default
+      // `overflow:hidden;text-overflow:ellipsis` styling on month-grid events.
+      // Set the native HTML `title` attribute so hovering reveals the full
+      // text via a browser tooltip — no JS dependency, accessible by default.
+      // Closes #8792.
+      if (info.event.title) {
+        info.el.setAttribute("title", info.event.title);
+      }
+    },
     loading: (isLoading) => {
       window.CRM.isCalendarLoading = isLoading;
     },


### PR DESCRIPTION
## Summary

Closes #8792 — long event titles on the calendar month-grid get clipped with `…` and there's no way to see the full text without clicking the event. Added a hover tooltip showing the full title.

## Approach

Single FullCalendar `eventDidMount` hook in `webpack/event-calendars.js`:

\`\`\`js
eventDidMount: (info) => {
  if (info.event.title) {
    info.el.setAttribute(\"title\", info.event.title);
  }
},
\`\`\`

Sets the native HTML \`title\` attribute on every rendered event element so the browser shows its built-in tooltip on hover. Zero JS dependency, accessible by default, works on every view.

## Why tooltip vs CSS wrap

Issue #8792's acceptance criteria: \"Long event titles either wrap onto a second line within the calendar cell **OR** show a tooltip on hover revealing the full title.\" Tooltip approach was preferred because:

- Wrapping on month-grid expands cell heights — affects layout of every day with long-titled events
- Native \`title\` is keyboard- and screen-reader-accessible by default
- Smaller, lower-risk diff (10 LOC)

## Background

A previous attempt at this fix lived on the unmerged local branch \`fix/8792-8791-calendar-title-tooltip-and-tz-fix\` (no PR was opened). Ported just the \`eventDidMount\` portion — the #8791 part of that branch already shipped in PR #8806 (timezone refactor).

## Files

| File | Change |
|------|--------|
| \`webpack/event-calendars.js\` | +10 LOC \`eventDidMount\` hook |

## Testing
- [x] Hover a long-titled event on the calendar month view → browser tooltip shows full title
- [x] Hover a short-titled event → tooltip still shows (matches title text — harmless)
- [x] Works in time-grid week / day views and list view
- [x] \`npm run lint\` passes
- [x] \`npm run build:webpack\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)