### PR TITLE
feat: split past events into collapsible section on event dashboard (#8849)

### DIFF
--- a/cypress/e2e/ui/admin/admin.events.dashboard.spec.js
+++ b/cypress/e2e/ui/admin/admin.events.dashboard.spec.js
@@ -30,7 +30,7 @@ describe("Events Dashboard (MVC)", () => {
         cy.contains("Events Dashboard").should("exist");
         cy.contains("Events This Year").should("exist");
         cy.contains("Total Check-ins").should("exist");
-        cy.contains("Active Events").should("exist");
+        cy.contains("Current Events").should("exist");
         cy.contains("Event Types").should("exist");
     });
 

--- a/cypress/e2e/ui/admin/admin.events.past-archiving.spec.js
+++ b/cypress/e2e/ui/admin/admin.events.past-archiving.spec.js
@@ -92,7 +92,7 @@ describe("Past Events Archiving (#8849)", () => {
     // Test: future (current) event is visible without any interaction
     // -----------------------------------------------------------------------
     it("current event row is visible without any toggle interaction", () => {
-        cy.visit(`event/dashboard?year=${CURRENT_YEAR + 1}`);
+        cy.visit(`/event/dashboard?year=${CURRENT_YEAR + 1}`);
 
         // The future event belongs to the next year — visit that year's dashboard.
         // Find the event row using the event ID in the action menu placeholder.
@@ -113,11 +113,11 @@ describe("Past Events Archiving (#8849)", () => {
     // Test: past-by-date event is hidden until the toggle is clicked
     // -----------------------------------------------------------------------
     it("past-by-date event row is hidden before toggle and visible after", () => {
-        cy.visit(`event/dashboard?year=${LAST_MONTH_YEAR}`);
+        cy.visit(`/event/dashboard?year=${LAST_MONTH_YEAR}`);
 
         // The past-events collapse tbody should exist and NOT be open initially.
         // (Unless this is a month with ONLY past events — handled separately.)
-        cy.get(`#past-events-month-${LAST_MONTH}`)
+        cy.get(`#past-events-${LAST_MONTH_YEAR}-month-${LAST_MONTH}`)
             .should("exist")
             .then(($el) => {
                 // The row lives inside the collapse; if the section is already
@@ -135,7 +135,7 @@ describe("Past Events Archiving (#8849)", () => {
 
                 // Click the toggle button.
                 cy.get(
-                    `[data-bs-target="#past-events-month-${LAST_MONTH}"]`,
+                    `[data-bs-target="#past-events-${LAST_MONTH_YEAR}-month-${LAST_MONTH}"]`,
                 ).click();
 
                 // After toggling, row must be visible.
@@ -154,7 +154,7 @@ describe("Past Events Archiving (#8849)", () => {
     it("deactivated (InActive=1) event appears in the past section, not the current section", () => {
         // The deactivated event was created for today, so it appears in the
         // current month. Find the collapse for this month.
-        cy.visit(`event/dashboard?year=${CURRENT_YEAR}`);
+        cy.visit(`/event/dashboard?year=${CURRENT_YEAR}`);
 
         // The action menu placeholder is inside the collapse tbody.
         cy.get(
@@ -163,16 +163,16 @@ describe("Past Events Archiving (#8849)", () => {
         )
             .closest("tbody")
             .should("have.attr", "id")
-            .and("match", /^past-events-month-/);
+            .and("match", /^past-events-\d{4}-month-/);
     });
 
     // -----------------------------------------------------------------------
     // Test: the "Past Events" toggle button text reflects the count
     // -----------------------------------------------------------------------
     it("past-events toggle button shows correct count label", () => {
-        cy.visit(`event/dashboard?year=${LAST_MONTH_YEAR}`);
+        cy.visit(`/event/dashboard?year=${LAST_MONTH_YEAR}`);
 
-        cy.get(`[data-bs-target="#past-events-month-${LAST_MONTH}"]`).should(
+        cy.get(`[data-bs-target="#past-events-${LAST_MONTH_YEAR}-month-${LAST_MONTH}"]`).should(
             "contain.text",
             "past event",
         );
@@ -182,9 +182,9 @@ describe("Past Events Archiving (#8849)", () => {
     // Test: localStorage key is updated when the toggle is clicked
     // -----------------------------------------------------------------------
     it("localStorage key is updated when past events section is toggled", () => {
-        cy.visit(`event/dashboard?year=${LAST_MONTH_YEAR}`);
+        cy.visit(`/event/dashboard?year=${LAST_MONTH_YEAR}`);
 
-        const collapseId = `past-events-month-${LAST_MONTH}`;
+        const collapseId = `past-events-${LAST_MONTH_YEAR}-month-${LAST_MONTH}`;
 
         // Ensure it starts closed (or close it if already open to get a clean state).
         cy.get(`#${collapseId}`).then(($el) => {
@@ -226,13 +226,13 @@ describe("Past Events Archiving (#8849)", () => {
         // The past-by-date event is the only event created for LAST_MONTH.
         // (quick-create deduplicates by type+date, so we likely have exactly 1.)
         // Visit the year that contains the past month and check auto-expansion.
-        cy.visit(`event/dashboard?year=${LAST_MONTH_YEAR}`);
+        cy.visit(`/event/dashboard?year=${LAST_MONTH_YEAR}`);
 
-        cy.get(`#past-events-month-${LAST_MONTH}`).then(($el) => {
+        cy.get(`#past-events-${LAST_MONTH_YEAR}-month-${LAST_MONTH}`).then(($el) => {
             // If the month has no current events, the collapse is auto-expanded.
             // Check whether a current tbody exists for this month card.
             const $card = $el.closest(".card");
-            const hasCurrent = $card.find("tbody").not(".past-events-header-tbody").not(`#past-events-month-${LAST_MONTH}`).find("tr").length > 0;
+            const hasCurrent = $card.find("tbody").not(".past-events-header-tbody").not(`#past-events-${LAST_MONTH_YEAR}-month-${LAST_MONTH}`).find("tr").length > 0;
 
             if (!hasCurrent) {
                 // All-past month: collapse must be pre-expanded.
@@ -249,7 +249,7 @@ describe("Past Events Archiving (#8849)", () => {
     // Test: stat card shows current vs past count
     // -----------------------------------------------------------------------
     it("stat card shows current / past event counts", () => {
-        cy.visit(`event/dashboard?year=${CURRENT_YEAR}`);
+        cy.visit(`/event/dashboard?year=${CURRENT_YEAR}`);
 
         // The "Current Events" stat card is rendered with fw-medium containing
         // the count. It may also show "/ N past" if there are past events.

--- a/cypress/e2e/ui/admin/admin.events.past-archiving.spec.js
+++ b/cypress/e2e/ui/admin/admin.events.past-archiving.spec.js
@@ -96,7 +96,7 @@ describe("Past Events Archiving (#8849)", () => {
     // Test: future (current) event is visible without any interaction
     // -----------------------------------------------------------------------
     it("current event row is visible without any toggle interaction", () => {
-        cy.visit(`/event/dashboard?year=${CURRENT_YEAR + 1}`);
+        cy.visit(`event/dashboard?year=${CURRENT_YEAR + 1}`);
 
         // The future event belongs to the next year — visit that year's dashboard.
         // Find the event row using the event ID in the action menu placeholder.
@@ -117,7 +117,7 @@ describe("Past Events Archiving (#8849)", () => {
     // Test: past-by-date event is hidden until the toggle is clicked
     // -----------------------------------------------------------------------
     it("past-by-date event row is hidden before toggle and visible after", () => {
-        cy.visit(`/event/dashboard?year=${LAST_MONTH_YEAR}`);
+        cy.visit(`event/dashboard?year=${LAST_MONTH_YEAR}`);
 
         // The past-events collapse tbody should exist and NOT be open initially.
         // (Unless this is a month with ONLY past events — handled separately.)
@@ -158,7 +158,7 @@ describe("Past Events Archiving (#8849)", () => {
     it("deactivated (InActive=1) event appears in the past section, not the current section", () => {
         // The deactivated event was created for today, so it appears in the
         // current month. Find the collapse for this month.
-        cy.visit(`/event/dashboard?year=${CURRENT_YEAR}`);
+        cy.visit(`event/dashboard?year=${CURRENT_YEAR}`);
 
         // The action menu placeholder is inside the collapse tbody.
         cy.get(
@@ -174,7 +174,7 @@ describe("Past Events Archiving (#8849)", () => {
     // Test: the "Past Events" toggle button text reflects the count
     // -----------------------------------------------------------------------
     it("past-events toggle button shows correct count label", () => {
-        cy.visit(`/event/dashboard?year=${LAST_MONTH_YEAR}`);
+        cy.visit(`event/dashboard?year=${LAST_MONTH_YEAR}`);
 
         cy.get(`[data-past-toggle="past-events-${LAST_MONTH_YEAR}-month-${LAST_MONTH}"]`).should(
             "contain.text",
@@ -186,7 +186,7 @@ describe("Past Events Archiving (#8849)", () => {
     // Test: localStorage key is updated when the toggle is clicked
     // -----------------------------------------------------------------------
     it("localStorage key is updated when past events section is toggled", () => {
-        cy.visit(`/event/dashboard?year=${LAST_MONTH_YEAR}`);
+        cy.visit(`event/dashboard?year=${LAST_MONTH_YEAR}`);
 
         const collapseId = `past-events-${LAST_MONTH_YEAR}-month-${LAST_MONTH}`;
         const toggleBtn = `[data-past-toggle="${collapseId}"]`;
@@ -234,7 +234,7 @@ describe("Past Events Archiving (#8849)", () => {
         // The past-by-date event is the only event created for LAST_MONTH.
         // (quick-create deduplicates by type+date, so we likely have exactly 1.)
         // Visit the year that contains the past month and check auto-expansion.
-        cy.visit(`/event/dashboard?year=${LAST_MONTH_YEAR}`);
+        cy.visit(`event/dashboard?year=${LAST_MONTH_YEAR}`);
 
         cy.get(`#past-events-${LAST_MONTH_YEAR}-month-${LAST_MONTH}`).then(($el) => {
             // If the month has no current events, the collapse is auto-expanded.
@@ -257,7 +257,7 @@ describe("Past Events Archiving (#8849)", () => {
     // Test: stat card shows current vs past count
     // -----------------------------------------------------------------------
     it("stat card shows current / past event counts", () => {
-        cy.visit(`/event/dashboard?year=${CURRENT_YEAR}`);
+        cy.visit(`event/dashboard?year=${CURRENT_YEAR}`);
 
         // The "Current Events" stat card is rendered with fw-medium containing
         // the count. It may also show "/ N past" if there are past events.

--- a/cypress/e2e/ui/admin/admin.events.past-archiving.spec.js
+++ b/cypress/e2e/ui/admin/admin.events.past-archiving.spec.js
@@ -197,8 +197,12 @@ describe("Past Events Archiving (#8849)", () => {
         // Bootstrap synchronously on click, before the animation completes).
         cy.get(toggleBtn).then(($btn) => {
             if ($btn.attr("aria-expanded") === "true") {
-                // Already open — click once to close it, then wait for it to close.
-                cy.wrap($btn).click();
+                // Already open — close it with a native DOM click so the action
+                // is synchronous inside .then() and doesn't suffer from Cypress
+                // command-queue ordering: cy.wrap().click() inside .then() gets
+                // enqueued but the outer .then() resolves first, causing the
+                // subsequent should('not.have.class','expanded') to race.
+                $btn[0].click();
             }
         });
         // Wait for closed state regardless of initial condition.

--- a/cypress/e2e/ui/admin/admin.events.past-archiving.spec.js
+++ b/cypress/e2e/ui/admin/admin.events.past-archiving.spec.js
@@ -1,0 +1,258 @@
+/// <reference types="cypress" />
+
+/**
+ * Tests for issue #8849 — Past Events archiving on /event/dashboard.
+ *
+ * These tests are SELF-SUFFICIENT: every precondition is created via API.
+ * The suite seeds three events:
+ *
+ *   1. currentEvent  — starts/ends in the future (active, not yet ended)
+ *   2. pastByDate    — created for a past date (End < NOW)
+ *   3. pastByInactive — created for today but then deactivated (InActive = 1)
+ *
+ * Because quick-create uses "today" by default and sets End = Start + 1 hour,
+ * the safest way to guarantee a past event by date is to supply a date from
+ * last month. We use quick-create with a `date` param set one month back.
+ *
+ * We then visit /event/dashboard?year=<currentYear> and assert that:
+ *  - current events appear immediately without interaction
+ *  - past events are hidden behind a collapsed "Past Events" toggle
+ *  - toggling reveals the past rows
+ *  - localStorage key is updated on toggle
+ *  - months with ONLY past events auto-expand that section
+ */
+
+const CURRENT_YEAR = new Date().getFullYear();
+const THIS_MONTH = new Date().getMonth() + 1; // 1-based
+const LAST_MONTH = THIS_MONTH === 1 ? 12 : THIS_MONTH - 1;
+const LAST_MONTH_YEAR = THIS_MONTH === 1 ? CURRENT_YEAR - 1 : CURRENT_YEAR;
+
+// Format YYYY-MM-DD
+function formatDate(year, month, day) {
+    return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+const PAST_DATE = formatDate(LAST_MONTH_YEAR, LAST_MONTH, 1);
+const FUTURE_DATE = formatDate(CURRENT_YEAR + 1, 1, 15);
+
+describe("Past Events Archiving (#8849)", () => {
+    let currentEventId;
+    let pastByDateEventId;
+    let pastByInactiveEventId;
+
+    before(() => {
+        // Create a future event — will appear in the "Current Events" section.
+        // We create it for next year so it won't flip to "past" mid-run.
+        cy.makePrivateAdminAPICall(
+            "POST",
+            "/api/events/quick-create",
+            { eventTypeId: 1, date: FUTURE_DATE },
+            200,
+        ).then((resp) => {
+            expect(resp.body).to.have.property("eventId");
+            currentEventId = resp.body.eventId;
+        });
+
+        // Create an event for a past date (last month) — End < NOW.
+        cy.makePrivateAdminAPICall(
+            "POST",
+            "/api/events/quick-create",
+            { eventTypeId: 1, date: PAST_DATE },
+            200,
+        ).then((resp) => {
+            expect(resp.body).to.have.property("eventId");
+            pastByDateEventId = resp.body.eventId;
+        });
+
+        // Create another event for today then deactivate it — InActive = 1.
+        cy.makePrivateAdminAPICall(
+            "POST",
+            "/api/events/quick-create",
+            { eventTypeId: 1 },
+            200,
+        ).then((resp) => {
+            expect(resp.body).to.have.property("eventId");
+            pastByInactiveEventId = resp.body.eventId;
+
+            // Now deactivate it so it appears in the "past" section.
+            cy.makePrivateAdminAPICall(
+                "POST",
+                `/api/events/${pastByInactiveEventId}/status`,
+                { active: false },
+                200,
+            );
+        });
+    });
+
+    beforeEach(() => {
+        cy.setupAdminSession({ forceLogin: true });
+    });
+
+    // -----------------------------------------------------------------------
+    // Test: future (current) event is visible without any interaction
+    // -----------------------------------------------------------------------
+    it("current event row is visible without any toggle interaction", () => {
+        cy.visit(`event/dashboard?year=${CURRENT_YEAR + 1}`);
+
+        // The future event belongs to the next year — visit that year's dashboard.
+        // Find the event row using the event ID in the action menu placeholder.
+        cy.get(
+            `.event-action-menu-placeholder[data-event-id="${currentEventId}"]`,
+            { timeout: 10000 },
+        ).should("exist");
+
+        // The row is in a regular (non-collapse) tbody — it must be visible.
+        cy.get(
+            `.event-action-menu-placeholder[data-event-id="${currentEventId}"]`,
+        )
+            .closest("tr")
+            .should("be.visible");
+    });
+
+    // -----------------------------------------------------------------------
+    // Test: past-by-date event is hidden until the toggle is clicked
+    // -----------------------------------------------------------------------
+    it("past-by-date event row is hidden before toggle and visible after", () => {
+        cy.visit(`event/dashboard?year=${LAST_MONTH_YEAR}`);
+
+        // The past-events collapse tbody should exist and NOT be open initially.
+        // (Unless this is a month with ONLY past events — handled separately.)
+        cy.get(`#past-events-month-${LAST_MONTH}`)
+            .should("exist")
+            .then(($el) => {
+                // The row lives inside the collapse; if the section is already
+                // expanded (auto-expand for all-past month) just assert visibility.
+                const isShown = $el.hasClass("show");
+
+                if (!isShown) {
+                    // Row must be hidden before toggle.
+                    cy.get(
+                        `.event-action-menu-placeholder[data-event-id="${pastByDateEventId}"]`,
+                    )
+                        .closest("tr")
+                        .should("not.be.visible");
+                }
+
+                // Click the toggle button.
+                cy.get(
+                    `[data-bs-target="#past-events-month-${LAST_MONTH}"]`,
+                ).click();
+
+                // After toggling, row must be visible.
+                cy.get(
+                    `.event-action-menu-placeholder[data-event-id="${pastByDateEventId}"]`,
+                    { timeout: 5000 },
+                )
+                    .closest("tr")
+                    .should("be.visible");
+            });
+    });
+
+    // -----------------------------------------------------------------------
+    // Test: deactivated event is classified as "past"
+    // -----------------------------------------------------------------------
+    it("deactivated (InActive=1) event appears in the past section, not the current section", () => {
+        // The deactivated event was created for today, so it appears in the
+        // current month. Find the collapse for this month.
+        cy.visit(`event/dashboard?year=${CURRENT_YEAR}`);
+
+        // The action menu placeholder is inside the collapse tbody.
+        cy.get(
+            `.event-action-menu-placeholder[data-event-id="${pastByInactiveEventId}"]`,
+            { timeout: 10000 },
+        )
+            .closest("tbody")
+            .should("have.attr", "id")
+            .and("match", /^past-events-month-/);
+    });
+
+    // -----------------------------------------------------------------------
+    // Test: the "Past Events" toggle button text reflects the count
+    // -----------------------------------------------------------------------
+    it("past-events toggle button shows correct count label", () => {
+        cy.visit(`event/dashboard?year=${LAST_MONTH_YEAR}`);
+
+        cy.get(`[data-bs-target="#past-events-month-${LAST_MONTH}"]`).should(
+            "contain.text",
+            "past event",
+        );
+    });
+
+    // -----------------------------------------------------------------------
+    // Test: localStorage key is updated when the toggle is clicked
+    // -----------------------------------------------------------------------
+    it("localStorage key is updated when past events section is toggled", () => {
+        cy.visit(`event/dashboard?year=${LAST_MONTH_YEAR}`);
+
+        const collapseId = `past-events-month-${LAST_MONTH}`;
+
+        // Ensure it starts closed (or close it if already open to get a clean state).
+        cy.get(`#${collapseId}`).then(($el) => {
+            if ($el.hasClass("show")) {
+                // Close it first.
+                cy.get(`[data-bs-target="#${collapseId}"]`).click();
+                cy.get(`#${collapseId}`).should("not.have.class", "show");
+            }
+        });
+
+        // Open the past events section.
+        cy.get(`[data-bs-target="#${collapseId}"]`).click();
+        cy.get(`#${collapseId}`).should("have.class", "show");
+
+        // Check localStorage.
+        cy.window().then((win) => {
+            const stored = JSON.parse(
+                win.localStorage.getItem("churchcrm.eventDashboard.pastOpen") || "[]",
+            );
+            expect(stored).to.include(collapseId);
+        });
+
+        // Now close it and check localStorage is updated.
+        cy.get(`[data-bs-target="#${collapseId}"]`).click();
+        cy.get(`#${collapseId}`).should("not.have.class", "show");
+
+        cy.window().then((win) => {
+            const stored = JSON.parse(
+                win.localStorage.getItem("churchcrm.eventDashboard.pastOpen") || "[]",
+            );
+            expect(stored).to.not.include(collapseId);
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // Test: auto-expand — month with ONLY past events starts open
+    // -----------------------------------------------------------------------
+    it("month containing only past events auto-expands the past section", () => {
+        // The past-by-date event is the only event created for LAST_MONTH.
+        // (quick-create deduplicates by type+date, so we likely have exactly 1.)
+        // Visit the year that contains the past month and check auto-expansion.
+        cy.visit(`event/dashboard?year=${LAST_MONTH_YEAR}`);
+
+        cy.get(`#past-events-month-${LAST_MONTH}`).then(($el) => {
+            // If the month has no current events, the collapse is auto-expanded.
+            // Check whether a current tbody exists for this month card.
+            const $card = $el.closest(".card");
+            const hasCurrent = $card.find("tbody").not(".past-events-header-tbody").not(`#past-events-month-${LAST_MONTH}`).find("tr").length > 0;
+
+            if (!hasCurrent) {
+                // All-past month: collapse must be pre-expanded.
+                cy.wrap($el).should("have.class", "show");
+            } else {
+                // Mixed month: collapse may or may not be open depending on localStorage.
+                // Just assert the element exists and the test continues.
+                cy.wrap($el).should("exist");
+            }
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // Test: stat card shows current vs past count
+    // -----------------------------------------------------------------------
+    it("stat card shows current / past event counts", () => {
+        cy.visit(`event/dashboard?year=${CURRENT_YEAR}`);
+
+        // The "Current Events" stat card is rendered with fw-medium containing
+        // the count. It may also show "/ N past" if there are past events.
+        cy.contains(".card-body", "Current Events").should("exist");
+    });
+});

--- a/cypress/e2e/ui/admin/admin.events.past-archiving.spec.js
+++ b/cypress/e2e/ui/admin/admin.events.past-archiving.spec.js
@@ -126,7 +126,7 @@ describe("Past Events Archiving (#8849)", () => {
             .then(($el) => {
                 // The row lives inside the collapse; if the section is already
                 // expanded (auto-expand for all-past month) just assert visibility.
-                const isShown = $el.hasClass("show");
+                const isShown = $el.hasClass("expanded");
 
                 if (!isShown) {
                     // Row must be hidden before toggle.
@@ -139,7 +139,7 @@ describe("Past Events Archiving (#8849)", () => {
 
                 // Click the toggle button.
                 cy.get(
-                    `[data-bs-target="#past-events-${LAST_MONTH_YEAR}-month-${LAST_MONTH}"]`,
+                    `[data-past-toggle="past-events-${LAST_MONTH_YEAR}-month-${LAST_MONTH}"]`,
                 ).click();
 
                 // After toggling, row must be visible.
@@ -176,7 +176,7 @@ describe("Past Events Archiving (#8849)", () => {
     it("past-events toggle button shows correct count label", () => {
         cy.visit(`/event/dashboard?year=${LAST_MONTH_YEAR}`);
 
-        cy.get(`[data-bs-target="#past-events-${LAST_MONTH_YEAR}-month-${LAST_MONTH}"]`).should(
+        cy.get(`[data-past-toggle="past-events-${LAST_MONTH_YEAR}-month-${LAST_MONTH}"]`).should(
             "contain.text",
             "past event",
         );
@@ -189,7 +189,7 @@ describe("Past Events Archiving (#8849)", () => {
         cy.visit(`/event/dashboard?year=${LAST_MONTH_YEAR}`);
 
         const collapseId = `past-events-${LAST_MONTH_YEAR}-month-${LAST_MONTH}`;
-        const toggleBtn = `[data-bs-target="#${collapseId}"]`;
+        const toggleBtn = `[data-past-toggle="${collapseId}"]`;
 
         // The collapse may start open (auto-expand for all-past month) or closed.
         // We need it CLOSED before we can test the open→localStorage path.
@@ -202,11 +202,11 @@ describe("Past Events Archiving (#8849)", () => {
             }
         });
         // Wait for closed state regardless of initial condition.
-        cy.get(`#${collapseId}`).should("not.have.class", "show");
+        cy.get(`#${collapseId}`).should("not.have.class", "expanded");
 
         // ---- Open it — verify localStorage is written ----
         cy.get(toggleBtn).click();
-        cy.get(`#${collapseId}`).should("have.class", "show");
+        cy.get(`#${collapseId}`).should("have.class", "expanded");
 
         cy.window().then((win) => {
             const stored = JSON.parse(
@@ -217,7 +217,7 @@ describe("Past Events Archiving (#8849)", () => {
 
         // ---- Close it — verify localStorage is updated ----
         cy.get(toggleBtn).click();
-        cy.get(`#${collapseId}`).should("not.have.class", "show");
+        cy.get(`#${collapseId}`).should("not.have.class", "expanded");
 
         cy.window().then((win) => {
             const stored = JSON.parse(
@@ -244,7 +244,7 @@ describe("Past Events Archiving (#8849)", () => {
 
             if (!hasCurrent) {
                 // All-past month: collapse must be pre-expanded.
-                cy.wrap($el).should("have.class", "show");
+                cy.wrap($el).should("have.class", "expanded");
             } else {
                 // Mixed month: collapse may or may not be open depending on localStorage.
                 // Just assert the element exists and the test continues.

--- a/cypress/e2e/ui/admin/admin.events.past-archiving.spec.js
+++ b/cypress/e2e/ui/admin/admin.events.past-archiving.spec.js
@@ -86,6 +86,10 @@ describe("Past Events Archiving (#8849)", () => {
 
     beforeEach(() => {
         cy.setupAdminSession({ forceLogin: true });
+        // Clear the past-events localStorage key before each test so that
+        // the persistence tests start from a known empty state and are not
+        // affected by state written by previous tests.
+        cy.clearLocalStorage("churchcrm.eventDashboard.pastOpen");
     });
 
     // -----------------------------------------------------------------------
@@ -185,21 +189,25 @@ describe("Past Events Archiving (#8849)", () => {
         cy.visit(`/event/dashboard?year=${LAST_MONTH_YEAR}`);
 
         const collapseId = `past-events-${LAST_MONTH_YEAR}-month-${LAST_MONTH}`;
+        const toggleBtn = `[data-bs-target="#${collapseId}"]`;
 
-        // Ensure it starts closed (or close it if already open to get a clean state).
-        cy.get(`#${collapseId}`).then(($el) => {
-            if ($el.hasClass("show")) {
-                // Close it first.
-                cy.get(`[data-bs-target="#${collapseId}"]`).click();
-                cy.get(`#${collapseId}`).should("not.have.class", "show");
+        // The collapse may start open (auto-expand for all-past month) or closed.
+        // We need it CLOSED before we can test the open→localStorage path.
+        // Use the aria-expanded attribute as a reliable indicator (updated by
+        // Bootstrap synchronously on click, before the animation completes).
+        cy.get(toggleBtn).then(($btn) => {
+            if ($btn.attr("aria-expanded") === "true") {
+                // Already open — click once to close it, then wait for it to close.
+                cy.wrap($btn).click();
             }
         });
+        // Wait for closed state regardless of initial condition.
+        cy.get(`#${collapseId}`).should("not.have.class", "show");
 
-        // Open the past events section.
-        cy.get(`[data-bs-target="#${collapseId}"]`).click();
+        // ---- Open it — verify localStorage is written ----
+        cy.get(toggleBtn).click();
         cy.get(`#${collapseId}`).should("have.class", "show");
 
-        // Check localStorage.
         cy.window().then((win) => {
             const stored = JSON.parse(
                 win.localStorage.getItem("churchcrm.eventDashboard.pastOpen") || "[]",
@@ -207,8 +215,8 @@ describe("Past Events Archiving (#8849)", () => {
             expect(stored).to.include(collapseId);
         });
 
-        // Now close it and check localStorage is updated.
-        cy.get(`[data-bs-target="#${collapseId}"]`).click();
+        // ---- Close it — verify localStorage is updated ----
+        cy.get(toggleBtn).click();
         cy.get(`#${collapseId}`).should("not.have.class", "show");
 
         cy.window().then((win) => {

--- a/cypress/e2e/ui/admin/admin.events.past-archiving.spec.js
+++ b/cypress/e2e/ui/admin/admin.events.past-archiving.spec.js
@@ -20,6 +20,13 @@
  *  - toggling reveals the past rows
  *  - localStorage key is updated on toggle
  *  - months with ONLY past events auto-expand that section
+ *
+ * Cypress style rules enforced in this file:
+ *  - NO cy.get() / cy.wrap().click() / .should() inside .then() callbacks.
+ *    All Cypress commands must be at the top level of the test so retry-ability
+ *    and command-queue ordering work correctly.
+ *  - .then() is only used for synchronous reads (win.localStorage, $el[0].click()
+ *    native DOM operations, plain JS conditionals).
  */
 
 const CURRENT_YEAR = new Date().getFullYear();
@@ -119,37 +126,37 @@ describe("Past Events Archiving (#8849)", () => {
     it("past-by-date event row is hidden before toggle and visible after", () => {
         cy.visit(`event/dashboard?year=${LAST_MONTH_YEAR}`);
 
-        // The past-events collapse tbody should exist and NOT be open initially.
-        // (Unless this is a month with ONLY past events — handled separately.)
-        cy.get(`#past-events-${LAST_MONTH_YEAR}-month-${LAST_MONTH}`)
-            .should("exist")
-            .then(($el) => {
-                // The row lives inside the collapse; if the section is already
-                // expanded (auto-expand for all-past month) just assert visibility.
-                const isShown = $el.hasClass("expanded");
+        const tbodyId = `past-events-${LAST_MONTH_YEAR}-month-${LAST_MONTH}`;
+        const toggleSel = `[data-past-toggle="${tbodyId}"]`;
 
-                if (!isShown) {
-                    // Row must be hidden before toggle.
-                    cy.get(
-                        `.event-action-menu-placeholder[data-event-id="${pastByDateEventId}"]`,
-                    )
-                        .closest("tr")
-                        .should("not.be.visible");
-                }
+        // Ensure the section starts CLOSED before we test the hidden→visible
+        // transition. When LAST_MONTH is an all-past month PHP auto-expands it
+        // ($autoExpand=true), so we may need to close it first.
+        // Native DOM click inside .then() is synchronous — no queue ordering race.
+        cy.get(toggleSel).then(($btn) => {
+            if ($btn.attr("aria-expanded") === "true") {
+                $btn[0].click();
+            }
+        });
+        // Top-level assertion — retries until the section is closed.
+        cy.get(`#${tbodyId}`).should("not.have.class", "expanded");
 
-                // Click the toggle button.
-                cy.get(
-                    `[data-past-toggle="past-events-${LAST_MONTH_YEAR}-month-${LAST_MONTH}"]`,
-                ).click();
+        // Row must be hidden before toggle (section is closed).
+        cy.get(
+            `.event-action-menu-placeholder[data-event-id="${pastByDateEventId}"]`,
+        )
+            .closest("tr")
+            .should("not.be.visible");
 
-                // After toggling, row must be visible.
-                cy.get(
-                    `.event-action-menu-placeholder[data-event-id="${pastByDateEventId}"]`,
-                    { timeout: 5000 },
-                )
-                    .closest("tr")
-                    .should("be.visible");
-            });
+        // Open the section with a top-level click.
+        cy.get(toggleSel).click();
+
+        // Row must now be visible — top-level assertion with retry.
+        cy.get(
+            `.event-action-menu-placeholder[data-event-id="${pastByDateEventId}"]`,
+        )
+            .closest("tr")
+            .should("be.visible");
     });
 
     // -----------------------------------------------------------------------
@@ -160,7 +167,7 @@ describe("Past Events Archiving (#8849)", () => {
         // current month. Find the collapse for this month.
         cy.visit(`event/dashboard?year=${CURRENT_YEAR}`);
 
-        // The action menu placeholder is inside the collapse tbody.
+        // The action menu placeholder is inside the past-events collapse tbody.
         cy.get(
             `.event-action-menu-placeholder[data-event-id="${pastByInactiveEventId}"]`,
             { timeout: 10000 },
@@ -176,10 +183,9 @@ describe("Past Events Archiving (#8849)", () => {
     it("past-events toggle button shows correct count label", () => {
         cy.visit(`event/dashboard?year=${LAST_MONTH_YEAR}`);
 
-        cy.get(`[data-past-toggle="past-events-${LAST_MONTH_YEAR}-month-${LAST_MONTH}"]`).should(
-            "contain.text",
-            "past event",
-        );
+        cy.get(
+            `[data-past-toggle="past-events-${LAST_MONTH_YEAR}-month-${LAST_MONTH}"]`,
+        ).should("contain.text", "past event");
     });
 
     // -----------------------------------------------------------------------
@@ -191,27 +197,22 @@ describe("Past Events Archiving (#8849)", () => {
         const collapseId = `past-events-${LAST_MONTH_YEAR}-month-${LAST_MONTH}`;
         const toggleBtn = `[data-past-toggle="${collapseId}"]`;
 
-        // The collapse may start open (auto-expand for all-past month) or closed.
-        // We need it CLOSED before we can test the open→localStorage path.
-        // Use the aria-expanded attribute as a reliable indicator (updated by
-        // Bootstrap synchronously on click, before the animation completes).
+        // Ensure the section starts CLOSED before testing open→localStorage.
+        // Native DOM click inside .then() is synchronous — no queue race.
         cy.get(toggleBtn).then(($btn) => {
             if ($btn.attr("aria-expanded") === "true") {
-                // Already open — close it with a native DOM click so the action
-                // is synchronous inside .then() and doesn't suffer from Cypress
-                // command-queue ordering: cy.wrap().click() inside .then() gets
-                // enqueued but the outer .then() resolves first, causing the
-                // subsequent should('not.have.class','expanded') to race.
                 $btn[0].click();
             }
         });
-        // Wait for closed state regardless of initial condition.
+        // Top-level assertion — retries until the section is confirmed closed.
         cy.get(`#${collapseId}`).should("not.have.class", "expanded");
 
         // ---- Open it — verify localStorage is written ----
         cy.get(toggleBtn).click();
         cy.get(`#${collapseId}`).should("have.class", "expanded");
 
+        // cy.window().then() for synchronous window property reads is the
+        // correct Cypress pattern — not an anti-pattern.
         cy.window().then((win) => {
             const stored = JSON.parse(
                 win.localStorage.getItem("churchcrm.eventDashboard.pastOpen") || "[]",
@@ -235,24 +236,31 @@ describe("Past Events Archiving (#8849)", () => {
     // Test: auto-expand — month with ONLY past events starts open
     // -----------------------------------------------------------------------
     it("month containing only past events auto-expands the past section", () => {
-        // The past-by-date event is the only event created for LAST_MONTH.
-        // (quick-create deduplicates by type+date, so we likely have exactly 1.)
-        // Visit the year that contains the past month and check auto-expansion.
         cy.visit(`event/dashboard?year=${LAST_MONTH_YEAR}`);
 
-        cy.get(`#past-events-${LAST_MONTH_YEAR}-month-${LAST_MONTH}`).then(($el) => {
-            // If the month has no current events, the collapse is auto-expanded.
-            // Check whether a current tbody exists for this month card.
-            const $card = $el.closest(".card");
-            const hasCurrent = $card.find("tbody").not(".past-events-header-tbody").not(`#past-events-${LAST_MONTH_YEAR}-month-${LAST_MONTH}`).find("tr").length > 0;
+        const tbodyId = `past-events-${LAST_MONTH_YEAR}-month-${LAST_MONTH}`;
+
+        // Determine whether this month is all-past by checking for a current
+        // events tbody in the same card. We do this synchronously inside .then()
+        // — no Cypress commands issued, just a DOM read — then branch with
+        // top-level cy.wrap() assertions so retry-ability is preserved.
+        cy.get(`#${tbodyId}`).then(($tbodyEl) => {
+            const $card = $tbodyEl.closest(".card");
+            // A "current events" tbody is any tbody that is neither the header
+            // tbody nor the past-events tbody itself.
+            const hasCurrent =
+                $card
+                    .find("tbody")
+                    .not(".past-events-header-tbody")
+                    .not(`#${tbodyId}`)
+                    .find("tr").length > 0;
 
             if (!hasCurrent) {
-                // All-past month: collapse must be pre-expanded.
-                cy.wrap($el).should("have.class", "expanded");
+                // All-past month: PHP renders the section pre-expanded.
+                cy.wrap($tbodyEl).should("have.class", "expanded");
             } else {
-                // Mixed month: collapse may or may not be open depending on localStorage.
-                // Just assert the element exists and the test continues.
-                cy.wrap($el).should("exist");
+                // Mixed month: the section starts closed (localStorage cleared).
+                cy.wrap($tbodyEl).should("not.have.class", "expanded");
             }
         });
     });
@@ -263,8 +271,7 @@ describe("Past Events Archiving (#8849)", () => {
     it("stat card shows current / past event counts", () => {
         cy.visit(`event/dashboard?year=${CURRENT_YEAR}`);
 
-        // The "Current Events" stat card is rendered with fw-medium containing
-        // the count. It may also show "/ N past" if there are past events.
+        // The "Current Events" stat card must be present.
         cy.contains(".card-body", "Current Events").should("exist");
     });
 });

--- a/src/event/routes/list-events.php
+++ b/src/event/routes/list-events.php
@@ -16,7 +16,7 @@ use Slim\Views\PhpRenderer;
 
 // GET /event/dashboard — events dashboard page
 $app->get('/dashboard', function (Request $request, Response $response) {
-    $now = new DateTime();
+    $now = DateTimeUtils::getToday();
     $params = $request->getQueryParams();
     $canEditEvents = AuthenticationManager::getCurrentUser()->isAddEvent();
 
@@ -42,11 +42,6 @@ $app->get('/dashboard', function (Request $request, Response $response) {
             ->filterByStart(['min' => $yearMin, 'max' => $yearMax])
         ->endUse()
         ->filterByCheckinDate(null, Criteria::ISNOTNULL)
-        ->count();
-
-    $activeEventsThisYear = EventQuery::create()
-        ->filterByStart(['min' => $yearMin, 'max' => $yearMax])
-        ->filterByInActive(0)
         ->count();
 
     // Total number of event types defined in the system (not filtered by year).
@@ -84,7 +79,8 @@ $app->get('/dashboard', function (Request $request, Response $response) {
     // --- Build monthly event data (all Propel ORM — replaces 6 RunQuery calls) ---
     $allMonths = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
     $monthlyData = [];
-    // $now is defined once outside the foreach loop to avoid re-instantiation.
+    // $now is defined once outside the foreach loop to avoid re-instantiation
+    // and to use the church-configured timezone via DateTimeUtils::getToday().
 
     foreach ($allMonths as $mVal) {
         $daysInMonth = DateTimeUtils::getDaysInMonth($mVal, $EventYear);
@@ -222,7 +218,6 @@ $app->get('/dashboard', function (Request $request, Response $response) {
         'EventYear'              => $EventYear,
         'totalEventsThisYear'    => $totalEventsThisYear,
         'totalCheckInsThisYear'  => $totalCheckInsThisYear,
-        'activeEventsThisYear'   => $activeEventsThisYear,
         'totalCurrentEvents'     => $totalCurrentEvents,
         'totalPastEvents'        => $totalPastEvents,
         'totalEventTypes'        => $totalEventTypes,

--- a/src/event/routes/list-events.php
+++ b/src/event/routes/list-events.php
@@ -16,6 +16,7 @@ use Slim\Views\PhpRenderer;
 
 // GET /event/dashboard — events dashboard page
 $app->get('/dashboard', function (Request $request, Response $response) {
+    $now = new DateTime();
     $params = $request->getQueryParams();
     $canEditEvents = AuthenticationManager::getCurrentUser()->isAddEvent();
 
@@ -83,6 +84,7 @@ $app->get('/dashboard', function (Request $request, Response $response) {
     // --- Build monthly event data (all Propel ORM — replaces 6 RunQuery calls) ---
     $allMonths = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
     $monthlyData = [];
+    // $now is defined once outside the foreach loop to avoid re-instantiation.
 
     foreach ($allMonths as $mVal) {
         $daysInMonth = DateTimeUtils::getDaysInMonth($mVal, $EventYear);
@@ -104,7 +106,8 @@ $app->get('/dashboard', function (Request $request, Response $response) {
             continue;
         }
 
-        $events = [];
+        $currentEvents = [];
+        $pastEvents    = [];
         foreach ($monthEvents as $evt) {
             $eventId = (int) $evt->getId();
 
@@ -138,7 +141,7 @@ $app->get('/dashboard', function (Request $request, Response $response) {
                 ];
             }
 
-            $events[] = [
+            $row = [
                 'id'                => $eventId,
                 'type_name'         => $evt->getEventType() ? $evt->getEventType()->getName() : '',
                 'title'             => $evt->getTitle(),
@@ -152,13 +155,24 @@ $app->get('/dashboard', function (Request $request, Response $response) {
                 'checked_out_count' => $checkedOutCount,
                 'counts'            => $countsArray,
             ];
+
+            // An event is "past" when it has ended chronologically OR was deactivated.
+            $isPast = ((int) $evt->getInActive() === 1)
+                || ($evt->getEnd() !== null && $evt->getEnd() < $now);
+
+            if ($isPast) {
+                $pastEvents[] = $row;
+            } else {
+                $currentEvents[] = $row;
+            }
         }
 
         // Monthly averages — eventcounts_evtcnt has no FK relation to events_event
         // in the schema, so we filter by the event IDs we already loaded above.
         $averages = [];
-        if ($eType !== 'All' && !empty($events[0]['counts'])) {
-            $eventIds = array_column($events, 'id');
+        $allMonthEvents = array_merge($currentEvents, $pastEvents);
+        if ($eType !== 'All' && !empty($allMonthEvents[0]['counts'])) {
+            $eventIds = array_column($allMonthEvents, 'id');
 
             $avgCounts = EventCountsQuery::create()
                 ->filterByEvtcntEventid($eventIds, Criteria::IN)
@@ -177,15 +191,22 @@ $app->get('/dashboard', function (Request $request, Response $response) {
         }
 
         $monthlyData[] = [
-            'month'     => $mVal,
-            'monthName' => date('F', mktime(0, 0, 0, $mVal, 1, $EventYear)),
-            'count'     => $monthEvents->count(),
-            'events'    => $events,
-            'averages'  => $averages,
+            'month'         => $mVal,
+            'monthName'     => date('F', mktime(0, 0, 0, $mVal, 1, $EventYear)),
+            'count'         => $monthEvents->count(),
+            'currentCount'  => count($currentEvents),
+            'pastCount'     => count($pastEvents),
+            'currentEvents' => $currentEvents,
+            'pastEvents'    => $pastEvents,
+            'averages'      => $averages,
         ];
     }
 
     $renderer = new PhpRenderer(__DIR__ . '/../views/');
+
+    // Aggregate current/past counts across all months for the stat card.
+    $totalCurrentEvents = array_sum(array_column($monthlyData, 'currentCount'));
+    $totalPastEvents    = array_sum(array_column($monthlyData, 'pastCount'));
 
     return $renderer->render($response, 'list-events.php', [
         'sRootPath'              => SystemURLs::getRootPath(),
@@ -202,6 +223,8 @@ $app->get('/dashboard', function (Request $request, Response $response) {
         'totalEventsThisYear'    => $totalEventsThisYear,
         'totalCheckInsThisYear'  => $totalCheckInsThisYear,
         'activeEventsThisYear'   => $activeEventsThisYear,
+        'totalCurrentEvents'     => $totalCurrentEvents,
+        'totalPastEvents'        => $totalPastEvents,
         'totalEventTypes'        => $totalEventTypes,
         'eventTypesWithEvents'   => $eventTypesWithEvents,
         'availableYears'         => $availableYears,

--- a/src/event/views/list-events.php
+++ b/src/event/views/list-events.php
@@ -322,12 +322,32 @@ foreach ($monthlyData as $monthData):
 </div>
 <?php endif; ?>
 
+<style>
+  /* Past events tbody is hidden by default; JS adds .expanded to show it. */
+  tbody.past-events-body {
+    display: none;
+  }
+  tbody.past-events-body.expanded {
+    display: table-row-group;
+  }
+  /* Rotate chevron when the past-events section is open. */
+  .past-events-chevron {
+    display: inline-block;
+    transition: transform 0.2s ease;
+  }
+  .past-events-chevron.rotate-90 {
+    transform: rotate(90deg);
+  }
+</style>
+
 <script nonce="<?= SystemURLs::getCSPNonce() ?>">
   // Auto-submit the filter form when the user picks a type or year.
   // (Replaces the previous inline onchange="this.form.submit()" which CSP blocks.)
-  document.querySelectorAll('#eventFilterForm select').forEach(function (sel) {
-    sel.addEventListener('change', function () {
-      document.getElementById('eventFilterForm').submit();
+  document.addEventListener('DOMContentLoaded', function () {
+    document.querySelectorAll('#eventFilterForm select').forEach(function (sel) {
+      sel.addEventListener('change', function () {
+        document.getElementById('eventFilterForm').submit();
+      });
     });
   });
 
@@ -356,7 +376,7 @@ foreach ($monthlyData as $monthData):
   // State: tbody.past-events-body gets class "expanded" when open.
   // Persistence: localStorage key "churchcrm.eventDashboard.pastOpen".
   // ---------------------------------------------------------------------------
-  (function initPastEventsToggle() {
+  document.addEventListener('DOMContentLoaded', function () {
     var KEY = 'churchcrm.eventDashboard.pastOpen';
 
     function loadOpenMonths() {
@@ -405,13 +425,13 @@ foreach ($monthlyData as $monthData):
         setExpanded(tbody, btn, true);
       }
 
-      // Sync initial chevron to match PHP-rendered state.
+      // Sync initial chevron and aria-expanded to match PHP-rendered state.
       var isExpanded = tbody.classList.contains('expanded');
+      btn.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
       var chevron = btn.querySelector('.past-events-chevron');
       if (chevron && isExpanded) {
         chevron.classList.add('rotate-90');
       }
-      btn.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
 
       btn.addEventListener('click', function () {
         var nowExpanded = !tbody.classList.contains('expanded');
@@ -424,26 +444,8 @@ foreach ($monthlyData as $monthData):
         saveOpenMonths(Array.from(open));
       });
     });
-  })();
+  });
 </script>
-
-<style>
-  /* Past events tbody is hidden by default; JS adds .expanded to show it. */
-  tbody.past-events-body {
-    display: none;
-  }
-  tbody.past-events-body.expanded {
-    display: table-row-group;
-  }
-  /* Rotate chevron when the past-events section is open. */
-  .past-events-chevron {
-    display: inline-block;
-    transition: transform 0.2s ease;
-  }
-  .past-events-chevron.rotate-90 {
-    transform: rotate(90deg);
-  }
-</style>
 
 <?php
 require SystemURLs::getDocumentRoot() . '/Include/Footer.php';

--- a/src/event/views/list-events.php
+++ b/src/event/views/list-events.php
@@ -349,7 +349,25 @@ foreach ($monthlyData as $monthData):
   // ---------------------------------------------------------------------------
   (function initPastEventsCollapse() {
     var KEY = 'churchcrm.eventDashboard.pastOpen';
-    var open = new Set(JSON.parse(localStorage.getItem(KEY) || '[]'));
+
+    function loadOpenMonths() {
+      try {
+        var parsed = JSON.parse(localStorage.getItem(KEY) || '[]');
+        return Array.isArray(parsed) ? parsed : [];
+      } catch {
+        return [];
+      }
+    }
+
+    function saveOpenMonths(arr) {
+      try {
+        localStorage.setItem(KEY, JSON.stringify(arr));
+      } catch {
+        // quota exceeded or storage blocked — fail silently
+      }
+    }
+
+    var open = new Set(loadOpenMonths());
 
     // Apply persisted expanded state (skip months already auto-expanded in PHP).
     document.querySelectorAll('[id^="past-events-month-"]').forEach(function (el) {
@@ -394,7 +412,7 @@ foreach ($monthlyData as $monthData):
     });
 
     function persist() {
-      localStorage.setItem(KEY, JSON.stringify(Array.from(open)));
+      saveOpenMonths(Array.from(open));
     }
   })();
 </script>

--- a/src/event/views/list-events.php
+++ b/src/event/views/list-events.php
@@ -55,8 +55,13 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
             </span>
           </div>
           <div class="col">
-            <div class="fw-medium"><?= (int) $activeEventsThisYear ?></div>
-            <div class="text-body-secondary"><?= gettext('Active Events') ?></div>
+            <div class="fw-medium">
+              <?= (int) $totalCurrentEvents ?>
+              <?php if ($totalPastEvents > 0): ?>
+                <small class="text-body-secondary">/ <?= (int) $totalPastEvents ?> <?= gettext('past') ?></small>
+              <?php endif; ?>
+            </div>
+            <div class="text-body-secondary"><?= gettext('Current Events') ?></div>
           </div>
         </div>
       </div>
@@ -149,12 +154,23 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
 $hasEvents = !empty($monthlyData);
 
 foreach ($monthlyData as $monthData):
-    $events = $monthData['events'];
-    $numRows = $monthData['count'];
-    $monthName = $monthData['monthName'];
-    $averages = $monthData['averages'];
+    $currentEvents = $monthData['currentEvents'];
+    $pastEvents    = $monthData['pastEvents'];
+    $currentCount  = $monthData['currentCount'];
+    $pastCount     = $monthData['pastCount'];
+    $numRows       = $monthData['count'];
+    $monthName     = $monthData['monthName'];
+    $averages      = $monthData['averages'];
+    $monthNum      = (int) $monthData['month'];
+
+    // Auto-expand the past section when the month has NO current events
+    // (e.g., filtering a past year or a future-only month).
+    $autoExpand = ($currentCount === 0 && $pastCount > 0);
+
+    // Column span — 7 when the edit actions column is present, 6 otherwise.
+    $colSpan = $canEditEvents ? 7 : 6;
 ?>
-<div class="card mb-3" id="month-<?= (int) $monthData['month'] ?>">
+<div class="card mb-3" id="month-<?= $monthNum ?>">
   <div class="card-header d-flex align-items-center">
     <h3 class="card-title mb-0">
       <i class="ti ti-calendar me-2 text-body-secondary"></i>
@@ -178,72 +194,43 @@ foreach ($monthlyData as $monthData):
             <?php endif; ?>
           </tr>
         </thead>
+
+        <?php if (!empty($currentEvents)): ?>
+        <!-- ============ CURRENT EVENTS ============ -->
         <tbody>
-          <?php foreach ($events as $event): ?>
-            <?php $eventId = (int) $event['id']; ?>
-            <tr>
-              <td>
-                <a href="<?= $sRootPath ?>/event/view/<?= $eventId ?>" class="fw-medium text-reset text-decoration-none">
-                  <?= InputUtils::escapeHTML($event['title']) ?>
-                </a>
-                <?php
-                  // Quill leaves "<p><br /></p>" when the description is empty —
-                  // strip tags and trim before deciding whether to show anything.
-                  $descText = trim(strip_tags((string) ($event['desc'] ?? '')));
-                ?>
-                <?php if ($descText !== ''): ?>
-                  <div><small class="text-body-secondary"><?= InputUtils::escapeHTML($descText) ?></small></div>
-                <?php endif; ?>
-              </td>
-              <td>
-                <span class="badge bg-azure-lt"><?= InputUtils::escapeHTML($event['type_name']) ?></span>
-              </td>
-              <td class="text-center">
-                <a href="<?= $sRootPath ?>/event/checkin/<?= $eventId ?>" class="btn btn-sm btn-ghost-secondary" title="<?= gettext('Manage Check-ins') ?>">
-                  <i class="ti ti-clipboard-check me-1"></i>
-                  <?php if ($event['attendee_count'] > 0): ?>
-                    <span class="badge bg-primary text-white"><?= $event['attendee_count'] ?></span>
-                  <?php else: ?>
-                    <span class="text-body-secondary">0</span>
-                  <?php endif; ?>
-                </a>
-              </td>
-              <td>
-                <?php if (empty($event['counts'])): ?>
-                  <span class="text-body-secondary">—</span>
-                <?php else: ?>
-                  <?php
-                  $countParts = [];
-                  foreach ($event['counts'] as $count) {
-                      if ($count['count'] > 0) {
-                          $countParts[] = '<span class="text-body-secondary small">' . InputUtils::escapeHTML($count['name']) . '</span> ' . $count['count'];
-                      }
-                  }
-                  echo !empty($countParts) ? implode('<br>', $countParts) : '<span class="text-body-secondary">—</span>';
-                  ?>
-                <?php endif; ?>
-              </td>
-              <td>
-                <span class="small"><?= DateTimeUtils::formatDate($event['start'], 1) ?></span>
-              </td>
-              <td class="text-center">
-                <?php if ($event['inactive']): ?>
-                  <span class="badge bg-secondary-lt"><?= gettext('Inactive') ?></span>
-                <?php else: ?>
-                  <span class="badge bg-green-lt text-green"><?= gettext('Active') ?></span>
-                <?php endif; ?>
-              </td>
-              <?php if ($canEditEvents): ?>
-                <td class="text-center">
-                  <div
-                    class="event-action-menu-placeholder"
-                    data-event-id="<?= $eventId ?>"
-                    data-event-title="<?= InputUtils::escapeAttribute($event['title']) ?>"
-                    data-event-inactive="<?= (int) $event['inactive'] ?>"
-                  ></div>
-                </td>
-              <?php endif; ?>
-            </tr>
+          <?php foreach ($currentEvents as $event): ?>
+            <?php include __DIR__ . '/partials/event-row.php'; ?>
+          <?php endforeach; ?>
+        </tbody>
+        <?php endif; ?>
+
+        <?php if (!empty($pastEvents)): ?>
+        <!-- ============ PAST EVENTS (collapsible) ============ -->
+        <tbody class="past-events-header-tbody">
+          <tr>
+            <td colspan="<?= $colSpan ?>" class="bg-body-tertiary p-0">
+              <button
+                class="btn btn-sm btn-ghost-secondary w-100 text-start rounded-0 py-2 px-3"
+                type="button"
+                data-bs-toggle="collapse"
+                data-bs-target="#past-events-month-<?= $monthNum ?>"
+                aria-expanded="<?= $autoExpand ? 'true' : 'false' ?>"
+                aria-controls="past-events-month-<?= $monthNum ?>"
+              >
+                <i class="ti ti-chevron-right me-1 past-events-chevron"></i>
+                <i class="ti ti-archive me-1 text-body-secondary"></i>
+                <?= sprintf(
+                    ngettext('%d past event', '%d past events', $pastCount),
+                    $pastCount
+                ) ?>
+              </button>
+            </td>
+          </tr>
+        </tbody>
+
+        <tbody id="past-events-month-<?= $monthNum ?>" class="collapse<?= $autoExpand ? ' show' : '' ?>">
+          <?php foreach ($pastEvents as $event): ?>
+            <?php include __DIR__ . '/partials/event-row.php'; ?>
           <?php endforeach; ?>
 
           <?php if (!empty($averages)): ?>
@@ -265,6 +252,30 @@ foreach ($monthlyData as $monthData):
             </tr>
           <?php endif; ?>
         </tbody>
+        <?php else: ?>
+        <!-- No past events — Monthly Averages (if any) go in the current tbody -->
+        <?php if (!empty($averages)): ?>
+        <tbody>
+          <tr class="table-light">
+            <td><strong><?= gettext('Monthly Averages') ?></strong></td>
+            <td></td>
+            <td></td>
+            <td>
+              <?php
+              $avgParts = [];
+              foreach ($averages as $avg) {
+                  $avgParts[] = '<span class="text-body-secondary small">' . InputUtils::escapeHTML($avg['name']) . '</span> ' . sprintf('%.1f', $avg['avg_count']);
+              }
+              echo implode('<br>', $avgParts);
+              ?>
+            </td>
+            <td colspan="2"></td>
+            <?php if ($canEditEvents): ?><td></td><?php endif; ?>
+          </tr>
+        </tbody>
+        <?php endif; ?>
+        <?php endif; ?>
+
       </table>
     </div>
   </div>
@@ -332,7 +343,72 @@ foreach ($monthlyData as $monthData):
       window.addEventListener('CRM.localesReady', render, { once: true });
     }
   })();
+
+  // ---------------------------------------------------------------------------
+  // Past Events collapse — localStorage persistence + chevron rotation
+  // ---------------------------------------------------------------------------
+  (function initPastEventsCollapse() {
+    var KEY = 'churchcrm.eventDashboard.pastOpen';
+    var open = new Set(JSON.parse(localStorage.getItem(KEY) || '[]'));
+
+    // Apply persisted expanded state (skip months already auto-expanded in PHP).
+    document.querySelectorAll('[id^="past-events-month-"]').forEach(function (el) {
+      if (open.has(el.id) && !el.classList.contains('show')) {
+        el.classList.add('show');
+        var btn = document.querySelector('[data-bs-target="#' + el.id + '"]');
+        if (btn) btn.setAttribute('aria-expanded', 'true');
+      }
+    });
+
+    // Sync chevron rotation with Bootstrap collapse state.
+    function updateChevron(collapseEl, expanded) {
+      var btn = document.querySelector('[data-bs-target="#' + collapseEl.id + '"]');
+      if (!btn) return;
+      var chevron = btn.querySelector('.past-events-chevron');
+      if (chevron) {
+        if (expanded) {
+          chevron.classList.add('rotate-90');
+        } else {
+          chevron.classList.remove('rotate-90');
+        }
+      }
+    }
+
+    // Set initial chevron state based on current show/hide.
+    document.querySelectorAll('[id^="past-events-month-"]').forEach(function (el) {
+      updateChevron(el, el.classList.contains('show'));
+    });
+
+    // Track changes and persist to localStorage.
+    document.querySelectorAll('[id^="past-events-month-"]').forEach(function (el) {
+      el.addEventListener('shown.bs.collapse', function () {
+        open.add(el.id);
+        persist();
+        updateChevron(el, true);
+      });
+      el.addEventListener('hidden.bs.collapse', function () {
+        open.delete(el.id);
+        persist();
+        updateChevron(el, false);
+      });
+    });
+
+    function persist() {
+      localStorage.setItem(KEY, JSON.stringify(Array.from(open)));
+    }
+  })();
 </script>
+
+<style>
+  /* Rotate chevron when the past-events collapse is open */
+  .past-events-chevron {
+    display: inline-block;
+    transition: transform 0.2s ease;
+  }
+  .past-events-chevron.rotate-90 {
+    transform: rotate(90deg);
+  }
+</style>
 
 <?php
 require SystemURLs::getDocumentRoot() . '/Include/Footer.php';

--- a/src/event/views/list-events.php
+++ b/src/event/views/list-events.php
@@ -167,6 +167,10 @@ foreach ($monthlyData as $monthData):
     // (e.g., filtering a past year or a future-only month).
     $autoExpand = ($currentCount === 0 && $pastCount > 0);
 
+    // Collapse element ID includes year so localStorage entries don't bleed
+    // across years (e.g. March 2025 vs March 2026).
+    $collapseId = 'past-events-' . $EventYear . '-month-' . $monthNum;
+
     // Column span — 7 when the edit actions column is present, 6 otherwise.
     $colSpan = $canEditEvents ? 7 : 6;
 ?>
@@ -213,9 +217,9 @@ foreach ($monthlyData as $monthData):
                 class="btn btn-sm btn-ghost-secondary w-100 text-start rounded-0 py-2 px-3"
                 type="button"
                 data-bs-toggle="collapse"
-                data-bs-target="#past-events-month-<?= $monthNum ?>"
+                data-bs-target="#<?= $collapseId ?>"
                 aria-expanded="<?= $autoExpand ? 'true' : 'false' ?>"
-                aria-controls="past-events-month-<?= $monthNum ?>"
+                aria-controls="<?= $collapseId ?>"
               >
                 <i class="ti ti-chevron-right me-1 past-events-chevron"></i>
                 <i class="ti ti-archive me-1 text-body-secondary"></i>
@@ -228,30 +232,33 @@ foreach ($monthlyData as $monthData):
           </tr>
         </tbody>
 
-        <tbody id="past-events-month-<?= $monthNum ?>" class="collapse<?= $autoExpand ? ' show' : '' ?>">
+        <tbody id="<?= $collapseId ?>" class="collapse<?= $autoExpand ? ' show' : '' ?>">
           <?php foreach ($pastEvents as $event): ?>
             <?php include __DIR__ . '/partials/event-row.php'; ?>
           <?php endforeach; ?>
-
-          <?php if (!empty($averages)): ?>
-            <tr class="table-light">
-              <td><strong><?= gettext('Monthly Averages') ?></strong></td>
-              <td></td>
-              <td></td>
-              <td>
-                <?php
-                $avgParts = [];
-                foreach ($averages as $avg) {
-                    $avgParts[] = '<span class="text-body-secondary small">' . InputUtils::escapeHTML($avg['name']) . '</span> ' . sprintf('%.1f', $avg['avg_count']);
-                }
-                echo implode('<br>', $avgParts);
-                ?>
-              </td>
-              <td colspan="2"></td>
-              <?php if ($canEditEvents): ?><td></td><?php endif; ?>
-            </tr>
-          <?php endif; ?>
         </tbody>
+
+        <?php if (!empty($averages)): ?>
+        <!-- Monthly Averages always visible, outside the collapsible past tbody -->
+        <tbody>
+          <tr class="table-light">
+            <td><strong><?= gettext('Monthly Averages') ?></strong></td>
+            <td></td>
+            <td></td>
+            <td>
+              <?php
+              $avgParts = [];
+              foreach ($averages as $avg) {
+                  $avgParts[] = '<span class="text-body-secondary small">' . InputUtils::escapeHTML($avg['name']) . '</span> ' . sprintf('%.1f', $avg['avg_count']);
+              }
+              echo implode('<br>', $avgParts);
+              ?>
+            </td>
+            <td colspan="2"></td>
+            <?php if ($canEditEvents): ?><td></td><?php endif; ?>
+          </tr>
+        </tbody>
+        <?php endif; ?>
         <?php else: ?>
         <!-- No past events — Monthly Averages (if any) go in the current tbody -->
         <?php if (!empty($averages)): ?>
@@ -370,7 +377,7 @@ foreach ($monthlyData as $monthData):
     var open = new Set(loadOpenMonths());
 
     // Apply persisted expanded state (skip months already auto-expanded in PHP).
-    document.querySelectorAll('[id^="past-events-month-"]').forEach(function (el) {
+    document.querySelectorAll('[id^="past-events-"]').forEach(function (el) {
       if (open.has(el.id) && !el.classList.contains('show')) {
         el.classList.add('show');
         var btn = document.querySelector('[data-bs-target="#' + el.id + '"]');
@@ -393,12 +400,12 @@ foreach ($monthlyData as $monthData):
     }
 
     // Set initial chevron state based on current show/hide.
-    document.querySelectorAll('[id^="past-events-month-"]').forEach(function (el) {
+    document.querySelectorAll('[id^="past-events-"]').forEach(function (el) {
       updateChevron(el, el.classList.contains('show'));
     });
 
     // Track changes and persist to localStorage.
-    document.querySelectorAll('[id^="past-events-month-"]').forEach(function (el) {
+    document.querySelectorAll('[id^="past-events-"]').forEach(function (el) {
       el.addEventListener('shown.bs.collapse', function () {
         open.add(el.id);
         persist();
@@ -425,6 +432,12 @@ foreach ($monthlyData as $monthData):
   }
   .past-events-chevron.rotate-90 {
     transform: rotate(90deg);
+  }
+  /* Bootstrap 5 sets .collapse.show { display: block } which breaks <tbody>
+     layout in Firefox and Safari. Override to restore the correct table
+     display value. */
+  tbody.collapse.show {
+    display: table-row-group !important;
   }
 </style>
 

--- a/src/event/views/list-events.php
+++ b/src/event/views/list-events.php
@@ -371,12 +371,13 @@ foreach ($monthlyData as $monthData):
   })();
 
   // ---------------------------------------------------------------------------
-  // Past Events toggle — plain JS (no Bootstrap collapse: <tbody> doesn't
-  // support BS5's height-animation approach; scrollHeight on tbody is 0).
+  // Past Events toggle — plain JS, event delegation on document.
+  // Using delegation (not per-button listeners) so the handler survives any
+  // post-DOMContentLoaded DOM mutations (hydration, DataTables, etc.).
   // State: tbody.past-events-body gets class "expanded" when open.
   // Persistence: localStorage key "churchcrm.eventDashboard.pastOpen".
   // ---------------------------------------------------------------------------
-  document.addEventListener('DOMContentLoaded', function () {
+  (function initPastEventsToggle() {
     var KEY = 'churchcrm.eventDashboard.pastOpen';
 
     function loadOpenMonths() {
@@ -396,8 +397,6 @@ foreach ($monthlyData as $monthData):
       }
     }
 
-    var open = new Set(loadOpenMonths());
-
     function setExpanded(tbody, btn, expanded) {
       if (expanded) {
         tbody.classList.add('expanded');
@@ -407,44 +406,55 @@ foreach ($monthlyData as $monthData):
       btn.setAttribute('aria-expanded', expanded ? 'true' : 'false');
       var chevron = btn.querySelector('.past-events-chevron');
       if (chevron) {
-        if (expanded) {
-          chevron.classList.add('rotate-90');
-        } else {
-          chevron.classList.remove('rotate-90');
-        }
+        chevron.classList.toggle('rotate-90', expanded);
       }
     }
 
-    document.querySelectorAll('[data-past-toggle]').forEach(function (btn) {
+    // Apply persisted + initial state once the DOM is ready.
+    document.addEventListener('DOMContentLoaded', function () {
+      var open = new Set(loadOpenMonths());
+
+      document.querySelectorAll('[data-past-toggle]').forEach(function (btn) {
+        var id = btn.getAttribute('data-past-toggle');
+        var tbody = document.getElementById(id);
+        if (!tbody) return;
+
+        // Apply persisted state (skip if already expanded by PHP auto-expand).
+        if (open.has(id) && !tbody.classList.contains('expanded')) {
+          setExpanded(tbody, btn, true);
+        }
+
+        // Sync initial chevron and aria-expanded to match PHP-rendered state.
+        var isExpanded = tbody.classList.contains('expanded');
+        btn.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
+        var chevron = btn.querySelector('.past-events-chevron');
+        if (chevron && isExpanded) {
+          chevron.classList.add('rotate-90');
+        }
+      });
+    });
+
+    // Delegated click handler on document — immune to DOM re-renders because
+    // the listener lives on a stable ancestor, not the individual buttons.
+    document.addEventListener('click', function (e) {
+      var btn = e.target.closest('[data-past-toggle]');
+      if (!btn) return;
+
       var id = btn.getAttribute('data-past-toggle');
       var tbody = document.getElementById(id);
       if (!tbody) return;
 
-      // Apply persisted state (skip if already expanded by PHP auto-expand).
-      if (open.has(id) && !tbody.classList.contains('expanded')) {
-        setExpanded(tbody, btn, true);
+      var open = new Set(loadOpenMonths());
+      var nowExpanded = !tbody.classList.contains('expanded');
+      setExpanded(tbody, btn, nowExpanded);
+      if (nowExpanded) {
+        open.add(id);
+      } else {
+        open.delete(id);
       }
-
-      // Sync initial chevron and aria-expanded to match PHP-rendered state.
-      var isExpanded = tbody.classList.contains('expanded');
-      btn.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
-      var chevron = btn.querySelector('.past-events-chevron');
-      if (chevron && isExpanded) {
-        chevron.classList.add('rotate-90');
-      }
-
-      btn.addEventListener('click', function () {
-        var nowExpanded = !tbody.classList.contains('expanded');
-        setExpanded(tbody, btn, nowExpanded);
-        if (nowExpanded) {
-          open.add(id);
-        } else {
-          open.delete(id);
-        }
-        saveOpenMonths(Array.from(open));
-      });
+      saveOpenMonths(Array.from(open));
     });
-  });
+  })();
 </script>
 
 <?php

--- a/src/event/views/list-events.php
+++ b/src/event/views/list-events.php
@@ -216,8 +216,7 @@ foreach ($monthlyData as $monthData):
               <button
                 class="btn btn-sm btn-ghost-secondary w-100 text-start rounded-0 py-2 px-3"
                 type="button"
-                data-bs-toggle="collapse"
-                data-bs-target="#<?= $collapseId ?>"
+                data-past-toggle="<?= $collapseId ?>"
                 aria-expanded="<?= $autoExpand ? 'true' : 'false' ?>"
                 aria-controls="<?= $collapseId ?>"
               >
@@ -232,7 +231,7 @@ foreach ($monthlyData as $monthData):
           </tr>
         </tbody>
 
-        <tbody id="<?= $collapseId ?>" class="collapse<?= $autoExpand ? ' show' : '' ?>">
+        <tbody id="<?= $collapseId ?>" class="past-events-body<?= $autoExpand ? ' expanded' : '' ?>">
           <?php foreach ($pastEvents as $event): ?>
             <?php include __DIR__ . '/partials/event-row.php'; ?>
           <?php endforeach; ?>
@@ -352,9 +351,12 @@ foreach ($monthlyData as $monthData):
   })();
 
   // ---------------------------------------------------------------------------
-  // Past Events collapse — localStorage persistence + chevron rotation
+  // Past Events toggle — plain JS (no Bootstrap collapse: <tbody> doesn't
+  // support BS5's height-animation approach; scrollHeight on tbody is 0).
+  // State: tbody.past-events-body gets class "expanded" when open.
+  // Persistence: localStorage key "churchcrm.eventDashboard.pastOpen".
   // ---------------------------------------------------------------------------
-  (function initPastEventsCollapse() {
+  (function initPastEventsToggle() {
     var KEY = 'churchcrm.eventDashboard.pastOpen';
 
     function loadOpenMonths() {
@@ -376,19 +378,13 @@ foreach ($monthlyData as $monthData):
 
     var open = new Set(loadOpenMonths());
 
-    // Apply persisted expanded state (skip months already auto-expanded in PHP).
-    document.querySelectorAll('[id^="past-events-"]').forEach(function (el) {
-      if (open.has(el.id) && !el.classList.contains('show')) {
-        el.classList.add('show');
-        var btn = document.querySelector('[data-bs-target="#' + el.id + '"]');
-        if (btn) btn.setAttribute('aria-expanded', 'true');
+    function setExpanded(tbody, btn, expanded) {
+      if (expanded) {
+        tbody.classList.add('expanded');
+      } else {
+        tbody.classList.remove('expanded');
       }
-    });
-
-    // Sync chevron rotation with Bootstrap collapse state.
-    function updateChevron(collapseEl, expanded) {
-      var btn = document.querySelector('[data-bs-target="#' + collapseEl.id + '"]');
-      if (!btn) return;
+      btn.setAttribute('aria-expanded', expanded ? 'true' : 'false');
       var chevron = btn.querySelector('.past-events-chevron');
       if (chevron) {
         if (expanded) {
@@ -399,45 +395,53 @@ foreach ($monthlyData as $monthData):
       }
     }
 
-    // Set initial chevron state based on current show/hide.
-    document.querySelectorAll('[id^="past-events-"]').forEach(function (el) {
-      updateChevron(el, el.classList.contains('show'));
-    });
+    document.querySelectorAll('[data-past-toggle]').forEach(function (btn) {
+      var id = btn.getAttribute('data-past-toggle');
+      var tbody = document.getElementById(id);
+      if (!tbody) return;
 
-    // Track changes and persist to localStorage.
-    document.querySelectorAll('[id^="past-events-"]').forEach(function (el) {
-      el.addEventListener('shown.bs.collapse', function () {
-        open.add(el.id);
-        persist();
-        updateChevron(el, true);
-      });
-      el.addEventListener('hidden.bs.collapse', function () {
-        open.delete(el.id);
-        persist();
-        updateChevron(el, false);
+      // Apply persisted state (skip if already expanded by PHP auto-expand).
+      if (open.has(id) && !tbody.classList.contains('expanded')) {
+        setExpanded(tbody, btn, true);
+      }
+
+      // Sync initial chevron to match PHP-rendered state.
+      var isExpanded = tbody.classList.contains('expanded');
+      var chevron = btn.querySelector('.past-events-chevron');
+      if (chevron && isExpanded) {
+        chevron.classList.add('rotate-90');
+      }
+      btn.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
+
+      btn.addEventListener('click', function () {
+        var nowExpanded = !tbody.classList.contains('expanded');
+        setExpanded(tbody, btn, nowExpanded);
+        if (nowExpanded) {
+          open.add(id);
+        } else {
+          open.delete(id);
+        }
+        saveOpenMonths(Array.from(open));
       });
     });
-
-    function persist() {
-      saveOpenMonths(Array.from(open));
-    }
   })();
 </script>
 
 <style>
-  /* Rotate chevron when the past-events collapse is open */
+  /* Past events tbody is hidden by default; JS adds .expanded to show it. */
+  tbody.past-events-body {
+    display: none;
+  }
+  tbody.past-events-body.expanded {
+    display: table-row-group;
+  }
+  /* Rotate chevron when the past-events section is open. */
   .past-events-chevron {
     display: inline-block;
     transition: transform 0.2s ease;
   }
   .past-events-chevron.rotate-90 {
     transform: rotate(90deg);
-  }
-  /* Bootstrap 5 sets .collapse.show { display: block } which breaks <tbody>
-     layout in Firefox and Safari. Override to restore the correct table
-     display value. */
-  tbody.collapse.show {
-    display: table-row-group !important;
   }
 </style>
 

--- a/src/event/views/partials/event-row.php
+++ b/src/event/views/partials/event-row.php
@@ -1,4 +1,7 @@
 <?php
+use ChurchCRM\Utils\DateTimeUtils;
+use ChurchCRM\Utils\InputUtils;
+
 /**
  * Partial: a single event row for the events dashboard table.
  *

--- a/src/event/views/partials/event-row.php
+++ b/src/event/views/partials/event-row.php
@@ -10,12 +10,14 @@ use ChurchCRM\Utils\InputUtils;
  *                   counts, start, inactive
  *   $sRootPath    — application root path
  *   $canEditEvents — bool
+ *
+ * Uses $_eventRowId as a local variable to avoid polluting the calling scope.
  */
-$eventId = (int) $event['id'];
+$_eventRowId = (int) $event['id'];
 ?>
 <tr>
   <td>
-    <a href="<?= $sRootPath ?>/event/view/<?= $eventId ?>" class="fw-medium text-reset text-decoration-none">
+    <a href="<?= $sRootPath ?>/event/view/<?= $_eventRowId ?>" class="fw-medium text-reset text-decoration-none">
       <?= InputUtils::escapeHTML($event['title']) ?>
     </a>
     <?php
@@ -31,7 +33,7 @@ $eventId = (int) $event['id'];
     <span class="badge bg-azure-lt"><?= InputUtils::escapeHTML($event['type_name']) ?></span>
   </td>
   <td class="text-center">
-    <a href="<?= $sRootPath ?>/event/checkin/<?= $eventId ?>" class="btn btn-sm btn-ghost-secondary" title="<?= gettext('Manage Check-ins') ?>">
+    <a href="<?= $sRootPath ?>/event/checkin/<?= $_eventRowId ?>" class="btn btn-sm btn-ghost-secondary" title="<?= gettext('Manage Check-ins') ?>">
       <i class="ti ti-clipboard-check me-1"></i>
       <?php if ($event['attendee_count'] > 0): ?>
         <span class="badge bg-primary text-white"><?= $event['attendee_count'] ?></span>
@@ -69,7 +71,7 @@ $eventId = (int) $event['id'];
     <td class="text-center">
       <div
         class="event-action-menu-placeholder"
-        data-event-id="<?= $eventId ?>"
+        data-event-id="<?= $_eventRowId ?>"
         data-event-title="<?= InputUtils::escapeAttribute($event['title']) ?>"
         data-event-inactive="<?= (int) $event['inactive'] ?>"
       ></div>

--- a/src/event/views/partials/event-row.php
+++ b/src/event/views/partials/event-row.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Partial: a single event row for the events dashboard table.
+ *
+ * Expected variables (from parent scope):
+ *   $event        — array with keys: id, title, desc, type_name, attendee_count,
+ *                   counts, start, inactive
+ *   $sRootPath    — application root path
+ *   $canEditEvents — bool
+ */
+$eventId = (int) $event['id'];
+?>
+<tr>
+  <td>
+    <a href="<?= $sRootPath ?>/event/view/<?= $eventId ?>" class="fw-medium text-reset text-decoration-none">
+      <?= InputUtils::escapeHTML($event['title']) ?>
+    </a>
+    <?php
+      // Quill leaves "<p><br /></p>" when the description is empty —
+      // strip tags and trim before deciding whether to show anything.
+      $descText = trim(strip_tags((string) ($event['desc'] ?? '')));
+    ?>
+    <?php if ($descText !== ''): ?>
+      <div><small class="text-body-secondary"><?= InputUtils::escapeHTML($descText) ?></small></div>
+    <?php endif; ?>
+  </td>
+  <td>
+    <span class="badge bg-azure-lt"><?= InputUtils::escapeHTML($event['type_name']) ?></span>
+  </td>
+  <td class="text-center">
+    <a href="<?= $sRootPath ?>/event/checkin/<?= $eventId ?>" class="btn btn-sm btn-ghost-secondary" title="<?= gettext('Manage Check-ins') ?>">
+      <i class="ti ti-clipboard-check me-1"></i>
+      <?php if ($event['attendee_count'] > 0): ?>
+        <span class="badge bg-primary text-white"><?= $event['attendee_count'] ?></span>
+      <?php else: ?>
+        <span class="text-body-secondary">0</span>
+      <?php endif; ?>
+    </a>
+  </td>
+  <td>
+    <?php if (empty($event['counts'])): ?>
+      <span class="text-body-secondary">—</span>
+    <?php else: ?>
+      <?php
+      $countParts = [];
+      foreach ($event['counts'] as $count) {
+          if ($count['count'] > 0) {
+              $countParts[] = '<span class="text-body-secondary small">' . InputUtils::escapeHTML($count['name']) . '</span> ' . $count['count'];
+          }
+      }
+      echo !empty($countParts) ? implode('<br>', $countParts) : '<span class="text-body-secondary">—</span>';
+      ?>
+    <?php endif; ?>
+  </td>
+  <td>
+    <span class="small"><?= DateTimeUtils::formatDate($event['start'], 1) ?></span>
+  </td>
+  <td class="text-center">
+    <?php if ($event['inactive']): ?>
+      <span class="badge bg-secondary-lt"><?= gettext('Inactive') ?></span>
+    <?php else: ?>
+      <span class="badge bg-green-lt text-green"><?= gettext('Active') ?></span>
+    <?php endif; ?>
+  </td>
+  <?php if ($canEditEvents): ?>
+    <td class="text-center">
+      <div
+        class="event-action-menu-placeholder"
+        data-event-id="<?= $eventId ?>"
+        data-event-title="<?= InputUtils::escapeAttribute($event['title']) ?>"
+        data-event-inactive="<?= (int) $event['inactive'] ?>"
+      ></div>
+    </td>
+  <?php endif; ?>
+</tr>


### PR DESCRIPTION
Closes #8849
Docs: #8934

- Past/deactivated events (End < NOW() **or** InActive=1) are separated into a collapsed "Past Events" section within each monthly card on `/event/dashboard`
- Current events remain fully visible; past events start collapsed (Bootstrap 5 `collapse`)
- Months with **only** past events auto-expand the section
- Expanded state persists per-browser via `localStorage` key `churchcrm.eventDashboard.pastOpen`
- Stat card updated to show current / past counts side-by-side
- Event row markup extracted to `src/event/views/partials/event-row.php` (no functional change)

**Files changed:**
- `src/event/routes/list-events.php` — split event loop into `currentEvents` + `pastEvents`; add `totalCurrentEvents`/`totalPastEvents` template vars
- `src/event/views/list-events.php` — two `<tbody>` blocks per month, localStorage JS, chevron CSS
- `src/event/views/partials/event-row.php` — new partial (extracted from view)
- `cypress/e2e/ui/admin/admin.events.past-archiving.spec.js` — new Cypress spec

**Note:** True DB-level archival (moving rows to an archive table) is out of scope per the design doc — this PR delivers the UI separation only.