### PR TITLE
fix: use sDefaultCountry instead of hardcoded USA checks in reports

### DIFF
--- a/src/ChurchCRM/Reports/ChurchInfoReport.php
+++ b/src/ChurchCRM/Reports/ChurchInfoReport.php
@@ -2,6 +2,7 @@
 
 namespace ChurchCRM\Reports;
 
+use ChurchCRM\data\Countries;
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\model\ChurchCRM\FamilyQuery;
 use FPDF;
@@ -112,7 +113,7 @@ class ChurchInfoReport extends FPDF
         }
         $this->writeAt(SystemConfig::getValue('leftX'), $curY, $fam_City . ', ' . $fam_State . '  ' . $fam_Zip);
         $curY += SystemConfig::getValue('incrementY');
-        if ($fam_Country !== null && $fam_Country !== '' && $fam_Country !== SystemConfig::getValue('sDefaultCountry')) {
+        if (Countries::isForeign($fam_Country)) {
             $this->writeAt(SystemConfig::getValue('leftX'), $curY, (string) $fam_Country);
             $curY += SystemConfig::getValue('incrementY');
         } // mm to get away from the second window

--- a/src/ChurchCRM/Reports/PdfDirectory.php
+++ b/src/ChurchCRM/Reports/PdfDirectory.php
@@ -324,7 +324,7 @@ class PdfDirectory extends ChurchInfoReport
             if (strlen($fam_City)) {
                 $sFamilyStr .= $fam_City . ', ' . $fam_State . ' ' . $fam_Zip . "\n";
             }
-            if ($fam_Country !== null && strlen($fam_Country) > 0 && Countries::toISO($fam_Country) !== SystemConfig::getValue('sDefaultCountry')) {
+            if (Countries::isForeign($fam_Country)) {
                 $sFamilyStr .= $fam_Country . "\n";
             }
         }

--- a/src/ChurchCRM/Reports/PdfDirectory.php
+++ b/src/ChurchCRM/Reports/PdfDirectory.php
@@ -323,6 +323,9 @@ class PdfDirectory extends ChurchInfoReport
             if (strlen($fam_City)) {
                 $sFamilyStr .= $fam_City . ', ' . $fam_State . ' ' . $fam_Zip . "\n";
             }
+            if (strlen($fam_Country) && $fam_Country !== SystemConfig::getValue('sDefaultCountry')) {
+                $sFamilyStr .= $fam_Country . "\n";
+            }
         }
 
         if ($bDirFamilyPhone && strlen($fam_HomePhone)) {

--- a/src/ChurchCRM/Reports/PdfDirectory.php
+++ b/src/ChurchCRM/Reports/PdfDirectory.php
@@ -2,6 +2,7 @@
 
 namespace ChurchCRM\Reports;
 
+use ChurchCRM\data\Countries;
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\model\ChurchCRM\FamilyQuery;
 use ChurchCRM\model\ChurchCRM\PersonQuery;

--- a/src/ChurchCRM/Reports/PdfDirectory.php
+++ b/src/ChurchCRM/Reports/PdfDirectory.php
@@ -323,7 +323,7 @@ class PdfDirectory extends ChurchInfoReport
             if (strlen($fam_City)) {
                 $sFamilyStr .= $fam_City . ', ' . $fam_State . ' ' . $fam_Zip . "\n";
             }
-            if (strlen($fam_Country) && $fam_Country !== SystemConfig::getValue('sDefaultCountry')) {
+            if ($fam_Country !== null && strlen($fam_Country) > 0 && Countries::toISO($fam_Country) !== SystemConfig::getValue('sDefaultCountry')) {
                 $sFamilyStr .= $fam_Country . "\n";
             }
         }

--- a/src/ChurchCRM/data/Countries.php
+++ b/src/ChurchCRM/data/Countries.php
@@ -2,8 +2,15 @@
 
 namespace ChurchCRM\data;
 
+use ChurchCRM\dto\SystemConfig;
+
 class Countries
 {
+    private const LEGACY_ALIASES = [
+        'US'            => 'US',
+        'USA'           => 'US',
+        'United States' => 'US',
+    ];
     private static ?array $countries = null;
 
     private static function initializeCountries(): void
@@ -335,11 +342,8 @@ class Countries
         }
 
         // Known legacy aliases not resolvable by name lookup
-        $aliases = [
-            'USA' => 'US',
-        ];
-        if (isset($aliases[$value])) {
-            return $aliases[$value];
+        if (isset(self::LEGACY_ALIASES[$value])) {
+            return self::LEGACY_ALIASES[$value];
         }
 
         // Try resolving by full country name (e.g. 'United States' -> 'US')
@@ -353,5 +357,25 @@ class Countries
         }
 
         return $value;
+    }
+
+    /**
+     * Returns true when $country is a foreign country relative to the
+     * configured default country (sDefaultCountry).
+     * Returns false for blank/null input (treat missing country as domestic).
+     * Applies toISO() to BOTH sides so legacy stored values (e.g. "United States"
+     * stored as sDefaultCountry) are handled correctly.
+     */
+    public static function isForeign(?string $country): bool
+    {
+        if (empty($country)) {
+            return false;
+        }
+        $default = SystemConfig::getValue('sDefaultCountry');
+        if (empty($default)) {
+            return true;
+        }
+
+        return self::toISO($country) !== self::toISO($default);
     }
 }

