### PR TITLE
Fix issue #8893: Pin archiver to <8.0.0 due to breaking change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2097,15 +2097,6 @@
                 "@xtuc/long": "4.2.2"
             }
         },
-        "node_modules/@xmldom/xmldom": {
-            "version": "0.8.12",
-            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
-            "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
         "node_modules/@xtuc/ieee754": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -11037,6 +11028,16 @@
             },
             "bin": {
                 "svg2ttf": "svg2ttf.js"
+            }
+        },
+        "node_modules/svg2ttf/node_modules/@xmldom/xmldom": {
+            "version": "0.8.12",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
+            "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
+            "deprecated": "this version has critical issues, please update to the latest version",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
             }
         },
         "node_modules/svg2ttf/node_modules/argparse": {

--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
         "webpack-cli": "^7.0.2"
     },
     "overrides": {
+        "archiver": "<8.0.0",
         "lodash": "4.18.1",
         "lodash-es": "4.18.1",
         "@xmldom/xmldom": "0.8.12",


### PR DESCRIPTION
## Summary
Pins archiver package to version <8.0.0 to resolve GitHub Actions build failures caused by archiver@8.0.0's breaking change with readdir-glob's minimatch import.

## Changes
- Added `"archiver": "<8.0.0"` to package.json overrides
- Prevents archiver@8.0.0 from being installed, which breaks the minimatch import used by readdir-glob

## Why
archiver@8.0.0 introduced a breaking change that causes:
```
SyntaxError: The requested module 'minimatch' does not provide an export named 'Minimatch'
```

This error occurred in GitHub Actions workflow run #25749738837 during the npm install step. The issue is in the archiver package dependency chain, not directly in ChurchCRM code.

## Related Issues
Fixes #8893