### PR TITLE
fix(plugins): TomSelect multiselect saves array indices instead of values

### DIFF
--- a/src/plugins/views/management.php
+++ b/src/plugins/views/management.php
@@ -708,7 +708,8 @@ $(document).ready(function() {
                 settings[key] = value;
             } else if (input.is('select[multiple]')) {
                 const ts = input[0].tomselect;
-                const vals = ts ? Object.keys(ts.items) : input.val();
+                // ts.items is an Array — Object.keys gives indices not values; use getValue()
+                const vals = ts ? ts.getValue() : input.val();
                 settings[key] = Array.isArray(vals) ? vals.join(',') : (vals || '');
             } else if (input.hasClass('plugin-checkboxes')) {
                 const groupKey = input.data('setting-key');
@@ -765,7 +766,8 @@ $(document).ready(function() {
                 settings[key] = input.is(':checked') ? '1' : '0';
             } else if (input.is('select[multiple]')) {
                 const ts = input[0].tomselect;
-                const vals = ts ? Object.keys(ts.items) : input.val();
+                // ts.items is an Array — Object.keys gives indices not values; use getValue()
+                const vals = ts ? ts.getValue() : input.val();
                 settings[key] = Array.isArray(vals) ? vals.join(',') : (vals || '');
             } else if (input.hasClass('plugin-checkboxes')) {
                 const groupKey = input.data('setting-key');


### PR DESCRIPTION
## Summary

Plugin settings of type \`multiselect\` (currently only the Holidays plugin's country picker) save the TomSelect Array's **numeric indices** (\`\"0,1,2\"\`) instead of the actual selected values (\`\"USA,Canada,Mexico\"\`).

## Visible impact (Holidays plugin)

- **Country dropdown didn't keep selection** on next page load: rendered \`<option>\` matched against \`\"0,1,2\"\` → no match → nothing selected.
- **Calendar page showed \"Holidays (1)\", \"Holidays (2)\"** instead of \"Holidays (USA)\", \"Holidays (Canada)\" because the indices were fed to \`HolidayCalendarProvider\` as Yasumi country class names.

## Root cause

Both call sites in \`src/plugins/views/management.php\` used:

\`\`\`js
const vals = ts ? Object.keys(ts.items) : input.val();
\`\`\`

\`tomselect.items\` is a JavaScript **Array** of selected value strings — not an Object — so \`Object.keys(arr)\` returns the array's numeric indices (\`[\"0\", \"1\", \"2\"]\`) instead of the values.

## Fix

Use TomSelect's documented \`getValue()\` API (also matches the existing memory rule \"TomSelect value reads — never \`option:selected\`, use \`el.tomselect.getValue()\`\").

\`\`\`js
const vals = ts ? ts.getValue() : input.val();
\`\`\`

Two occurrences fixed identically (form submit handler + dirty-check helper).

## Bug history

Introduced in commit \`78fd311d2\` (2026-04-24, on master via PR #8665) — ironically titled \"fix(holidays): fix ... TomSelect read ...\". The fix attempt that intended to read TomSelect values instead broke them. **Not in any released tag** — only affects users running master.

## Bad data cleanup (dev only)

Local dev DBs that hit the bug should clear bad rows from \`config_cfg\` before reconfiguring the affected plugin. No production impact since this never released.

## Files

| File | Change |
|------|--------|
| \`src/plugins/views/management.php\` | 2 × \`Object.keys(ts.items)\` → \`ts.getValue()\` |

## Testing
- [x] Open Holidays plugin settings → select 2-3 countries → save
- [x] Reload page → countries still selected
- [x] Verify \`config_cfg.cfg_value\` for \`plugin.holidays.countries\` contains the country names (not indices)
- [x] Visit calendar → calendar list shows \"Holidays (USA)\", \"Holidays (Canada)\" etc.
- [x] \`npm run build:php\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)