### PR TITLE
fix: upgrade wizard — handle prerelease/dev version, fix stale UI, fix Copilot review bugs

### DIFF
--- a/src/ChurchCRM/dto/ChurchCRMReleaseManager.php
+++ b/src/ChurchCRM/dto/ChurchCRMReleaseManager.php
@@ -734,6 +734,23 @@ class ChurchCRMReleaseManager
         $nextRelease = self::getNextReleaseStep($installedRelease);
         $releasesAhead = self::getReleasesAhead($installedVersionStr);
 
+        // Detect the prerelease/dev-build case: installed version is strictly
+        // ahead of the latest stable release known from GitHub.  In that case
+        // getReleasesAhead() returns [] (nothing is strictly ahead of the
+        // installed build) and getNextReleaseStep() also returns null, leaving
+        // the wizard blank.  We treat latest stable as the "reinstall" target.
+        $latestStable = !empty($_SESSION['ChurchCRMReleases']) ? $_SESSION['ChurchCRMReleases'][0] : null;
+        $isAheadOfStable = false;
+
+        if (empty($releasesAhead) && $latestStable !== null) {
+            if (version_compare($installedVersionStr, $latestStable->__toString()) > 0) {
+                // Running a prerelease/dev build ahead of latest stable.
+                // Offer latest stable as a "reinstall" target.
+                $isAheadOfStable = true;
+                $nextRelease = $latestStable;
+                // $releasesAhead stays [] — there truly are no releases strictly ahead.
+            }
+        }
         $githubBaseUrl = 'https://github.com/' . self::GITHUB_USER_NAME . '/' . self::GITHUB_REPOSITORY_NAME;
         $changelogBaseUrl = $githubBaseUrl . '/blob/master/changelog/';
 
@@ -760,16 +777,18 @@ class ChurchCRMReleaseManager
         }
 
         $nextVersionStr = $nextRelease !== null ? $nextRelease->__toString() : null;
-        $latestVersionStr = !empty($releasesAhead) ? end($releasesAhead)->__toString() : ($latestKnownRelease !== null ? $latestKnownRelease->__toString() : $installedVersionStr);
+        $latestVersionStr = !empty($releasesAhead)
+            ? end($releasesAhead)->__toString()
+            : ($latestStable !== null ? $latestStable->__toString() : $installedVersionStr);
 
         // Fetch notes for the latest known GitHub release so the frontend can display
         // them when the system is already up to date (releasesAhead === 0).
-        $latestKnownRelease = !empty($_SESSION['ChurchCRMReleases']) ? $_SESSION['ChurchCRMReleases'][0] : null;
-        $latestReleaseNotes = $latestKnownRelease !== null ? $latestKnownRelease->getReleaseNotes() : '';
+        // $latestStable is already computed above; reuse it here to avoid a redundant assignment.
+        $latestReleaseNotes = $latestStable !== null ? $latestStable->getReleaseNotes() : '';
         // Use the version string from the actual latest release object so the changelog
         // URL stays accurate on dev builds where $installedVersionStr may be ahead of
         // any published stable release.
-        $latestReleaseVersionStr = $latestKnownRelease !== null ? $latestKnownRelease->__toString() : $latestVersionStr;
+        $latestReleaseVersionStr = $latestStable !== null ? $latestStable->__toString() : $latestVersionStr;
         $latestChangelogUrl = $changelogBaseUrl . $latestReleaseVersionStr . '.md';
 
         return [
@@ -782,6 +801,7 @@ class ChurchCRMReleaseManager
             'upgradePath'      => $pathEntries,
             'latestReleaseNotes' => $latestReleaseNotes,
             'latestChangelogUrl' => $latestChangelogUrl,
+            'isAheadOfStable'    => $isAheadOfStable,
         ];
     }
 

