### PR TITLE
Fix #2509: Compute monthly event AVG in PHP from in-memory counts data

### DIFF
--- a/src/event/routes/list-events.php
+++ b/src/event/routes/list-events.php
@@ -163,26 +163,32 @@ $app->get('/dashboard', function (Request $request, Response $response) {
             }
         }
 
-        // Monthly averages — eventcounts_evtcnt has no FK relation to events_event
-        // in the schema, so we filter by the event IDs we already loaded above.
+        // Monthly averages — computed in PHP from the per-event counts data
+        // already fetched above. This avoids a separate DB query, and is always
+        // computed regardless of the event-type filter (fixes issue #2509).
+        // Average is taken only over events that have a given count name, so
+        // events without that count name do not dilute the average.
         $averages = [];
         $allMonthEvents = array_merge($currentEvents, $pastEvents);
-        if ($eType !== 'All' && !empty($allMonthEvents[0]['counts'])) {
-            $eventIds = array_column($allMonthEvents, 'id');
-
-            $avgCounts = EventCountsQuery::create()
-                ->filterByEvtcntEventid($eventIds, Criteria::IN)
-                ->addAsColumn('avg_count', 'AVG(evtcnt_countcount)')
-                ->select(['EvtcntCountname', 'avg_count'])
-                ->groupByEvtcntCountid()
-                ->orderByEvtcntCountid()
-                ->find();
-
-            foreach ($avgCounts as $avg) {
-                $averages[] = [
-                    'name'      => $avg['EvtcntCountname'],
-                    'avg_count' => (float) $avg['avg_count'],
-                ];
+        if (!empty($allMonthEvents)) {
+            $countTotals = []; // ['Adults' => ['total' => 60, 'n' => 2], ...]
+            foreach ($allMonthEvents as $evt) {
+                foreach ($evt['counts'] as $c) {
+                    $name = $c['name'];
+                    if (!isset($countTotals[$name])) {
+                        $countTotals[$name] = ['total' => 0, 'n' => 0];
+                    }
+                    $countTotals[$name]['total'] += (int) $c['count'];
+                    $countTotals[$name]['n']++;
+                }
+            }
+            foreach ($countTotals as $name => $data) {
+                if ($data['n'] > 0) {
+                    $averages[] = [
+                        'name'      => $name,
+                        'avg_count' => $data['total'] / $data['n'],
+                    ];
+                }
             }
         }
 

--- a/src/event/routes/list-events.php
+++ b/src/event/routes/list-events.php
@@ -173,7 +173,7 @@ $app->get('/dashboard', function (Request $request, Response $response) {
         if (!empty($allMonthEvents)) {
             $countTotals = []; // ['Adults' => ['total' => 60, 'n' => 2], ...]
             foreach ($allMonthEvents as $evt) {
-                foreach ($evt['counts'] as $c) {
+                foreach ($evt['counts'] ?? [] as $c) {
                     $name = $c['name'];
                     if (!isset($countTotals[$name])) {
                         $countTotals[$name] = ['total' => 0, 'n' => 0];
@@ -182,6 +182,7 @@ $app->get('/dashboard', function (Request $request, Response $response) {
                     $countTotals[$name]['n']++;
                 }
             }
+            ksort($countTotals); // Sort by name for deterministic output across months
             foreach ($countTotals as $name => $data) {
                 if ($data['n'] > 0) {
                     $averages[] = [


### PR DESCRIPTION
## Summary

Fixes #2509 — monthly average attendance on the Events dashboard showed incorrect values.

## Root cause

The original bug was an implicit cross-join SQL query in the old `ListEvents.php` that computed `AVG` across all event types and months rather than the filtered set. After the page was migrated to Propel ORM, a secondary correctness issue remained:

- Monthly averages were only computed when a specific event type was selected (`$eType !== 'All'`), so they were **completely hidden** when viewing all event types.
- A separate `EventCountsQuery` DB call was made to compute the average, even though per-event count data was already fetched in the loop above.

## Fix

Replaced the DB-query-based average calculation with a PHP-computed one that uses the per-event `counts` data already in memory:

- **Always computed** — no longer gated on `$eType !== 'All'`
- **Correct averaging** — averages only over events that _have_ a given count name; events without that count do not dilute the result
- **One fewer DB query per month** — eliminates the redundant `EventCountsQuery` AVG call

## Testing

Manually verified the PHP logic. Biome lint passed (1 pre-existing unrelated warning in `event-form.js`).