### PR TITLE
Ensuring gender, role and classification variables are initiated.

### DIFF
--- a/src/people/views/person-list.php
+++ b/src/people/views/person-list.php
@@ -116,6 +116,18 @@ $personListColumns = [
 ?>
 
 <?php
+
+// Initialize data quality check counts if not already set by included scripts
+if (!isset($genderDataCheckCount)) {
+    $genderDataCheckCount = 0;
+}
+if (!isset($roleDataCheckCount)) {
+    $roleDataCheckCount = 0;
+}
+if (!isset($classificationDataCheckCount)) {
+    $classificationDataCheckCount = 0;
+}
+
 // Calculate data quality status
 $hasDataQualityIssues = $genderDataCheckCount > 0 || $roleDataCheckCount > 0 ||
                         $classificationDataCheckCount > 0;


### PR DESCRIPTION
## What Changed
Initialized three variables because PHP were throwing warnings:
$genderDataCheckCount, $roleDataCheckCount and $classificationDataCheckCount

Fixes #

## Type
<!-- Check one -->
- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
<!-- How to verify this works -->

## Screenshots
<!-- Only for UI changes - drag & drop images here -->
## Pre-Merge
- [ ] Tested locally
- [ ] No new warnings
- [ ] Build passes
- [ ] Backward compatible (or migration documented)