### PR TITLE
chore: disable issue auto-comment job

### DIFF
--- a/.github/workflows/issue-management.yml
+++ b/.github/workflows/issue-management.yml
@@ -51,9 +51,7 @@ jobs:
   # Auto-comment on newly opened issues with appropriate templates
   # =========================================================================
   auto-comment:
-    if: |
-      github.event_name == 'issues' && github.event.action == 'opened' ||
-      (inputs.operation == 'comment-and-triage' || inputs.operation == 'all')
+    if: false
     name: Auto-comment on new issues
     timeout-minutes: 5
     runs-on: ubuntu-latest


### PR DESCRIPTION
Disabling the `auto-comment` job temporarily while we switch to Hazel (AI agent) for issue triage and responses. Other jobs (stale, ensure-bug-type, review-closed-issues) remain active.

To re-enable: remove the `if: false` line from the `auto-comment` job.