### PR TITLE
Grant zero-permission users read-only access to people and families

### DIFF
--- a/cypress/e2e/api/private/standard/private.notes.visibility.spec.js
+++ b/cypress/e2e/api/private/standard/private.notes.visibility.spec.js
@@ -260,7 +260,7 @@ describe("Notes Visibility Policy (#9036)", () => {
         });
 
         it("limited.user (Notes=0, all flags=0) CANNOT GET person timeline → 403", () => {
-            // limited.user is blocked by AuthMiddleware::hasNoAdminPermissions() → 403.
+            // limited.user is an EditSelf-only user blocked by AuthMiddleware (User::isEditSelfExclusive()) → 403.
             // This is different from the 'authenticated but no notes' case above.
             cy.makePrivateLimitedAPICall("GET", "/api/timeline/person/2", null, 403);
         });

--- a/cypress/e2e/api/private/standard/private.plainauth.read-default.spec.js
+++ b/cypress/e2e/api/private/standard/private.plainauth.read-default.spec.js
@@ -9,7 +9,8 @@
  *
  * Test user: john.plainauth (user ID 900, `plainauth.api.key`)
  *   - Permissions: Notes=1 only (Admin=0, EditRecords=0, EditSelf=0, AddRecords=0)
- *   - Notes=1 is required to pass the hasNoAdminPermissions() check in AuthMiddleware.
+ *   - Not being EditSelf-exclusive, this user passes the AuthMiddleware entry gate
+ *     (User::isEditSelfExclusive() is false for non-EditSelf users).
  *   - No EditSelf flag, so canViewFamily() / canReadPerson() must grant access via the
  *     read-default baseline (canReadFamily() / canReadPerson() both return true).
  *

--- a/cypress/e2e/api/private/standard/private.selfedit.family-scope.spec.js
+++ b/cypress/e2e/api/private/standard/private.selfedit.family-scope.spec.js
@@ -5,8 +5,7 @@
  *
  * EditSelf is now an exclusive permission mode: a non-admin user with EditSelf=1
  * has ALL other module permissions suppressed at the model layer
- * (User::isEditSelfExclusive()), which causes hasNoAdminPermissions() to return
- * true. AuthMiddleware therefore blocks every internal API request with 403 —
+ * (User::isEditSelfExclusive()). AuthMiddleware therefore blocks every internal API request with 403 —
  * including the user's OWN family and OWN person record.
  *
  * Test user: amanda.black (user ID 99, `selfedit.api.key`)
@@ -21,7 +20,7 @@
  *
  * Note: avatar, nav, and photo GET endpoints use FamilyReadMiddleware (canReadFamily())
  * instead of FamilyMiddleware (canViewFamily()), making them accessible to plain-auth
- * users. They still return 403 here because AuthMiddleware::hasNoAdminPermissions()
+ * users. They still return 403 here because AuthMiddleware (User::isEditSelfExclusive())
  * blocks EditSelf-exclusive users before FamilyReadMiddleware is ever reached.
  * See private.plainauth.read-default.spec.js for 200-response coverage of those endpoints.
  */
