### PR TITLE
feat: add meeting-outlines community plugin to allowlist

### DIFF
--- a/src/plugins/approved-plugins.json
+++ b/src/plugins/approved-plugins.json
@@ -16,7 +16,7 @@
     "notes": "optional free-form notes shown to admins on the install screen"
   },
   "schemaVersion": 2,
-  "updatedAt": "2026-04-24",
+  "updatedAt": "2026-04-28",
   "plugins": [
     {
       "id": "hello-world",
@@ -32,6 +32,21 @@
       "homepage": "https://github.com/ChurchCRM/community-plugin-hello-world",
       "reviewedAt": "2026-04-24",
       "notes": "Reference implementation plugin. Safe to install on any ChurchCRM instance."
+    },
+    {
+      "id": "meeting-outlines",
+      "name": "Meeting Outlines",
+      "version": "1.0.1",
+      "downloadUrl": "https://github.com/huckjs-sys/meeting-outlines/releases/download/v1.0.1/meeting-outlines-1.0.1.zip",
+      "sha256": "ebf5a6524a486126be2c80c16a11b554e37f7787757a81014d6a45794a7e922f",
+      "risk": "low",
+      "riskSummary": "Downloads Bible texts from api.getbible.net for printing and loads SortableJS from cdn.jsdelivr.net for drag-and-drop reordering.",
+      "permissions": ["network.outbound", "network.inbound", "db.read", "db.write", "email.send"],
+      "minimumCRMVersion": "7.0.0",
+      "author": "Eoles Conseil",
+      "homepage": "https://github.com/huckjs-sys/meeting-outlines",
+      "reviewedAt": "2026-04-28",
+      "notes": "Outbound HTTPS only to api.getbible.net (Bible text downloads) and cdn.jsdelivr.net (SortableJS CDN). All file writes confined to data/text/ inside the plugin directory."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds the **Meeting Outlines** community plugin (\`meeting-outlines\` v1.0.1) to \`src/plugins/approved-plugins.json\`. The plugin lets churches build, edit, print and email weekly meeting programs.

- Source: https://github.com/huckjs-sys/meeting-outlines
- Release: https://github.com/huckjs-sys/meeting-outlines/releases/tag/v1.0.1
- SHA-256: \`ebf5a6524a486126be2c80c16a11b554e37f7787757a81014d6a45794a7e922f\`
- Risk: **low**

## Capability inventory

| Capability tag | Where in code | What it does |
|---|---|---|
| \`network.outbound\` | \`src/MeetingOutlinesPlugin.php:416\` | HTTPS GET to \`api.getbible.net\` to download Bible texts on admin demand |
| \`network.outbound\` | \`views/edit.php:413\` | Loads \`SortableJS\` from \`cdn.jsdelivr.net\` for drag-and-drop reordering |
| \`network.inbound\` | \`routes/routes.php\` | Exposes Slim routes under \`/plugins/meeting-outlines/...\` (admin-only via inherited middleware) |
| \`db.read\` | \`src/MeetingOutlinesPlugin.php\` | Reads \`person_per\` and groups via configured group IDs to populate Preacher/Responsible dropdowns |
| \`db.write\` | \`src/MeetingOutlinesPlugin.php\` | CRUD on plugin-owned tables: meetings, meeting items, meeting types |
| \`email.send\` | \`src/MeetingOutlinesPlugin.php\` | Sends meeting outline notification to assigned participants via the CRM SMTP config |

No \`fs.write\` is declared because all file writes (\`data/text/<version>/<book>.json\`) stay inside the plugin directory, per the security-scan definition.

## Plugin scanner output

Run on the release zip contents:

\`\`\`
errors:   0
warnings: 1
infos:    3
Result: PASS with warnings
\`\`\`

### Warning justification

\`src/MeetingOutlinesPlugin.php:377\` — \`file_put_contents()\`. This call writes downloaded Bible verse text to \`data/text/<version>/<book>.json\` inside the plugin directory. The path is built from a known set of 66 Bible book codes and a 3-letter version code, both validated against an internal allowlist. No user input reaches the path argument.

### Outbound hostnames covered by \`riskSummary\`

- \`api.getbible.net\` — Bible texts source (admin-initiated downloads only)
- \`cdn.jsdelivr.net\` — SortableJS UMD bundle (page asset)

## Vulnerability disclosure

Issues and security reports are accepted at https://github.com/huckjs-sys/meeting-outlines/issues. A \`SECURITY.md\` will be added to the plugin repo on next push.

## Test plan

- [ ] Maintainer re-runs \`php scripts/plugin-scan.php\` against the zip
- [ ] Maintainer downloads zip and verifies SHA-256 matches the registry entry
- [ ] Smoke test install via the URL installer on a 7.0.0+ instance