### PR TITLE
Add Finance permission guards to fundraiser and pledge pages

### DIFF
--- a/cypress/e2e/ui/security/finance-page-guards.spec.js
+++ b/cypress/e2e/ui/security/finance-page-guards.spec.js
@@ -1,0 +1,92 @@
+/// <reference types="cypress" />
+
+/**
+ * Tests the Finance permission guard on the fundraiser and pledge pages.
+ *
+ * Background: these pages previously had NO top-of-file access guard. The only
+ * thing keeping users off them was the coarse hasNoAdminPermissions() entry gate
+ * in PageInit.php, which blocks a user only when they have ZERO permissions. Any
+ * user with a single unrelated permission (e.g. AddRecords) cleared that gate and
+ * reached fundraiser, donor, paddle-number and pledge data. They are now gated on
+ * isFinanceEnabled(), which redirects to /v2/access-denied?role=Finance.
+ *
+ * Finance is an interim stand-in until a dedicated fundraiser permission exists.
+ *
+ * Seed users (cypress/configs/docker.config.ts -> cypress/data/seed.sql):
+ *  - standard  = tony.wade@example.com       usr_Finance=1, usr_Admin=0  -> ALLOWED
+ *  - nofinance = judith.matthews@example.com usr_AddRecords=1, usr_EditRecords=1,
+ *                                            usr_Finance=0, usr_Admin=0  -> DENIED
+ *
+ * judith is the load-bearing user here: she HAS permissions, so she passes the
+ * PageInit entry gate. She is the only seeded user who can prove the per-page
+ * Finance guard works. noperm.user would be bounced by the entry gate regardless,
+ * and would pass this test even if the guard did not exist.
+ *
+ * The positive path (a Finance user can still use these pages) is additionally
+ * covered by cypress/e2e/ui/fundraiser/*.spec.js, which run as tony.wade.
+ */
+
+const ACCESS_DENIED = "/v2/access-denied";
+
+// Pages that render a form/list on GET without mutating anything.
+// Safe to load as an allowed user in the positive test.
+const READABLE_PAGES = [
+    "FindFundRaiser.php",
+    "PaddleNumList.php",
+    "FundRaiserEditor.php?FundRaiserID=-1",
+    "DonatedItemEditor.php",
+    "PaddleNumEditor.php",
+];
+
+// Pages whose GET handler performs writes or a destructive action. These are only
+// exercised in the negative test — visiting them as a Finance user would mutate
+// seed data, so the positive path is never asserted against them.
+const MUTATING_PAGES = [
+    "AddDonors.php?FundRaiserID=1",
+    "BatchWinnerEntry.php?CurrentFundraiser=1",
+    "DonatedItemReplicate.php?DonatedItemID=1&Count=1",
+    "FundRaiserDelete.php?FundRaiserID=999999",
+];
+
+const ALL_GUARDED_PAGES = [...READABLE_PAGES, ...MUTATING_PAGES, "PledgeEditor.php"];
+
+describe("Finance permission guard on fundraiser and pledge pages", () => {
+    describe("User WITHOUT Finance (judith.matthews: AddRecords+EditRecords, Finance=0)", () => {
+        beforeEach(() => {
+            cy.setupNoFinanceSession();
+        });
+
+        ALL_GUARDED_PAGES.forEach((page) => {
+            it(`denies ${page}`, () => {
+                cy.visit(`/${page}`, { failOnStatusCode: false });
+                cy.url().should("include", ACCESS_DENIED);
+                cy.url().should("include", "role=Finance");
+            });
+        });
+
+        it("does not show Fundraiser menu items", () => {
+            cy.visit("/v2/dashboard");
+            cy.contains("a", "Create New Fundraiser").should("not.exist");
+            cy.contains("a", "Add Donors to Buyer List").should("not.exist");
+            cy.contains("a", "View Buyers").should("not.exist");
+        });
+    });
+
+    describe("User WITH Finance (tony.wade: Finance=1, Admin=0)", () => {
+        beforeEach(() => {
+            cy.setupStandardSession();
+        });
+
+        READABLE_PAGES.forEach((page) => {
+            it(`allows ${page}`, () => {
+                cy.visit(`/${page}`, { failOnStatusCode: false });
+                cy.url().should("not.include", ACCESS_DENIED);
+            });
+        });
+
+        it("shows Fundraiser menu items", () => {
+            cy.visit("/v2/dashboard");
+            cy.contains("a", "Create New Fundraiser").should("exist");
+        });
+    });
+});

