### PR TITLE
fix: Update @xmldom/xmldom to 0.9.10 - resolve Dependabot security alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2098,12 +2098,12 @@
             }
         },
         "node_modules/@xmldom/xmldom": {
-            "version": "0.8.12",
-            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
-            "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
+            "version": "0.9.10",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+            "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
             "license": "MIT",
             "engines": {
-                "node": ">=10.0.0"
+                "node": ">=14.6"
             }
         },
         "node_modules/@xtuc/ieee754": {

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "overrides": {
         "lodash": "4.18.1",
         "lodash-es": "4.18.1",
-        "@xmldom/xmldom": "0.8.12",
+        "@xmldom/xmldom": "0.9.10",
         "picomatch": "4.0.4",
         "grunt": {
             "minimatch": "3.1.4",


### PR DESCRIPTION
## Summary
Resolves 4 HIGH severity Dependabot security alerts by updating @xmldom/xmldom from 0.8.12 to 0.9.10.

## Changes
- Updated `@xmldom/xmldom` override in package.json from 0.8.12 → 0.9.10
- Regenerated package-lock.json with patched version
- The override forces the security-patched version up the transitive dependency chain

## Why
- Fixes GHSA-mp2w-4q3r-ppx7 (CVE-2026-39337): xmldom Remote Code Execution
- @xmldom/xmldom 0.8.12 is transitive via: @tabler/icons-webfont → svgtofont → svg2ttf
- Override pattern ensures consistent patched version across the entire dependency tree

## Testing
- ✅ npm install succeeded with new version
- ✅ Biome lint passed
- ✅ Verified: @xmldom/xmldom@0.9.10 overridden (npm ls @xmldom/xmldom)

## Related Issues
Closes Dependabot alerts #233, #234, #235, #236