### PR TITLE
fix: Reflected XSS in FamilyCustomFieldsEditor, PaddleNumList, church-info (GHSA-p6j6-vrpg-4pp8)

### DIFF
--- a/src/Include/Header.php
+++ b/src/Include/Header.php
@@ -57,7 +57,7 @@ $MenuFirst = 1;
     <div class="modal-dialog">
       <div class="modal-content" id="bugForm">
         <form name="issueReport">
-          <input type="hidden" name="pageName" value="<?= htmlspecialchars($_SERVER['REQUEST_URI'], ENT_QUOTES, 'UTF-8') ?>"/>
+          <input type="hidden" name="pageName" value="<?= InputUtils::escapeAttribute($_SERVER['REQUEST_URI'] ?? '') ?>"/>
           <div class="modal-header">
             <h5 class="modal-title"><i class="ti ti-bug me-2"></i><?= gettext('Report an Issue') ?></h5>
             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="<?= gettext('Close') ?>"></button>
@@ -162,7 +162,7 @@ $MenuFirst = 1;
                   ]
               }
           },
-          PageName:<?= json_encode($_SERVER['REQUEST_URI'] ?? '', JSON_HEX_TAG) ?>
+          PageName:<?= json_encode($_SERVER['REQUEST_URI'] ?? '', JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_THROW_ON_ERROR) ?>
       });
       // Initialize moment locale if available
       if (typeof moment !== 'undefined' && window.CRM.shortLocale) {

--- a/src/Include/Header.php
+++ b/src/Include/Header.php
@@ -162,7 +162,7 @@ $MenuFirst = 1;
                   ]
               }
           },
-          PageName:<?= json_encode($_SERVER['REQUEST_URI']) ?>
+          PageName:<?= json_encode($_SERVER['REQUEST_URI'] ?? '', JSON_HEX_TAG) ?>
       });
       // Initialize moment locale if available
       if (typeof moment !== 'undefined' && window.CRM.shortLocale) {

--- a/src/Include/Header.php
+++ b/src/Include/Header.php
@@ -57,7 +57,7 @@ $MenuFirst = 1;
     <div class="modal-dialog">
       <div class="modal-content" id="bugForm">
         <form name="issueReport">
-          <input type="hidden" name="pageName" value="<?= $_SERVER['REQUEST_URI'] ?>"/>
+          <input type="hidden" name="pageName" value="<?= htmlspecialchars($_SERVER['REQUEST_URI'], ENT_QUOTES, 'UTF-8') ?>"/>
           <div class="modal-header">
             <h5 class="modal-title"><i class="ti ti-bug me-2"></i><?= gettext('Report an Issue') ?></h5>
             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="<?= gettext('Close') ?>"></button>
@@ -162,7 +162,7 @@ $MenuFirst = 1;
                   ]
               }
           },
-          PageName:"<?= $_SERVER['REQUEST_URI']; ?>"
+          PageName:<?= json_encode($_SERVER['REQUEST_URI']) ?>
       });
       // Initialize moment locale if available
       if (typeof moment !== 'undefined' && window.CRM.shortLocale) {

--- a/src/PaddleNumList.php
+++ b/src/PaddleNumList.php
@@ -9,7 +9,7 @@ use ChurchCRM\view\PageHeader;
 
 $linkBack = RedirectUtils::getLinkBackFromRequest('');
 
-$iFundRaiserID = $_SESSION['iCurrentFundraiser'];
+$iFundRaiserID = (int) ($_SESSION['iCurrentFundraiser'] ?? 0);
 
 if ($iFundRaiserID > 0) {
     //Get the paddlenum records for this fundraiser


### PR DESCRIPTION
Fixes GHSA-p6j6-vrpg-4pp8 — Reflected XSS via unsanitized request parameter names and values.

**Root cause:** `$_SERVER['REQUEST_URI']` was echoed raw into both an HTML attribute and a JS string in `Header.php`, reflecting attacker-controlled query parameter names. Additionally, `$_SESSION['iCurrentFundraiser']` was used untyped in JS `onclick` attributes in `PaddleNumList.php`.

**Fixes:**

- `src/Include/Header.php` (line 60): wrap `$_SERVER['REQUEST_URI']` with `htmlspecialchars($val, ENT_QUOTES, 'UTF-8')` in HTML attribute context (issue-report modal).
- `src/Include/Header.php` (line 165): replace bare interpolation in JS string with `json_encode($_SERVER['REQUEST_URI'])` in `window.CRM.PageName`.
- `src/PaddleNumList.php` (line 12): cast session value to `(int)` at assignment so all JS `onclick` attribute uses are type-safe integers.

**Affected endpoints (PoC vectors):**
- `POST /FamilyCustomFieldsEditor.php?<xss-param>=1`
- `GET /PaddleNumList.php?FundRaiserID=<xss-value>`
- `GET /admin/system/church-info?<xss-param>=1`

No other unescaped request data found in audit of these files.