@@ -81,7 +80,7 @@ describe("GHSA-jjcj-h3cm-p7x7 - EditSelf is exclusive: all internal APIs return 
  *     but has canViewFamily(nonOwnFamily)=false would start receiving 403 instead of 200.
  *
  * CURRENT STATE — PR #9016 EditSelf exclusive constraint:
- *   hasNoAdminPermissions() returns true for ANY user with isEditSelf()=true, regardless
+ *   User::isEditSelfExclusive() returns true for ANY non-admin user with isEditSelf()=true, regardless
  *   of Notes=1. AuthMiddleware therefore blocks this user (403) before FamilyReadMiddleware
  *   or FamilyMiddleware is ever reached. All assertions below reflect this current state.
  *

--- a/cypress/e2e/ui/security/finance-page-guards.spec.js
+++ b/cypress/e2e/ui/security/finance-page-guards.spec.js
@@ -4,8 +4,8 @@
  * Tests the Finance permission guard on the fundraiser and pledge pages.
  *
  * Background: these pages previously had NO top-of-file access guard. The only
- * thing keeping users off them was the coarse hasNoAdminPermissions() entry gate
- * in PageInit.php, which blocks a user only when they have ZERO permissions. Any
+ * thing keeping users off them was the coarse User::isEditSelfExclusive() entry gate
+ * in PageInit.php, which now only blocks EditSelf-exclusive users. Any
  * user with a single unrelated permission (e.g. AddRecords) cleared that gate and
  * reached fundraiser, donor, paddle-number and pledge data. They are now gated on
  * isFinanceEnabled(), which redirects to /v2/access-denied?role=Finance.

--- a/cypress/e2e/ui/security/limited-access.spec.js
+++ b/cypress/e2e/ui/security/limited-access.spec.js
@@ -92,7 +92,7 @@ describe("Self-only access — EditSelf account user (limited.user)", () => {
     it("Session-based internal API call is blocked with 403", () => {
         // Complements the api-key 403 test: a logged-in browser SESSION for a
         // limited user must also be rejected from internal APIs (AuthMiddleware
-        // hasNoAdminPermissions gate), so they can't pivot via the cookie.
+        // User::isEditSelfExclusive() gate), so they can't pivot via the cookie.
         cy.clearCookies();
         cy.visit("session/begin");
         cy.get("input[name=User]").type(limitedUser);

--- a/cypress/e2e/ui/security/no-permission-user.spec.js
+++ b/cypress/e2e/ui/security/no-permission-user.spec.js
@@ -82,9 +82,11 @@ describe("Zero-Permission User (EditSelf=0, all flags 0)", () => {
         beforeEach(login);
 
         // Write pages are gated on AddRecords / EditRecords, which are 0.
+        // PersonEditor.php redirects denied users to the dashboard (not access-denied);
+        // FamilyEditor.php uses securityRedirect → access-denied (tested separately below).
         it("PersonEditor (add/edit person) is denied", () => {
             cy.visit("PersonEditor.php?PersonID=2", { failOnStatusCode: false });
-            cy.url().should("include", "/v2/access-denied");
+            cy.url().should("include", "/v2/dashboard");
         });
 
         it("FamilyEditor (add/edit family) is denied", () => {
@@ -163,7 +165,9 @@ describe("Zero-Permission User (EditSelf=0, all flags 0)", () => {
 
         it("Log Out returns to the login page", () => {
             cy.visit("v2/dashboard");
-            cy.contains("Log Out").click();
+            // Open the user-menu dropdown, then click the 'Sign out' link
+            cy.get('[aria-label="Open user menu"]').click();
+            cy.contains("Sign out").click();
             cy.url().should("include", "/session/begin");
         });
     });

--- a/cypress/e2e/ui/security/no-permission-user.spec.js
+++ b/cypress/e2e/ui/security/no-permission-user.spec.js
@@ -3,134 +3,168 @@
 /**
  * Tests for a zero-permission user (all flags = 0, including usr_EditSelf=0).
  *
- * Seed data: user "noperm.user" (person ID 901, family 1 — Campbell) has
- * every permission flag set to 0: AddRecords=0, EditRecords=0, DeleteRecords=0,
+ * Seed data: user "noperm.user" (person ID 901, family 1 — Campbell) has every
+ * permission flag set to 0: AddRecords=0, EditRecords=0, DeleteRecords=0,
  * MenuOptions=0, ManageGroups=0, Finance=0, Notes=0, Admin=0, EditSelf=0.
  * Password: "changeme".
  *
- * Business rule under test:
- *  - Self-edit is NOT a default right; usr_EditSelf must be explicitly 1.
- *  - A user with all flags 0 can log in but gains no CRM access:
- *      * Redirected to /external/limited-access (GHSA-5w59-32c8-933v gate)
- *      * Must NOT see "Verify Family Info" button even though they belong to
- *        a family (fixes GitHub issue #9079)
- *      * All internal CRM pages redirect to limited-access
- *      * Internal API calls return 403
+ * Business rule under test (read-default policy, #9003):
+ *  - A zero-permission user CAN log in and READ people and family records.
+ *    They are NOT redirected to /external/limited-access — that flow is now
+ *    reserved for EditSelf-only users (see limited-access.spec.js).
+ *  - They CANNOT write anything: no add/edit/delete of person or family, and no
+ *    access to finance, notes, admin, or menu-option pages.
  *
- * Contrast: limited.user (EditSelf=1, person 4, family 1) DOES get the
- * "Verify Family Info" button — see limited-access.spec.js.
+ * The entry gate in PageInit.php and AuthMiddleware.php is now
+ * User::isEditSelfExclusive(), replacing the removed hasNoAdminPermissions().
+ * Zero-permission users fall through it; EditSelf-only users do not.
+ *
+ * Contrast: limited.user (EditSelf=1, person 4, family 1) IS confined to
+ * /external/limited-access and gets the "Verify Family Info" button — see
+ * limited-access.spec.js.
  */
 describe("Zero-Permission User (EditSelf=0, all flags 0)", () => {
     const noPermUser = "noperm.user";
     const noPermPassword = "changeme";
     const noPermApiKey = "noPermUserApiKeyForTesting123456789012345678";
 
-    it("Login redirects to /external/limited-access", () => {
+    const login = () => {
         cy.clearCookies();
         cy.visit("session/begin");
         cy.get("input[name=User]").type(noPermUser);
         cy.get("input[name=Password]").type(noPermPassword + "{enter}");
+        cy.url({ timeout: 10000 }).should("not.include", "/session/begin");
+    };
 
-        cy.url({ timeout: 10000 }).should("include", "/external/limited-access");
-        cy.contains("Welcome");
-    });
+    describe("Can log in and read people/families", () => {
+        beforeEach(login);
 
-    it("Limited-access page does NOT show 'Verify Family Info' (fix #9079)", () => {
-        // Person 901 belongs to family 1 (Campbell). Without the fix, a user with
-        // EditSelf=0 who has a family would incorrectly receive a verify token and
-        // see this button. After the fix, isEditSelfEnabled()=false suppresses it.
-        cy.clearCookies();
-        cy.visit("session/begin");
-        cy.get("input[name=User]").type(noPermUser);
-        cy.get("input[name=Password]").type(noPermPassword + "{enter}");
+        it("Login lands in the CRM, NOT on limited-access", () => {
+            cy.url().should("not.include", "/external/limited-access");
+        });
 
-        cy.url({ timeout: 10000 }).should("include", "/external/limited-access");
-        cy.contains("Verify Family Info").should("not.exist");
-        cy.contains("Log Out").should("exist");
-    });
+        it("Can view the main dashboard", () => {
+            cy.visit("v2/dashboard");
+            cy.url().should("include", "/v2/dashboard");
+            cy.url().should("not.include", "/external/limited-access");
+        });
 
-    it("Log Out returns to login page", () => {
-        cy.clearCookies();
-        cy.visit("session/begin");
-        cy.get("input[name=User]").type(noPermUser);
-        cy.get("input[name=Password]").type(noPermPassword + "{enter}");
+        it("Can view the people dashboard", () => {
+            cy.visit("people/dashboard");
+            cy.url().should("include", "/people/dashboard");
+            cy.url().should("not.include", "/external/limited-access");
+        });
 
-        cy.url({ timeout: 10000 }).should("include", "/external/limited-access");
-        cy.contains("Log Out").click();
-        cy.url().should("include", "/session/begin");
-    });
+        it("Can view the person listing", () => {
+            cy.visit("people/list");
+            cy.url().should("include", "/people/list");
+            cy.url().should("not.include", "/v2/access-denied");
+        });
 
-    it("Direct visit to /v2/dashboard redirects to limited-access", () => {
-        cy.clearCookies();
-        cy.visit("session/begin");
-        cy.get("input[name=User]").type(noPermUser);
-        cy.get("input[name=Password]").type(noPermPassword + "{enter}");
+        it("Can view the family listing", () => {
+            cy.visit("people/family");
+            cy.url().should("include", "/people/family");
+            cy.url().should("not.include", "/v2/access-denied");
+        });
 
-        cy.url({ timeout: 10000 }).should("include", "/external/limited-access");
-
-        cy.visit("v2/dashboard", { failOnStatusCode: false });
-        cy.url().should("include", "/external/limited-access");
-    });
-
-    it("Direct visit to /people/dashboard redirects to limited-access", () => {
-        cy.clearCookies();
-        cy.visit("session/begin");
-        cy.get("input[name=User]").type(noPermUser);
-        cy.get("input[name=Password]").type(noPermPassword + "{enter}");
-        cy.url({ timeout: 10000 }).should("include", "/external/limited-access");
-
-        cy.visit("people/dashboard", { failOnStatusCode: false });
-        cy.url().should("include", "/external/limited-access");
-    });
-
-    it("Direct visit to PersonEditor (edit attempt) redirects to limited-access", () => {
-        cy.clearCookies();
-        cy.visit("session/begin");
-        cy.get("input[name=User]").type(noPermUser);
-        cy.get("input[name=Password]").type(noPermPassword + "{enter}");
-        cy.url({ timeout: 10000 }).should("include", "/external/limited-access");
-
-        cy.visit("PersonEditor.php?PersonID=2", { failOnStatusCode: false });
-        cy.url().should("include", "/external/limited-access");
-    });
-
-    it("Direct visit to FamilyEditor (edit attempt) redirects to limited-access", () => {
-        cy.clearCookies();
-        cy.visit("session/begin");
-        cy.get("input[name=User]").type(noPermUser);
-        cy.get("input[name=Password]").type(noPermPassword + "{enter}");
-        cy.url({ timeout: 10000 }).should("include", "/external/limited-access");
-
-        cy.visit("FamilyEditor.php?FamilyID=1", { failOnStatusCode: false });
-        cy.url().should("include", "/external/limited-access");
-    });
-
-    it("Session-based internal API call is blocked with 403", () => {
-        cy.clearCookies();
-        cy.visit("session/begin");
-        cy.get("input[name=User]").type(noPermUser);
-        cy.get("input[name=Password]").type(noPermPassword + "{enter}");
-        cy.url({ timeout: 10000 }).should("include", "/external/limited-access");
-
-        cy.request({
-            method: "GET",
-            url: "/api/person/2",
-            failOnStatusCode: false,
-        }).then((resp) => {
-            expect(resp.status).to.eq(403);
+        it("Session-based person API read succeeds", () => {
+            cy.request({
+                method: "GET",
+                url: "/api/person/2",
+                failOnStatusCode: false,
+            }).then((resp) => {
+                expect(resp.status).to.eq(200);
+            });
         });
     });
 
-    it("API call with zero-permission user key returns 403", () => {
-        cy.apiRequest({
-            method: "GET",
-            url: "/api/person/1",
-            headers: {
-                "x-api-key": noPermApiKey,
-            },
-            failOnStatusCode: false,
-        }).then((resp) => {
-            expect(resp.status).to.eq(403);
+    describe("Cannot write or reach privileged modules", () => {
+        beforeEach(login);
+
+        // Write pages are gated on AddRecords / EditRecords, which are 0.
+        it("PersonEditor (add/edit person) is denied", () => {
+            cy.visit("PersonEditor.php?PersonID=2", { failOnStatusCode: false });
+            cy.url().should("include", "/v2/access-denied");
+        });
+
+        it("FamilyEditor (add/edit family) is denied", () => {
+            cy.visit("FamilyEditor.php?FamilyID=1", { failOnStatusCode: false });
+            cy.url().should("include", "/v2/access-denied");
+        });
+
+        // MenuOptions=0 — pages newly guarded alongside the gate change.
+        it("LettersAndLabels is denied (MenuOptions)", () => {
+            cy.visit("LettersAndLabels.php", { failOnStatusCode: false });
+            cy.url().should("include", "/v2/access-denied");
+        });
+
+        it("WhyCameEditor is denied (MenuOptions)", () => {
+            cy.visit("WhyCameEditor.php?PersonID=2", { failOnStatusCode: false });
+            cy.url().should("include", "/v2/access-denied");
+        });
+
+        // Finance=0 — the finance module stays closed.
+        it("Finance dashboard is denied", () => {
+            cy.visit("finance/", { failOnStatusCode: false });
+            cy.url().should("include", "/v2/access-denied");
+        });
+
+        // Notes=0 — note routes are wrapped in NotesRoleAuthMiddleware.
+        it("Note API is blocked with 403", () => {
+            cy.request({
+                method: "GET",
+                url: "/api/person/2/notes",
+                failOnStatusCode: false,
+            }).then((resp) => {
+                expect(resp.status).to.eq(403);
+            });
+        });
+    });
+
+    describe("API-key access", () => {
+        it("Person read via API key succeeds", () => {
+            cy.apiRequest({
+                method: "GET",
+                url: "/api/person/1",
+                headers: { "x-api-key": noPermApiKey },
+                failOnStatusCode: false,
+            }).then((resp) => {
+                expect(resp.status).to.eq(200);
+            });
+        });
+
+        it("Note read via API key is blocked with 403", () => {
+            cy.apiRequest({
+                method: "GET",
+                url: "/api/person/1/notes",
+                headers: { "x-api-key": noPermApiKey },
+                failOnStatusCode: false,
+            }).then((resp) => {
+                expect(resp.status).to.eq(403);
+            });
+        });
+    });
+
+    describe("Menu reflects the zero-permission state", () => {
+        beforeEach(login);
+
+        it("Shows People, hides write actions", () => {
+            cy.visit("v2/dashboard");
+            // Read-default: the People menu is available.
+            cy.contains("People").should("exist");
+            // No write actions.
+            cy.contains("a", "Add New Person").should("not.exist");
+            cy.contains("a", "Add New Family").should("not.exist");
+        });
+    });
+
+    describe("Log out", () => {
+        beforeEach(login);
+
+        it("Log Out returns to the login page", () => {
+            cy.visit("v2/dashboard");
+            cy.contains("Log Out").click();
+            cy.url().should("include", "/session/begin");
         });
     });
 });

--- a/cypress/support/api-commands.js
+++ b/cypress/support/api-commands.js
@@ -111,11 +111,16 @@ Cypress.Commands.add(
     "makePrivateLimitedAPICall",
     (method, url, body, expectedStatus = 200, timeoutMs) => {
         // limited.user (id=4): usr_Notes=0, usr_Admin=0, usr_EditRecords=0,
-        // usr_EditSelf=0 — truly zero-permission user. Blocked by
-        // AuthMiddleware::hasNoAdminPermissions() → always returns 403.
+        // usr_EditSelf=1 — an EditSelf-ONLY user (NOT a zero-permission user).
+        // EditSelf is exclusive, so AuthMiddleware::isEditSelfExclusive() blocks
+        // this user → always returns 403.
         // Use this fixture ONLY to verify that Notes-gated endpoints return 403.
         // Do NOT use for routes that should return 200 for authenticated users
         // (e.g. timeline) — use makePrivateEditRecordsAPICall instead.
+        //
+        // For a genuinely zero-permission user (all flags 0, EditSelf=0) see
+        // noperm.user (id=901), which now passes the gate with read-only access
+        // under the read-default policy (#9003).
         return cy.makePrivateAPICall(
             Cypress.env("limited.api.key"),
             method,

--- a/cypress/support/api-commands.js
+++ b/cypress/support/api-commands.js
@@ -84,9 +84,9 @@ Cypress.Commands.add(
  *
  * User: lena.black (ID 100, family 20) with usr_EditSelf=1, usr_Notes=1 in DB.
  *
- * Post-PR#9016 (EditSelf exclusive mode): hasNoAdminPermissions() returns true for any
- * user with isEditSelf()=true, regardless of Notes. AuthMiddleware therefore blocks this
- * user (403) before reaching FamilyReadMiddleware or FamilyMiddleware.
+ * Post-PR#9016 (EditSelf exclusive mode): User::isEditSelfExclusive() (checked by AuthMiddleware)
+ * returns true for any non-admin user with isEditSelf()=true, regardless of Notes. AuthMiddleware
+ * therefore blocks this user (403) before reaching FamilyReadMiddleware or FamilyMiddleware.
  *
  * Future use: if EditSelf exclusivity is ever relaxed to permit EditSelf+Notes, this user
  * should get 200 on avatar/nav/photo (FamilyReadMiddleware, canReadFamily=true) and 403 on

--- a/cypress/support/commands.d.ts
+++ b/cypress/support/commands.d.ts
@@ -141,8 +141,12 @@ declare namespace Cypress {
 
     /**
      * Make API request as limited.user (id=4) — usr_Notes=0, usr_Admin=0,
-     * usr_EditRecords=0, usr_EditSelf=0. Blocked by hasNoAdminPermissions()
-     * → always returns 403. Use ONLY for Notes-gated 403 assertions.
+     * usr_EditRecords=0, usr_EditSelf=1. An EditSelf-ONLY user, blocked by
+     * AuthMiddleware::isEditSelfExclusive() → always returns 403.
+     * Use ONLY for Notes-gated 403 assertions.
+     *
+     * NOT a zero-permission user — that is noperm.user (id=901, EditSelf=0),
+     * which now passes the gate with read-only access (read-default policy).
      */
     makePrivateLimitedAPICall(
       method: string,

--- a/src/ChurchCRM/Slim/Middleware/Api/FamilyReadMiddleware.php
+++ b/src/ChurchCRM/Slim/Middleware/Api/FamilyReadMiddleware.php
@@ -19,7 +19,7 @@ use Psr\Http\Message\ServerRequestInterface;
  * This middleware:
  *   - Loads the family entity and returns 404 if it does not exist (same as FamilyMiddleware).
  *   - Uses User::canReadFamily() for authorisation (currently always true — the
- *     entry gate is AuthMiddleware::isEditSelfExclusive(), NOT this middleware).
+ *     entry gate is User::isEditSelfExclusive() (checked by AuthMiddleware), NOT this middleware).
  *   - Does NOT enforce the family-scope restriction from GHSA-jjcj-h3cm-p7x7.
  *     That restriction belongs on FamilyMiddleware (sensitive/write endpoints only).
  *
@@ -52,7 +52,7 @@ class FamilyReadMiddleware extends AbstractEntityMiddleware
      *
      * Unlike FamilyMiddleware, this does NOT call canViewFamily() and therefore
      * never restricts EditSelf-scoped users to their own family. Access is still
-     * gated by AuthMiddleware upstream (isEditSelfExclusive()).
+     * gated by AuthMiddleware upstream (User::isEditSelfExclusive()).
      *
      * The canReadFamily() call exists for defence-in-depth and as a hook point
      * for future row-level security (e.g. pastoral-confidentiality holds). It

--- a/src/ChurchCRM/Slim/Middleware/Api/FamilyReadMiddleware.php
+++ b/src/ChurchCRM/Slim/Middleware/Api/FamilyReadMiddleware.php
@@ -19,7 +19,7 @@ use Psr\Http\Message\ServerRequestInterface;
  * This middleware:
  *   - Loads the family entity and returns 404 if it does not exist (same as FamilyMiddleware).
  *   - Uses User::canReadFamily() for authorisation (currently always true — the
- *     entry gate is AuthMiddleware::hasNoAdminPermissions(), NOT this middleware).
+ *     entry gate is AuthMiddleware::isEditSelfExclusive(), NOT this middleware).
  *   - Does NOT enforce the family-scope restriction from GHSA-jjcj-h3cm-p7x7.
  *     That restriction belongs on FamilyMiddleware (sensitive/write endpoints only).
  *
@@ -52,7 +52,7 @@ class FamilyReadMiddleware extends AbstractEntityMiddleware
      *
      * Unlike FamilyMiddleware, this does NOT call canViewFamily() and therefore
      * never restricts EditSelf-scoped users to their own family. Access is still
-     * gated by AuthMiddleware upstream (hasNoAdminPermissions()).
+     * gated by AuthMiddleware upstream (isEditSelfExclusive()).
      *
      * The canReadFamily() call exists for defence-in-depth and as a hook point
      * for future row-level security (e.g. pastoral-confidentiality holds). It

--- a/src/ChurchCRM/Slim/Middleware/AuthMiddleware.php
+++ b/src/ChurchCRM/Slim/Middleware/AuthMiddleware.php
@@ -51,9 +51,13 @@ class AuthMiddleware implements MiddlewareInterface
                     'path' => $request->getUri()->getPath()
                 ]);
 
-                // Block users with no admin permissions from API access (GHSA-5w59-32c8-933v)
+                // Confine EditSelf-only users to the self-service flow — they have no
+                // module permissions and no business on the internal API surface.
+                // Zero-permission users are NOT blocked: they retain read-only access
+                // to people/family records (read-default policy, #9003). Writes are
+                // denied by the per-route role middleware.
                 $apiUser = AuthenticationManager::getCurrentUser();
-                if ($apiUser->hasNoAdminPermissions()) {
+                if ($apiUser->isEditSelfExclusive()) {
                     $response = new Response();
                     $response->getBody()->write(json_encode(['error' => 'Account has limited permissions. Contact an administrator.']));
                     return $response->withStatus(403)->withHeader('Content-Type', 'application/json');
@@ -62,11 +66,14 @@ class AuthMiddleware implements MiddlewareInterface
                 // validate the user session; however, do not update tLastOperation if the requested path is "/background"
                 // since /background operations do not connotate user activity.
 
-                // Block users with no admin permissions from MVC/API access (GHSA-5w59-32c8-933v)
+                // Confine EditSelf-only users to the self-service flow.
                 // BUT allow them through if they need to change their password — blocking
                 // the change-password page locks new users out permanently. See #8680.
+                // Zero-permission users are NOT redirected: they retain read-only access
+                // to people/family records (read-default policy, #9003). Writes are denied
+                // by the per-route role middleware and the per-page permission guards.
                 $sessionUser = AuthenticationManager::getCurrentUser();
-                if ($sessionUser->hasNoAdminPermissions() && !$this->isAuthFlowExemptPath($request)) {
+                if ($sessionUser->isEditSelfExclusive() && !$this->isAuthFlowExemptPath($request)) {
                     if ($this->isBrowserRequest($request)) {
                         $rootPath = SystemURLs::getRootPath();
                         return (new Response())->withStatus(302)->withHeader('Location', $rootPath . '/external/limited-access');

--- a/src/ChurchCRM/model/ChurchCRM/User.php
+++ b/src/ChurchCRM/model/ChurchCRM/User.php
@@ -63,11 +63,22 @@ class User extends BaseUser
     //
     // EditSelf is an exclusive mode: when a non-admin user has EditSelf=1,
     // all module permissions (AddRecords, EditRecords, …, Notes, Finance) are
-    // treated as false regardless of what is stored in the database. This
-    // ensures hasNoAdminPermissions() correctly blocks EditSelf users from
-    // the internal API surface and every consumer sees a consistent view.
+    // treated as false regardless of what is stored in the database, so every
+    // consumer sees a consistent view.
 
-    private function isEditSelfExclusive(): bool
+    /**
+     * True when the user is confined to the self-service flow.
+     *
+     * A non-admin user with EditSelf=1 has no module permissions and cannot use
+     * the CRM interface — PageInit and AuthMiddleware redirect them to
+     * /external/limited-access.
+     *
+     * Deliberately NOT true for a zero-permission user (all flags 0). Those users
+     * retain read-only access to people and family records under the read-default
+     * policy (#9003); writes are denied by the per-page and per-route permission
+     * checks.
+     */
+    public function isEditSelfExclusive(): bool
     {
         return !$this->isAdmin() && $this->isEditSelf();
     }
@@ -212,31 +223,6 @@ class User extends BaseUser
             'canViewEvents'       => $this->canViewEvents(),
             'canManageEvents'     => $this->canManageEvents(),
         ];
-    }
-
-    /**
-     * Check if the user lacks all functional admin permissions.
-     * Users with no permissions (or only EditSelf) cannot use the admin interface
-     * and should be redirected to a self-service flow or blocked.
-     *
-     * @see https://github.com/ChurchCRM/CRM/issues/8617
-     */
-    public function hasNoAdminPermissions(): bool
-    {
-        if ($this->isAdmin()) {
-            return false;
-        }
-        if ($this->isEditSelf()) {
-            // EditSelf is exclusive — no module permissions apply
-            return true;
-        }
-        return !$this->isAddRecords()
-            && !$this->isEditRecords()
-            && !$this->isDeleteRecords()
-            && !$this->isMenuOptions()
-            && !$this->isManageGroups()
-            && !$this->isFinance()
-            && !$this->isNotes();
     }
 
     /**

--- a/src/GeoPage.php
+++ b/src/GeoPage.php
@@ -3,6 +3,7 @@
 require_once __DIR__ . '/Include/Config.php';
 require_once __DIR__ . '/Include/PageInit.php';
 
+use ChurchCRM\Authentication\AuthenticationManager;
 use ChurchCRM\dto\Classification;
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\dto\SystemURLs;
@@ -11,6 +12,9 @@ use ChurchCRM\model\ChurchCRM\ListOptionQuery;
 use ChurchCRM\Utils\GeoUtils;
 use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\view\PageHeader;
+
+// Security: User must have menu options permission to use this page
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isMenuOptionsEnabled(), 'MenuOptions');
 
 function CompareDistance($elem1, $elem2)
 {

--- a/src/GetText.php
+++ b/src/GetText.php
@@ -1,5 +1,6 @@
 <?php
 
+use ChurchCRM\Authentication\AuthenticationManager;
 use ChurchCRM\model\ChurchCRM\EventQuery;
 use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\LoggerUtils;
@@ -7,6 +8,9 @@ use ChurchCRM\dto\SystemURLs;
 
 require_once __DIR__ . '/Include/Config.php';
 require_once __DIR__ . '/Include/PageInit.php';
+
+// Security: User must have menu options permission to use this page
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isMenuOptionsEnabled(), 'MenuOptions');
 
 $eidQueryParam = $_GET['EID'];
 $sanitizedEidQueryParam = InputUtils::filterInt($eidQueryParam);

--- a/src/Include/PageInit.php
+++ b/src/Include/PageInit.php
@@ -17,9 +17,12 @@ $systemService = new SystemService();
 if (empty($bSuppressSessionTests)) {  // This is used for the login page only.
     AuthenticationManager::ensureAuthentication();
 
-    // Block users with no admin permissions (GHSA-5w59-32c8-933v / #8617)
+    // Confine EditSelf-only users to the self-service flow. Zero-permission users
+    // are NOT blocked here — they keep read-only access to people and family
+    // records (read-default policy, #9003). Writes are denied by the per-page
+    // permission guards.
     $currentUser = AuthenticationManager::getCurrentUser();
-    if ($currentUser->hasNoAdminPermissions()) {
+    if ($currentUser->isEditSelfExclusive()) {
         RedirectUtils::redirect(SystemURLs::getRootPath() . '/external/limited-access');
     }
 

--- a/src/LettersAndLabels.php
+++ b/src/LettersAndLabels.php
@@ -4,9 +4,13 @@ require_once __DIR__ . '/Include/Config.php';
 require_once __DIR__ . '/Include/PageInit.php';
 require_once __DIR__ . '/Include/LabelFunctions.php';
 
+use ChurchCRM\Authentication\AuthenticationManager;
 use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 use ChurchCRM\view\PageHeader;
+
+// Security: User must have menu options permission to use this page
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isMenuOptionsEnabled(), 'MenuOptions');
 
 $sPageTitle = gettext('Letters and Mailing Labels');
 $sPageSubtitle = gettext('Generate mailing labels and form letters');

--- a/src/WhyCameEditor.php
+++ b/src/WhyCameEditor.php
@@ -3,6 +3,7 @@
 require_once __DIR__ . '/Include/Config.php';
 require_once __DIR__ . '/Include/PageInit.php';
 
+use ChurchCRM\Authentication\AuthenticationManager;
 use ChurchCRM\model\ChurchCRM\Person;
 use ChurchCRM\model\ChurchCRM\PersonQuery;
 use ChurchCRM\model\ChurchCRM\WhyCame;
@@ -10,6 +11,9 @@ use ChurchCRM\model\ChurchCRM\WhyCameQuery;
 use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\LoggerUtils;
 use ChurchCRM\Utils\RedirectUtils;
+
+// Security: User must have menu options permission to use this page
+AuthenticationManager::redirectHomeIfFalse(AuthenticationManager::getCurrentUser()->isMenuOptionsEnabled(), 'MenuOptions');
 
 $logger = LoggerUtils::getAppLogger();
 

--- a/src/api/routes/people/notes.php
+++ b/src/api/routes/people/notes.php
@@ -85,7 +85,7 @@ $app->group('/person/{personId:[0-9]+}', function (RouteCollectorProxy $group): 
 
         // EditSelf-only scope: restrict to own family.
         // (ABAC hook for future per-record holds — EditSelf+Notes users
-        //  are not currently allowed past hasNoAdminPermissions() entry gate,
+        //  are not currently allowed past the isEditSelfExclusive() entry gate,
         //  but this check ensures correctness if that ever changes.)
         $personFamilyId = (int) $person->getFamId();
         if ($personFamilyId > 0 && !$currentUser->canViewFamily($personFamilyId)) {

--- a/src/api/routes/people/people-families.php
+++ b/src/api/routes/people/people-families.php
@@ -9,6 +9,8 @@ use ChurchCRM\model\ChurchCRM\PersonQuery;
 use ChurchCRM\model\ChurchCRM\Token;
 use ChurchCRM\model\ChurchCRM\TokenQuery;
 use ChurchCRM\Service\FinancialService;
+use ChurchCRM\Slim\Middleware\Request\Auth\EditRecordsRoleAuthMiddleware;
+use ChurchCRM\Slim\Middleware\Request\Auth\FinanceRoleAuthMiddleware;
 use ChurchCRM\Slim\SlimUtils;
 use ChurchCRM\Utils\DateTimeUtils;
 use Propel\Runtime\ActiveQuery\Criteria;
@@ -166,7 +168,7 @@ $app->group('/families', function (RouteCollectorProxy $group): void {
             ->find();
 
         return SlimUtils::renderJSON($response, ['families' => $verificationNotes->toArray()]);
-    });
+    })->add(new EditRecordsRoleAuthMiddleware());
 
     /**
      * @OA\Get(
@@ -191,7 +193,7 @@ $app->group('/families', function (RouteCollectorProxy $group): void {
             ->find();
 
         return SlimUtils::renderJSON($response, ['families' => $pendingTokens->toArray()]);
-    });
+    })->add(new EditRecordsRoleAuthMiddleware());
 
     /**
      * @OA\Get(
@@ -209,7 +211,7 @@ $app->group('/families', function (RouteCollectorProxy $group): void {
         $financialService = new FinancialService();
 
         return SlimUtils::renderJSON($response, $financialService->getMemberByScanString($scanString));
-    });
+    })->add(FinanceRoleAuthMiddleware::class);
 });
 
 /**

--- a/src/api/routes/people/people-family.php
+++ b/src/api/routes/people/people-family.php
@@ -32,9 +32,9 @@ use Slim\HttpCache\Cache;
 // FamilyReadMiddleware which enforces entity existence (404 if family not
 // found) but applies the read-default baseline (canReadFamily) instead of the
 // family-scope restriction. This makes them accessible to any authenticated
-// user who has passed the hasNoAdminPermissions() check in AuthMiddleware —
-// including EditSelf+Notes users who are otherwise scoped to their own family
-// for sensitive data.
+// user who has passed the isEditSelfExclusive() check in AuthMiddleware —
+// including zero-permission users, who retain read-only access to people and
+// family records under the read-default policy (#9003).
 //
 // Sensitive endpoints (full profile, geolocation, write ops, notes, timeline)
 // remain in the FamilyMiddleware group below which enforces canViewFamily()

--- a/src/api/routes/people/people-person.php
+++ b/src/api/routes/people/people-person.php
@@ -243,7 +243,7 @@ $app->group('/person/{personId:[0-9]+}', function (RouteCollectorProxy $group): 
     $group->post('/addToCart', function (Request $request, Response $response, array $args): Response {
         Cart::addPerson($args['personId']);
         return SlimUtils::renderSuccessJSON($response);
-    });
+    })->add(new EditRecordsRoleAuthMiddleware());
 })->add(new PersonMiddleware());
 
 /**

--- a/src/api/routes/people/people-persons.php
+++ b/src/api/routes/people/people-persons.php
@@ -5,6 +5,7 @@ use ChurchCRM\model\ChurchCRM\FamilyQuery;
 use ChurchCRM\model\ChurchCRM\ListOptionQuery;
 use ChurchCRM\model\ChurchCRM\Person;
 use ChurchCRM\model\ChurchCRM\PersonQuery;
+use ChurchCRM\Slim\Middleware\Request\Auth\EditRecordsRoleAuthMiddleware;
 use ChurchCRM\Slim\SlimUtils;
 use ChurchCRM\Utils\DateTimeUtils;
 use Propel\Runtime\ActiveQuery\Criteria;
@@ -17,7 +18,7 @@ use Slim\Routing\RouteCollectorProxy;
 $app->group('/persons', function (RouteCollectorProxy $group): void {
     $group->get('/roles', 'getAllRolesAPI');
     $group->get('/roles/', 'getAllRolesAPI');
-    $group->get('/duplicate/emails', 'getEmailDupesAPI');
+    $group->get('/duplicate/emails', 'getEmailDupesAPI')->add(new EditRecordsRoleAuthMiddleware());
 
     /**
      * @OA\Get(


### PR DESCRIPTION
> ### ⚠️ BLOCKED ON #9119 — DO NOT MERGE FIRST
> This PR removes the entry gate that is currently the **only** guard on the fundraiser and pledge pages. #9119 adds per-page Finance guards to those pages. **If this merges before #9119, a zero-permission user can reach fundraiser, donor, paddle-number and pledge data.** Merge #9119 first.

## Summary

Replaces the coarse `hasNoAdminPermissions()` entry gate with `User::isEditSelfExclusive()`, and **removes `hasNoAdminPermissions()` entirely** — it is now unused.

The old gate collapsed two different populations into one check:

| User | Before | After |
|---|---|---|
| **EditSelf-only** (`limited.user`, id 4, `EditSelf=1`) | → `/external/limited-access` | → `/external/limited-access` (unchanged) |
| **Zero-permission** (`noperm.user`, id 901, all flags 0) | → `/external/limited-access` | falls through, **read-only access to people + families** |

This aligns the gate with the read-default policy from #9003 ("read access to people/family records is the explicit default for authenticated users"), which the blanket gate was contradicting.

## Why this is safe

Writes are **not** newly exposed. A zero-permission user is still denied everywhere it matters:

- **Write pages** (`PersonEditor`, `FamilyEditor`, …) — gated on `AddRecords`/`EditRecords`, both 0.
- **API writes** — gated by the per-route `*RoleAuthMiddleware`.
- **Notes** — every note route is wrapped in `NotesRoleAuthMiddleware` (`Notes=1` required).
- **Timeline** — `TimelineService` filters notes via `Note::isVisibleTo()`; a zero-perm user gets timeline items *without* notes.
- **Finance / Admin** — module permissions still 0.

I audited every API route for role-middleware coverage. The routes with no role middleware are `people-persons`, `people-families` (the read-default surface this PR is *for*), `public/*` (public by design), `user-current` (own user), `search`, `cart`, `geocoder`, `background`, `system-issues`.

## Closing the gap the gate was hiding

The gate was also the only guard on four legacy pages. They are now gated on **MenuOptions**:

`GeoPage.php`, `GetText.php`, `LettersAndLabels.php`, `WhyCameEditor.php`

## Test changes

- **`no-permission-user.spec.js` rewritten.** Its assertions were exactly inverted by this change — it asserted zero-perm users get redirected to `/external/limited-access`. It now asserts they can log in, read the people/family dashboards and listings, and read the person API (200) — while being denied `PersonEditor`, `FamilyEditor`, the MenuOptions pages, finance, and the notes API (403).
- **`limited-access.spec.js` unaffected** — `limited.user` is `EditSelf=1`, still confined to the self-service flow.
- **Fixture docs corrected.** `api-commands.js` / `commands.d.ts` described `limited.user` as "truly zero-permission user, `usr_EditSelf=0`". That was **wrong** — `seed.sql` has `usr_EditSelf=1` for id 4. The behavior is unchanged (she's EditSelf-exclusive, still 403), but the comment was actively misleading.

## Testing

- `npm run build:php` — 746 PHP files, all pass
- `npm run lint` — Biome clean
- **Cypress not executed** — can't be driven from this shell. Needs a run against a seeded Docker instance before merge; `no-permission-user.spec.js` is the spec to watch.

## Follow-ups

- `DepositSlipEditor.php` has a broken guard: line 15 dereferences `$thisDeposit` before assignment (line 20), so a non-Finance user hits a fatal error instead of a redirect, and the "deposit creator may edit their own deposit" exception has never worked.
- Add a dedicated fundraiser permission and move #9119's guards onto it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)