### PR TITLE
locale: translate all locales (7.4.3)

### DIFF
--- a/locale/terms/missing/fil/fil-1.json
+++ b/locale/terms/missing/fil/fil-1.json
@@ -1,7 +1,7 @@
 {
-  "Access": "",
-  "Self-service": "",
-  "Changelog": "",
-  "Feature": "",
-  "Major": ""
+  "Access": "Access",
+  "Self-service": "Self-service",
+  "Changelog": "Changelog",
+  "Feature": "Tampok",
+  "Major": "Pangunahin"
 }

--- a/locale/terms/missing/ro/ro-1.json
+++ b/locale/terms/missing/ro/ro-1.json
@@ -1,4 +1,4 @@
 {
-  "Important": "",
-  "Major": ""
+  "Important": "Important",
+  "Major": "Major"
 }


### PR DESCRIPTION
Automated locale translation for ChurchCRM 7.4.3.

## Translation Summary
- **fil** (Filipino - Philippines): 5 terms ✅
- **ro** (Romanian - Romania): 2 terms ✅

**Total:** 2 locales, 7 terms

## Changes
- `locale/terms/missing/fil/fil-1.json` — Access, Self-service, Changelog, Feature (Tampok), Major (Pangunahin)
- `locale/terms/missing/ro/ro-1.json` — Important, Major

## Next Steps
1. Review and merge
2. Run: `npm run locale:upload:missing -- --yes`