--- a/src/AddDonors.php
+++ b/src/AddDonors.php
@@ -3,8 +3,12 @@
 require_once __DIR__ . '/Include/Config.php';
 require_once __DIR__ . '/Include/PageInit.php';
 
+use ChurchCRM\Authentication\AuthenticationManager;
 use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
+
+// Security: User must have finance permission to use this page
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isFinanceEnabled(), 'Finance');
 
 $linkBack = RedirectUtils::getLinkBackFromRequest('');
 $iFundRaiserID = InputUtils::filterInt($_GET['FundRaiserID']);

--- a/src/BatchWinnerEntry.php
+++ b/src/BatchWinnerEntry.php
@@ -3,10 +3,14 @@
 require_once __DIR__ . '/Include/Config.php';
 require_once __DIR__ . '/Include/PageInit.php';
 
+use ChurchCRM\Authentication\AuthenticationManager;
 use ChurchCRM\model\ChurchCRM\DonatedItemQuery;
 use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 use ChurchCRM\view\PageHeader;
+
+// Security: User must have finance permission to use this page
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isFinanceEnabled(), 'Finance');
 
 $linkBack = RedirectUtils::getLinkBackFromRequest('v2/dashboard');
 $iCurrentFundraiser = InputUtils::filterInt($_GET['CurrentFundraiser']);

--- a/src/ChurchCRM/Config/Menu/Menu.php
+++ b/src/ChurchCRM/Config/Menu/Menu.php
@@ -43,7 +43,7 @@ class Menu
             'Communication' => self::getCommunicationMenu(),
             'Events'       => self::getEventsMenu($currentUser->isAddEventEnabled(), $canViewEvents),
             'Deposits'     => self::getDepositsMenu($isAdmin, $currentUser->isFinanceEnabled()),
-            'Fundraiser'   => self::getFundraisersMenu($isAdmin),
+            'Fundraiser'   => self::getFundraisersMenu($isAdmin, $currentUser->isFinanceEnabled()),
             'Reports'      => self::getReportsMenu(),
         ];
         
@@ -279,13 +279,16 @@ class Menu
         return $depositsMenu;
     }
 
-    private static function getFundraisersMenu(bool $isAdmin): MenuItem
+    private static function getFundraisersMenu(bool $isAdmin, bool $isFinanceEnabled): MenuItem
     {
-        $fundraiserMenu = new MenuItem(gettext('Fundraiser'), '', $isAdmin || SystemConfig::getBooleanValue('bEnabledFundraiser'), 'fa-money-bill-1');
-        $fundraiserMenu->addSubMenu(new MenuItem(gettext('Dashboard'), 'FindFundRaiser.php', true, 'fa-list'));
-        $fundraiserMenu->addSubMenu(new MenuItem(gettext('Create New Fundraiser'), 'FundRaiserEditor.php?FundRaiserID=-1', true, 'fa-circle-plus'));
-        $fundraiserMenu->addSubMenu(new MenuItem(gettext('Add Donors to Buyer List'), 'AddDonors.php', true, 'fa-user-plus'));
-        $fundraiserMenu->addSubMenu(new MenuItem(gettext('View Buyers'), 'PaddleNumList.php', true, 'fa-users'));
+        // Fundraiser pages are gated on the Finance permission until a dedicated
+        // fundraiser permission exists. $isFinanceEnabled already includes the admin bypass.
+        $isFundraiserVisible = $isFinanceEnabled && ($isAdmin || SystemConfig::getBooleanValue('bEnabledFundraiser'));
+        $fundraiserMenu = new MenuItem(gettext('Fundraiser'), '', $isFundraiserVisible, 'fa-money-bill-1');
+        $fundraiserMenu->addSubMenu(new MenuItem(gettext('Dashboard'), 'FindFundRaiser.php', $isFundraiserVisible, 'fa-list'));
+        $fundraiserMenu->addSubMenu(new MenuItem(gettext('Create New Fundraiser'), 'FundRaiserEditor.php?FundRaiserID=-1', $isFundraiserVisible, 'fa-circle-plus'));
+        $fundraiserMenu->addSubMenu(new MenuItem(gettext('Add Donors to Buyer List'), 'AddDonors.php', $isFundraiserVisible, 'fa-user-plus'));
+        $fundraiserMenu->addSubMenu(new MenuItem(gettext('View Buyers'), 'PaddleNumList.php', $isFundraiserVisible, 'fa-users'));
         $iCurrentFundraiser = 0;
         if (array_key_exists('iCurrentFundraiser', $_SESSION)) {
             $iCurrentFundraiser = $_SESSION['iCurrentFundraiser'];

--- a/src/DonatedItemEditor.php
+++ b/src/DonatedItemEditor.php
@@ -13,6 +13,9 @@ use ChurchCRM\Utils\MiscUtils;
 use ChurchCRM\Utils\RedirectUtils;
 use ChurchCRM\view\PageHeader;
 
+// Security: User must have finance permission to use this page
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isFinanceEnabled(), 'Finance');
+
 $iDonatedItemID = InputUtils::filterInt(InputUtils::legacyFilterInputArr($_GET, 'DonatedItemID', 'int'));
 $linkBack = RedirectUtils::getLinkBackFromRequest('v2/dashboard');
 $iCurrentFundraiser = InputUtils::filterInt(InputUtils::legacyFilterInputArr($_GET, 'CurrentFundraiser'));

--- a/src/DonatedItemReplicate.php
+++ b/src/DonatedItemReplicate.php
@@ -8,6 +8,9 @@ use ChurchCRM\model\ChurchCRM\DonatedItemQuery;
 use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
+// Security: User must have finance permission to use this page
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isFinanceEnabled(), 'Finance');
+
 $iFundRaiserID = $_SESSION['iCurrentFundraiser'];
 $iDonatedItemID = InputUtils::legacyFilterInputArr($_GET, 'DonatedItemID', 'int');
 $iCount = InputUtils::legacyFilterInputArr($_GET, 'Count', 'int');

