### PR TITLE
fix(security): constrain countryCode route param to prevent path traversal (GHSA-3g57-j655-gjv3)

### DIFF
--- a/cypress/e2e/api/public/public.data.spec.js
+++ b/cypress/e2e/api/public/public.data.spec.js
@@ -48,12 +48,33 @@ describe("API Public Data", () => {
         });
     });
 
+    it("Canada States uppercase country code returns 200", () => {
+        cy.request({
+            method: "GET",
+            url: "/api/public/data/countries/CA/states",
+        }).then((resp) => {
+            const result = JSON.parse(JSON.stringify(resp.body));
+            expect(resp.status).to.eq(200);
+            expect(result["BC"]).to.eq("British Columbia");
+        });
+    });
+
     // --- Valid ISO code with no states file returns 200 with empty object ---
     // XK (Kosovo) is in the Countries list but has no locale/states/xk.json file.
     it("Valid country code with no states file returns 200 empty object", () => {
         cy.request({
             method: "GET",
             url: "/api/public/data/countries/xk/states",
+        }).then((resp) => {
+            expect(resp.status).to.eq(200);
+            expect(resp.body).to.deep.equal({});
+        });
+    });
+
+    it("Valid country code uppercase with no states file returns 200 empty object", () => {
+        cy.request({
+            method: "GET",
+            url: "/api/public/data/countries/XK/states",
         }).then((resp) => {
             expect(resp.status).to.eq(200);
             expect(resp.body).to.deep.equal({});

--- a/cypress/e2e/api/public/public.data.spec.js
+++ b/cypress/e2e/api/public/public.data.spec.js
@@ -34,4 +34,80 @@ describe("API Public Data", () => {
             expect(result["BC"]).to.eq("British Columbia");
         });
     });
+
+    // --- Regression guard: route must accept uppercase codes (frontend lowercases, but
+    //     the regex [A-Za-z]{2} should also allow uppercase for robustness) ---
+    it("US States uppercase country code returns 200", () => {
+        cy.request({
+            method: "GET",
+            url: "/api/public/data/countries/US/states",
+        }).then((resp) => {
+            const result = JSON.parse(JSON.stringify(resp.body));
+            expect(resp.status).to.eq(200);
+            expect(result["AL"]).to.eq("Alabama");
+        });
+    });
+
+    // --- Valid ISO code with no states file returns 200 with empty object ---
+    // XK (Kosovo) is in the Countries list but has no locale/states/xk.json file.
+    it("Valid country code with no states file returns 200 empty object", () => {
+        cy.request({
+            method: "GET",
+            url: "/api/public/data/countries/xk/states",
+        }).then((resp) => {
+            expect(resp.status).to.eq(200);
+            expect(resp.body).to.deep.equal({});
+        });
+    });
+
+    // --- Path traversal and invalid inputs must all 404 ---
+    it("Path traversal attempt returns 404", () => {
+        cy.request({
+            method: "GET",
+            url: "/api/public/data/countries/../locale/messages/states",
+            failOnStatusCode: false,
+        }).then((resp) => {
+            expect(resp.status).to.eq(404);
+        });
+    });
+
+    it("Country code too short (1 char) returns 404", () => {
+        cy.request({
+            method: "GET",
+            url: "/api/public/data/countries/u/states",
+            failOnStatusCode: false,
+        }).then((resp) => {
+            expect(resp.status).to.eq(404);
+        });
+    });
+
+    it("Country code too long (3 chars) returns 404", () => {
+        cy.request({
+            method: "GET",
+            url: "/api/public/data/countries/usa/states",
+            failOnStatusCode: false,
+        }).then((resp) => {
+            expect(resp.status).to.eq(404);
+        });
+    });
+
+    it("Country code with digit returns 404", () => {
+        cy.request({
+            method: "GET",
+            url: "/api/public/data/countries/u1/states",
+            failOnStatusCode: false,
+        }).then((resp) => {
+            expect(resp.status).to.eq(404);
+        });
+    });
+
+    it("Country code with special character returns 404", () => {
+        cy.request({
+            method: "GET",
+            url: "/api/public/data/countries/u./states",
+            failOnStatusCode: false,
+        }).then((resp) => {
+            expect(resp.status).to.eq(404);
+        });
+    });
 });

--- a/src/ChurchCRM/data/States.php
+++ b/src/ChurchCRM/data/States.php
@@ -2,6 +2,7 @@
 
 namespace ChurchCRM\data;
 
