### PR TITLE
Fix birthday doubling on person profile view

### DIFF
--- a/src/people/views/person-view.php
+++ b/src/people/views/person-view.php
@@ -436,7 +436,7 @@ $fam_Longitude      = (float) ($personData['fam_Longitude'] ?? 0);
                                 <td class="text-center">
                                     <span class="badge bg-secondary-lt text-secondary"><?= $familyMember->getFamilyRoleName() ?></span>
                                 </td>
-                                <td><?= $familyMember->getFormattedBirthDate(); ?></td>
+                                <td><?= $isSelf ? '' : $familyMember->getFormattedBirthDate(); ?></td>
                                 <td>
                                     <?php $tmpEmail = $familyMember->getEmail();
                                     if ($tmpEmail !== '') { ?>


### PR DESCRIPTION
The person profile page (`/people/view/{id}`) displayed the current person's birthday in two places:

- In the **Personal** info card (via `getFormattedBirthDate()` in the route)
- In the **Family members** table, which iterates all family members including the current person

For anyone viewing their own profile (or any person who belongs to a family), their birthday appeared twice on the same page.

## Changes

- **`src/people/views/person-view.php`**: skip the birthday cell for the self-row in the family table (`$isSelf`), since the value is already shown in the Personal section above it

## How to Test

1. Create or open a person who is part of a family and has a birthday set
2. Navigate to `/people/view/{id}`
3. Confirm the birthday appears once (in the Personal section) and the family table row for the current person shows an empty birthday cell

Fixes #8957