### PR TITLE
Fix issue #8896: Wrap cart handler registration in document.ready()

### DIFF
--- a/src/QueryView.php
+++ b/src/QueryView.php
@@ -277,21 +277,21 @@ function DoQuery()
                 <button type="button" id="removeResultsFromCart" class="btn btn-danger" > <?= gettext('Remove Results from Cart') ?></button>
             </div>
             <script nonce="<?= SystemURLs::getCSPNonce() ?>">
-                // Wait for locales to load before setting up cart handlers
-                // CartManager uses i18next for notifications
-                window.CRM.onLocalesReady(function() {
-                    $("#addResultsToCart").click(function () {
-                        var selectedPersons = <?= json_encode($aAddToCartIDs) ?>;
-                        window.CRM.cartManager.addPerson(selectedPersons, {
-                            showNotification: true
+                $(document).ready(function() {
+                    window.CRM.onLocalesReady(function() {
+                        $("#addResultsToCart").click(function () {
+                            var selectedPersons = <?= json_encode($aAddToCartIDs) ?>;
+                            window.CRM.cartManager.addPerson(selectedPersons, {
+                                showNotification: true
+                            });
                         });
-                    });
 
-                    $("#removeResultsFromCart").click(function(){
-                        var selectedPersons = <?= json_encode($aAddToCartIDs) ?>;
-                        window.CRM.cartManager.removePerson(selectedPersons, {
-                            confirm: true,
-                            showNotification: true
+                        $("#removeResultsFromCart").click(function(){
+                            var selectedPersons = <?= json_encode($aAddToCartIDs) ?>;
+                            window.CRM.cartManager.removePerson(selectedPersons, {
+                                confirm: true,
+                                showNotification: true
+                            });
                         });
                     });
                 });


### PR DESCRIPTION
## Summary

Fixes the unresponsive "Add Results to Cart" / "Remove Results from Cart" buttons on the Birthday (and other) query results pages.

## Root Cause

`window.CRM.onLocalesReady` is defined in `Footer.js`, which is loaded via a `<script src>` tag at the bottom of the page (inside `Footer.php`). The inline `<script>` block in `QueryView.php` called `window.CRM.onLocalesReady()` directly during page parsing — before `Footer.js` had been downloaded and executed — resulting in a silent `TypeError` that dropped both click handler registrations.

## Changes

- Wrapped the `window.CRM.onLocalesReady(...)` call in `$(document).ready()` so it runs only after all synchronous scripts (including `Footer.js` and `cart.js`) have loaded and executed.

## Why

By the time jQuery's DOM-ready callback fires, all parser-blocking `<script src>` tags are already executed, so both `window.CRM.onLocalesReady` and `window.CRM.cartManager` are guaranteed to be available.

This pattern is already used correctly in `PropertyList.php` and `DepositSlipEditor.php` — `QueryView.php` was the only legacy page that missed the outer wrapper.

## Files Changed

- `src/QueryView.php` — added `$(document).ready()` wrapper around the `onLocalesReady` call (lines 279–298)

## Testing

Run a People → Queries query that returns results (e.g. Birthday query). Confirm the "Add Results to Cart" and "Remove Results from Cart" buttons respond on click and show the success/confirmation notification.

## Related Issues

Fixes #8896

🤖 Generated with [Claude Code](https://claude.com/claude-code)