### PR TITLE
fix(people-list): filter desync on redirect and group pill contrast

### DIFF
--- a/src/people/views/person-list.php
+++ b/src/people/views/person-list.php
@@ -342,7 +342,7 @@ $hasDataQualityIssues = $genderDataCheckCount > 0 || $roleDataCheckCount > 0 ||
                             if (is_array($columnData) && !empty($columnData)) {
                                 // Always render badges for display
                                 foreach ($columnData as $group) {
-                                    echo '<span class="badge bg-info me-1">' . InputUtils::escapeHTML($group) . '</span>';
+                                    echo '<span class="badge bg-info-lt text-info me-1">' . InputUtils::escapeHTML($group) . '</span>';
                                 }
                                 // Add hidden span with JSON for DataTables filtering
                                 echo '<span style="display:none;">' . InputUtils::escapeHTML(json_encode($columnData, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR)) . '</span>';
@@ -825,34 +825,36 @@ $hasDataQualityIssues = $genderDataCheckCount > 0 || $roleDataCheckCount > 0 ||
         }
         
         // Apply initial filters from URL parameters via TomSelect API
-        // This ensures filters are set and properly trigger DataTable updates
+        // This ensures filters are set and properly trigger DataTable updates.
+        // NOTE: setValue(value, false) — silent=false so onChange fires and filterColumn() is called.
+        // Using silent=true would visually select the option but never apply the DataTable search.
         setTimeout(function() {
             // Set Gender filter if specified
             if (shouldTriggerGenderFilter && filterByGender) {
                 var genderIndex = Gender.indexOf(filterByGender);
                 if (genderIndex !== -1 && tomSelectInstances['Gender']) {
-                    tomSelectInstances['Gender'].ts.setValue(String(genderIndex), true);
+                    tomSelectInstances['Gender'].ts.setValue(String(genderIndex), false);
                 }
             }
 
             // Set Classification filter if specified
             if (shouldTriggerClassificationFilter && tomSelectInstances['Classification']) {
                 // filterByClsOptionId comes from the route and is an integer
-                tomSelectInstances['Classification'].ts.setValue(String(serverVars.filterByClsId), true);
+                tomSelectInstances['Classification'].ts.setValue(String(serverVars.filterByClsId), false);
             }
 
             // Set Role filter if specified
             if (shouldTriggerRoleFilter && tomSelectInstances['Role']) {
                 // filterByFmrOptionId comes from the route and is an integer
-                tomSelectInstances['Role'].ts.setValue(String(serverVars.filterByFmrId), true);
+                tomSelectInstances['Role'].ts.setValue(String(serverVars.filterByFmrId), false);
             }
 
             // Set Family Status filter if specified
             if (shouldTriggerFamilyStatusFilter && tomSelectInstances['Family Status']) {
                 if (serverVars.familyActiveStatus === 'active') {
-                    tomSelectInstances['Family Status'].ts.setValue(serverVars.FamilyStatusList[0], true);
+                    tomSelectInstances['Family Status'].ts.setValue(serverVars.FamilyStatusList[0], false);
                 } else if (serverVars.familyActiveStatus === 'inactive') {
-                    tomSelectInstances['Family Status'].ts.setValue(serverVars.FamilyStatusList[1], true);
+                    tomSelectInstances['Family Status'].ts.setValue(serverVars.FamilyStatusList[1], false);
                 }
             }
         }, 100);


### PR DESCRIPTION
Fixes #9025

**Bug 1 — Filter desync on redirect:**
- `TomSelect.setValue()` was called with `silent=true`, suppressing the `onChange` event
- `filterColumn()` was never invoked, so DataTable showed all records even though the filter UI appeared active
- Fix: changed all 4 `setValue()` calls to `silent=false` so `onChange` fires and the DataTable search is applied on load

**Bug 2 — Group pill contrast:**
- Group badges used `bg-info` (solid cyan with white text) causing low contrast
- Fix: changed to `bg-info-lt text-info` to match the Tabler light-variant pattern used throughout the codebase (family-view, person-view, group-view, etc.)

**Files changed:** `src/people/views/person-list.php` only