--- a/src/FindFundRaiser.php
+++ b/src/FindFundRaiser.php
@@ -3,11 +3,15 @@
 require_once __DIR__ . '/Include/Config.php';
 require_once __DIR__ . '/Include/PageInit.php';
 
+use ChurchCRM\Authentication\AuthenticationManager;
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\model\ChurchCRM\FundRaiserQuery;
 use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\view\PageHeader;
 use Propel\Runtime\ActiveQuery\Criteria;
+
+// Security: User must have finance permission to use this page
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isFinanceEnabled(), 'Finance');
 
 $sPageTitle = gettext('Fundraiser Listing');
 $sPageSubtitle = gettext('Browse and search fundraiser campaigns');

--- a/src/FundRaiserDelete.php
+++ b/src/FundRaiserDelete.php
@@ -8,8 +8,8 @@ use ChurchCRM\model\ChurchCRM\FundRaiserQuery;
 use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
-// Security: User must have Delete records permission
-AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isDeleteRecordsEnabled(), 'DeleteRecords');
+// Security: User must have finance permissions
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isFinanceEnabled(), 'Finance');
 
 $iFundRaiserID = (int) InputUtils::legacyFilterInput($_GET['FundRaiserID'], 'int');
 $linkBack = RedirectUtils::getLinkBackFromRequest('FindFundRaiser.php');

--- a/src/FundRaiserEditor.php
+++ b/src/FundRaiserEditor.php
@@ -13,6 +13,9 @@ use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 use ChurchCRM\view\PageHeader;
 
+// Security: User must have finance permission to use this page
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isFinanceEnabled(), 'Finance');
+
 $sPageTitle = gettext('Create New Fund Raiser');
 
 // Check if linkBack was explicitly provided (not the fallback)

--- a/src/PaddleNumEditor.php
+++ b/src/PaddleNumEditor.php
@@ -10,6 +10,9 @@ use ChurchCRM\Utils\MiscUtils;
 use ChurchCRM\Utils\RedirectUtils;
 use ChurchCRM\view\PageHeader;
 
+// Security: User must have finance permission to use this page
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isFinanceEnabled(), 'Finance');
+
 $iPaddleNumID = InputUtils::legacyFilterInputArr($_GET, 'PaddleNumID', 'int');
 $linkBack = RedirectUtils::getLinkBackFromRequest('v2/dashboard');
 

--- a/src/PaddleNumList.php
+++ b/src/PaddleNumList.php
@@ -3,9 +3,13 @@
 require_once __DIR__ . '/Include/Config.php';
 require_once __DIR__ . '/Include/PageInit.php';
 
+use ChurchCRM\Authentication\AuthenticationManager;
 use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 use ChurchCRM\view\PageHeader;
