### PR TITLE
fix: coerce empty donated-item price fields to 0.0 to avoid 500 on save

### DIFF
--- a/cypress/e2e/ui/fundraiser/standard.fundraiser.spec.js
+++ b/cypress/e2e/ui/fundraiser/standard.fundraiser.spec.js
@@ -160,6 +160,40 @@ describe("Fund Raiser", () => {
         });
     });
 
+    it("saves a donated item with empty price fields (no 500 on blank DECIMAL columns)", () => {
+        // Regression: blank price inputs arrive as '' and were passed straight to
+        // ->setSellprice('') etc., which the DECIMAL columns reject with a 500
+        // (Incorrect decimal value: ''). The route now coerces blanks to 0.0.
+        cy.request("/fundraiser/1/donated-items/editor").then((res) => {
+            const token = extractCsrf(res.body);
+            cy.request({
+                method: "POST",
+                url: "/fundraiser/1/donated-items/editor",
+                form: true,
+                followRedirect: false,
+                failOnStatusCode: false,
+                body: {
+                    csrf_token: token,
+                    Item: "Empty Price Item",
+                    Title: "No Prices",
+                    Description: "",
+                    Donor: 0,
+                    Buyer: 0,
+                    Multibuy: 0,
+                    SellPrice: "",
+                    EstPrice: "",
+                    MaterialValue: "",
+                    MinimumPrice: "",
+                    PictureURL: "",
+                    DonatedItemSubmit: "Save",
+                },
+            }).then((post) => {
+                expect(post.status, "blank prices must not 500").to.eq(302);
+                expect(post.headers.location).to.include("/fundraiser/editor/1");
+            });
+        });
+    });
+
     it("rejects a donated-item save with a missing CSRF token (403)", () => {
         cy.request({
             method: "POST",

--- a/src/fundraiser/routes/donated-item.php
+++ b/src/fundraiser/routes/donated-item.php
@@ -158,10 +158,11 @@ $app->post('/{fundraiserId}/donated-items/editor[/{itemId}]', function (Request 
     $iBuyer        = (int) InputUtils::legacyFilterInput($body['Buyer'] ?? '0', 'int');
     $sTitle        = InputUtils::legacyFilterInput($body['Title'] ?? '');
     $sDescription  = InputUtils::legacyFilterInput($body['Description'] ?? '');
-    $nSellPrice    = InputUtils::legacyFilterInput($body['SellPrice'] ?? '');
-    $nEstPrice     = InputUtils::legacyFilterInput($body['EstPrice'] ?? '');
-    $nMaterialValue = InputUtils::legacyFilterInput($body['MaterialValue'] ?? '');
-    $nMinimumPrice = InputUtils::legacyFilterInput($body['MinimumPrice'] ?? '');
+    // DECIMAL columns reject empty/non-numeric strings, so coerce blank price fields to 0.0.
+    $nSellPrice     = (float) InputUtils::legacyFilterInput($body['SellPrice'] ?? '');
+    $nEstPrice      = (float) InputUtils::legacyFilterInput($body['EstPrice'] ?? '');
+    $nMaterialValue = (float) InputUtils::legacyFilterInput($body['MaterialValue'] ?? '');
+    $nMinimumPrice  = (float) InputUtils::legacyFilterInput($body['MinimumPrice'] ?? '');
     $sPictureURL   = InputUtils::legacyFilterInput($body['PictureURL'] ?? '');
 
     if (!$bMultibuy) { $bMultibuy = 0; }


### PR DESCRIPTION
## Summary
Saving a donated item in the fundraiser MVC module with a blank price field returned a 500 instead of saving. This coerces the money fields to a numeric value so blanks are stored as `0.0`.

## Changes
- `src/fundraiser/routes/donated-item.php` — cast `SellPrice`, `EstPrice`, `MaterialValue`, `MinimumPrice` to `(float)` after `legacyFilterInput`, so an empty input becomes `0.0` instead of `''`. Covers both the create (`itemId < 1`) and update branches, which share these variables.
- `cypress/e2e/ui/fundraiser/standard.fundraiser.spec.js` — added a regression asserting a donated-item save with empty price fields returns 302 (not 500).

## Why
Blank price inputs arrived as `''` and were passed straight to the Propel DECIMAL setters (`->setSellprice('')` etc.). MySQL rejects an empty string for a DECIMAL column:

```
SQLSTATE[22007]: Invalid datetime format: 1366
Incorrect decimal value: '' for column `churchcrm`.`donateditem_di`.`di_sellprice`
```

## Other routes checked
- `batch-winner.php` — already safe: defaults to `'0'` and only sets the price when `(float) $price > 0`.
- `paddle-num.php` — no DECIMAL fields (only integer inputs). No change needed.

## Testing
- `php -l` on the edited route in the container: no syntax errors.
- Full fundraiser Cypress spec: **18/18 passing**, including the new empty-price test. No PHP errors logged.
- `npm run lint`: passes (the 2 warnings are pre-existing and unrelated).

Run: `npx cypress run --config-file cypress/configs/docker.config.ts --spec 'cypress/e2e/ui/fundraiser/standard.fundraiser.spec.js'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)