### PR TITLE
security: fix GHSA-4vj2-gm78-3q63 — restrict CSV export to admin users only

### DIFF
--- a/.agents/skills/churchcrm/cypress-testing.md
+++ b/.agents/skills/churchcrm/cypress-testing.md
@@ -1953,3 +1953,85 @@ describe("Family Activation", () => {
     it("...", () => { /* ... */ });
 });
 ```
+
+## Authorization Testing — Admin vs Standard Users <!-- learned: 2026-05-13 -->
+
+### User Types and Capabilities
+
+When testing authorization gates, use the appropriate session setup command:
+
+| Session Type | Usage | Capabilities |
+|--------------|-------|--------------|
+| `cy.setupAdminSession()` | Admin-only features | Full access to all admin pages, CSV export, system config, user management |
+| `cy.setupStandardSession()` | Standard user with basic permissions | View/edit own profile, view groups, participate in events; NO access to admin pages or system config |
+| `cy.setupNoFinanceSession()` | User without finance access | Same as standard, but no access to finance/donation records |
+
+### Authorization Test Pattern
+
+For features that require admin access, test three scenarios: admin **can** do it, standard user **cannot**, and unauthenticated user **cannot**:
+
+```js
+describe("CSV Export Authorization", () => {
+    it("should allow admin users to submit CSV export", () => {
+        cy.setupAdminSession();
+        cy.visit("/CSVExport.php");
+        cy.contains("CSV Export").should("be.visible");
+
+        cy.request({
+            method: "POST",
+            url: "/CSVCreateFile.php",
+            body: { Title: 1, FirstName: 1, ... }
+        }).then((response) => {
+            expect(response.status).to.eq(200);
+            expect(response.headers["content-type"]).to.include("text/csv");
+        });
+    });
+
+    it("should deny non-admin users access to CSVExport.php", () => {
+        cy.setupStandardSession();
+        cy.visit("/CSVExport.php", { failOnStatusCode: false });
+
+        // Standard users are redirected to session/begin (security redirect)
+        cy.url().should("include", "/session/begin");
+    });
+
+    it("should deny non-admin users POST to CSVCreateFile.php", () => {
+        cy.setupStandardSession();
+        cy.request({
+            method: "POST",
+            url: "/CSVCreateFile.php",
+            body: { Title: 1, FirstName: 1, ... },
+            failOnStatusCode: false
+        }).then((response) => {
+            // Non-admin users get 302 redirect (security redirect)
+            expect([301, 302]).to.include(response.status);
+        });
+    });
+
+    it("should deny unauthenticated access to CSVExport.php", () => {
+        cy.visit("/CSVExport.php", { failOnStatusCode: false });
+        cy.url().should("include", "/session/begin");
+    });
+
+    it("should deny unauthenticated POST to CSVCreateFile.php", () => {
+        cy.request({
+            method: "POST",
+            url: "/CSVCreateFile.php",
+            body: { Title: 1, FirstName: 1, ... },
+            failOnStatusCode: false
+        }).then((response) => {
+            // Unauthenticated users get redirect to login
+            expect([301, 302, 401]).to.include(response.status);
+        });
+    });
+});
+```
+
+### Key Rules for Authorization Testing
+
+1. **Use separate `describe` blocks per user type** when testing multiple permission levels in one file
+2. **For GET requests**, check URL redirect (e.g., `cy.url().should("include", "/session/begin")`)
+3. **For POST requests**, check HTTP status code (302 for `RedirectUtils::securityRedirect()`, 401/403 for API errors)
+4. **Always test the happy path first** (admin can do it), then test denials
+5. **Test both GET and POST paths** when a feature has both (form page + form submission)
+6. **Use `failOnStatusCode: false`** on `cy.visit()` and `cy.request()` when expecting non-2xx responses

--- a/.agents/skills/churchcrm/cypress-testing.md
+++ b/.agents/skills/churchcrm/cypress-testing.md
@@ -1991,8 +1991,8 @@ describe("CSV Export Authorization", () => {
         cy.setupStandardSession();
         cy.visit("/CSVExport.php", { failOnStatusCode: false });
 
-        // Standard users are redirected to session/begin (security redirect)
-        cy.url().should("include", "/session/begin");
+        // Authenticated non-admin users are redirected to access-denied (security redirect)
+        cy.url().should("include", "/v2/access-denied");
     });
 
     it("should deny non-admin users POST to CSVCreateFile.php", () => {
@@ -2010,7 +2010,7 @@ describe("CSV Export Authorization", () => {
 
     it("should deny unauthenticated access to CSVExport.php", () => {
         cy.visit("/CSVExport.php", { failOnStatusCode: false });
-        cy.url().should("include", "/session/begin");
+        cy.url().should("include", "/session/begin"); // unauthenticated → login page
     });
 
     it("should deny unauthenticated POST to CSVCreateFile.php", () => {
@@ -2030,7 +2030,7 @@ describe("CSV Export Authorization", () => {
 ### Key Rules for Authorization Testing
 
 1. **Use separate `describe` blocks per user type** when testing multiple permission levels in one file
-2. **For GET requests**, check URL redirect (e.g., `cy.url().should("include", "/session/begin")`)
+2. **For GET requests**, check URL redirect: authenticated non-admin → `/v2/access-denied`; unauthenticated → `/session/begin`
 3. **For POST requests**, check HTTP status code (302 for `RedirectUtils::securityRedirect()`, 401/403 for API errors)
 4. **Always test the happy path first** (admin can do it), then test denials
 5. **Test both GET and POST paths** when a feature has both (form page + form submission)

--- a/cypress/e2e/ui/admin/admin.csv-export.spec.js
+++ b/cypress/e2e/ui/admin/admin.csv-export.spec.js
@@ -160,10 +160,52 @@ describe("CSV Export Authorization (GHSA-4vj2-gm78-3q63)", () => {
                 Format: "Default",
                 Submit: "Create File"
             },
-            failOnStatusCode: false
+            failOnStatusCode: false,
+            followRedirect: false
         }).then((response) => {
             // Should get 302 redirect to login or 401 Unauthorized
             expect([301, 302, 401]).to.include(response.status);
+        });
+    });
+});
+
+describe("CSV Export Authorization — Standard Users", () => {
+    beforeEach(() => {
+        cy.setupStandardSession();
+    });
+
+    it("should deny non-admin users access to CSVExport.php", () => {
+        // Should not be able to visit the form
+        cy.visit("/CSVExport.php", { failOnStatusCode: false });
+
+        // Should be redirected to access-denied page
+        cy.url().should("include", "/v2/access-denied");
+    });
+
+    it("should deny non-admin users POST to CSVCreateFile.php", () => {
+        // Attempt to POST to CSVCreateFile.php as non-admin
+        cy.request({
+            method: "POST",
+            url: "/CSVCreateFile.php",
+            body: {
+                Title: 1,
+                FirstName: 1,
+                Address1: 1,
+                City: 1,
+                State: 1,
+                Zip: 1,
+                Country: 1,
+                Email: 1,
+                Source: "all",
+                Gender: 0,
+                Format: "Default",
+                Submit: "Create File"
+            },
+            failOnStatusCode: false,
+            followRedirect: false
+        }).then((response) => {
+            // Should get 302 redirect (security redirect)
+            expect([301, 302]).to.include(response.status);
         });
     });
 });

--- a/cypress/e2e/ui/admin/admin.csv-export.spec.js
+++ b/cypress/e2e/ui/admin/admin.csv-export.spec.js
@@ -99,3 +99,101 @@ describe("CSV Export Page", () => {
         cy.contains("ChMeetings Export").should("not.exist");
     });
 });
+
+describe("CSV Export Authorization (GHSA-4vj2-gm78-3q63)", () => {
+    it("should deny non-admin users access to CSVExport.php", () => {
+        // Create a low-privileged user (only DeleteRecords permission)
+        cy.createUser({
+            user_name: "csvlowpriv",
+            user_password: "test1234",
+            user_role: 0,
+            user_AddRecords: 0,
+            user_EditRecords: 0,
+            user_DeleteRecords: 1,
+            user_Admin: 0
+        });
+
+        // Login as low-privileged user
+        cy.logout();
+        cy.login("csvlowpriv", "test1234");
+
+        // Attempt to access CSVExport.php directly
+        cy.visit("/CSVExport.php", { failOnStatusCode: false });
+
+        // Should be redirected to access denied page
+        cy.contains("You do not have permission").should("be.visible");
+    });
+
+    it("should deny non-admin users access to CSVCreateFile.php form submission", () => {
+        // Create a low-privileged user
+        cy.createUser({
+            user_name: "csvlowpriv2",
+            user_password: "test1234",
+            user_role: 0,
+            user_AddRecords: 1,
+            user_EditRecords: 0,
+            user_DeleteRecords: 0,
+            user_Admin: 0
+        });
+
+        // Login as low-privileged user
+        cy.logout();
+        cy.login("csvlowpriv2", "test1234");
+
+        // Attempt to POST to CSVCreateFile.php (form submission)
+        cy.request({
+            method: "POST",
+            url: "/CSVCreateFile.php",
+            body: {
+                Title: 1,
+                FirstName: 1,
+                Address1: 1,
+                City: 1,
+                State: 1,
+                Zip: 1,
+                Country: 1,
+                Email: 1,
+                Source: "all",
+                Gender: 0,
+                Format: "Default",
+                Submit: "Create File"
+            },
+            failOnStatusCode: false
+        }).then((response) => {
+            // Should get 403 Forbidden or be redirected
+            expect([403, 302]).to.include(response.status);
+        });
+    });
+
+    it("should allow admin users to access CSVExport.php and submit form", () => {
+        cy.setupAdminSession();
+
+        // Should be able to visit the form
+        cy.visit("/CSVExport.php");
+        cy.contains("CSV Export").should("be.visible");
+
+        // Should be able to submit the form (POST to CSVCreateFile.php)
+        cy.request({
+            method: "POST",
+            url: "/CSVCreateFile.php",
+            body: {
+                Title: 1,
+                FirstName: 1,
+                Address1: 1,
+                City: 1,
+                State: 1,
+                Zip: 1,
+                Country: 1,
+                Email: 1,
+                Source: "all",
+                Gender: 0,
+                Format: "Default",
+                Submit: "Create File"
+            }
+        }).then((response) => {
+            // Should succeed with 200 and CSV content-type
+            expect(response.status).to.eq(200);
+            expect(response.headers["content-type"]).to.include("text/csv");
+        });
+    });
+});

--- a/cypress/e2e/ui/admin/admin.csv-export.spec.js
+++ b/cypress/e2e/ui/admin/admin.csv-export.spec.js
@@ -187,6 +187,7 @@ describe("CSV Export Authorization — Standard Users", () => {
         cy.request({
             method: "POST",
             url: "/CSVCreateFile.php",
+            form: true,
             body: {
                 Title: 1,
                 FirstName: 1,

--- a/cypress/e2e/ui/admin/admin.csv-export.spec.js
+++ b/cypress/e2e/ui/admin/admin.csv-export.spec.js
@@ -101,71 +101,7 @@ describe("CSV Export Page", () => {
 });
 
 describe("CSV Export Authorization (GHSA-4vj2-gm78-3q63)", () => {
-    it("should deny non-admin users access to CSVExport.php", () => {
-        // Create a low-privileged user (only DeleteRecords permission)
-        cy.createUser({
-            user_name: "csvlowpriv",
-            user_password: "test1234",
-            user_role: 0,
-            user_AddRecords: 0,
-            user_EditRecords: 0,
-            user_DeleteRecords: 1,
-            user_Admin: 0
-        });
-
-        // Login as low-privileged user
-        cy.logout();
-        cy.login("csvlowpriv", "test1234");
-
-        // Attempt to access CSVExport.php directly
-        cy.visit("/CSVExport.php", { failOnStatusCode: false });
-
-        // Should be redirected to access denied page
-        cy.contains("You do not have permission").should("be.visible");
-    });
-
-    it("should deny non-admin users access to CSVCreateFile.php form submission", () => {
-        // Create a low-privileged user
-        cy.createUser({
-            user_name: "csvlowpriv2",
-            user_password: "test1234",
-            user_role: 0,
-            user_AddRecords: 1,
-            user_EditRecords: 0,
-            user_DeleteRecords: 0,
-            user_Admin: 0
-        });
-
-        // Login as low-privileged user
-        cy.logout();
-        cy.login("csvlowpriv2", "test1234");
-
-        // Attempt to POST to CSVCreateFile.php (form submission)
-        cy.request({
-            method: "POST",
-            url: "/CSVCreateFile.php",
-            body: {
-                Title: 1,
-                FirstName: 1,
-                Address1: 1,
-                City: 1,
-                State: 1,
-                Zip: 1,
-                Country: 1,
-                Email: 1,
-                Source: "all",
-                Gender: 0,
-                Format: "Default",
-                Submit: "Create File"
-            },
-            failOnStatusCode: false
-        }).then((response) => {
-            // Should get 403 Forbidden or be redirected
-            expect([403, 302]).to.include(response.status);
-        });
-    });
-
-    it("should allow admin users to access CSVExport.php and submit form", () => {
+    it("should allow admin users to submit CSV export form", () => {
         cy.setupAdminSession();
 
         // Should be able to visit the form
@@ -194,6 +130,40 @@ describe("CSV Export Authorization (GHSA-4vj2-gm78-3q63)", () => {
             // Should succeed with 200 and CSV content-type
             expect(response.status).to.eq(200);
             expect(response.headers["content-type"]).to.include("text/csv");
+        });
+    });
+
+    it("should deny unauthenticated access to CSVExport.php", () => {
+        // Attempt to access CSVExport.php without authentication
+        cy.visit("/CSVExport.php", { failOnStatusCode: false });
+
+        // Should be redirected to login (or show auth error)
+        cy.url().should("include", "/session/begin");
+    });
+
+    it("should deny unauthenticated POST to CSVCreateFile.php", () => {
+        // Attempt to POST to CSVCreateFile.php without authentication
+        cy.request({
+            method: "POST",
+            url: "/CSVCreateFile.php",
+            body: {
+                Title: 1,
+                FirstName: 1,
+                Address1: 1,
+                City: 1,
+                State: 1,
+                Zip: 1,
+                Country: 1,
+                Email: 1,
+                Source: "all",
+                Gender: 0,
+                Format: "Default",
+                Submit: "Create File"
+            },
+            failOnStatusCode: false
+        }).then((response) => {
+            // Should get 302 redirect to login or 401 Unauthorized
+            expect([301, 302, 401]).to.include(response.status);
         });
     });
 });

--- a/cypress/e2e/ui/admin/admin.csv-export.spec.js
+++ b/cypress/e2e/ui/admin/admin.csv-export.spec.js
@@ -164,7 +164,7 @@ describe("CSV Export Authorization (GHSA-4vj2-gm78-3q63)", () => {
             followRedirect: false
         }).then((response) => {
             // Should get 302 redirect to login or 401 Unauthorized
-            expect([301, 302, 401]).to.include(response.status);
+            expect([302, 401]).to.include(response.status);
         });
     });
 });
@@ -206,7 +206,7 @@ describe("CSV Export Authorization — Standard Users", () => {
             followRedirect: false
         }).then((response) => {
             // Should get 302 redirect (security redirect)
-            expect([301, 302]).to.include(response.status);
+            expect(response.status).to.eq(302);
         });
     });
 });

--- a/src/CSVCreateFile.php
+++ b/src/CSVCreateFile.php
@@ -3,6 +3,7 @@
 require_once __DIR__ . '/Include/Config.php';
 require_once __DIR__ . '/Include/PageInit.php';
 
+use ChurchCRM\Authentication\AuthenticationManager;
 use ChurchCRM\dto\Cart;
 use ChurchCRM\dto\Classification;
 use ChurchCRM\model\ChurchCRM\Base\PersonQuery;
@@ -13,8 +14,9 @@ use ChurchCRM\Utils\MiscUtils;
 use ChurchCRM\Utils\RedirectUtils;
 use ChurchCRM\Utils\CsvExporter;
 
-if (!$currentUser->isAdmin()) {
-    RedirectUtils::securityRedirect('You do not have permission to export member data.');
+if (!AuthenticationManager::getCurrentUser()->isAdmin()) {
+    RedirectUtils::securityRedirect('Admin');
+    exit;
 }
 
 // Initialize data collection arrays

--- a/src/CSVCreateFile.php
+++ b/src/CSVCreateFile.php
@@ -3,6 +3,12 @@
 require_once __DIR__ . '/Include/Config.php';
 require_once __DIR__ . '/Include/PageInit.php';
 
+use ChurchCRM\Utils\RedirectUtils;
+
+if (!$currentUser->isAdmin()) {
+    RedirectUtils::securityRedirect('You do not have permission to export member data.');
+}
+
 use ChurchCRM\dto\Cart;
 use ChurchCRM\dto\Classification;
 use ChurchCRM\model\ChurchCRM\Base\PersonQuery;
@@ -10,7 +16,6 @@ use ChurchCRM\model\ChurchCRM\FamilyQuery;
 use ChurchCRM\Utils\CustomFieldUtils;
 use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\MiscUtils;
-use ChurchCRM\Utils\RedirectUtils;
 use ChurchCRM\Utils\CsvExporter;
 
 // Initialize data collection arrays

--- a/src/CSVCreateFile.php
+++ b/src/CSVCreateFile.php
@@ -3,12 +3,6 @@
 require_once __DIR__ . '/Include/Config.php';
 require_once __DIR__ . '/Include/PageInit.php';
 
-use ChurchCRM\Utils\RedirectUtils;
-
-if (!$currentUser->isAdmin()) {
-    RedirectUtils::securityRedirect('You do not have permission to export member data.');
-}
-
 use ChurchCRM\dto\Cart;
 use ChurchCRM\dto\Classification;
 use ChurchCRM\model\ChurchCRM\Base\PersonQuery;
@@ -16,7 +10,12 @@ use ChurchCRM\model\ChurchCRM\FamilyQuery;
 use ChurchCRM\Utils\CustomFieldUtils;
 use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\MiscUtils;
+use ChurchCRM\Utils\RedirectUtils;
 use ChurchCRM\Utils\CsvExporter;
+
+if (!$currentUser->isAdmin()) {
+    RedirectUtils::securityRedirect('You do not have permission to export member data.');
+}
 
 // Initialize data collection arrays
 $headers = [];

--- a/src/CSVExport.php
+++ b/src/CSVExport.php
@@ -3,6 +3,12 @@
 require_once __DIR__ . '/Include/Config.php';
 require_once __DIR__ . '/Include/PageInit.php';
 
+use ChurchCRM\Utils\RedirectUtils;
+
+if (!$currentUser->isAdmin()) {
+    RedirectUtils::securityRedirect('You do not have permission to export member data.');
+}
+
 use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\view\PageHeader;
 

--- a/src/CSVExport.php
+++ b/src/CSVExport.php
@@ -3,14 +3,15 @@
 require_once __DIR__ . '/Include/Config.php';
 require_once __DIR__ . '/Include/PageInit.php';
 
-use ChurchCRM\Utils\RedirectUtils;
-
-if (!$currentUser->isAdmin()) {
-    RedirectUtils::securityRedirect('You do not have permission to export member data.');
-}
-
+use ChurchCRM\Authentication\AuthenticationManager;
 use ChurchCRM\Utils\InputUtils;
+use ChurchCRM\Utils\RedirectUtils;
 use ChurchCRM\view\PageHeader;
+
+if (!AuthenticationManager::getCurrentUser()->isAdmin()) {
+    RedirectUtils::securityRedirect('Admin');
+    exit;
+}
 
 // Get Classifications for the drop-down
 $sSQL = 'SELECT * FROM list_lst WHERE lst_ID = 1 ORDER BY lst_OptionSequence';


### PR DESCRIPTION
## Summary
Implements authorization fix for GHSA-4vj2-gm78-3q63: broken access control in CSV export. Restricts CSV export (`CSVExport.php` and `CSVCreateFile.php`) to admin users only. Previously, low-privileged users could bypass the UI and directly POST to `CSVCreateFile.php` to exfiltrate all member PII.

## Changes
- **src/CSVCreateFile.php** — Add admin authorization check after PageInit.php using `RedirectUtils::securityRedirect()`
- **src/CSVExport.php** — Add same admin authorization check for consistency
- **cypress/e2e/ui/admin/admin.csv-export.spec.js** — Reorganize authorization tests into separate describe blocks (admin, standard user, unauthenticated); add `followRedirect: false` to POST tests to capture actual 302 redirect status
- **.agents/skills/churchcrm/cypress-testing.md** — Document authorization testing patterns with admin vs standard user capabilities table and test structure guidelines
- **scripts/release-changelog.js** — Fix misleading CodeQL security comment (PR #8919)

## Why
The CSV export was only gated by high-level "admin?" check in UI (`CSVExport.php` via `PageInit.php`), but no server-side authorization on the export file generation endpoint (`CSVCreateFile.php`). Users with granular permissions (AddRecords, EditRecords, DeleteRecords, ManageGroups, Finance, Notes) could bypass the UI and POST directly to generate CSV exports with full member records, including sensitive PII.

## Test Plan
- ✅ Admin users can submit CSV export (GET + POST, expect 200 with CSV content-type)
- ✅ Non-admin authenticated users are denied (GET redirects to /v2/access-denied; POST returns 302 redirect)
- ✅ Unauthenticated users are denied (GET redirects to /session/begin; POST returns 302/401)
- ✅ All existing UI tests pass (field selection, filtering, output format)
- ✅ Lint and build pass

## Related Issues
- Fixes GHSA-4vj2-gm78-3q63

🤖 Generated with [Claude Code](https://claude.com/claude-code)