### PR TITLE
refactor: standardize API write-route sanitization on InputSanitizationMiddleware

### DIFF
--- a/.agents/skills/churchcrm/security-best-practices.md
+++ b/.agents/skills/churchcrm/security-best-practices.md
@@ -1021,4 +1021,85 @@ external/templates/registration/family-register.php.
 
 ---
 
-Last updated: April 5, 2026
+### InputSanitizationMiddleware Is the Standard for API Write Routes <!-- learned: 2026-07-11 -->
+
+For Slim API/MVC write routes (`post`/`put`/`patch`), sanitize free-text body
+fields with **`InputSanitizationMiddleware`** attached to the route — do **not**
+call `InputUtils::sanitizeText()` / `sanitizeHTML()` inline in the handler. The
+middleware sanitizes the parsed body **before** the handler runs, so every code
+path in the handler (storage, logging, echo-back) sees the clean value and no
+field can be forgotten.
+
+```php
+use ChurchCRM\Slim\Middleware\InputSanitizationMiddleware;
+
+// Field map: 'text' → InputUtils::sanitizeText() (strip tags);
+//            'html' → InputUtils::sanitizeHTML() (HTMLPurifier, safe rich text).
+$group->post('', 'createFund')
+    ->add(new InputSanitizationMiddleware(['name' => 'text', 'description' => 'text']));
+
+$group->put('', 'updateNote')
+    ->add(new InputSanitizationMiddleware(['text' => 'html']));
+
+// Handler reads the already-sanitized field directly — cast for type safety,
+// keep validation (empty/length/uniqueness) which now runs on the clean value:
+function createFund(Request $request, Response $response): Response
+{
+    $input = (array) $request->getParsedBody();
+    $name  = (string) ($input['name'] ?? '');   // already sanitized by middleware
+    if ($name === '') { /* 400 */ }
+    // ...
+}
+```
+
+**Middleware order:** attach it so it runs *after* auth/entity middleware
+(auth first, then sanitize). In Slim, later `->add()` calls run outermost, so
+put `InputSanitizationMiddleware` in the chain and let the auth middleware wrap
+it — the field is sanitized just before the handler.
+
+**Routes using this pattern** (`src/ChurchCRM/Slim/Middleware/InputSanitizationMiddleware.php`):
+calendar events/`calendar.php`, group create + roles (`people-groups.php`),
+finance deposits/donation-funds/fundraisers, property-types,
+volunteer-opportunities, list options (`admin/api/options.php`), person/family
+notes (`html`), and person/group property values. When adding a **new** write
+route that stores free text, add the middleware — never a bare `getParsedBody()`
+value into a setter.
+
+> Note: legacy `src/*.php` pages still sanitize inline with `InputUtils` because
+> they are not Slim routes — the middleware only applies to the Slim apps.
+
+### Input Sanitization Is Not Output Escaping — Escape Names Client-Side Too <!-- learned: 2026-07-11 -->
+
+`InputSanitizationMiddleware` / `sanitizeText()` strips tags **on the primary
+write paths**, but it is **not** a complete XSS defense on its own. Values can
+still contain markup when they arrive by a path that bypasses the middleware —
+data migrated from older versions, SQL/backup restore, CSV import, or a future
+route that forgets the middleware. **Output escaping is the authoritative
+control**, and it must be applied on the **client side** too, not only in PHP.
+
+The server-side ListOption/`OptionName` escaping was fixed in GHSA-j9gv-26c7-3qrh,
+but the **JavaScript** renderings of the same values were missed (draft
+GHSA-mfmp-q643-vj39): `src/skin/js/GroupView.js` and `GroupRoles.js` injected
+group-role names into the DOM as raw HTML via `.html()` / `.append()`.
+
+```js
+// ❌ WRONG — role name injected as raw HTML (executes if it contains markup)
+html += '<a class="nav-link" href="#">' + i18next.t(role.OptionName) + '</a>';
+$pills.html(html);
+
+// ✅ CORRECT — escape every DB/API-sourced string before it becomes HTML
+html += '<a class="nav-link" href="#">' +
+        window.CRM.escapeHtml(i18next.t(role.OptionName)) + '</a>';
+$pills.html(html);
+```
+
+**Rule:** any DB/API-sourced string (names, titles, `OptionName`, `getName()`,
+custom-field labels) inserted into the DOM via `.html()`, `.append()`,
+`innerHTML`, or a template literal MUST be wrapped in `window.CRM.escapeHtml()`
+— even when the write path sanitizes input. When reviewing JS, grep for
+`.OptionName`, `.Name`, `.title` near `.html(`/`.append(`/`innerHTML` and confirm
+`escapeHtml` wraps each one. `$("<div>").text(x).html()` is an equivalent escape.
+
+---
+
+Last updated: July 11, 2026