--- a/src/ChurchCRM/data/Countries.php
+++ b/src/ChurchCRM/data/Countries.php
@@ -309,4 +309,49 @@ class Countries
 
         throw new \Exception(gettext('Invalid country name supplied'));
     }
+
+    /**
+     * Normalize a stored country value to an ISO 3166-1 alpha-2 code.
+     *
+     * Legacy data may contain aliases like 'USA' or full names like 'United States'
+     * instead of the canonical 2-letter code ('US'). This method resolves those
+     * variants so callers can compare consistently against sDefaultCountry (which
+     * always stores an ISO code).
+     *
+     * Returns the original value unchanged when it cannot be resolved, so display
+     * code can still render something meaningful for truly unknown values.
+     */
+    public static function toISO(?string $value): string
+    {
+        if ($value === null || $value === '') {
+            return '';
+        }
+
+        self::initializeCountries();
+
+        // Already a valid ISO code
+        if (isset(self::$countries[$value])) {
+            return $value;
+        }
+
+        // Known legacy aliases not resolvable by name lookup
+        $aliases = [
+            'USA' => 'US',
+        ];
+        if (isset($aliases[$value])) {
+            return $aliases[$value];
+        }
+
+        // Try resolving by full country name (e.g. 'United States' -> 'US')
+        try {
+            $country = self::getCountryByName($value);
+            if ($country !== null) {
+                return $country->getCountryCode();
+            }
+        } catch (\Exception $e) {
+            // Unknown name — fall through to return original value
+        }
+
+        return $value;
+    }
 }

--- a/src/Reports/ConfirmLabels.php
+++ b/src/Reports/ConfirmLabels.php
@@ -43,7 +43,7 @@ foreach ($families as $family) {
     }
     $labelText .= sprintf("\n%s, %s  %s", $family->getCity(), $family->getState(), $family->getZip());
 
