### PR TITLE
Hide menu entries the user has no permission to open

### DIFF
--- a/cypress/e2e/ui/security/no-permission-user.spec.js
+++ b/cypress/e2e/ui/security/no-permission-user.spec.js
@@ -201,16 +201,22 @@ describe("Zero-Permission User (EditSelf=0, all flags 0)", () => {
         // A menu entry must not advertise a page the user is bounced out of.
         it("Hides Groups and Sunday School (ManageGroups=0)", () => {
             cy.visit("v2/dashboard");
-            cy.get(".navbar-nav").within(() => {
-                cy.contains("Groups").should("not.exist");
-                cy.contains("Sunday School").should("not.exist");
+            // .navbar-nav matches multiple elements (main menu + header navs);
+            // iterate each so cy.within() receives a single element at a time.
+            cy.get(".navbar-nav").each(($nav) => {
+                cy.wrap($nav).within(() => {
+                    cy.contains("Groups").should("not.exist");
+                    cy.contains("Sunday School").should("not.exist");
+                });
             });
         });
 
         it("Hides Communication (EmailMailto=0)", () => {
             cy.visit("v2/dashboard");
-            cy.get(".navbar-nav").within(() => {
-                cy.contains("Communication").should("not.exist");
+            cy.get(".navbar-nav").each(($nav) => {
+                cy.wrap($nav).within(() => {
+                    cy.contains("Communication").should("not.exist");
+                });
             });
         });
 

--- a/cypress/e2e/ui/security/no-permission-user.spec.js
+++ b/cypress/e2e/ui/security/no-permission-user.spec.js
@@ -121,6 +121,45 @@ describe("Zero-Permission User (EditSelf=0, all flags 0)", () => {
                 expect(resp.status).to.eq(403);
             });
         });
+
+        // ManageGroups=0 — the whole /groups app is behind ManageGroupRoleAuthMiddleware.
+        it("Groups dashboard is denied", () => {
+            cy.visit("groups/dashboard", { failOnStatusCode: false });
+            cy.url().should("include", "/v2/access-denied");
+        });
+
+        it("Sunday School dashboard is denied", () => {
+            cy.visit("groups/sundayschool/dashboard", { failOnStatusCode: false });
+            cy.url().should("include", "/v2/access-denied");
+        });
+
+        // EmailMailto=0 — /v2/email and /v2/text are behind EmailRoleAuthMiddleware.
+        it("Email dashboard is denied", () => {
+            cy.visit("v2/email/dashboard", { failOnStatusCode: false });
+            cy.url().should("include", "/v2/access-denied");
+        });
+
+        it("Text dashboard is denied", () => {
+            cy.visit("v2/text/dashboard", { failOnStatusCode: false });
+            cy.url().should("include", "/v2/access-denied");
+        });
+    });
+
+    describe("Query list hides finance-only queries", () => {
+        beforeEach(login);
+
+        // aFinanceQueries defaults to "28,30" — those rows require Finance=1.
+        it("Query list renders without the finance queries", () => {
+            cy.visit("QueryList.php");
+            cy.get('a[href*="QueryView.php"]').should("have.length.greaterThan", 0);
+            cy.get('a[href*="QueryID=28"]').should("not.exist");
+            cy.get('a[href*="QueryID=30"]').should("not.exist");
+        });
+
+        it("Opening a finance query directly redirects away", () => {
+            cy.visit("QueryView.php?QueryID=28", { failOnStatusCode: false });
+            cy.url().should("include", "/v2/dashboard");
+        });
     });
 
     describe("API-key access", () => {
@@ -157,6 +196,30 @@ describe("Zero-Permission User (EditSelf=0, all flags 0)", () => {
             // No write actions.
             cy.contains("a", "Add New Person").should("not.exist");
             cy.contains("a", "Add New Family").should("not.exist");
+        });
+
+        // A menu entry must not advertise a page the user is bounced out of.
+        it("Hides Groups and Sunday School (ManageGroups=0)", () => {
+            cy.visit("v2/dashboard");
+            cy.get(".navbar-nav").within(() => {
+                cy.contains("Groups").should("not.exist");
+                cy.contains("Sunday School").should("not.exist");
+            });
+        });
+
+        it("Hides Communication (EmailMailto=0)", () => {
+            cy.visit("v2/dashboard");
+            cy.get(".navbar-nav").within(() => {
+                cy.contains("Communication").should("not.exist");
+            });
+        });
+
+        it("Data/Reports links straight to the query list", () => {
+            cy.visit("v2/dashboard");
+            cy.get(".navbar-nav")
+                .contains("a", "Data/Reports")
+                .should("have.attr", "href")
+                .and("include", "QueryList.php");
         });
     });
 

--- a/src/ChurchCRM/Config/Menu/Menu.php
+++ b/src/ChurchCRM/Config/Menu/Menu.php
@@ -39,8 +39,8 @@ class Menu
             'Calendar'     => self::getCalendarMenu($canViewEvents),
             'People'       => self::getPeopleMenu($isAdmin, $isMenuOptions, $currentUser->isAddRecordsEnabled()),
             'Groups'       => self::getGroupMenu($isAdmin, $isMenuOptions, $isManageGroups),
-            'SundaySchool' => self::getSundaySchoolMenu($isAdmin),
-            'Communication' => self::getCommunicationMenu(),
+            'SundaySchool' => self::getSundaySchoolMenu($isAdmin, $isManageGroups),
+            'Communication' => self::getCommunicationMenu($currentUser->isEmailEnabled()),
             'Events'       => self::getEventsMenu($currentUser->isAddEventEnabled(), $canViewEvents),
             'Deposits'     => self::getDepositsMenu($isAdmin, $currentUser->isFinanceEnabled()),
             'Fundraiser'   => self::getFundraisersMenu($isAdmin, $currentUser->isFinanceEnabled()),
@@ -112,7 +112,12 @@ class Menu
 
     private static function getGroupMenu(bool $isAdmin, bool $isMenuOptions, bool $isManageGroups): MenuItem
     {
-        $groupMenu = new MenuItem(gettext('Groups'), '', true, 'fa-users');
+        $groupMenu = new MenuItem(gettext('Groups'), '', $isManageGroups, 'fa-users');
+        if (!$isManageGroups) {
+            // Every /groups route is behind ManageGroupRoleAuthMiddleware; skip the lookups.
+            return $groupMenu;
+        }
+
         $groupMenu->addSubMenu(new MenuItem(gettext('Dashboard'), 'groups/dashboard', true, 'fa-gauge'));
         // fetch list options lightweight (only name/id)
         $listOptions = ListOptionQuery::create()
@@ -175,9 +180,15 @@ class Menu
         return $groupMenu;
     }
 
-    private static function getSundaySchoolMenu(bool $isAdmin): MenuItem
+    private static function getSundaySchoolMenu(bool $isAdmin, bool $isManageGroups): MenuItem
     {
-        $sundaySchoolMenu = new MenuItem(gettext('Sunday School'), '', $isAdmin || SystemConfig::getBooleanValue('bEnabledSundaySchool'), 'fa-school');
+        $isEnabled = $isManageGroups && ($isAdmin || SystemConfig::getBooleanValue('bEnabledSundaySchool'));
+        $sundaySchoolMenu = new MenuItem(gettext('Sunday School'), '', $isEnabled, 'fa-school');
+        if (!$isEnabled) {
+            // Sunday School pages live under /groups/sundayschool, behind ManageGroupRoleAuthMiddleware.
+            return $sundaySchoolMenu;
+        }
+
         $sundaySchoolMenu->addSubMenu(new MenuItem(gettext('Dashboard'), 'groups/sundayschool/dashboard', true, 'fa-gauge'));
         $classes = GroupQuery::create()->filterByType(4)->orderByName()->select(['Id','Name'])->find()->toArray();
         if (!empty($classes)) {
@@ -189,11 +200,11 @@ class Menu
         return $sundaySchoolMenu;
     }
 
-    private static function getCommunicationMenu(): MenuItem
+    private static function getCommunicationMenu(bool $isEmailEnabled): MenuItem
     {
-        $commMenu = new MenuItem(gettext('Communication'), '', true, 'fa-comments');
-        $commMenu->addSubMenu(new MenuItem(gettext('Email'), 'v2/email/dashboard', true, 'fa-envelope'));
-        $commMenu->addSubMenu(new MenuItem(gettext('Text'), 'v2/text/dashboard', true, 'fa-comment-sms'));
+        $commMenu = new MenuItem(gettext('Communication'), '', $isEmailEnabled, 'fa-comments');
+        $commMenu->addSubMenu(new MenuItem(gettext('Email'), 'v2/email/dashboard', $isEmailEnabled, 'fa-envelope'));
+        $commMenu->addSubMenu(new MenuItem(gettext('Text'), 'v2/text/dashboard', $isEmailEnabled, 'fa-comment-sms'));
 
         return $commMenu;
     }
@@ -300,10 +311,8 @@ class Menu
 
     private static function getReportsMenu(): MenuItem
     {
-        $reportsMenu = new MenuItem(gettext('Data/Reports'), '', true, 'fa-database');
-        $reportsMenu->addSubMenu(new MenuItem(gettext('Query Menu'), 'QueryList.php', true, 'fa-magnifying-glass'));
-
-        return $reportsMenu;
+        // Query Menu is the only entry, so link straight to it rather than nesting a single child.
+        return new MenuItem(gettext('Data/Reports'), 'QueryList.php', true, 'fa-database');
     }
 
     private static function addGroupSubMenus($menuName, $groupId, string $viewURl, ?array $groupsByType = null): ?MenuItem

--- a/src/ChurchCRM/Slim/Middleware/Request/Auth/EmailRoleAuthMiddleware.php
+++ b/src/ChurchCRM/Slim/Middleware/Request/Auth/EmailRoleAuthMiddleware.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace ChurchCRM\Slim\Middleware\Request\Auth;
+
+class EmailRoleAuthMiddleware extends BaseAuthRoleMiddleware
+{
+    protected function hasRole(): bool
+    {
+        return $this->user->isEmailEnabled();
+    }
+
+    protected function noRoleMessage(): string
+    {
+        return gettext('User must have Email permission');
+    }
+
+    protected function getRoleName(): string
+    {
+        return 'Email';
+    }
+}

--- a/src/QueryList.php
+++ b/src/QueryList.php
@@ -4,6 +4,7 @@ require_once __DIR__ . '/Include/Config.php';
 require_once __DIR__ . '/Include/PageInit.php';
 
 use ChurchCRM\Authentication\AuthenticationManager;
+use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\model\ChurchCRM\PredefinedReportsQuery;
 use ChurchCRM\view\PageHeader;
 
@@ -12,7 +13,8 @@ $sPageSubtitle = gettext('View and run saved database queries');
 
 $queries = PredefinedReportsQuery::create()->orderByQryName()->find();
 
-$aFinanceQueries = explode(',', $aFinanceQueries);
+$aFinanceQueries = array_map('intval', explode(',', SystemConfig::getValue('aFinanceQueries')));
+$isFinanceEnabled = AuthenticationManager::getCurrentUser()->isFinanceEnabled();
 
 $aBreadcrumbs = PageHeader::breadcrumbs([
     [gettext('Data & Reports')],
@@ -23,7 +25,7 @@ require_once __DIR__ . '/Include/Header.php';
 <div class="card">
     <div class="list-group list-group-flush">
         <?php foreach ($queries as $query) :
-            if (AuthenticationManager::getCurrentUser()->isFinanceEnabled() || !in_array($query->getQryId(), $aFinanceQueries)) : ?>
+            if ($isFinanceEnabled || !in_array((int) $query->getQryId(), $aFinanceQueries, true)) : ?>
         <div class="list-group-item">
             <div class="row align-items-center">
                 <div class="col">

--- a/src/QueryView.php
+++ b/src/QueryView.php
@@ -16,9 +16,9 @@ $sPageSubtitle = gettext('View query results');
 // Get the QueryID from the querystring
 $iQueryID = InputUtils::legacyFilterInput($_GET['QueryID'], 'int');
 
-$aFinanceQueries = explode(',', SystemConfig::getValue('aFinanceQueries'));
+$aFinanceQueries = array_map('intval', explode(',', SystemConfig::getValue('aFinanceQueries')));
 
-if (!AuthenticationManager::getCurrentUser()->isFinanceEnabled() && in_array($iQueryID, $aFinanceQueries)) {
+if (!AuthenticationManager::getCurrentUser()->isFinanceEnabled() && in_array((int) $iQueryID, $aFinanceQueries, true)) {
     RedirectUtils::redirect('v2/dashboard');
 }
 

--- a/src/v2/routes/email.php
+++ b/src/v2/routes/email.php
@@ -3,6 +3,7 @@
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\dto\SystemURLs;
 use ChurchCRM\Plugin\PluginManager;
+use ChurchCRM\Slim\Middleware\Request\Auth\EmailRoleAuthMiddleware;
 use ChurchCRM\view\PageHeader;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
@@ -15,7 +16,7 @@ $app->group('/email', function (RouteCollectorProxy $group): void {
     $group->get('/missing', 'getPeopleWithoutEmailsMVC');
     $group->get('', 'getEmailDashboardMVC');
     $group->get('/', 'getEmailDashboardMVC');
-});
+})->add(EmailRoleAuthMiddleware::class);
 
 function getEmailDashboardMVC(Request $request, Response $response, array $args): Response
 {

--- a/src/v2/routes/text.php
+++ b/src/v2/routes/text.php
@@ -3,6 +3,7 @@
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\dto\SystemURLs;
 use ChurchCRM\Plugin\PluginManager;
+use ChurchCRM\Slim\Middleware\Request\Auth\EmailRoleAuthMiddleware;
 use ChurchCRM\view\PageHeader;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
@@ -13,7 +14,7 @@ $app->group('/text', function (RouteCollectorProxy $group): void {
     $group->get('/dashboard', 'getTextDashboardMVC');
     $group->get('', 'getTextDashboardMVC');
     $group->get('/', 'getTextDashboardMVC');
-});
+})->add(EmailRoleAuthMiddleware::class);
 
 function getTextDashboardMVC(Request $request, Response $response, array $args): Response
 {


### PR DESCRIPTION
## Summary

A user with only view permissions (`noperm.user`) saw **Groups**, **Sunday School**, and **Communication** in the sidebar, but clicking them bounced to access-denied. This PR aligns menu visibility with the permission that actually guards each route, closes an unguarded route group, and fixes a broken finance filter on the query list.

## Changes

**Groups + Sunday School — menu now gated on "Manage Groups and Roles"**
- Every `/groups` route is behind `ManageGroupRoleAuthMiddleware`, but `getGroupMenu()` passed `true` for visibility. Both menus now gate on `isManageGroupsEnabled()`, matching the middleware.
- Sunday School pages live under `/groups/sundayschool/*`, so they inherit the same guard — its menu keeps the existing `bEnabledSundaySchool` feature check *and* adds the permission check.
- When the user lacks the permission, both builders return early, skipping the `ListOptionQuery` / `GroupQuery` lookups that were previously run to build menus nobody could use.

**Communication — was unguarded, now enforced**
- `/v2/email/*` and `/v2/text/*` had **no role middleware at all**: any logged-in user could open the Email and Text dashboards. The `bEmailMailto` permission (`User::isEmailEnabled()`) existed but nothing enforced it.
- New `EmailRoleAuthMiddleware` applied to both route groups, and the Communication menu gated on the same permission.

**Data/Reports — collapsed a single-child menu**
- The menu wrapped exactly one child (Query Menu → `QueryList.php`); the top-level entry now links straight there.

**QueryList.php — finance filter never worked**
- The page filtered finance-only queries against `$aFinanceQueries`, a variable **never defined anywhere**. `explode(',', null)` yields `['']`, so `in_array()` never matched and finance queries (IDs 28, 30) were listed for *every* user, including zero-permission ones. `QueryView.php` correctly blocked them on click, so the leak was the listing itself.
- Now reads `SystemConfig::getValue('aFinanceQueries')` and compares strictly against int-cast IDs. The same strict comparison is applied in `QueryView.php`, which was relying on loose int↔string matching.

## Why

A menu entry must not advertise a page the user is bounced out of — it reads as a broken app. Two of these were cosmetic mismatches; the Communication routes and the query-list filter were real gaps where the guard was missing or dead.

## Files Changed

- `src/ChurchCRM/Config/Menu/Menu.php` — gate Groups, Sunday School, Communication; flatten Data/Reports
- `src/ChurchCRM/Slim/Middleware/Request/Auth/EmailRoleAuthMiddleware.php` — **new**
- `src/v2/routes/email.php`, `src/v2/routes/text.php` — apply the middleware
- `src/QueryList.php` — read `aFinanceQueries` from config; strict comparison
- `src/QueryView.php` — strict comparison
- `cypress/e2e/ui/security/no-permission-user.spec.js` — coverage below

## Testing

Extends the existing zero-permission suite (`noperm.user`, all flags 0):

- Groups / Sunday School / Email / Text dashboards each redirect to `/v2/access-denied`
- Sidebar hides Groups, Sunday School, and Communication
- Data/Reports links directly to `QueryList.php`
- Query list renders no `QueryID=28` / `QueryID=30` links; opening one directly redirects away

```
npx cypress run --spec "cypress/e2e/ui/security/no-permission-user.spec.js"
```

`npm run lint` clean; `npm run build:php` validates all 746 PHP files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)