+
+// Security: User must have finance permission to use this page
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isFinanceEnabled(), 'Finance');
 
 $linkBack = RedirectUtils::getLinkBackFromRequest('');
 

--- a/src/PledgeEditor.php
+++ b/src/PledgeEditor.php
@@ -20,6 +20,9 @@ use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\MiscUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
+// Security: User must have finance permission to use this page
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isFinanceEnabled(), 'Finance');
+
 if (SystemConfig::getBooleanValue('bUseScannedChecks')) { // Instantiate the MICR class
     $micrObj = new MICRUtils();
 }


### PR DESCRIPTION
## Summary

The fundraiser/auction pages and `PledgeEditor.php` had **no top-of-file access guard of any kind** — no `isAdmin()`, no `redirectHomeIfNotAdmin()`, no `redirectHomeIfFalse(...Enabled())`. The only thing keeping a user off them was the coarse `hasNoAdminPermissions()` entry gate in `PageInit.php` (added for GHSA-5w59-32c8-933v). Any user who cleared that gate — i.e. anyone with *any* single permission, such as Notes-only — could reach fundraiser, donor, paddle-number and pledge data.

This PR gates those pages on the **Finance** permission. Finance is an interim stand-in until a dedicated fundraiser permission exists.

## Changes

- Added `AuthenticationManager::redirectHomeIfFalse(...isFinanceEnabled(), 'Finance')` to:
  - `FindFundRaiser.php`, `PaddleNumList.php` (read)
  - `AddDonors.php`, `BatchWinnerEntry.php`, `DonatedItemEditor.php`, `DonatedItemReplicate.php`, `FundRaiserEditor.php`, `PaddleNumEditor.php`, `PledgeEditor.php` (write)
  - `FundRaiserDelete.php` (previously guarded on `DeleteRecords` only)
- `Menu.php` — the Fundraiser menu and every one of its sub-items were registered with a hardcoded visibility of `true`. They are now gated on `isFinanceEnabled()`, matching the Deposits menu directly above it.

## Why

Two independent problems, same root cause — the fundraiser module was never given a permission:

1. **Page layer:** no guard at all on 8 fundraiser pages + `PledgeEditor.php`.
2. **Menu layer:** items visible to every user regardless of permission.

Gating on Finance closes both, and reduces how much load `hasNoAdminPermissions()` is carrying as a blanket backstop.

## Behavior change to be aware of

`isFinanceEnabled()` is `isAdmin() || (bEnabledFinance && isFinance())`. A church running the **fundraiser module with the finance module off** (`bEnabledFundraiser=1`, `bEnabledFinance=0`) will now block **non-admin** users from fundraiser pages. Admins are unaffected. This is inherent to borrowing the Finance permission and resolves when a dedicated fundraiser permission lands.

## Files Changed

`src/AddDonors.php`, `src/BatchWinnerEntry.php`, `src/ChurchCRM/Config/Menu/Menu.php`, `src/DonatedItemEditor.php`, `src/DonatedItemReplicate.php`, `src/FindFundRaiser.php`, `src/FundRaiserDelete.php`, `src/FundRaiserEditor.php`, `src/PaddleNumEditor.php`, `src/PaddleNumList.php`, `src/PledgeEditor.php`

## Testing

- `npm run build:php` — 746 PHP files validated, all pass
- `npm run lint` — Biome clean
- **Not yet covered:** no automated test asserts that a Finance user can still *reach* these pages, nor that a non-Finance user is redirected. Worth adding before merge.

## Follow-ups (not in this PR)

- **`DepositSlipEditor.php` has a broken guard.** Line 15 dereferences `$thisDeposit` before it is assigned (line 20; loaded line 28). `||` short-circuits so Finance users pass, but a **non-Finance user hits a fatal "call to member function on null"** instead of a redirect — and the intended "deposit creator may edit their own deposit" exception has never actually worked. Needs a decision on whether to keep that exception.
- Four remaining unguarded legacy pages: `GeoPage.php`, `GetText.php`, `LettersAndLabels.php`, `WhyCameEditor.php`.
- Add a dedicated fundraiser permission and switch these guards over to it.
- Rename `hasNoAdminPermissions()` — the name implies the `isAdmin` flag, but the method early-exits on `isAdmin()` and actually means "has zero functional permissions."

🤖 Generated with [Claude Code](https://claude.com/claude-code)