-    if ($family->getCountry() !== '' && $family->getCountry() !== 'USA' && $family->getCountry() !== 'United States') {
+    if ($family->getCountry() !== '' && $family->getCountry() !== SystemConfig::getValue('sDefaultCountry')) {
         $labelText .="\n" . $family->getCountry();
     }
 

--- a/src/Reports/ConfirmLabels.php
+++ b/src/Reports/ConfirmLabels.php
@@ -44,8 +44,8 @@ foreach ($families as $family) {
     }
     $labelText .= sprintf("\n%s, %s  %s", $family->getCity(), $family->getState(), $family->getZip());
 
-    if ($family->getCountry() !== '' && Countries::toISO($family->getCountry()) !== SystemConfig::getValue('sDefaultCountry')) {
-        $labelText .="\n" . $family->getCountry();
+    if (Countries::isForeign($family->getCountry())) {
+        $labelText .= "\n" . $family->getCountry();
     }
 
     $pdf->addPdfLabel($labelText);

--- a/src/Reports/ConfirmLabels.php
+++ b/src/Reports/ConfirmLabels.php
@@ -3,6 +3,7 @@
 require_once __DIR__ . '/../Include/Config.php';
 require_once __DIR__ . '/../Include/PageInit.php';
 
+use ChurchCRM\data\Countries;
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\model\ChurchCRM\FamilyQuery;
 use ChurchCRM\Reports\PdfLabel;
@@ -43,7 +44,7 @@ foreach ($families as $family) {
     }
     $labelText .= sprintf("\n%s, %s  %s", $family->getCity(), $family->getState(), $family->getZip());
 
-    if ($family->getCountry() !== '' && $family->getCountry() !== SystemConfig::getValue('sDefaultCountry')) {
+    if ($family->getCountry() !== '' && Countries::toISO($family->getCountry()) !== SystemConfig::getValue('sDefaultCountry')) {
         $labelText .="\n" . $family->getCountry();
     }
 

--- a/src/Reports/NewsLetterLabels.php
+++ b/src/Reports/NewsLetterLabels.php
@@ -45,7 +45,7 @@ foreach ($families as $family) {
     }
     $labelText .= sprintf("\n%s, %s  %s", $family->getCity(), $family->getState(), $family->getZip());
 
-    if ($family->getCountry() !== '' && $family->getCountry() !== 'US' && $family->getCountry() !== 'USA' && $family->getCountry() !== 'United States') {
+    if ($family->getCountry() !== '' && $family->getCountry() !== SystemConfig::getValue('sDefaultCountry')) {
         $labelText .="\n" . $family->getCountry();
     }
 

--- a/src/Reports/NewsLetterLabels.php
+++ b/src/Reports/NewsLetterLabels.php
@@ -3,6 +3,7 @@
 require_once __DIR__ . '/../Include/Config.php';
 require_once __DIR__ . '/../Include/PageInit.php';
 
+use ChurchCRM\data\Countries;
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\model\ChurchCRM\FamilyQuery;
 use ChurchCRM\Reports\PdfNewsletterLabels;
@@ -45,7 +46,7 @@ foreach ($families as $family) {
     }
     $labelText .= sprintf("\n%s, %s  %s", $family->getCity(), $family->getState(), $family->getZip());
 
-    if ($family->getCountry() !== '' && $family->getCountry() !== SystemConfig::getValue('sDefaultCountry')) {
+    if ($family->getCountry() !== '' && Countries::toISO($family->getCountry()) !== SystemConfig::getValue('sDefaultCountry')) {
         $labelText .="\n" . $family->getCountry();
     }
 

--- a/src/Reports/NewsLetterLabels.php
+++ b/src/Reports/NewsLetterLabels.php
@@ -46,8 +46,8 @@ foreach ($families as $family) {
     }
     $labelText .= sprintf("\n%s, %s  %s", $family->getCity(), $family->getState(), $family->getZip());
 
-    if ($family->getCountry() !== '' && Countries::toISO($family->getCountry()) !== SystemConfig::getValue('sDefaultCountry')) {
-        $labelText .="\n" . $family->getCountry();
+    if (Countries::isForeign($family->getCountry())) {
+        $labelText .= "\n" . $family->getCountry();
     }
 
     $pdf->addPdfLabel($labelText);

--- a/src/Reports/TaxReport.php
+++ b/src/Reports/TaxReport.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/../Include/Config.php';
 require_once __DIR__ . '/../Include/PageInit.php';
 
 use ChurchCRM\Authentication\AuthenticationManager;
+use ChurchCRM\data\Countries;
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\Service\FinancialService;
 use ChurchCRM\Utils\CsvExporter;
@@ -206,7 +207,7 @@ if ($output === 'pdf') {
                 }
                 $this->writeAt(SystemConfig::getValue('leftX'), $curY, $fam_City . ', ' . $fam_State . '  ' . $fam_Zip);
                 $curY += SystemConfig::getValue('incrementY');
-                if ($fam_Country !== '' && $fam_Country !== SystemConfig::getValue('sDefaultCountry')) {
+                if ($fam_Country !== '' && Countries::toISO($fam_Country) !== SystemConfig::getValue('sDefaultCountry')) {
                     $this->writeAt(SystemConfig::getValue('leftX'), $curY, $fam_Country);
                     $curY += SystemConfig::getValue('incrementY');
                 }
@@ -220,7 +221,7 @@ if ($output === 'pdf') {
                 }
                 $this->writeAt(SystemConfig::getValue('leftX') + 5, $curY, SystemConfig::getValue('sChurchCity') . ', ' . SystemConfig::getValue('sChurchState') . '  ' . SystemConfig::getValue('sChurchZip'));
                 $curY += SystemConfig::getValue('incrementY');
-                if ($fam_Country !== '' && $fam_Country !== SystemConfig::getValue('sDefaultCountry')) {
+                if ($fam_Country !== '' && Countries::toISO($fam_Country) !== SystemConfig::getValue('sDefaultCountry')) {
                     $this->writeAt(SystemConfig::getValue('leftX') + 5, $curY, $fam_Country);
                     $curY += SystemConfig::getValue('incrementY');
                 }

--- a/src/Reports/TaxReport.php
+++ b/src/Reports/TaxReport.php
@@ -206,7 +206,7 @@ if ($output === 'pdf') {
                 }
                 $this->writeAt(SystemConfig::getValue('leftX'), $curY, $fam_City . ', ' . $fam_State . '  ' . $fam_Zip);
                 $curY += SystemConfig::getValue('incrementY');
-                if ($fam_Country !== '' && $fam_Country !== 'USA' && $fam_Country !== 'United States') {
+                if ($fam_Country !== '' && $fam_Country !== SystemConfig::getValue('sDefaultCountry')) {
                     $this->writeAt(SystemConfig::getValue('leftX'), $curY, $fam_Country);
                     $curY += SystemConfig::getValue('incrementY');
                 }
@@ -220,7 +220,7 @@ if ($output === 'pdf') {
                 }
                 $this->writeAt(SystemConfig::getValue('leftX') + 5, $curY, SystemConfig::getValue('sChurchCity') . ', ' . SystemConfig::getValue('sChurchState') . '  ' . SystemConfig::getValue('sChurchZip'));
                 $curY += SystemConfig::getValue('incrementY');
-                if ($fam_Country !== '' && $fam_Country !== 'USA' && $fam_Country !== 'United States') {
+                if ($fam_Country !== '' && $fam_Country !== SystemConfig::getValue('sDefaultCountry')) {
                     $this->writeAt(SystemConfig::getValue('leftX') + 5, $curY, $fam_Country);
                     $curY += SystemConfig::getValue('incrementY');
                 }

--- a/src/Reports/TaxReport.php
+++ b/src/Reports/TaxReport.php
@@ -207,7 +207,7 @@ if ($output === 'pdf') {
                 }
                 $this->writeAt(SystemConfig::getValue('leftX'), $curY, $fam_City . ', ' . $fam_State . '  ' . $fam_Zip);
                 $curY += SystemConfig::getValue('incrementY');
-                if ($fam_Country !== '' && Countries::toISO($fam_Country) !== SystemConfig::getValue('sDefaultCountry')) {
+                if (Countries::isForeign($fam_Country)) {
                     $this->writeAt(SystemConfig::getValue('leftX'), $curY, $fam_Country);
                     $curY += SystemConfig::getValue('incrementY');
                 }
@@ -221,7 +221,7 @@ if ($output === 'pdf') {
                 }
                 $this->writeAt(SystemConfig::getValue('leftX') + 5, $curY, SystemConfig::getValue('sChurchCity') . ', ' . SystemConfig::getValue('sChurchState') . '  ' . SystemConfig::getValue('sChurchZip'));
                 $curY += SystemConfig::getValue('incrementY');
-                if ($fam_Country !== '' && Countries::toISO($fam_Country) !== SystemConfig::getValue('sDefaultCountry')) {
+                if (Countries::isForeign($fam_Country)) {
                     $this->writeAt(SystemConfig::getValue('leftX') + 5, $curY, $fam_Country);
                     $curY += SystemConfig::getValue('incrementY');
                 }


### PR DESCRIPTION
Fixes #5986

Replace hardcoded `'USA'`/`'United States'` checks with `SystemConfig::getValue('sDefaultCountry')` in mailing labels and reports. This matches the pattern already used correctly in `ChurchInfoReport::startLetterPage()`.

- `ConfirmLabels.php`: replace 2-variant USA check
- `NewsLetterLabels.php`: replace 3-variant US/USA/United States check
- `TaxReport.php`: replace both occurrences in `finishPage()` (recipient + remittance slip)
- `PdfDirectory.php` `sGetFamilyString()`: add country output (was always omitted) — prints only when different from default country

Non-US installs now correctly suppress the domestic country on local addresses and show the country for foreign addresses.