### PR TITLE
locale: translate all locales (7.4.3)

### DIFF
--- a/locale/terms/missing/fil/fil-1.json
+++ b/locale/terms/missing/fil/fil-1.json
@@ -1,7 +1,7 @@
 {
-  "Access": "",
-  "Self-service": "",
-  "Changelog": "",
-  "Feature": "",
-  "Major": ""
+  "Access": "Access",
+  "Self-service": "Self-service",
+  "Changelog": "Changelog",
+  "Feature": "Feature",
+  "Major": "Pangunahin"
 }

--- a/locale/terms/missing/ro/ro-1.json
+++ b/locale/terms/missing/ro/ro-1.json
@@ -1,4 +1,4 @@
 {
-  "Important": "",
-  "Major": ""
+  "Important": "Important",
+  "Major": "Major"
 }


### PR DESCRIPTION
Automated locale translation for ChurchCRM 7.4.3.

## Translation Summary

| Locale | Language | Terms | Status |
|--------|----------|-------|--------|
| ro | Romanian | 2 | ✅ |
| fil | Filipino | 5 | ✅ |

**Total: 2 locales, 7 terms translated**

## Changes
- `ro`: "Important" → "Important", "Major" → "Major"
- `fil`: "Access" → "Access", "Self-service" → "Self-service", "Changelog" → "Changelog", "Feature" → "Feature", "Major" → "Pangunahin"

## Next Steps
1. Review and merge
2. Run: `npm run locale:upload:missing -- --yes` (manual step — no POEditor token in CI)