### PR TITLE
feat: add date display to kiosk manager event dropdown

### DIFF
--- a/src/kiosk/views/manager.php
+++ b/src/kiosk/views/manager.php
@@ -205,8 +205,16 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
               var event = window.CRM.events.futureEvents[i];
               var selected = (currentAssignment && currentAssignment.EventId === event.Id) ? 'selected' : '';
               
-              // Build event label with group name if available
+              // Build event label with date and group name if available
               var eventLabel = window.CRM.escapeHtml(event.Title);
+              
+              // Add start date if available
+              if (event.Start) {
+                  var eventDate = moment(event.Start).format('MMM D, YYYY');
+                  eventLabel += ' - ' + eventDate;
+              }
+              
+              // Add group names if available
               if (event.Groups && event.Groups.length > 0) {
                   var groupNames = event.Groups.map(function(g) { return g.Name; }).join(', ');
                   eventLabel += ' [' + window.CRM.escapeHtml(groupNames) + ']';


### PR DESCRIPTION
- Include event start date (formatted as 'MMM D, YYYY') in the Sunday School event dropdown
- Dropdown now shows: 'Event Title - Apr 12, 2025 [Class Name]'
- Uses moment.js to format date from API event data
- Resolves #8666

## What Changed
<!-- Short summary - what and why (not how) -->

Fixes #

## Type
<!-- Check one -->
- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
<!-- How to verify this works -->

## Screenshots
<!-- Only for UI changes - drag & drop images here -->
## Pre-Merge
- [ ] Tested locally
- [ ] No new warnings
- [ ] Build passes
- [ ] Backward compatible (or migration documented)