### PR TITLE
feat: update meeting-outlines to v1.0.2 (security fixes)

### DIFF
--- a/approved-plugins.json
+++ b/approved-plugins.json
@@ -36,17 +36,17 @@
     {
       "id": "meeting-outlines",
       "name": "Meeting Outlines",
-      "version": "1.0.1",
-      "downloadUrl": "https://github.com/huckjs-sys/meeting-outlines/releases/download/v1.0.1/meeting-outlines-1.0.1.zip",
-      "sha256": "ebf5a6524a486126be2c80c16a11b554e37f7787757a81014d6a45794a7e922f",
+      "version": "1.0.2",
+      "downloadUrl": "https://github.com/huckjs-sys/meeting-outlines/releases/download/v1.0.2/meeting-outlines-1.0.2.zip",
+      "sha256": "494e6534861ea6a6a74435d0efcbdab7474bca72c54bb9d0d34e994e7f51a81f",
       "risk": "high",
       "riskSummary": "Downloads Bible texts from api.getbible.net and writes them to local JSON files inside the plugin directory; also sends email notifications to meeting participants via CRM SMTP and performs CRUD on plugin-owned database tables.",
       "permissions": ["network.outbound", "network.inbound", "db.read", "db.write", "email.send", "fs.write"],
       "minimumCRMVersion": "7.0.0",
-      "author": "Eoles Conseil",
+      "author": "huckjs-sys",
       "homepage": "https://github.com/huckjs-sys/meeting-outlines",
-      "reviewedAt": "2026-04-28",
-      "notes": "Outbound HTTPS to api.getbible.net (Bible text downloads, admin-initiated) and cdn.jsdelivr.net (SortableJS CDN asset). All file writes confined to data/text/ inside the plugin directory. Two maintainer reviews required before production use (high-risk policy)."
+      "reviewedAt": "2026-05-15",
+      "notes": "Outbound HTTPS to api.getbible.net (Bible text downloads, admin-initiated) and cdn.jsdelivr.net (SortableJS CDN asset, SRI-pinned). All file writes confined to data/text/ inside the plugin directory. Two maintainer reviews required before production use (high-risk policy)."
     }
   ]
 }


### PR DESCRIPTION
Bumps meeting-outlines from 1.0.1 to 1.0.2.

## Changes in this release

- **Server-side enum validation** — \status\, \	ype\, and \item_type\ are now validated against allowed values before any database write
- **Bible version validation** — \ible_version\ is rejected in settings if not in the known versions list
- **SRI on SortableJS CDN** — \integrity\ + \crossorigin\ attributes added to the SortableJS script tag (tamper protection)
- Author name updated to \huckjs-sys\

## Checklist

- [x] Version bumped to 1.0.2 in \plugin.json\
- [x] \downloadUrl\ updated to v1.0.2 zip
- [x] \sha256\ updated (verified against uploaded zip asset)
- [x] \uthor\ updated to huckjs-sys
- [x] \eviewedAt\ updated to 2026-05-15
- [x] \
otes\ updated to mention SRI-pinned CDN