### PR TITLE
fix: delete user fails when userconfig rows exist (composite PK)

### DIFF
--- a/src/admin/routes/api/user-admin.php
+++ b/src/admin/routes/api/user-admin.php
@@ -128,10 +128,7 @@ $app->group('/api/user/{userId:[0-9]+}', function (RouteCollectorProxy $group): 
     $group->delete('/', function (Request $request, Response $response, array $args): Response {
         $user = $request->getAttribute('user');
         $userName = $user->getName();
-        $userConfig = UserConfigQuery::create()->findPk($user->getId());
-        if ($userConfig !== null) {
-            $userConfig->delete();
-        }
+        UserConfigQuery::create()->filterByPeronId($user->getId())->delete();
 
         $user->delete();
         if (SystemConfig::getBooleanValue('bSendUserDeletedEmail')) {


### PR DESCRIPTION
Fixes #8924

The `userconfig_ucfg` table has a composite primary key (`ucfg_per_id`, `ucfg_id`). `UserConfigQuery->findPk()` expects an array for composite PKs but was passed a single integer, causing:

```
array_map(): Argument #2 ($array) must be of type array, int given
```

Replace the broken 3-line `findPk` block with `filterByPeronId()->delete()` to correctly find and delete all UserConfig rows for the user.