--- a/src/admin/routes/system.php
+++ b/src/admin/routes/system.php
@@ -404,6 +404,13 @@ $app->group('/system', function (RouteCollectorProxy $group): void {
         if (isset($_SESSION['systemLatestVersion']) && $_SESSION['systemLatestVersion'] !== null) {
             $latestGitHubVersion = $_SESSION['systemLatestVersion']->__toString();
         }
+
+        // Detect "running ahead of stable" — e.g. a prerelease or dev build installed
+        // that is newer than the latest stable release known from GitHub.
+        $isAheadOfStable = false;
+        if ($latestGitHubVersion !== null && !$isUpdateAvailable) {
+            $isAheadOfStable = version_compare($currentVersion, $latestGitHubVersion) > 0;
+        }
         
         $pageArgs = [
             'sRootPath'             => SystemURLs::getRootPath(),
@@ -425,6 +432,7 @@ $app->group('/system', function (RouteCollectorProxy $group): void {
             'availableVersion'      => $availableVersion,
             'latestGitHubVersion'   => $latestGitHubVersion,
             'isUpdateAvailable'     => $isUpdateAvailable,
+            'isAheadOfStable'       => $isAheadOfStable,
         ];
 
         return $renderer->render($response, 'upgrade.php', $pageArgs);

--- a/src/admin/views/upgrade.php
+++ b/src/admin/views/upgrade.php
@@ -27,6 +27,9 @@ $orphanedCount = count($integrityCheckData['orphanedFiles'] ?? []);
                             <?php if ($isUpdateAvailable): ?>
                                 <span class="badge bg-success-lt fs-5"><?= InputUtils::escapeHTML($latestGitHubVersion) ?></span>
                                 <span class="badge bg-success"><?= gettext('Update Available') ?></span>
+                            <?php elseif (isset($isAheadOfStable) && $isAheadOfStable): ?>
+                                <span class="badge bg-primary-lt fs-5"><?= InputUtils::escapeHTML($latestGitHubVersion) ?></span>
+                                <span class="badge bg-warning-lt text-warning"><?= gettext('Running Pre-release') ?></span>
                             <?php else: ?>
                                 <span class="badge bg-primary-lt fs-5"><?= InputUtils::escapeHTML($latestGitHubVersion) ?></span>
                                 <span class="badge bg-success-lt text-success"><?= gettext('Up to Date') ?></span>

--- a/webpack/upgrade-wizard-app.js
+++ b/webpack/upgrade-wizard-app.js
@@ -40,6 +40,9 @@ let installedChangelogUrl = null;
 // keeps the proceed button visible even when the system is already up to date.
 let forceReinstallMode = false;
 
+// Stores the stable version to reinstall when running a prerelease build ahead of latest stable
+let prereleaseTargetVersion = null;
+
 // Ensure AdminAPIRequest is available - fallback to regular APIRequest if not defined
 if (window.CRM && !window.CRM.AdminAPIRequest) {
   window.CRM.AdminAPIRequest = (options) => {
@@ -124,7 +127,9 @@ function setupNavigationHandlers() {
   // "Download & Install" — stores the selected version then advances to download step
   $("#proceedToDownload").click(() => {
     const sel = $("#targetVersionSelect").val();
-    selectedTargetVersion = sel && sel !== "" ? sel : null;
+    // For the prerelease reinstall case there is no version selector; fall back
+    // to the stable version stored by renderWhatsNew().
+    selectedTargetVersion = sel && sel !== "" ? sel : prereleaseTargetVersion;
     upgradeStepper.next();
   });
 
@@ -278,16 +283,48 @@ function setWhatsNewHeading(version) {
  * Render the What's New content from preview API response
  */
 function renderWhatsNew(data) {
-  const { nextVersion, nextReleaseNotes, nextChangelogUrl, releasesAhead, upgradePath } = data;
+  const { nextVersion, nextReleaseNotes, nextChangelogUrl, releasesAhead, upgradePath, isAheadOfStable } = data;
 
-  // Already up-to-date: show banner, then render the current version's release notes.
-  // In force-reinstall mode the proceed button is kept visible so the wizard can continue.
+  // --- Bug fix: reset stale UI state before every render ---
+  $("#whatsNewChangelogLink").addClass("d-none").attr("href", "#");
+  $("#upgradePathPanel").addClass("d-none");
+  $("#advancedVersionCollapse").closest(".mb-4").addClass("d-none");
+  $("#whatsNewContent .alert-success, #whatsNewContent .alert-warning, #whatsNewContent .js-uptodate-banner").remove();
+  $("#proceedToDownload")
+    .removeClass("d-none")
+    .html(`<i class="fa fa-cloud-arrow-down me-1"></i>${i18next.t("Download & Install")}`);
+  prereleaseTargetVersion = null;
+
+  // Case 1: Running a prerelease/dev build ahead of latest stable
+  if (isAheadOfStable && nextVersion) {
+    prereleaseTargetVersion = nextVersion;
+    setWhatsNewHeading(nextVersion);
+    $("#whatsNewNotes").html(marked.parse(nextReleaseNotes || ""));
+    if (nextChangelogUrl) {
+      $("#whatsNewChangelogLink").attr("href", nextChangelogUrl).removeClass("d-none");
+    }
+    installedChangelogUrl = nextChangelogUrl || null;
+    $("#whatsNewContent").prepend(
+      `<div class="alert alert-warning d-flex align-items-center gap-2 mb-3">
+        <i class="fa fa-triangle-exclamation fa-lg"></i>
+        <span>
+          <strong>${i18next.t("You are running a pre-release version.")}</strong>
+          ${i18next.t("The latest stable release is {{version}}. You can reinstall it below.", { version: escapeHtml(nextVersion) })}
+        </span>
+      </div>`,
+    );
+    $("#proceedToDownload").html(
+      `<i class="fa fa-cloud-arrow-down me-1"></i>${i18next.t("Install stable {{version}}", { version: escapeHtml(nextVersion) })}`,
+    );
+    return;
+  }
+
+  // Case 2: Truly up to date — no releases ahead, not a prerelease
   if (releasesAhead === 0) {
     const latestNotes = data.latestReleaseNotes || "";
     const latestUrl = data.latestChangelogUrl || null;
     const latestVer = data.latestVersion || "";
 
-    $("#upgradePathPanel").addClass("d-none");
     $("#advancedVersionCollapse").closest(".mb-4").addClass("d-none");
 
     // Remove any banner left from a previous render (e.g. wizard re-entry or preview re-fetch)
@@ -332,21 +369,14 @@ function renderWhatsNew(data) {
     return;
   }
 
-  // Version heading
+  // Case 3: Normal upgrade — one or more releases ahead
   setWhatsNewHeading(nextVersion);
-
-  // Changelog link
   if (nextChangelogUrl) {
     $("#whatsNewChangelogLink").attr("href", nextChangelogUrl).removeClass("d-none");
   }
-
-  // Release notes
   $("#whatsNewNotes").html(marked.parse(nextReleaseNotes || ""));
-
-  // Store the changelog URL for the completion screen (use the version being installed)
   installedChangelogUrl = nextChangelogUrl || null;
 
-  // Upgrade path panel (only when ≥ 2 releases ahead)
   if (releasesAhead >= 2 && upgradePath && upgradePath.length >= 2) {
     const count = upgradePath.length;
     $("#upgradePathSummary").html(
@@ -358,7 +388,6 @@ function renderWhatsNew(data) {
     $("#upgradePathPanel").removeClass("d-none");
   }
 
-  // Target version selector
   renderVersionSelector(upgradePath, nextVersion);
 }
 
@@ -375,7 +404,7 @@ function renderUpgradePath(upgradePath) {
       ? `<span class="badge bg-primary-lt text-primary ms-1">${i18next.t("Installing next release")}</span>`
       : "";
     const changelogLink = entry.changelogUrl
-      ? `<a href="${escapeHtml(entry.changelogUrl)}" target="_blank" rel="noopener noreferrer" class="btn btn-ghost-secondary btn-sm ms-auto">
+      ? `<a href="${escapeHtml(entry.changelogUrl)}" target="_blank" rel="noopener noreferrer" class="btn btn-ghost-secondary btn-sm ms-2 flex-shrink-0">
            <i class="fa fa-external-link me-1"></i>${i18next.t("Changelog")}
          </a>`
       : "";
@@ -384,14 +413,16 @@ function renderUpgradePath(upgradePath) {
 
     $accordion.append(`
       <div class="upgrade-path-entry">
-        <button class="upgrade-path-header collapse-toggle d-flex align-items-center gap-2 w-100 text-start py-2 px-3 border-0 bg-transparent"
-            data-bs-toggle="collapse" data-bs-target="#${collapseId}" aria-expanded="false">
-          <i class="fa fa-chevron-down upgrade-path-chevron text-secondary small"></i>
-          <span class="fw-semibold">${escapeHtml(entry.version)}</span>
-          ${typeBadge}
-          ${isNextBadge}
+        <div class="d-flex align-items-center w-100">
+          <button class="upgrade-path-header collapse-toggle d-flex align-items-center gap-2 flex-grow-1 text-start py-2 px-3 border-0 bg-transparent"
+              data-bs-toggle="collapse" data-bs-target="#${collapseId}" aria-expanded="false">
+            <i class="fa fa-chevron-down upgrade-path-chevron text-secondary small"></i>
+            <span class="fw-semibold">${escapeHtml(entry.version)}</span>
+            ${typeBadge}
+            ${isNextBadge}
+          </button>
           ${changelogLink}
-        </button>
+        </div>
         <div id="${collapseId}" class="collapse upgrade-path-notes px-3 pb-2">
           <div class="release-notes p-3 border rounded">${notes}</div>
         </div>
@@ -420,8 +451,12 @@ function renderVersionSelector(upgradePath, defaultNextVersion) {
     $select.append(`<option value="${escapeHtml(entry.version)}">${escapeHtml(label)}</option>`);
   });
 
-  // Update the "What's New" notes when selection changes
-  $select.on("change", function () {
+  // Re-show the advanced selector panel (hidden by the reset block in renderWhatsNew).
+  $("#advancedVersionCollapse").closest(".mb-4").removeClass("d-none");
+
+  // Update the "What's New" notes when selection changes; deregister any
+  // stale listener from a previous call before attaching a fresh one.
+  $select.off("change").on("change", function () {
     const ver = $(this).val();
     if (!ver) {
       // Reset to default next version notes
@@ -723,6 +758,7 @@ function setupForceReinstallButton() {
     // Clear stale download state so the Download & Apply step starts fresh
     window.CRM.updateFile = null;
     selectedTargetVersion = null;
+    prereleaseTargetVersion = null;
     $("#downloadStatus").empty();
     $("#updateDetails").addClass("d-none");
     $("#applyButtonContainer").addClass("d-none");


### PR DESCRIPTION
## What this fixes

### Bug 1 — Blank 'What's New' step when running prerelease ahead of latest stable
When installed version is a prerelease/dev build *ahead* of the latest stable GitHub release (e.g. 7.4.2-beta installed, 7.4.1 is latest stable), the wizard now:
- Shows a warning banner: "You are running a pre-release version. The latest stable release is X.Y.Z."
- Shows the latest stable release notes in the What's New step
- Offers an "Install stable X.Y.Z" button so the user can reinstall the stable release
- Shows a "Running Pre-release" badge in the version bar

Previously the wizard showed "You're up to date!" with no proceed button — leaving the user with a blank, non-functional step and no way to get back to stable.

Three root causes fixed:
- `ChurchCRMReleaseManager::getUpgradePreviewData()` returned empty when installed > latest stable; now detects this case, sets `nextRelease = $latestStable`, returns `isAheadOfStable: true`
- `system.php` upgrade route was not computing `$isAheadOfStable`; fixed and passed to view
- `renderWhatsNew()` in JS had no prerelease case; full new branch added

### Bug 2 — `renderWhatsNew()` doesn't reset stale UI state (Copilot)
Changelog link, upgrade-path panel, and alert banners from a previous render were not cleared before re-rendering. Fixed by resetting all dynamic elements at the top of the function.

### Bug 3 — `renderVersionSelector()` registers duplicate `change` handlers (Copilot)
Each call to `renderVersionSelector()` added a new `change` event listener without removing the old one. Fixed with `.off('change').on('change', ...)`.

### Bug 4 — `<a>` nested inside `<button>` in upgrade-path entry (Copilot)
Invalid HTML causing accessibility and click behaviour issues. Moved changelog link outside the button into a sibling flex element.

### Bug 5 — Step 4 description not updated for prerelease reinstall (Copilot)
When in the prerelease case, `selectedTargetVersion` was never set so step 4 always said "Download the latest release…". Fixed with a `prereleaseTargetVersion` module variable set during `renderWhatsNew()` and read by the `#proceedToDownload` click handler.

### Bug 6 — Advanced version selector permanently hidden after rebase (automated review)
The stale-UI reset block (Bug 2 fix) unconditionally called `addClass("d-none")` on `#advancedVersionCollapse` but `renderVersionSelector()` never called `removeClass("d-none")` to re-show it. Result: the advanced target-version selector was invisible for all normal upgrade paths, confirmed by Cypress CI failures. Fixed by adding `removeClass("d-none")` in `renderVersionSelector()` after options are populated.

### Bug 7 — `prereleaseTargetVersion` not cleared in force-reinstall handler (automated review)
The new `prereleaseTargetVersion` module variable was correctly reset inside `renderWhatsNew()`, but the `#confirmForceReinstall` handler only cleared `selectedTargetVersion`. If the subsequent preview API call failed (network error etc.), the stale prerelease version would be used as the download target on the next attempt. Fixed by also resetting `prereleaseTargetVersion = null` in the force-reinstall handler.

### Rebase onto #9112
This PR was rebased onto `feat(upgrade): show latest release notes when up to date; restore Force Re-install` (#9112). Conflicts in `ChurchCRMReleaseManager.php` and `upgrade-wizard-app.js` were resolved by unifying `$latestStable` / `$latestKnownRelease` (same session value, now one variable) and merging the three `renderWhatsNew()` cases — prerelease (this PR), up-to-date with release notes + force-reinstall (from #9112), and normal upgrade.

Fixes #8801