--- a/.agents/skills/churchcrm/security-best-practices.md
+++ b/.agents/skills/churchcrm/security-best-practices.md
@@ -1052,10 +1052,35 @@ function createFund(Request $request, Response $response): Response
 }
 ```
 
-**Middleware order:** attach it so it runs *after* auth/entity middleware
-(auth first, then sanitize). In Slim, later `->add()` calls run outermost, so
-put `InputSanitizationMiddleware` in the chain and let the auth middleware wrap
-it — the field is sanitized just before the handler.
+**Middleware order (LIFO rule):** In Slim 4, `->add()` is Last-In-First-Out —
+the **last** `->add()` call is outermost and runs **first**. Therefore:
+
+- Add `InputSanitizationMiddleware` **first** (`->add()` call #1) so it is
+  innermost and runs **just before the handler** (sanitize-then-handle).
+- Add auth/entity middleware **after** it so they are outer layers and run
+  **before** sanitization.
+
+Concrete pattern (follows `groups-properties.php`):
+
+```php
+$group->post('/{id}/resource/{resId}', 'myHandler')
+    ->add(new InputSanitizationMiddleware(['name' => 'text'])) // 1st = innermost = runs last
+    ->add($entityMiddleware)                                   // 2nd = runs before sanitize
+    ->add(SomeAuthMiddleware::class);                          // 3rd = outermost = runs first
+// Execution order: SomeAuthMiddleware → $entityMiddleware → InputSanitizationMiddleware → handler
+```
+
+❌ **Wrong** — adding `InputSanitizationMiddleware` last makes it outermost
+(runs before auth), defeating the purpose of sanitizing input that only
+arrives after entity resolution:
+
+```php
+// WRONG — sanitize runs before auth/entity (inverted LIFO order)
+$group->post('/…', 'handler')
+    ->add($entityMiddleware)
+    ->add(SomeAuthMiddleware::class)
+    ->add(new InputSanitizationMiddleware(['name' => 'text'])); // last = outermost = wrong
+```
 
 **Routes using this pattern** (`src/ChurchCRM/Slim/Middleware/InputSanitizationMiddleware.php`):
 calendar events/`calendar.php`, group create + roles (`people-groups.php`),

--- a/src/admin/routes/api/options.php
+++ b/src/admin/routes/api/options.php
@@ -4,8 +4,8 @@ use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\model\ChurchCRM\GroupQuery;
 use ChurchCRM\model\ChurchCRM\ListOption;
 use ChurchCRM\model\ChurchCRM\ListOptionQuery;
+use ChurchCRM\Slim\Middleware\InputSanitizationMiddleware;
 use ChurchCRM\Slim\SlimUtils;
-use ChurchCRM\Utils\InputUtils;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Exception\HttpBadRequestException;
@@ -38,7 +38,7 @@ $app->group('/api/options', function (RouteCollectorProxy $group): void {
         $listId = (int) $args['listId'];
         $input = (array) $request->getParsedBody();
 
-        $name = InputUtils::sanitizeText($input['name'] ?? '');
+        $name = (string) ($input['name'] ?? '');
         if (empty($name)) {
             throw new HttpBadRequestException($request, gettext('Option name is required'));
         }
@@ -73,7 +73,7 @@ $app->group('/api/options', function (RouteCollectorProxy $group): void {
             'optionName' => $option->getOptionName(),
             'optionSequence' => $option->getOptionSequence(),
         ]);
-    });
+    })->add(new InputSanitizationMiddleware(['name' => 'text']));
 
     // Update option name
     $group->patch('/{listId:[0-9]+}/{optionId:[0-9]+}', function (Request $request, Response $response, array $args): Response {
@@ -90,7 +90,7 @@ $app->group('/api/options', function (RouteCollectorProxy $group): void {
         }
 
         if (isset($input['name'])) {
-            $name = InputUtils::sanitizeText($input['name']);
+            $name = (string) $input['name'];
             if (empty($name)) {
                 throw new HttpBadRequestException($request, gettext('Option name is required'));
             }
@@ -113,7 +113,7 @@ $app->group('/api/options', function (RouteCollectorProxy $group): void {
             'optionName' => $option->getOptionName(),
             'optionSequence' => $option->getOptionSequence(),
         ]);
-    });
+    })->add(new InputSanitizationMiddleware(['name' => 'text']));
 
     // Delete an option
     $group->delete('/{listId:[0-9]+}/{optionId:[0-9]+}', function (Request $request, Response $response, array $args): Response {

--- a/src/api/routes/finance/finance-donation-funds.php
+++ b/src/api/routes/finance/finance-donation-funds.php
@@ -3,9 +3,9 @@
 use ChurchCRM\model\ChurchCRM\DonationFund;
 use ChurchCRM\model\ChurchCRM\DonationFundQuery;
 use ChurchCRM\Service\DonationFundService;
+use ChurchCRM\Slim\Middleware\InputSanitizationMiddleware;
 use ChurchCRM\Slim\Middleware\Request\Auth\FinanceRoleAuthMiddleware;
 use ChurchCRM\Slim\SlimUtils;
-use ChurchCRM\Utils\InputUtils;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Routing\RouteCollectorProxy;
@@ -86,8 +86,8 @@ $app->group('/donation-funds', function (RouteCollectorProxy $group): void {
     $group->post('', function (Request $request, Response $response, array $args): Response {
         try {
             $input = (array) $request->getParsedBody();
-            $name = InputUtils::sanitizeText($input['name'] ?? '');
-            $description = InputUtils::sanitizeText($input['description'] ?? '');
+            $name = (string) ($input['name'] ?? '');
+            $description = (string) ($input['description'] ?? '');
             $active = array_key_exists('active', $input)
                 ? filter_var($input['active'], FILTER_VALIDATE_BOOLEAN)
                 : true;
@@ -117,7 +117,7 @@ $app->group('/donation-funds', function (RouteCollectorProxy $group): void {
         } catch (\Throwable $e) {
             return SlimUtils::renderErrorJSON($response, gettext('Failed to create donation fund'), [], 500, $e, $request);
         }
-    });
+    })->add(new InputSanitizationMiddleware(['name' => 'text', 'description' => 'text']));
 
     /**
      * @OA\Get(
@@ -173,7 +173,7 @@ $app->group('/donation-funds', function (RouteCollectorProxy $group): void {
             $input = (array) $request->getParsedBody();
 
             if (array_key_exists('name', $input)) {
-                $name = InputUtils::sanitizeText($input['name']);
+                $name = (string) $input['name'];
                 if ($name === '') {
                     return SlimUtils::renderErrorJSON($response, gettext('You must enter a name'), [], 400);
                 }
@@ -186,7 +186,7 @@ $app->group('/donation-funds', function (RouteCollectorProxy $group): void {
             }
 
             if (array_key_exists('description', $input)) {
-                $fund->setDescription(InputUtils::sanitizeText($input['description']));
+                $fund->setDescription((string) $input['description']);
             }
 
             if (array_key_exists('active', $input)) {
@@ -199,7 +199,7 @@ $app->group('/donation-funds', function (RouteCollectorProxy $group): void {
         } catch (\Throwable $e) {
             return SlimUtils::renderErrorJSON($response, gettext('Failed to update donation fund'), [], 500, $e, $request);
         }
-    });
+    })->add(new InputSanitizationMiddleware(['name' => 'text', 'description' => 'text']));
 
     /**
      * @OA\Delete(

--- a/src/api/routes/finance/finance-fundraisers.php
+++ b/src/api/routes/finance/finance-fundraisers.php
@@ -4,10 +4,10 @@ use ChurchCRM\Authentication\AuthenticationManager;
 use ChurchCRM\model\ChurchCRM\DonatedItemQuery;
 use ChurchCRM\model\ChurchCRM\FundRaiser;
 use ChurchCRM\model\ChurchCRM\FundRaiserQuery;
+use ChurchCRM\Slim\Middleware\InputSanitizationMiddleware;
 use ChurchCRM\Slim\Middleware\Request\Auth\FinanceRoleAuthMiddleware;
 use ChurchCRM\Slim\SlimUtils;
 use ChurchCRM\Utils\DateTimeUtils;
-use ChurchCRM\Utils\InputUtils;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Routing\RouteCollectorProxy;
@@ -83,8 +83,8 @@ $app->group('/fundraisers', function (RouteCollectorProxy $group): void {
     $group->post('', function (Request $request, Response $response, array $args): Response {
         try {
             $input = (array) $request->getParsedBody();
-            $title = InputUtils::sanitizeText($input['title'] ?? '');
-            $description = InputUtils::sanitizeText($input['description'] ?? '');
+            $title = (string) ($input['title'] ?? '');
+            $description = (string) ($input['description'] ?? '');
             $date = trim((string) ($input['date'] ?? ''));
 
             if ($title === '') {
@@ -112,7 +112,7 @@ $app->group('/fundraisers', function (RouteCollectorProxy $group): void {
         } catch (\Throwable $e) {
             return SlimUtils::renderErrorJSON($response, gettext('Failed to create fundraiser'), [], 500, $e, $request);
         }
-    });
+    })->add(new InputSanitizationMiddleware(['title' => 'text', 'description' => 'text']));
 
     /**
      * @OA\Get(
@@ -167,7 +167,7 @@ $app->group('/fundraisers', function (RouteCollectorProxy $group): void {
             $input = (array) $request->getParsedBody();
 
             if (array_key_exists('title', $input)) {
-                $title = InputUtils::sanitizeText($input['title']);
+                $title = (string) $input['title'];
                 if ($title === '') {
                     return SlimUtils::renderErrorJSON($response, gettext('Title is required'), [], 400);
                 }
@@ -175,7 +175,7 @@ $app->group('/fundraisers', function (RouteCollectorProxy $group): void {
             }
 
             if (array_key_exists('description', $input)) {
-                $fr->setDescription(InputUtils::sanitizeText($input['description']));
+                $fr->setDescription((string) $input['description']);
             }
 
             if (array_key_exists('date', $input)) {
@@ -195,7 +195,7 @@ $app->group('/fundraisers', function (RouteCollectorProxy $group): void {
         } catch (\Throwable $e) {
             return SlimUtils::renderErrorJSON($response, gettext('Failed to update fundraiser'), [], 500, $e, $request);
         }
-    });
+    })->add(new InputSanitizationMiddleware(['title' => 'text', 'description' => 'text']));
 
     /**
      * @OA\Delete(

--- a/src/api/routes/people/groups-properties.php
+++ b/src/api/routes/people/groups-properties.php
@@ -8,8 +8,8 @@ use ChurchCRM\Slim\Middleware\Request\Auth\ManageGroupRoleAuthMiddleware;
 use ChurchCRM\Slim\Middleware\Request\Auth\MenuOptionsRoleAuthMiddleware;
 use ChurchCRM\Slim\Middleware\Api\GroupMiddleware;
 use ChurchCRM\Slim\Middleware\Api\PropertyMiddleware;
+use ChurchCRM\Slim\Middleware\InputSanitizationMiddleware;
 use ChurchCRM\Slim\SlimUtils;
-use ChurchCRM\Utils\InputUtils;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Exception\HttpNotFoundException;
@@ -22,6 +22,7 @@ $app->group('/groups', function (RouteCollectorProxy $group): void {
     $group->get('/properties', 'getAllGroupPropertyDefinitions');
     $group->get('/{groupID}/properties', 'getGroupAssignedProperties')->add($groupMiddleware);
     $group->post('/{groupID}/properties/{propertyId}', 'assignPropertyToGroup')
+        ->add(new InputSanitizationMiddleware(['value' => 'text']))
         ->add($groupMiddleware)
         ->add($groupPropertyMiddleware)
         ->add(ManageGroupRoleAuthMiddleware::class);
@@ -128,8 +129,8 @@ function assignPropertyToGroup(Request $request, Response $response, array $args
     $value = '';
     if (!empty($property->getProPrompt())) {
         $data  = $request->getParsedBody();
-        $raw   = empty($data['value']) ? 'N/A' : $data['value'];
-        $value = InputUtils::sanitizeText($raw);
+        // Value is sanitized upstream by InputSanitizationMiddleware(['value' => 'text']).
+        $value = empty($data['value']) ? 'N/A' : (string) $data['value'];
     }
 
     if ($existing !== null) {

--- a/src/api/routes/people/notes.php
+++ b/src/api/routes/people/notes.php
@@ -9,9 +9,9 @@ use ChurchCRM\model\ChurchCRM\PersonQuery;
 use ChurchCRM\Slim\Middleware\Api\FamilyMiddleware;
 use ChurchCRM\Slim\Middleware\Api\NoteMiddleware;
 use ChurchCRM\Slim\Middleware\Api\PersonMiddleware;
+use ChurchCRM\Slim\Middleware\InputSanitizationMiddleware;
 use ChurchCRM\Slim\Middleware\Request\Auth\NotesRoleAuthMiddleware;
 use ChurchCRM\Slim\SlimUtils;
-use ChurchCRM\Utils\InputUtils;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Routing\RouteCollectorProxy;
@@ -151,7 +151,7 @@ $app->group('/person/{personId:[0-9]+}', function (RouteCollectorProxy $group): 
             return SlimUtils::renderErrorJSON($response, gettext('Access denied'), [], 403);
         }
 
-        $text = InputUtils::sanitizeHTML($input['text'] ?? '');
+        $text = (string) ($input['text'] ?? '');
         if ($text === '') {
             return SlimUtils::renderErrorJSON($response, gettext('Note text is required'), [], 400);
         }
@@ -168,7 +168,7 @@ $app->group('/person/{personId:[0-9]+}', function (RouteCollectorProxy $group): 
         $note->save();
 
         return SlimUtils::renderJSON($response, ['note' => noteToArray($note)], 201);
-    });
+    })->add(new InputSanitizationMiddleware(['text' => 'html']));
 })->add(new PersonMiddleware())->add(NotesRoleAuthMiddleware::class);
 
 // ---------------------------------------------------------------------------
@@ -272,7 +272,7 @@ $app->group('/family/{familyId:[0-9]+}', function (RouteCollectorProxy $group): 
             return SlimUtils::renderErrorJSON($response, gettext('Access denied'), [], 403);
         }
 
-        $text = InputUtils::sanitizeHTML($input['text'] ?? '');
+        $text = (string) ($input['text'] ?? '');
         if ($text === '') {
             return SlimUtils::renderErrorJSON($response, gettext('Note text is required'), [], 400);
         }
@@ -289,7 +289,7 @@ $app->group('/family/{familyId:[0-9]+}', function (RouteCollectorProxy $group): 
         $note->save();
 
         return SlimUtils::renderJSON($response, ['note' => noteToArray($note)], 201);
-    });
+    })->add(new InputSanitizationMiddleware(['text' => 'html']));
 })->add(FamilyMiddleware::class)->add(NotesRoleAuthMiddleware::class);
 
 // ---------------------------------------------------------------------------
@@ -367,7 +367,7 @@ $app->group('/note/{noteId:[0-9]+}', function (RouteCollectorProxy $group): void
         }
 
         $input = (array) $request->getParsedBody();
-        $text = InputUtils::sanitizeHTML($input['text'] ?? '');
+        $text = (string) ($input['text'] ?? '');
         if ($text === '') {
             return SlimUtils::renderErrorJSON($response, gettext('Note text is required'), [], 400);
         }
@@ -381,7 +381,7 @@ $app->group('/note/{noteId:[0-9]+}', function (RouteCollectorProxy $group): void
         $note->save();
 
         return SlimUtils::renderJSON($response, ['note' => noteToArray($note)]);
-    });
+    })->add(new InputSanitizationMiddleware(['text' => 'html']));
 
     /**
      * @OA\Delete(

--- a/src/api/routes/people/people-properties.php
+++ b/src/api/routes/people/people-properties.php
@@ -23,11 +23,17 @@ $app->group('/people/properties', function (RouteCollectorProxy $group): void {
     $familyAPIMiddleware = new FamilyMiddleware();
     $group->get('/person', 'getAllPersonProperties');
     $group->get('/person/{personId}', 'getPersonProperties')->add($personAPIMiddleware);
-    $group->post('/person/{personId}/{propertyId}', 'addPropertyToPerson')->add($personAPIMiddleware)->add($personPropertyAPIMiddleware)->add(new InputSanitizationMiddleware(['value' => 'text']));
+    $group->post('/person/{personId}/{propertyId}', 'addPropertyToPerson')
+        ->add(new InputSanitizationMiddleware(['value' => 'text']))
+        ->add($personAPIMiddleware)
+        ->add($personPropertyAPIMiddleware);
     $group->delete('/person/{personId}/{propertyId}', 'removePropertyFromPerson')->add($personAPIMiddleware)->add($personPropertyAPIMiddleware);
     $group->get('/family', 'getAllFamilyProperties');
     $group->get('/family/{familyId}', 'getFamilyProperties')->add($familyAPIMiddleware);
-    $group->post('/family/{familyId}/{propertyId}', 'addPropertyToFamily')->add($familyAPIMiddleware)->add($familyPropertyAPIMiddleware)->add(new InputSanitizationMiddleware(['value' => 'text']));
+    $group->post('/family/{familyId}/{propertyId}', 'addPropertyToFamily')
+        ->add(new InputSanitizationMiddleware(['value' => 'text']))
+        ->add($familyAPIMiddleware)
+        ->add($familyPropertyAPIMiddleware);
     $group->delete('/family/{familyId}/{propertyId}', 'removePropertyFromFamily')->add($familyAPIMiddleware)->add($familyPropertyAPIMiddleware);
 
     $group->delete('/definition/{propertyId}', 'deletePropertyDefinition');

--- a/src/api/routes/people/people-properties.php
+++ b/src/api/routes/people/people-properties.php
@@ -8,8 +8,8 @@ use ChurchCRM\Slim\Middleware\Request\Auth\MenuOptionsRoleAuthMiddleware;
 use ChurchCRM\Slim\Middleware\Api\FamilyMiddleware;
 use ChurchCRM\Slim\Middleware\Api\PersonMiddleware;
 use ChurchCRM\Slim\Middleware\Api\PropertyMiddleware;
+use ChurchCRM\Slim\Middleware\InputSanitizationMiddleware;
 use ChurchCRM\Slim\SlimUtils;
-use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\LoggerUtils;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
@@ -23,11 +23,11 @@ $app->group('/people/properties', function (RouteCollectorProxy $group): void {
     $familyAPIMiddleware = new FamilyMiddleware();
     $group->get('/person', 'getAllPersonProperties');
     $group->get('/person/{personId}', 'getPersonProperties')->add($personAPIMiddleware);
-    $group->post('/person/{personId}/{propertyId}', 'addPropertyToPerson')->add($personAPIMiddleware)->add($personPropertyAPIMiddleware);
+    $group->post('/person/{personId}/{propertyId}', 'addPropertyToPerson')->add($personAPIMiddleware)->add($personPropertyAPIMiddleware)->add(new InputSanitizationMiddleware(['value' => 'text']));
     $group->delete('/person/{personId}/{propertyId}', 'removePropertyFromPerson')->add($personAPIMiddleware)->add($personPropertyAPIMiddleware);
     $group->get('/family', 'getAllFamilyProperties');
     $group->get('/family/{familyId}', 'getFamilyProperties')->add($familyAPIMiddleware);
-    $group->post('/family/{familyId}/{propertyId}', 'addPropertyToFamily')->add($familyAPIMiddleware)->add($familyPropertyAPIMiddleware);
+    $group->post('/family/{familyId}/{propertyId}', 'addPropertyToFamily')->add($familyAPIMiddleware)->add($familyPropertyAPIMiddleware)->add(new InputSanitizationMiddleware(['value' => 'text']));
     $group->delete('/family/{familyId}/{propertyId}', 'removePropertyFromFamily')->add($familyAPIMiddleware)->add($familyPropertyAPIMiddleware);
 
     $group->delete('/definition/{propertyId}', 'deletePropertyDefinition');
@@ -246,9 +246,9 @@ function addProperty(Request $request, Response $response, $id, $property): Resp
     $propertyValue = '';
     if (!empty($property->getProPrompt())) {
         $data = $request->getParsedBody();
-        // GHSA-8r36-fvxj-26qv: Sanitize property value to prevent stored XSS
-        $rawValue = empty($data['value']) ? 'N/A' : $data['value'];
-        $propertyValue = InputUtils::sanitizeText($rawValue);
+        // GHSA-8r36-fvxj-26qv: property value is sanitized upstream by
+        // InputSanitizationMiddleware(['value' => 'text']) on the route.
+        $propertyValue = empty($data['value']) ? 'N/A' : (string) $data['value'];
         LoggerUtils::getAppLogger()->debug('final value is: ' . $propertyValue);
     }
 

--- a/src/api/routes/system/property-types.php
+++ b/src/api/routes/system/property-types.php
@@ -4,8 +4,8 @@ use ChurchCRM\model\ChurchCRM\PropertyQuery;
 use ChurchCRM\model\ChurchCRM\PropertyType;
 use ChurchCRM\model\ChurchCRM\PropertyTypeQuery;
 use ChurchCRM\Slim\Middleware\Request\Auth\MenuOptionsRoleAuthMiddleware;
+use ChurchCRM\Slim\Middleware\InputSanitizationMiddleware;
 use ChurchCRM\Slim\SlimUtils;
-use ChurchCRM\Utils\InputUtils;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Routing\RouteCollectorProxy;
@@ -90,8 +90,8 @@ $app->group('/property-types', function (RouteCollectorProxy $group): void {
         try {
             $input = (array) $request->getParsedBody();
             $class = strtolower(trim((string) ($input['class'] ?? '')));
-            $name = InputUtils::sanitizeText($input['name'] ?? '');
-            $description = InputUtils::sanitizeText($input['description'] ?? '');
+            $name = (string) ($input['name'] ?? '');
+            $description = (string) ($input['description'] ?? '');
 
             if (!in_array($class, PROPERTY_TYPE_VALID_CLASSES, true)) {
                 return SlimUtils::renderErrorJSON($response, gettext('Class must be one of p, f, or g'), [], 400);
@@ -110,7 +110,7 @@ $app->group('/property-types', function (RouteCollectorProxy $group): void {
         } catch (\Throwable $e) {
             return SlimUtils::renderErrorJSON($response, gettext('Failed to create property type'), [], 500, $e, $request);
         }
-    });
+    })->add(new InputSanitizationMiddleware(['name' => 'text', 'description' => 'text']));
 
     /**
      * @OA\Get(
@@ -173,7 +173,7 @@ $app->group('/property-types', function (RouteCollectorProxy $group): void {
             }
 
             if (array_key_exists('name', $input)) {
-                $name = InputUtils::sanitizeText($input['name']);
+                $name = (string) $input['name'];
                 if ($name === '') {
                     return SlimUtils::renderErrorJSON($response, gettext('You must enter a name'), [], 400);
                 }
@@ -181,7 +181,7 @@ $app->group('/property-types', function (RouteCollectorProxy $group): void {
             }
 
             if (array_key_exists('description', $input)) {
-                $pt->setPrtDescription(InputUtils::sanitizeText($input['description']));
+                $pt->setPrtDescription((string) $input['description']);
             }
 
             $pt->save();
@@ -190,7 +190,7 @@ $app->group('/property-types', function (RouteCollectorProxy $group): void {
         } catch (\Throwable $e) {
             return SlimUtils::renderErrorJSON($response, gettext('Failed to update property type'), [], 500, $e, $request);
         }
-    });
+    })->add(new InputSanitizationMiddleware(['name' => 'text', 'description' => 'text']));
 
     /**
      * @OA\Delete(

--- a/src/api/routes/system/volunteer-opportunities.php
+++ b/src/api/routes/system/volunteer-opportunities.php
@@ -3,9 +3,9 @@
 use ChurchCRM\model\ChurchCRM\PersonVolunteerOpportunityQuery;
 use ChurchCRM\model\ChurchCRM\VolunteerOpportunity;
 use ChurchCRM\model\ChurchCRM\VolunteerOpportunityQuery;
+use ChurchCRM\Slim\Middleware\InputSanitizationMiddleware;
 use ChurchCRM\Slim\Middleware\Request\Auth\AdminRoleAuthMiddleware;
 use ChurchCRM\Slim\SlimUtils;
-use ChurchCRM\Utils\InputUtils;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Routing\RouteCollectorProxy;
@@ -89,8 +89,8 @@ $app->group('/volunteer-opportunities', function (RouteCollectorProxy $group): v
     $group->post('', function (Request $request, Response $response, array $args): Response {
         try {
             $input = (array) $request->getParsedBody();
-            $name = InputUtils::sanitizeText($input['name'] ?? '');
-            $description = InputUtils::sanitizeText($input['description'] ?? '');
+            $name = (string) ($input['name'] ?? '');
+            $description = (string) ($input['description'] ?? '');
             $active = array_key_exists('active', $input)
                 ? filter_var($input['active'], FILTER_VALIDATE_BOOLEAN)
                 : true;
@@ -125,7 +125,7 @@ $app->group('/volunteer-opportunities', function (RouteCollectorProxy $group): v
         } catch (\Throwable $e) {
             return SlimUtils::renderErrorJSON($response, gettext('Failed to create volunteer opportunity'), [], 500, $e, $request);
         }
-    });
+    })->add(new InputSanitizationMiddleware(['name' => 'text', 'description' => 'text']));
 
     /**
      * @OA\Get(
@@ -181,7 +181,7 @@ $app->group('/volunteer-opportunities', function (RouteCollectorProxy $group): v
             $input = (array) $request->getParsedBody();
 
             if (array_key_exists('name', $input)) {
-                $name = InputUtils::sanitizeText($input['name']);
+                $name = (string) $input['name'];
                 if ($name === '') {
                     return SlimUtils::renderErrorJSON($response, gettext('You must enter a name'), [], 400);
                 }
@@ -196,7 +196,7 @@ $app->group('/volunteer-opportunities', function (RouteCollectorProxy $group): v
             }
 
             if (array_key_exists('description', $input)) {
-                $desc = InputUtils::sanitizeText($input['description']);
+                $desc = (string) $input['description'];
                 if (strlen($desc) > 100) {
                     return SlimUtils::renderErrorJSON($response, gettext('Description cannot exceed 100 characters'), [], 400);
                 }
@@ -213,7 +213,7 @@ $app->group('/volunteer-opportunities', function (RouteCollectorProxy $group): v
         } catch (\Throwable $e) {
             return SlimUtils::renderErrorJSON($response, gettext('Failed to update volunteer opportunity'), [], 500, $e, $request);
         }
-    });
+    })->add(new InputSanitizationMiddleware(['name' => 'text', 'description' => 'text']));
 
     /**
      * @OA\Delete(


### PR DESCRIPTION
## Summary
Standardizes free-text sanitization on Slim API write routes: every `post`/`put`/`patch` route that stores user-supplied strings now sanitizes those fields via route-level **`InputSanitizationMiddleware`** instead of calling `InputUtils::sanitizeText()`/`sanitizeHTML()` inline in the handler. This matches the pattern already used by calendar events, group create/roles, and finance deposits, so sanitization is declared at the route boundary and no field can be missed by a future handler edit.

No behavior change: handlers read the already-sanitized field directly and keep all existing validation (empty/length/uniqueness). Stored values are identical (`text` → `sanitizeText`/strip-tags, `html` → `sanitizeHTML`/HTMLPurifier — same as before).

## Changes
Migrated inline sanitization → `InputSanitizationMiddleware` on these routes:

| File | Routes | Field map |
|------|--------|-----------|
| `system/property-types.php` | POST, PUT | `name`, `description` → text |
| `system/volunteer-opportunities.php` | POST, PUT | `name`, `description` → text |
| `finance/finance-donation-funds.php` | POST, PUT | `name`, `description` → text |
| `finance/finance-fundraisers.php` | POST, PUT | `title`, `description` → text |
| `admin/api/options.php` | POST, PATCH | `name` → text |
| `people/notes.php` | 2×POST, PUT | `text` → **html** |
| `people/people-properties.php` | person + family POST | `value` → text |
| `people/groups-properties.php` | POST | `value` → text |

Each handler now reads `(string) ($input[x] ?? '')` from the pre-sanitized body; unused `InputUtils` imports removed, `InputSanitizationMiddleware` imported.

## Why
- **Consistency**: one declarative sanitization mechanism across all write routes, matching the existing middleware-using routes.
- **Robustness**: the middleware sanitizes before the handler, so every downstream use (storage, logging, echo-back) sees the clean value and a newly-added field can't silently bypass sanitization.
- Review context: `InputSanitizationMiddleware` was used on only ~5 route files; the remainder relied on inline sanitization. This brings coverage to every free-text write route.

## Scope notes
- Legacy `src/*.php` pages are **not** Slim routes and keep their inline `InputUtils` sanitization — the middleware only applies to the Slim apps.
- Write routes that accept only IDs/booleans/enums are untouched (nothing to sanitize).

## Docs
- `security-best-practices.md`: added **"InputSanitizationMiddleware Is the Standard for API Write Routes"** (pattern, field-map, middleware ordering, route inventory) and **"Input Sanitization Is Not Output Escaping — Escape Names Client-Side Too"** (escape DB/API strings client-side with `window.CRM.escapeHtml()`).

## Testing
- `npm run build:php` → 746 files pass
- `npm run lint` (Biome) → clean; pre-push hook passed
- `php -l` on all touched files → no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)