### PR TITLE
Fix issue #4347: Honor sDefaultCountry on CSV import

### DIFF
--- a/cypress/e2e/ui/admin/admin.csvimport.spec.js
+++ b/cypress/e2e/ui/admin/admin.csvimport.spec.js
@@ -302,7 +302,7 @@ describe(
 
                 const idByName = {};
                 personsGroup.children.forEach((child) => {
-                    const match = child.uri.match(/PersonID=(\d+)/);
+                    const match = child.uri.match(/\/people\/view\/(\d+)/);
                     if (match) idByName[child.text.split(" ")[0]] = match[1];
                 });
 

--- a/cypress/e2e/ui/admin/admin.csvimport.spec.js
+++ b/cypress/e2e/ui/admin/admin.csvimport.spec.js
@@ -280,5 +280,64 @@ describe(
                 });
             });
         });
+
+        it("Verify CSV Import applies sDefaultCountry when row Country is missing/blank (issue #4347)", () => {
+            // seed.sql sets sDefaultCountry = 'United States'. Fixture mixes:
+            //  - FamilyID 300 → both rows have blank Country (Family + both Persons fall back to default)
+            //  - FamilyID 301 → first row explicit "Canada" (Family + first Person keep Canada);
+            //                   second row blank (Person falls back to default, Family stays Canada)
+            cy.visit("admin/import/csv");
+            cy.get("#csvFile").selectFile("cypress/fixtures/test_import_country.csv", { force: true });
+            cy.get("#csv-import-form").submit();
+            cy.get("#mapping-card").should("be.visible");
+            cy.get("#execute-import").click();
+            cy.get("#summary-card").should("be.visible");
+            cy.get("#summary-imported").should("not.have.text", "0");
+
+            cy.request("GET", "/api/search/CountryTest").then((response) => {
+                expect(response.status).to.eq(200);
+                const personsGroup = response.body.find((g) => g.text.startsWith("Persons"));
+                expect(personsGroup, "CountryTest persons found").to.exist;
+                expect(personsGroup.children).to.have.length.at.least(4);
+
+                const idByName = {};
+                personsGroup.children.forEach((child) => {
+                    const match = child.uri.match(/PersonID=(\d+)/);
+                    if (match) idByName[child.text.split(" ")[0]] = match[1];
+                });
+
+                const expectations = {
+                    blankFamHead:      "United States",
+                    blankFamChild:     "United States",
+                    explicitCanada:    "Canada",
+                    blankOnCanadaFam:  "United States",
+                };
+
+                Object.entries(expectations).forEach(([firstName, expectedCountry]) => {
+                    const personId = idByName[firstName];
+                    expect(personId, `imported person ${firstName} exists`).to.exist;
+                    cy.makePrivateAdminAPICall("GET", `/api/person/${personId}`, null, 200).then((resp) => {
+                        expect(resp.body.Country, `Person ${firstName} Country`).to.eq(expectedCountry);
+                    });
+                });
+
+                // Family-level: FamilyID 300 had no explicit Country on its creation row → default.
+                //               FamilyID 301's creation row had "Canada" → Canada preserved.
+                cy.makePrivateAdminAPICall("GET", `/api/person/${idByName.blankFamHead}`, null, 200).then((resp) => {
+                    const famId = resp.body.FamId;
+                    expect(famId, "blankFamHead attached to a family").to.be.greaterThan(0);
+                    cy.makePrivateAdminAPICall("GET", `/api/family/${famId}`, null, 200).then((famResp) => {
+                        expect(famResp.body.Country, "Family (blank-Country creation row) Country").to.eq("United States");
+                    });
+                });
+                cy.makePrivateAdminAPICall("GET", `/api/person/${idByName.explicitCanada}`, null, 200).then((resp) => {
+                    const famId = resp.body.FamId;
+                    expect(famId, "explicitCanada attached to a family").to.be.greaterThan(0);
+                    cy.makePrivateAdminAPICall("GET", `/api/family/${famId}`, null, 200).then((famResp) => {
+                        expect(famResp.body.Country, "Family (explicit-Canada creation row) Country").to.eq("Canada");
+                    });
+                });
+            });
+        });
     },
 );

--- a/cypress/fixtures/test_import_country.csv
+++ b/cypress/fixtures/test_import_country.csv
@@ -1,0 +1,5 @@
+FamilyID,LastName,FirstName,Address1,City,State,Zip,Country,Email
+300,CountryTest,blankFamHead,100 Oak St,Default City,TX,77777,,blankFamHead@example.com
+300,CountryTest,blankFamChild,100 Oak St,Default City,TX,77777,,blankFamChild@example.com
+301,CountryTest,explicitCanada,200 Elm St,Toronto,ON,M5H,Canada,explicitCanada@example.com
+301,CountryTest,blankOnCanadaFam,200 Elm St,Toronto,ON,M5H,,blankOnCanadaFam@example.com

--- a/src/admin/routes/api/import.php
+++ b/src/admin/routes/api/import.php
@@ -1,6 +1,7 @@
 <?php
 
 use ChurchCRM\Authentication\AuthenticationManager;
+use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\model\ChurchCRM\Family;
 use ChurchCRM\model\ChurchCRM\FamilyCustomMasterQuery;
 use ChurchCRM\model\ChurchCRM\ListOptionQuery;
@@ -621,6 +622,12 @@ $app->group('/api/import', function (RouteCollectorProxy $group): void {
             $familyPropPrompts[(int) $prop->getProId()] = (string) $prop->getProPrompt();
         }
 
+        // Fallback default country from system settings — matches the interactive
+        // Person/Family editors (PersonEditor.php, FamilyEditor.php) so rows whose
+        // CSV omits a Country aren't silently stored blank and rendered as the
+        // first country in the dropdown (Afghanistan). See issue #4347.
+        $defaultCountry = (string) SystemConfig::getValue('sDefaultCountry');
+
         try {
             foreach ($csv->getRecords() as $row) {
                 // Partition the mapping into core / person-custom / family-custom / properties
@@ -662,6 +669,10 @@ $app->group('/api/import', function (RouteCollectorProxy $group): void {
                 if (empty($data['FirstName']) || empty($data['LastName'])) {
                     $skipped++;
                     continue;
+                }
+
+                if (empty($data['Country']) && $defaultCountry !== '') {
+                    $data['Country'] = $defaultCountry;
                 }
 
                 // Resolve or create Family


### PR DESCRIPTION
## Summary
Fixes issue #4347 by honoring the configured default country (sDefaultCountry) when importing person records via CSV.

## Changes
- Fixed CSV importer to use sDefaultCountry as fallback when country is not specified in the import
- Added regression test coverage for sDefaultCountry fallback behavior
- Updated person search test URL regex to use /people/view/ format

## Why
Users expect the configured default country to be applied automatically during CSV imports instead of leaving the country field blank. This ensures data consistency with system defaults.

## Testing
- ✅ All existing tests pass
- ✅ Added regression tests for sDefaultCountry fallback (#4347)
- ✅ Test URL regex updated to match /people/view/ pattern
- Tests: `npx cypress run --spec "cypress/e2e/ui/admin/admin.csvimport.spec.js"`

## Related Issues
Fixes #4347