### PR TITLE
fix: merge split i18n strings for upgrade UI strings

### DIFF
--- a/.agents/skills/churchcrm/i18n-localization.md
+++ b/.agents/skills/churchcrm/i18n-localization.md
@@ -686,6 +686,97 @@ echo sprintf(gettext('%d record(s) returned'), mysqli_num_rows($rs));
 
 **Checklist addition:** Add `- [ ] No gettext() fragments — full sentence per call, sprintf for values` to your pre-commit review.
 
+### Never Split a Sentence in JavaScript (i18next template literals) <!-- learned: 2026-07-11 -->
+
+The same anti-pattern occurs in JS where two `i18next.t()` calls are concatenated in a template literal, often with HTML or a runtime value in between. The extracted msgids are short, decontextualised fragments that translators cannot understand.
+
+```javascript
+// ❌ WRONG — three fragments; count bolded via HTML between two t() calls
+$("#upgradePathSummary").html(
+  `${i18next.t("You are")} <strong>${count}</strong> ${i18next.t("releases behind. Here's what you'll gain:")}`,
+);
+// Produces msgids: "You are" and "releases behind. Here's what you'll gain:"
+
+// ✅ CORRECT — single parameterised msgid; HTML emphasis kept inside the template key
+$("#upgradePathSummary").html(
+  i18next.t("You are <strong>{{releaseCount}}</strong> releases behind. Here's what you'll gain:", {
+    releaseCount: count,
+  }),
+);
+```
+
+**Detection — grep for JS template-literal split patterns:**
+```bash
+# Detects: `...${i18next.t(...)} ... ${i18next.t(...)}...`
+grep -rn '\${i18next\.t(' webpack/src/skin/js/ | grep -v '//' | head
+# Multiple i18next.t hits on the same line = likely fragment concatenation
+grep -rn 'i18next\.t(' webpack/ | awk -F: '{if (gsub(/i18next\.t\(/, "&", $2) > 1) print}'
+```
+
+**i18next `count` reserved key — use named alternatives:**
+i18next treats `count` as a special interpolation key that triggers plural-form lookup. When injecting a plain integer that is *not* a plural selector, use a distinct name to avoid unintended plural behaviour:
+```javascript
+// ❌ WRONG — triggers i18next plural lookup
+i18next.t("{{count}} releases behind", { count })
+
+// ✅ CORRECT — named interpolation, no plural side-effect
+i18next.t("{{releaseCount}} releases behind", { releaseCount: count })
+```
+
+**HTML-valued interpolation (i18next `escapeValue: false`):**
+When an interpolated value must contain HTML (e.g. a `<span>` to keep an element ID stable for Cypress), sanitize the inner text with `escapeHtml()` yourself, then disable escaping per-call:
+```javascript
+function setWhatsNewHeading(version) {
+  const versionHtml = `<span id="whatsNewVersion" class="text-primary">${escapeHtml(version || "")}</span>`;
+  $("#whatsNewHeading").html(
+    i18next.t("What's New in {{version}}", {
+      version: versionHtml,
+      interpolation: { escapeValue: false }, // safe: inner text manually escaped
+    }),
+  );
+}
+```
+This is a per-call option; it does not affect other `i18next.t()` calls.
+
+**HTML in msgid keys is established precedent** in this codebase (e.g. `msgid "Ends with a <strong>trailing slash</strong> (/)"`). Using `<strong>` inside a msgid for emphasis that must be preserved by translators is acceptable. Keep it minimal — body paragraphs should use `%d`/`{{n}}` interpolation without markup.
+
+### Trailing-Preposition / Cross-Language Split (PHP prefix + JS suffix) <!-- learned: 2026-07-11 -->
+
+A subtle variant of the split-sentence anti-pattern occurs when **PHP renders a translatable prefix** and **JavaScript appends the dynamic suffix** at runtime. The PHP msgid ends in a dangling preposition or incomplete phrase:
+
+```php
+// ❌ WRONG — "What's New in" ends in a preposition; JS appends the version
+<?= gettext("What's New in") ?> <span id="whatsNewVersion" class="text-primary"></span>
+// JS later: $("#whatsNewVersion").text(nextVersion)
+// Translator sees msgid "What's New in" with no idea what follows.
+```
+
+**Detection in messages.po:**
+```bash
+# Short msgids (≤ 5 words) that end in a preposition or article suggest a suffix will be appended
+grep '^msgid ' locale/messages.po | awk '{if (NF <= 6) print}' | grep -iE '" ?(in|of|for|to|a|the|an)"$'
+```
+
+**Fix:** Move the *complete* sentence into a single JS `i18next.t()` call with a named placeholder, and remove the PHP `gettext()` call entirely:
+```php
+<!-- PHP: static shell only, no translatable prefix -->
+<h4 class="mb-0">
+    <i class="fa fa-tag me-1 text-primary"></i>
+    <span id="whatsNewHeading"></span>
+</h4>
+```
+```javascript
+// JS: full sentence, single msgid
+$("#whatsNewHeading").html(
+  i18next.t("What's New in {{version}}", {
+    version: versionHtml,
+    interpolation: { escapeValue: false },
+  }),
+);
+```
+
+**Rule:** If a PHP `gettext()` key ends in a preposition (`in`, `of`, `for`, `to`) or an article and the rendered element is later updated by JS, it is a cross-language split. Consolidate into one JS (or PHP) parameterised string.
+
 ### Plural Forms
 
 ```php
@@ -759,6 +850,8 @@ Before committing:
 - [ ] No hardcoded user-facing strings
 - [ ] No brand / technical literals wrapped — see ["Do Not Wrap Brand / Technical Literals"](#do-not-wrap-brand--technical-literals----learned-2026-04-22---) (brand names, config keys, protocol acronyms, `name@example.com`-style placeholders all stay as bare literals)
 - [ ] No split-sentence fragments — each `gettext()` call wraps a complete sentence; dynamic values use `sprintf()` — see ["Never Split a Sentence"](#never-split-a-sentence-across-multiple-gettext-calls----learned-2026-04-22-)
+- [ ] No JS template-literal split — no `${i18next.t(...)} ... ${i18next.t(...)}` concatenation; use single parameterised `i18next.t()` with `{{placeholder}}` — see ["Never Split in JavaScript"](#never-split-a-sentence-in-javascript-i18next-template-literals----learned-2026-07-11-)
+- [ ] No trailing-preposition PHP msgid followed by JS runtime suffix — use a single JS `i18next.t('... {{version}}')` instead — see ["Trailing-Preposition"](#trailing-preposition--cross-language-split-php-prefix--js-suffix----learned-2026-07-11-)
 - [ ] If strings added: Ran `npm run locale:build`
 - [ ] If strings added: Ran `npm run build`
 - [ ] Committed `locale/terms/messages.po`

--- a/.agents/skills/churchcrm/locale-translation-workflow.md
+++ b/.agents/skills/churchcrm/locale-translation-workflow.md
@@ -333,6 +333,35 @@ git push origin --delete locale/7.2.0-2026-04-27-143015
 
 ---
 
+## Detecting i18n Anti-Patterns Before Locale Extraction <!-- learned: 2026-07-11 -->
+
+Run these grep recipes on the source tree **before** `npm run locale:build` to catch split-sentence patterns early — they are much cheaper to fix at the source than after extraction has already committed broken msgids to the PO file.
+
+### JS template-literal split (`i18next.t()` fragments)
+```bash
+# Lines with 2+ i18next.t() calls = likely template-literal concatenation
+grep -rn 'i18next\.t(' webpack/ src/skin/js/ 2>/dev/null \
+  | awk -F: '{ line=$0; n=split(line,_,"i18next.t("); if (n>2) print }'
+```
+A hit means two translation fragments are concatenated in the same expression. Merge them into one `i18next.t("full sentence {{var}}", { var })` call.
+
+### PHP gettext() trailing-preposition split
+```bash
+# msgids that end in a preposition/article suggest a runtime suffix is appended
+grep -rn "gettext('" src/ | grep -iE "gettext\('[^']{1,40} (in|of|for|to|a|the|an)'\)"
+# Also check messages.po after extraction:
+grep '^msgid ' locale/messages.po | grep -iE '" ?(in|of|for|to|a|the|an)"$'
+```
+
+### Short unexplained msgids in messages.po
+```bash
+# One-to-three word msgids that are lower-case are frequently JS badge/label fragments
+grep '^msgid "[a-z][a-z ]\{1,30\}"$' locale/messages.po
+```
+Inspect each hit: if it reads like half a sentence (e.g. `"installing next"`, `"You are"`), trace it to the source and merge into a full parameterised string.
+
+---
+
 ## Troubleshooting
 
 **Q: How do I resume if interrupted during translation?**

--- a/cypress/e2e/ui/admin/system-upgrade.spec.js
+++ b/cypress/e2e/ui/admin/system-upgrade.spec.js
@@ -222,6 +222,7 @@ describe("System Upgrade Page", () => {
             cy.wait("@previewRequest", { timeout: 10000 });
             cy.get("#upgradePathPanel").should("not.have.class", "d-none");
             cy.get("#upgradePathSummary").should("contain", "3");
+            cy.get("#upgradePathAccordion .badge.bg-primary-lt.text-primary").should("contain", "Installing next release");
             cy.get("#proceedToDownload").should("be.visible");
         });
 

--- a/locale/messages.po
+++ b/locale/messages.po
@@ -5861,6 +5861,9 @@ msgstr ""
 msgid "Installed on Server"
 msgstr ""
 
+msgid "Installing next release"
+msgstr ""
+
 msgid "Installing…"
 msgstr ""
 
@@ -11878,7 +11881,7 @@ msgstr ""
 msgid "What's New"
 msgstr ""
 
-msgid "What's New in"
+msgid "What's New in {{version}}"
 msgstr ""
 
 #. plugin:mailchimp:section:3:content
@@ -12012,7 +12015,7 @@ msgstr ""
 msgid "Yes, delete this record"
 msgstr ""
 
-msgid "You are"
+msgid "You are <strong>{{releaseCount}}</strong> releases behind. Here's what you'll gain:"
 msgstr ""
 
 msgid "You are about to add a new deposit without a comment"
@@ -12386,9 +12389,6 @@ msgstr ""
 msgid "in cart"
 msgstr ""
 
-msgid "installing next"
-msgstr ""
-
 msgid "invalid calendar pinning"
 msgstr ""
 
@@ -12542,9 +12542,6 @@ msgid "record(s) successfully deleted from the selected Group."
 msgstr ""
 
 msgid "records"
-msgstr ""
-
-msgid "releases behind. Here's what you'll gain:"
 msgstr ""
 
 msgid "risk"

--- a/src/admin/views/upgrade.php
+++ b/src/admin/views/upgrade.php
@@ -218,7 +218,7 @@ $orphanedCount = count($integrityCheckData['orphanedFiles'] ?? []);
                                 <div class="d-flex align-items-center justify-content-between mb-2">
                                     <h4 class="mb-0">
                                         <i class="fa fa-tag me-1 text-primary"></i>
-                                        <?= gettext("What's New in") ?> <span id="whatsNewVersion" class="text-primary"></span>
+                                        <span id="whatsNewHeading"></span>
                                     </h4>
                                     <a id="whatsNewChangelogLink" href="#" target="_blank" rel="noopener noreferrer" class="btn btn-ghost-secondary btn-sm d-none">
                                         <i class="fa fa-external-link me-1"></i><?= gettext('Full changelog') ?>

--- a/webpack/upgrade-wizard-app.js
+++ b/webpack/upgrade-wizard-app.js
@@ -251,6 +251,21 @@ function fetchUpgradePreview() {
 }
 
 /**
+ * Set the "What's New in <version>" heading, keeping #whatsNewVersion
+ * accessible for Cypress and other selectors while using a single
+ * parameterised i18n string instead of two concatenated fragments.
+ */
+function setWhatsNewHeading(version) {
+  const versionHtml = `<span id="whatsNewVersion" class="text-primary">${escapeHtml(version || "")}</span>`;
+  $("#whatsNewHeading").html(
+    i18next.t("What's New in {{version}}", {
+      version: versionHtml,
+      interpolation: { escapeValue: false },
+    }),
+  );
+}
+
+/**
  * Render the What's New content from preview API response
  */
 function renderWhatsNew(data) {
@@ -258,7 +273,7 @@ function renderWhatsNew(data) {
 
   // Already up-to-date: show a clear message and hide the proceed button
   if (releasesAhead === 0) {
-    $("#whatsNewVersion").text("");
+    $("#whatsNewHeading").empty();
     $("#whatsNewNotes").html("");
     $("#whatsNewChangelogLink").addClass("d-none");
     $("#upgradePathPanel").addClass("d-none");
@@ -274,7 +289,7 @@ function renderWhatsNew(data) {
   }
 
   // Version heading
-  $("#whatsNewVersion").text(nextVersion || "");
+  setWhatsNewHeading(nextVersion);
 
   // Changelog link
   if (nextChangelogUrl) {
@@ -291,7 +306,9 @@ function renderWhatsNew(data) {
   if (releasesAhead >= 2 && upgradePath && upgradePath.length >= 2) {
     const count = upgradePath.length;
     $("#upgradePathSummary").html(
-      `${i18next.t("You are")} <strong>${count}</strong> ${i18next.t("releases behind. Here's what you'll gain:")}`,
+      i18next.t("You are <strong>{{releaseCount}}</strong> releases behind. Here's what you'll gain:", {
+        releaseCount: count,
+      }),
     );
     renderUpgradePath(upgradePath);
     $("#upgradePathPanel").removeClass("d-none");
@@ -311,7 +328,7 @@ function renderUpgradePath(upgradePath) {
     const collapseId = `upgradePath-${idx}`;
     const typeBadge = badgeForType(entry.type);
     const isNextBadge = entry.isNext
-      ? `<span class="badge bg-primary-lt text-primary ms-1">${i18next.t("installing next")}</span>`
+      ? `<span class="badge bg-primary-lt text-primary ms-1">${i18next.t("Installing next release")}</span>`
       : "";
     const changelogLink = entry.changelogUrl
       ? `<a href="${escapeHtml(entry.changelogUrl)}" target="_blank" rel="noopener noreferrer" class="btn btn-ghost-secondary btn-sm ms-auto">
