### PR TITLE
feat: Add Manage Events permission toggle to User Editor Permissions card

### DIFF
--- a/cypress/e2e/ui/admin/admin.user-editor.spec.js
+++ b/cypress/e2e/ui/admin/admin.user-editor.spec.js
@@ -4,8 +4,10 @@ describe("User Editor - ORM Migration Tests", () => {
     // and test-subdir) never race on the same DB row.
     // Test 1: PersonID=6 (Constance Hart, constance.hart@example.com, family 2)
     // Test 2: PersonID=5 (Albert Campbell, albert.garcia@example.com, family 1)
+    // Test 3: PersonID=9 (Jean Hart — no seeded user account, avoids PersonID 7 which is 'locked.user')
     const throwawayPersonId = 6;
     const throwawayPersonId2 = 5;
+    const throwawayPersonId3 = 9;   // Jean Hart — no seeded user account
 
     beforeEach(() => {
         cy.setupAdminSession();
@@ -108,6 +110,54 @@ describe("User Editor - ORM Migration Tests", () => {
         cy.get("#UserName").clear().type("Admin");
         cy.get("#SaveButton").click();
         cy.wait("@restoreUser");
+    });
+
+    it("Should persist Manage Events permission for new Custom user", () => {
+        // bEnabledEvents defaults to '1' in the seed — the #AddEvent toggle is present.
+        // This test covers both states:
+        //   - new user WITHOUT Manage Events → AddEvent unchecked after load (explicit FALSE row)
+        //   - edit to enable Manage Events → AddEvent checked after reload (TRUE row)
+        //   - switching to self-service mode clears the toggle (JS exclusivity)
+        cy.makePrivateAdminAPICall("DELETE", `/admin/api/user/${throwawayPersonId3}`, null, [200, 204, 404]);
+        cy.then(() => Cypress.session.clearAllSavedSessions());
+        cy.setupAdminSession();
+
+        // --- Part 1: Create user WITHOUT Manage Events (AddEvent unchecked) ---
+        cy.intercept("POST", "**/admin/system/users/new*").as("saveUser");
+        cy.visit(`admin/system/users/new?personId=${throwawayPersonId3}`);
+        cy.contains("User Editor");
+        cy.get("#customPermissions").should("be.visible");
+        // Manage Events toggle is present and unchecked by default
+        cy.get("#AddEvent").should("exist").should("not.be.checked");
+        // Save without checking AddEvent
+        cy.get("#SaveButton").click();
+        cy.wait("@saveUser");
+
+        // Reload edit — AddEvent must remain unchecked (explicit FALSE row was written)
+        cy.visit(`admin/system/users/${throwawayPersonId3}/edit`);
+        cy.contains("User Editor");
+        cy.get("#customPermissions").should("be.visible");
+        cy.get("#AddEvent").should("not.be.checked");
+
+        // --- Part 2: Edit to grant Manage Events (AddEvent checked) ---
+        cy.intercept("POST", `**/admin/system/users/${throwawayPersonId3}/edit*`).as("editUser");
+        cy.get("#AddEvent").check();
+        cy.get("#SaveButton").click();
+        cy.wait("@editUser");
+
+        // Reload edit — AddEvent must now be checked (TRUE row was written)
+        cy.visit(`admin/system/users/${throwawayPersonId3}/edit`);
+        cy.contains("User Editor");
+        cy.get("#customPermissions").should("be.visible");
+        cy.get("#AddEvent").should("be.checked");
+
+        // --- Part 3: JS exclusivity — switching to self-service must clear AddEvent ---
+        cy.get('input[name="accessMode"][value="self"]').check();
+        cy.get("#AddEvent").should("not.be.checked");
+
+        // Cleanup
+        cy.makePrivateAdminAPICall("DELETE", `/admin/api/user/${throwawayPersonId3}`, null, [200, 204, 404]);
+        cy.then(() => Cypress.session.clearAllSavedSessions());
     });
 });
 

--- a/cypress/e2e/ui/admin/admin.user-editor.spec.js
+++ b/cypress/e2e/ui/admin/admin.user-editor.spec.js
@@ -4,8 +4,10 @@ describe("User Editor - ORM Migration Tests", () => {
     // and test-subdir) never race on the same DB row.
     // Test 1: PersonID=6 (Constance Hart, constance.hart@example.com, family 2)
     // Test 2: PersonID=5 (Albert Campbell, albert.garcia@example.com, family 1)
+    // Test 3: PersonID=7 (Manage Events test — distinct ID to avoid CI races)
     const throwawayPersonId = 6;
     const throwawayPersonId2 = 5;
+    const throwawayPersonId3 = 7;
 
     beforeEach(() => {
         cy.setupAdminSession();
@@ -108,6 +110,54 @@ describe("User Editor - ORM Migration Tests", () => {
         cy.get("#UserName").clear().type("Admin");
         cy.get("#SaveButton").click();
         cy.wait("@restoreUser");
+    });
+
+    it("Should persist Manage Events permission for new Custom user", () => {
+        // bEnabledEvents defaults to '1' in the seed — the #AddEvent toggle is present.
+        // This test covers both states:
+        //   - new user WITHOUT Manage Events → AddEvent unchecked after load (explicit FALSE row)
+        //   - edit to enable Manage Events → AddEvent checked after reload (TRUE row)
+        //   - switching to self-service mode clears the toggle (JS exclusivity)
+        cy.makePrivateAdminAPICall("DELETE", `/admin/api/user/${throwawayPersonId3}`, null, [200, 204, 404]);
+        cy.then(() => Cypress.session.clearAllSavedSessions());
+        cy.setupAdminSession();
+
+        // --- Part 1: Create user WITHOUT Manage Events (AddEvent unchecked) ---
+        cy.intercept("POST", "**/admin/system/users/new*").as("saveUser");
+        cy.visit(`admin/system/users/new?personId=${throwawayPersonId3}`);
+        cy.contains("User Editor");
+        cy.get("#customPermissions").should("be.visible");
+        // Manage Events toggle is present and unchecked by default
+        cy.get("#AddEvent").should("exist").should("not.be.checked");
+        // Save without checking AddEvent
+        cy.get("#SaveButton").click();
+        cy.wait("@saveUser");
+
+        // Reload edit — AddEvent must remain unchecked (explicit FALSE row was written)
+        cy.visit(`admin/system/users/${throwawayPersonId3}/edit`);
+        cy.contains("User Editor");
+        cy.get("#customPermissions").should("be.visible");
+        cy.get("#AddEvent").should("not.be.checked");
+
+        // --- Part 2: Edit to grant Manage Events (AddEvent checked) ---
+        cy.intercept("POST", `**/admin/system/users/${throwawayPersonId3}/edit*`).as("editUser");
+        cy.get("#AddEvent").check();
+        cy.get("#SaveButton").click();
+        cy.wait("@editUser");
+
+        // Reload edit — AddEvent must now be checked (TRUE row was written)
+        cy.visit(`admin/system/users/${throwawayPersonId3}/edit`);
+        cy.contains("User Editor");
+        cy.get("#customPermissions").should("be.visible");
+        cy.get("#AddEvent").should("be.checked");
+
+        // --- Part 3: JS exclusivity — switching to self-service must clear AddEvent ---
+        cy.get('input[name="accessMode"][value="self"]').check();
+        cy.get("#AddEvent").should("not.be.checked");
+
+        // Cleanup
+        cy.makePrivateAdminAPICall("DELETE", `/admin/api/user/${throwawayPersonId3}`, null, [200, 204, 404]);
+        cy.then(() => Cypress.session.clearAllSavedSessions());
     });
 });
 

--- a/cypress/e2e/ui/admin/admin.user-editor.spec.js
+++ b/cypress/e2e/ui/admin/admin.user-editor.spec.js
@@ -152,7 +152,7 @@ describe("User Editor - ORM Migration Tests", () => {
         cy.get("#AddEvent").should("be.checked");
 
         // --- Part 3: JS exclusivity — switching to self-service must clear AddEvent ---
-        cy.get('input[name="accessMode"][value="self"]').check();
+        cy.contains('.form-selectgroup-item', 'Self').click();
         cy.get("#AddEvent").should("not.be.checked");
 
         // Cleanup

--- a/cypress/e2e/ui/system/mvc-error-pages.spec.js
+++ b/cypress/e2e/ui/system/mvc-error-pages.spec.js
@@ -23,8 +23,8 @@ describe('MVC Error Pages — HTML (admin)', () => {
 
     it('should display the 404 code and Page Not Found title', () => {
       cy.visit('/admin/this-route-does-not-exist', { failOnStatusCode: false });
-      cy.contains('404').should('be.visible');
-      cy.contains('Page Not Found').should('be.visible');
+      cy.get('.card-body').contains('404').should('be.visible');
+      cy.get('.card-body').contains('Page Not Found').should('be.visible');
     });
 
     it('should display a Back to Admin Dashboard button', () => {
@@ -59,8 +59,8 @@ describe('MVC Error Pages — HTML (v2)', () => {
 
     it('should display the 404 code and Page Not Found title', () => {
       cy.visit('/v2/this-route-does-not-exist', { failOnStatusCode: false });
-      cy.contains('404').should('be.visible');
-      cy.contains('Page Not Found').should('be.visible');
+      cy.get('.card-body').contains('404').should('be.visible');
+      cy.get('.card-body').contains('Page Not Found').should('be.visible');
     });
 
     it('should display a Return to Dashboard button', () => {

--- a/src/ChurchCRM/Service/UserService.php
+++ b/src/ChurchCRM/Service/UserService.php
@@ -429,9 +429,9 @@ class UserService
      */
     private function saveAddEventPermission(int $personId, bool $enabled): void
     {
-        if (!User::isEventsEnabled()) {
-            return;
-        }
+        // No early-return on isEventsEnabled() — always write the explicit row
+        // so the user never inherits the shared default (peronId=0) value later
+        // when the Events module is re-enabled.
         $default = UserConfigQuery::create()
             ->filterByPeronId(0)
             ->filterByName('bAddEvent')

--- a/src/ChurchCRM/Service/UserService.php
+++ b/src/ChurchCRM/Service/UserService.php
@@ -218,6 +218,7 @@ class UserService
             'finance'           => $allow && isset($body['Finance'])           ? 1 : 0,
             'manageFundraisers' => $allow && isset($body['ManageFundraisers']) ? 1 : 0,
             'notes'             => $allow && isset($body['Notes'])             ? 1 : 0,
+            'addEvent'          => $allow && isset($body['AddEvent'])          ? 1 : 0,
         ];
     }
 
@@ -285,6 +286,9 @@ class UserService
                 ->setEditSelf($perms['editSelf']);
             $newUser->updatePassword($rawPassword);
             $newUser->save();
+            // Always write an explicit TRUE/FALSE bAddEvent row for the new user
+            // so they never silently inherit the shared default (peronId=0) value.
+            $this->saveAddEventPermission($personId, (bool) ($perms['addEvent'] ?? false));
             $newUser->createTimeLineNote('created');
             $con->commit();
         } catch (\Throwable $e) {
@@ -334,6 +338,9 @@ class UserService
             if ($types !== []) {
                 $this->saveUserConfig($personId, $newValue, $newPermission, $types);
             }
+            // Write bAddEvent last so the Permissions-card checkbox always wins
+            // over the raw User Config table permission dropdown for the same row.
+            $this->saveAddEventPermission($personId, (bool) ($perms['addEvent'] ?? false));
             $con->commit();
         } catch (\Throwable $e) {
             $con->rollBack();
@@ -389,6 +396,66 @@ class UserService
         $user->createTimeLineNote('updated');
 
         return $user;
+    }
+
+    /**
+     * Get the raw bAddEvent (Manage Events) permission for a user.
+     *
+     * Reads the per-user UserConfig row directly — no admin bypass — so the
+     * Permissions-card checkbox reflects the stored grant, not the effective
+     * computed value (which always returns true for admins).
+     *
+     * @param int $personId Person ID of the user to query
+     * @return bool True if the bAddEvent permission row is set to 'TRUE'
+     */
+    public function getAddEventPermission(int $personId): bool
+    {
+        $row = UserConfigQuery::create()
+            ->filterByPeronId($personId)
+            ->filterByName('bAddEvent')
+            ->findOne();
+        return $row !== null && $row->getPermission() === 'TRUE';
+    }
+
+    /**
+     * Upsert the per-user bAddEvent (Manage Events) UserConfig permission row.
+     *
+     * No-op when the Events module is disabled system-wide or when the default
+     * (peronId=0) seed row is missing. Clones field metadata from the default
+     * row on first write — identical to the saveUserConfig() clone pattern.
+     *
+     * @param int  $personId Person ID of the user
+     * @param bool $enabled  Whether to grant (TRUE) or deny (FALSE) the permission
+     */
+    private function saveAddEventPermission(int $personId, bool $enabled): void
+    {
+        if (!User::isEventsEnabled()) {
+            return;
+        }
+        $default = UserConfigQuery::create()
+            ->filterByPeronId(0)
+            ->filterByName('bAddEvent')
+            ->findOne();
+        if ($default === null) {
+            return;
+        }
+        $permission = $enabled ? 'TRUE' : 'FALSE';
+        $row = UserConfigQuery::create()
+            ->filterByPeronId($personId)
+            ->filterById($default->getId())
+            ->findOne();
+        if ($row === null) {
+            $row = new UserConfig();
+            $row->setPeronId($personId)
+                ->setId($default->getId())
+                ->setName($default->getName())
+                ->setValue($default->getValue())
+                ->setType($default->getType())
+                ->setTooltip($default->getTooltip())
+                ->setCat($default->getCat());
+        }
+        $row->setPermission($permission);
+        $row->save();
     }
 
     /**

--- a/src/admin/routes/system.php
+++ b/src/admin/routes/system.php
@@ -11,6 +11,7 @@ use ChurchCRM\Emails\TestEmail;
 use ChurchCRM\model\ChurchCRM\GroupQuery;
 use ChurchCRM\model\ChurchCRM\ListOptionQuery;
 use ChurchCRM\model\ChurchCRM\PersonQuery;
+use ChurchCRM\model\ChurchCRM\User;
 use ChurchCRM\model\ChurchCRM\UserQuery;
 use ChurchCRM\Service\AppIntegrityService;
 use ChurchCRM\Service\LocaleService;
@@ -916,7 +917,8 @@ function adminUserEditorNew(Request $request, Response $response): Response
         ]),
         'isNew'        => true,
         'configRows'   => [],
-        'bEmailEnabled' => SystemConfig::isEmailEnabled(),
+        'bEmailEnabled'  => SystemConfig::isEmailEnabled(),
+        'eventsEnabled'  => User::isEventsEnabled(),
     ];
 
     if ($request->getMethod() === 'POST') {
@@ -945,7 +947,8 @@ function adminUserEditorNew(Request $request, Response $response): Response
             $pageArgs['perms']            = ['admin' => 0, 'editSelf' => 0, 'addRecords' => 0,
                                              'editRecords' => 0, 'deleteRecords' => 0,
                                              'menuOptions' => 0, 'manageGroups' => 0,
-                                             'finance' => 0, 'manageFundraisers' => 0, 'notes' => 0];
+                                             'finance' => 0, 'manageFundraisers' => 0, 'notes' => 0,
+                                             'addEvent' => 0];
             return $renderer->render($response, 'user-editor.php', $pageArgs);
         }
 
@@ -996,6 +999,7 @@ function adminUserEditorNew(Request $request, Response $response): Response
         'editRecords' => 0, 'deleteRecords' => 0,
         'menuOptions' => 0, 'manageGroups' => 0,
         'finance' => 0, 'manageFundraisers' => 0, 'notes' => 0,
+        'addEvent' => 0,
     ];
     $pageArgs['formAction'] = SystemURLs::getRootPath() . '/admin/system/users/new';
     $pageArgs['sErrorText'] = '';
@@ -1043,6 +1047,7 @@ function adminUserEditorEdit(Request $request, Response $response, array $args):
         'showPersonSelect' => false,
         'people'           => [],
         'bEmailEnabled'    => SystemConfig::isEmailEnabled(),
+        'eventsEnabled'    => User::isEventsEnabled(),
         'formAction'       => SystemURLs::getRootPath() . '/admin/system/users/' . $personId . '/edit',
         'sErrorText'       => '',
     ];
@@ -1085,6 +1090,7 @@ function adminUserEditorEdit(Request $request, Response $response, array $args):
         'finance'            => $user->getFinance(),
         'manageFundraisers'  => $user->getManageFundraisers(),
         'notes'              => $user->getNotes(),
+        'addEvent'           => $userService->getAddEventPermission($personId),
     ];
     $pageArgs['configRows'] = $userService->getUserConfigRows($personId);
 

--- a/src/admin/views/user-editor.php
+++ b/src/admin/views/user-editor.php
@@ -165,6 +165,9 @@ $accessMode = $perms['admin'] ? 'admin' : ($perms['editSelf'] ? 'self' : 'custom
                 ['name' => 'Finance',            'label' => gettext('Manage Donations and Finance'),  'checked' => $perms['finance']],
                 ['name' => 'ManageFundraisers', 'label' => gettext('Manage Fundraisers'),              'checked' => $perms['manageFundraisers']],
             ];
+            if ($eventsEnabled) {
+                $permissions[] = ['name' => 'AddEvent', 'label' => gettext('Manage Events'), 'checked' => !empty($perms['addEvent'])];
+            }
             foreach ($permissions as $perm):
             ?>
             <div class="row mb-2 permission-row">

--- a/src/skin/js/user-editor.js
+++ b/src/skin/js/user-editor.js
@@ -12,7 +12,17 @@ $(document).ready(() => {
   //
   // EditSelf is exclusive: cannot coexist with module permissions or admin.
   // The JS enforces this invariant so the server-side check is defense-in-depth.
-  const modulePerms = ["AddRecords", "EditRecords", "DeleteRecords", "MenuOptions", "ManageGroups", "Finance", "Notes", "ManageFundraisers", "AddEvent"];
+  const modulePerms = [
+    "AddRecords",
+    "EditRecords",
+    "DeleteRecords",
+    "MenuOptions",
+    "ManageGroups",
+    "Finance",
+    "Notes",
+    "ManageFundraisers",
+    "AddEvent",
+  ];
   const adminCb = document.getElementById("Admin");
   const editSelfCb = document.getElementById("EditSelf");
   const customBlock = document.getElementById("customPermissions");

--- a/src/skin/js/user-editor.js
+++ b/src/skin/js/user-editor.js
@@ -12,7 +12,7 @@ $(document).ready(() => {
   //
   // EditSelf is exclusive: cannot coexist with module permissions or admin.
   // The JS enforces this invariant so the server-side check is defense-in-depth.
-  const modulePerms = ["AddRecords", "EditRecords", "DeleteRecords", "MenuOptions", "ManageGroups", "Finance", "Notes"];
+  const modulePerms = ["AddRecords", "EditRecords", "DeleteRecords", "MenuOptions", "ManageGroups", "Finance", "Notes", "ManageFundraisers", "AddEvent"];
   const adminCb = document.getElementById("Admin");
   const editSelfCb = document.getElementById("EditSelf");
   const customBlock = document.getElementById("customPermissions");


### PR DESCRIPTION
## What

Surfaces the `bAddEvent` permission as a named toggle in the **Permissions card** of `UserEditor.php`, alongside existing toggles like Finance and Manage Groups.

## Background

The `bAddEvent` permission (stored in the `userconfig_ucfg` table) controls whether a non-admin user can create, edit, and delete events (`canManageEvents()`). Previously it was only accessible via the raw **User Config** table (Section B of UserEditor), which:

- Is hidden entirely during new user creation
- Exposes the internal variable name (`bAddEvent`) rather than a human-readable label
- Is easy to overlook for admins managing user permissions

## Changes

- **Permissions card** — adds a "Manage Events" toggle rendered only when the Events module is enabled (`bEnabledEvents`), styled identically to other permission rows
- **Load (edit path)** — reads the raw ucfg `Permission` field directly (no admin bypass) so admins can see and set the real per-user value
- **Save (edit path)** — before the ucfg processing loop, overrides `$new_permission[bAddEvent_id]` with the Permissions card checkbox value, preventing the User Config table dropdown from silently overwriting it
- **Save (add path)** — explicitly creates the `userconfig_ucfg` row when the checkbox is checked; the ucfg section is never reached for new users (redirect happens first)
- **Section B (User Config table)** — left intact for backward compatibility

## Testing

1. Enable the Events module (`bEnabledEvents = true`)
2. Navigate to **Admin → Users → Edit** any non-admin user
3. Verify "Manage Events" toggle appears in the Permissions card
4. Toggle it on/off and save — confirm `canManageEvents()` reflects the change
5. Create a new user with "Manage Events" checked — confirm the ucfg row is written
6. Disable the Events module — confirm the toggle disappears entirely