### PR TITLE
locale: translate all locales (7.4.3)

### DIFF
--- a/locale/terms/missing/fil/fil-1.json
+++ b/locale/terms/missing/fil/fil-1.json
@@ -1,7 +1,7 @@
 {
-  "Access": "",
-  "Self-service": "",
-  "Changelog": "",
-  "Feature": "",
-  "Major": ""
+  "Access": "Akses",
+  "Self-service": "Self-service",
+  "Changelog": "Talaan ng mga Pagbabago",
+  "Feature": "Tampok",
+  "Major": "Pangunahin"
 }

--- a/locale/terms/missing/ro/ro-1.json
+++ b/locale/terms/missing/ro/ro-1.json
@@ -1,4 +1,4 @@
 {
-  "Important": "",
-  "Major": ""
+  "Important": "Important",
+  "Major": "Major"
 }


### PR DESCRIPTION
Automated locale translation for ChurchCRM 7.4.3.

## Translation Summary

Only 2 locales had outstanding terms this run:

| Locale | Language | Terms | Denomination |
|--------|----------|-------|-------------|
| `fil` | Filipino (Philippines) | 5 | Evangelical |
| `ro` | Romanian (Romania) | 2 | Catholic |

**Total: 7 terms across 2 locales**

### Terms Translated
**fil (Filipino):**
- Access → Akses
- Self-service → Self-service
- Changelog → Talaan ng mga Pagbabago
- Feature → Tampok
- Major → Pangunahin

**ro (Romanian):**
- Important → Important
- Major → Major

## Verification
`node locale/scripts/locale-translate.js --list` → ✅ All locales are fully translated.

## Next Steps
After merging, run: `npm run locale:upload:missing -- --yes` to sync with POEditor.