### PR TITLE
fix: null-guard getPerson() in canViewFamily and canEditPerson

### DIFF
--- a/src/ChurchCRM/model/ChurchCRM/User.php
+++ b/src/ChurchCRM/model/ChurchCRM/User.php
@@ -218,7 +218,11 @@ class User extends BaseUser
             }
 
             // Can edit family members (if person has a family)
-            if ($personFamilyId > 0 && $personFamilyId === $this->getPerson()->getFamId()) {
+            $person = $this->getPerson();
+            if ($person === null) {
+                return false; // orphaned user — deny access
+            }
+            if ($personFamilyId > 0 && $personFamilyId === $person->getFamId()) {
                 return true;
             }
         }
@@ -241,7 +245,11 @@ class User extends BaseUser
         }
         if ($this->isEditSelfEnabled()) {
             // EditSelf users may only access their own family
-            return $familyId > 0 && $familyId === (int) $this->getPerson()->getFamId();
+            $person = $this->getPerson();
+            if ($person === null) {
+                return false; // orphaned user — deny access
+            }
+            return $familyId > 0 && $familyId === (int) $person->getFamId();
         }
         return false;
     }


### PR DESCRIPTION
Fixes #9001

Both `canViewFamily()` and `canEditPerson()` called `$this->getPerson()->getFamId()` without checking whether `getPerson()` returns `null` first. For orphaned users whose person record is missing, this caused a fatal PHP error.

**Changes:**
- Store `getPerson()` result in a local variable before use
- Return `false` early if the result is `null` (orphaned user — deny access)
- Applies to both `canViewFamily()` (introduced in #8964) and `canEditPerson()`