### PR TITLE
ci: reduce stale timer to 45 days, protect features/epics from auto-close

### DIFF
--- a/.github/workflows/issue-management.yml
+++ b/.github/workflows/issue-management.yml
@@ -239,13 +239,13 @@ jobs:
         uses: actions/stale@v10
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-issue-message: 'This issue has been inactive for 90 days. If this is still relevant, please comment to keep it open. Otherwise it will be closed in 7 days.'
-          stale-pr-message: 'This PR has been inactive for 90 days. If this is still relevant, please comment to keep it open. Otherwise it will be closed in 7 days.'
-          days-before-stale: 90
+          stale-issue-message: 'This issue has been inactive for 45 days. If this is still relevant, please comment to keep it open. Otherwise it will be closed in 7 days.'
+          stale-pr-message: 'This PR has been inactive for 45 days. If this is still relevant, please comment to keep it open. Otherwise it will be closed in 7 days.'
+          days-before-stale: 45
           days-before-close: 7
           stale-issue-label: stale
           stale-pr-label: stale
-          exempt-issue-labels: 'security,security-delete-required,pinned,documentation,type: documentation'
+          exempt-issue-labels: 'security,security-delete-required,pinned,documentation,type: documentation,enhancement,Epic,accepted,Feature Request: Multi-Church,Feature: Attendance,Feature: Cart,Feature: Data Import / Export,Feature: Emails,Feature: Events / Calendar,Feature: Financial,Feature: Geographical / Maps,Feature: Groups,Feature: Kiosk,Feature: Members,Feature: Non-Admin Member Access,Feature: Notifications,Feature: Reports,Feature: Search,Feature: Self-Register / Verify,Feature: SMS,Feature: Social,Feature: Sunday School,Feature: Users,Feature: Volunteer'
           exempt-pr-labels: 'security,security-delete-required,pinned,documentation,type: documentation'
           remove-stale-when-updated: true
           remove-stale-when-commented: true


### PR DESCRIPTION
## Summary

- **Stale timer: 90 → 45 days** — issues now go stale after 45 days of inactivity instead of 90
- **Feature/epic protection:** All `enhancement`, `Epic`, `Feature:` labels, and `Feature Request: Multi-Church` are now exempt from stale closing — these will never be auto-closed
- **New `accepted` label:** Any issue tagged `accepted` is also exempt — use this to protect issues that are valid and on the roadmap

## New labels created

- `waiting-for-reporter` (pink) — applied when we ask the reporter for more info; Hazel tracks these and sends a nudge after 14 days
- `accepted` (blue) — marks issues as valid/accepted, protects from stale close

## Exempt labels (full list)

`security`, `security-delete-required`, `pinned`, `documentation`, `type: documentation`, `enhancement`, `Epic`, `accepted`, `Feature Request: Multi-Church`, all `Feature:` category labels

## Test plan

- [ ] Verify mark-stale job shows `days-before-stale: 45` in logs
- [ ] Confirm issues with `Epic` or `enhancement` labels are not marked stale
- [ ] Confirm issues with `accepted` label are not marked stale

🤖 Drafted by Hazel (NanoClaw)