+use ChurchCRM\data\Countries;
 use ChurchCRM\dto\SystemURLs;
 use ChurchCRM\Utils\MiscUtils;
 
@@ -11,7 +12,14 @@ class States
 
     public function __construct(string $countryCode)
     {
-        $stateFileName = SystemURLs::getDocumentRoot() . '/locale/states/' . $countryCode . '.json';
+        // Defense-in-depth: reject codes not in the canonical country list,
+        // regardless of how this class is called (not just via the route).
+        if (!array_key_exists(strtoupper($countryCode), Countries::getAll())) {
+            return;
+        }
+
+        // State files are stored as lowercase ISO codes (e.g. us.json, ca.json).
+        $stateFileName = SystemURLs::getDocumentRoot() . '/locale/states/' . strtolower($countryCode) . '.json';
         if (is_file($stateFileName)) {
             $statesFile = file_get_contents($stateFileName);
             MiscUtils::throwIfFailed($statesFile);

--- a/src/api/routes/public/public-data.php
+++ b/src/api/routes/public/public-data.php
@@ -10,8 +10,8 @@ use Slim\Routing\RouteCollectorProxy;
 $app->group('/public/data', function (RouteCollectorProxy $group): void {
     $group->get('/countries', 'getCountries');
     $group->get('/countries/', 'getCountries');
-    $group->get('/countries/{countryCode:[A-Z]{2}}/states', 'getStates');
-    $group->get('/countries/{countryCode:[A-Z]{2}}/states/', 'getStates');
+    $group->get('/countries/{countryCode:[A-Za-z]{2}}/states', 'getStates');
+    $group->get('/countries/{countryCode:[A-Za-z]{2}}/states/', 'getStates');
 });
 
 /**

--- a/src/api/routes/public/public-data.php
+++ b/src/api/routes/public/public-data.php
@@ -10,8 +10,8 @@ use Slim\Routing\RouteCollectorProxy;
 $app->group('/public/data', function (RouteCollectorProxy $group): void {
     $group->get('/countries', 'getCountries');
     $group->get('/countries/', 'getCountries');
-    $group->get('/countries/{countryCode}/states', 'getStates');
-    $group->get('/countries/{countryCode}/states/', 'getStates');
+    $group->get('/countries/{countryCode:[A-Z]{2}}/states', 'getStates');
+    $group->get('/countries/{countryCode:[A-Z]{2}}/states/', 'getStates');
 });
 
 /**

--- a/src/api/routes/public/public-data.php
+++ b/src/api/routes/public/public-data.php
@@ -72,5 +72,6 @@ function getStates(Request $request, Response $response, array $args): Response
 {
     $states = new States($args['countryCode']);
 
-    return SlimUtils::renderJSON($response, $states->getAll());
+    // JSON_FORCE_OBJECT ensures an empty states array encodes as {} not []
+    return SlimUtils::renderStringJSON($response, json_encode($states->getAll(), JSON_THROW_ON_ERROR | JSON_FORCE_OBJECT));
 }


### PR DESCRIPTION
## Summary

Fixes a path traversal vulnerability in the public States API endpoint.

### Root cause

The `/public/data/countries/{countryCode}/states` route accepted any string in `{countryCode}` with no format constraint. The value was passed directly to `States::__construct()`, which concatenated it into a filesystem path:

```php
$stateFileName = SystemURLs::getDocumentRoot() . '/locale/states/' . $countryCode . '.json';
```

An unauthenticated attacker could supply path traversal sequences (`../`) to read arbitrary `.json` files from the server.

### Fix

Adds a Slim regex pattern to both route definitions, restricting `countryCode` to valid ISO 3166-1 alpha-2 codes (two uppercase letters):

```php
// Before
$group->get('/countries/{countryCode}/states', 'getStates');

// After
$group->get('/countries/{countryCode:[A-Z]{2}}/states', 'getStates');
```

This rejects path traversal sequences at the routing layer, before they reach the handler or file system.

### Impact

- **Affected:** All versions ≤ 7.4.0
- **Auth required:** None — endpoint is public
- **Disclosure scope:** Files ending in `.json` reachable via path traversal from `/locale/states/`
- **CVSS 3.1:** 5.3 (Medium) — `AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N`

Reported by @eliassanchez173. Advisory: GHSA-3g57-j655-gjv3.