@@ -366,7 +383,7 @@ function renderVersionSelector(upgradePath, defaultNextVersion) {
       // Reset to default next version notes
       const defaultEntry = upgradePath.find((e) => e.isNext);
       if (defaultEntry) {
-        $("#whatsNewVersion").text(defaultEntry.version);
+        setWhatsNewHeading(defaultEntry.version);
         $("#whatsNewNotes").html(marked.parse(defaultEntry.notes || ""));
         if (defaultEntry.changelogUrl) {
           $("#whatsNewChangelogLink").attr("href", defaultEntry.changelogUrl).removeClass("d-none");
@@ -376,7 +393,7 @@ function renderVersionSelector(upgradePath, defaultNextVersion) {
     } else {
       const entry = upgradePath.find((e) => e.version === ver);
       if (entry) {
-        $("#whatsNewVersion").text(entry.version);
+        setWhatsNewHeading(entry.version);
         $("#whatsNewNotes").html(marked.parse(entry.notes || ""));
         if (entry.changelogUrl) {
           $("#whatsNewChangelogLink").attr("href", entry.changelogUrl).removeClass("d-none");


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Fixes 4 i18n anti-patterns in the upgrade wizard UI identified during review of PR #9107 (locale/messages.po automated update).

**Root cause:** four `msgid` entries in the generated `locale/messages.po` were fragments — either split sentences or dangling prepositions — making them untranslatable in isolation across 45+ languages.

**Changes:**

| # | Severity | Old msgids | New msgid | Location |
|---|---|---|---|---|
| 1+2 | MEDIUM | `"You are"` + `"releases behind. Here's what you'll gain:"` | `"You are <strong>{{releaseCount}}</strong> releases behind. Here's what you'll gain:"` | `webpack/upgrade-wizard-app.js` |
| 3 | MEDIUM | `"What's New in"` (PHP, cross-language split) | `"What's New in {{version}}"` (JS, single parameterised) | `upgrade.php` + `upgrade-wizard-app.js` |
| 4 | LOW | `"installing next"` | `"Installing next release"` | `webpack/upgrade-wizard-app.js` |

**Implementation notes:**
- Added `setWhatsNewHeading(version)` helper: reconstructs `#whatsNewVersion` span inside `#whatsNewHeading` so existing Cypress selectors remain valid.
- Used `releaseCount` (not `count`) to avoid i18next plural-form side-effects.
- `locale/messages.po` updated surgically (full `npm run locale:build` requires xgettext + MySQL, unavailable in CI; manual edit matches what extraction would produce).
- Cypress: added badge text assertion `.should("contain", "Installing next release")` to the multi-release-behind test.
- Skill files updated with new i18n anti-pattern documentation (JS template-literal split, trailing-preposition/cross-language split, detection grep recipes).

Refs: #9107