### PR TITLE
fix(security): escape PledgeEditor URL params in form action (GHSA-8rv4-2mxp-gh5w)

### DIFF
--- a/src/PledgeEditor.php
+++ b/src/PledgeEditor.php
@@ -67,6 +67,9 @@ while ($aRow = mysqli_fetch_array($rsFunds)) {
 // Handle URL via _GET first
 if (array_key_exists('PledgeOrPayment', $_GET)) {
     $PledgeOrPayment = InputUtils::legacyFilterInput($_GET['PledgeOrPayment'], 'string');
+    if (!in_array($PledgeOrPayment, ['Pledge', 'Payment'], true)) {
+        $PledgeOrPayment = 'Pledge';
+    }
 }
 $sGroupKey = '';
 if (array_key_exists('GroupKey', $_GET)) {
@@ -515,7 +518,7 @@ require_once __DIR__ . '/Include/Header.php';
 
 ?>
 
-<form method="post" action="PledgeEditor.php?CurrentDeposit=<?= $iCurrentDeposit ?>&GroupKey=<?= $sGroupKey ?>&PledgeOrPayment=<?= $PledgeOrPayment ?>&linkBack=<?= $linkBack ?>" name="PledgeEditor">
+<form method="post" action="PledgeEditor.php?CurrentDeposit=<?= $iCurrentDeposit ?>&GroupKey=<?= InputUtils::escapeAttribute($sGroupKey) ?>&PledgeOrPayment=<?= InputUtils::escapeAttribute($PledgeOrPayment) ?>&linkBack=<?= InputUtils::escapeAttribute($linkBack) ?>" name="PledgeEditor">
 
     <!-- Mode Indicator Banner -->
     <div class="row mb-3">


### PR DESCRIPTION
## Summary

Fixes a reflected XSS vulnerability in `src/PledgeEditor.php` reported in GHSA-8rv4-2mxp-gh5w.

**Vulnerability:** `PledgeOrPayment` and `GroupKey` URL parameters were read from `$_GET` via `InputUtils::legacyFilterInput()` (SQL-context only) and then echoed raw into the HTML form `action` attribute. A double-quote in the parameter value could break out of the attribute and inject an event handler (e.g. `onmouseover=alert(1)`). An attacker could send a crafted link to any authenticated Finance user; when they open it and interact with the form, JavaScript executes in their session.

**Changes:**
- Wrap `$sGroupKey`, `$PledgeOrPayment`, and `$linkBack` in `InputUtils::escapeAttribute()` at the output site in the form `action` attribute
- Add allowlist validation on `$PledgeOrPayment` at input time — constrain to `['Pledge', 'Payment']`, defaulting to `'Pledge'` for any other value

`InputUtils::escapeAttribute()` already exists in `src/ChurchCRM/utils/InputUtils.php` and uses `htmlspecialchars($input, ENT_QUOTES, 'UTF-8')` — the correct encoding for HTML attribute context.

## Test plan

- [ ] Open `/PledgeEditor.php?PledgeOrPayment=Payment&CurrentDeposit=0` — form renders normally
- [ ] Open PoC URL: `/PledgeEditor.php?PledgeOrPayment=x"%20onmouseover%3Dalert(1)%20x%3D"&CurrentDeposit=0` — form renders safely, no alert on mouse interaction
- [ ] Open PoC URL with GroupKey: `/PledgeEditor.php?PledgeOrPayment=Payment&CurrentDeposit=0&GroupKey=g"%20onmouseover%3Dalert(1)%20g%3D"` — safe
- [ ] Normal pledge entry and payment recording workflows still function correctly
- [ ] Invalid `PledgeOrPayment` value (e.g. `?PledgeOrPayment=foo`) defaults to `Pledge` mode

Resolves: GHSA-8rv4-2mxp-gh5w