### PR TITLE
Fix #9038: ClearFilter button not resetting DataTable (silent TomSelect clear)

### DIFF
--- a/src/people/views/person-list.php
+++ b/src/people/views/person-list.php
@@ -700,7 +700,7 @@ $hasDataQualityIssues = $genderDataCheckCount > 0 || $roleDataCheckCount > 0 ||
             Object.keys(tomSelectInstances).forEach(function(colName) {
                 var instance = tomSelectInstances[colName];
                 if (instance && instance.ts) {
-                    instance.ts.clear(true); // true = trigger onChange event
+                    instance.ts.clear(false); // false = trigger onChange event (true = silent, suppresses onChange)
                 }
             });
         });

--- a/src/people/views/person-list.php
+++ b/src/people/views/person-list.php
@@ -700,7 +700,7 @@ $hasDataQualityIssues = $genderDataCheckCount > 0 || $roleDataCheckCount > 0 ||
             Object.keys(tomSelectInstances).forEach(function(colName) {
                 var instance = tomSelectInstances[colName];
                 if (instance && instance.ts) {
-                    instance.ts.clear(false); // false = trigger onChange event (true = silent, suppresses onChange)
+                    instance.ts.clear(); // default silent=false: onChange fires and filterColumn() resets the DataTable
                 }
             });
         });


### PR DESCRIPTION
## Summary

"Clear Filter" button on the People List page visually reset the TomSelect dropdowns but left the DataTable filtered. Clicking the button had no effect on the displayed data.

## Root Cause

`ts.clear(true)` passes `silent=true` to TomSelect, which suppresses the `change` event. Since `filterColumn()` is only called from the `onChange` handler, the DataTable search was never reset.

The inline comment `// true = trigger onChange event` was also backwards — `true` means silent (suppress onChange), not trigger it.

## Changes

- `src/people/views/person-list.php`: change `ts.clear(true)` → `ts.clear(false)` in the ClearFilter click handler so `onChange` fires and `filterColumn()` resets the DataTable search for each column
- Correct the misleading comment to accurately describe the `silent` parameter semantics

## Testing

1. Navigate to People List
2. Select any filter value (e.g. a Classification)
3. Confirm the DataTable filters correctly
4. Click "Clear Filter"
5. Verify the DataTable shows all rows (previously it stayed filtered)

Fixes #9038