### PR TITLE
fix(auth): use cryptographically secure token for password reset

### DIFF
--- a/src/ChurchCRM/model/ChurchCRM/Token.php
+++ b/src/ChurchCRM/model/ChurchCRM/Token.php
@@ -21,7 +21,7 @@ class Token extends BaseToken
     public function build($type, $referenceId): void
     {
         $this->setReferenceId($referenceId);
-        $this->setToken(uniqid());
+        $this->setToken(bin2hex(random_bytes(32)));
         switch ($type) {
             case 'verifyFamily':
                 $this->setValidUntilDate(strtotime('+1 week'));


### PR DESCRIPTION
## Summary

Fixes VULN-08 from security advisory GHSA-3j8q-fwpj-f8j5.

### Problem
`uniqid()` generates tokens based on microsecond timestamps (~1M candidates per second window). An attacker who knows approximately when a reset was requested can brute-force the token and take over any account.

### Fix
Replace `uniqid()` with `bin2hex(random_bytes(32))` — generates a 64-character cryptographically secure random token from the OS CSPRNG.

### Security Impact
- Before: ~1,000,000 token candidates per second window
- After: 2^256 possible tokens — brute-force infeasible

Ref: [GHSA-3j8q-fwpj-f8j5](https://github.com/ChurchCRM/CRM/security/advisories/GHSA-3j8q-fwpj-f8j5)

🤖 Generated with Hazel (NanoClaw AI Agent)