### PR TITLE
fix(locale-workflow): skip PR only when POT-Creation-Date is the only diff

### DIFF
--- a/.github/workflows/locale-update.yml
+++ b/.github/workflows/locale-update.yml
@@ -81,16 +81,19 @@ jobs:
             exit 0
           fi
           
-          # Check if changes are only in the header (first 20 lines typically contain headers)
-          # We'll check if there are changes beyond line 25 to be safe
-          CHANGES=$(git diff -- "$PO_FILE" | grep -E '^\+[^+]|^\-[^-]' | tail -n +25 | wc -l)
-          
+          # Skip PR only when the diff is purely auto-bumped header timestamps.
+          # Previous tail -n +25 heuristic silently dropped small valid changes.
+          CHANGES=$(git diff -- "$PO_FILE" \
+            | grep -E '^\+[^+]|^\-[^-]' \
+            | grep -vE '^[+-]"(POT-Creation-Date|PO-Revision-Date):' \
+            | wc -l)
+
           if [ "$CHANGES" -gt 0 ]; then
             echo "has_changes=true" >> $GITHUB_OUTPUT
             echo "Meaningful changes detected: $CHANGES lines"
           else
             echo "has_changes=false" >> $GITHUB_OUTPUT
-            echo "Only header changes detected, skipping PR creation"
+            echo "Only POT-Creation-Date/PO-Revision-Date changed, skipping PR creation"
           fi
       
       - name: Configure Git


### PR DESCRIPTION
## Summary

The locale-update workflow's "Check for meaningful changes" step used a brittle line-position heuristic (`tail -n +25`) that silently dropped small but valid translation changes. Translators never saw new strings shipped in small commits.

## Root cause

Workflow line 86 (before):

```bash
CHANGES=$(git diff -- "$PO_FILE" | grep -E '^\+[^+]|^\-[^-]' | tail -n +25 | wc -l)
```

This:
1. Greps `+`/`-` lines from the diff
2. **Skips the first 24 lines** assuming they're all PO header fields
3. Counts what's left

Problem: a commit adding **1 new translatable string** produces only **~4 +/- diff lines total** (2 header timestamp updates + 2 for the new `msgid`/`msgstr`). 4 < 25 → tail returns nothing → `has_changes=false` → **PR never created**.

Real-world impact: every commit that added a small handful of strings silently produced no locale-update PR. The user reported "skipping uploading valid files" — exactly this.

## Fix

Filter out only the header lines `xgettext` actually auto-bumps on every run (`POT-Creation-Date`, `PO-Revision-Date`) by content match. Any other `+`/`-` line is a real change.

```bash
CHANGES=$(git diff -- "$PO_FILE" \
  | grep -E '^\+[^+]|^\-[^-]' \
  | grep -vE '^[+-]"(POT-Creation-Date|PO-Revision-Date):' \
  | wc -l)
```

## Tested

| Scenario | Old logic | New logic |
|---|---|---|
| Header-only timestamp bump (no real change) | Skip ✓ | Skip ✓ (count=0) |
| 1 new translatable string + timestamp bump | **Skip ✗** | Create PR ✓ (count=2) |
| 50 string changes | Create PR ✓ | Create PR ✓ |

## Files

| File | Change |
|------|--------|
| `.github/workflows/locale-update.yml` | Replace `tail -n +25` heuristic with content-based filter; update skip-message wording |

🤖 Generated with [Claude Code](https://claude.com/claude-code)