### PR TITLE
security: escape HTML in GroupView/GroupRoles role-name sinks (GHSA-mfmp-q643-vj39)

### DIFF
--- a/src/skin/js/GroupRoles.js
+++ b/src/skin/js/GroupRoles.js
@@ -10,7 +10,7 @@ function UpdateRoles() {
     $.each(data, function (index, value) {
       html += '<option value="' + value.OptionId + '"';
       // i18next-disable-next-line
-      html += ">" + i18next.t(value.OptionName) + "</option>";
+      html += ">" + window.CRM.escapeHtml(i18next.t(value.OptionName)) + "</option>";
     });
     $("#GroupRole").html(html);
   });

--- a/src/skin/js/GroupView.js
+++ b/src/skin/js/GroupView.js
@@ -721,7 +721,7 @@ function buildRolePills() {
       '<a class="nav-link role-filter-pill" data-role-id="' +
       role.OptionId +
       '" href="#">' +
-      i18next.t(role.OptionName) +
+      window.CRM.escapeHtml(i18next.t(role.OptionName)) +
       ' <span class="badge bg-secondary-lt text-secondary ms-1">' +
       count +
       "</span></a></li>";
@@ -739,7 +739,7 @@ function buildRolePills() {
         role.OptionId +
         '" href="#">' +
         '<i class="fa-solid fa-user me-2"></i>' +
-        i18next.t(role.OptionName) +
+        window.CRM.escapeHtml(i18next.t(role.OptionName)) +
         ' <span class="badge bg-secondary-lt text-secondary ms-1">' +
         count +
         "</span></a>",
@@ -753,7 +753,7 @@ function buildRolePills() {
   window.CRM.groupRoles.forEach((role) => {
     var count = roleCounts[role.OptionId] || 0;
     if (count === 0) return;
-    var roleName = i18next.t(role.OptionName);
+    var roleName = window.CRM.escapeHtml(i18next.t(role.OptionName));
     var badge = ' <span class="badge bg-secondary-lt text-secondary ms-1">' + count + "</span>";
     $copyItems.append(
       '<a class="dropdown-item copy-role-to-group" data-role-id="' +


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Closes incomplete client-side fix for GHSA-mfmp-q643-vj39 (Stored XSS via unescaped role names). The server-side fix landed with GHSA-j9gv-26c7-3qrh but three sinks in GroupView.js and one in GroupRoles.js were missed.

**Changed sinks (4 lines across 2 files):**
- `GroupView.js:724` — role filter pill labels injected via `$pills.html(html)`
- `GroupView.js:742` — "Add role to cart" dropdown via `$cartMenu.append()`
- `GroupView.js:756` — `var roleName` shared by both copy/move Actions dropdowns
- `GroupRoles.js:13` — `<option>` label injected via `$("#GroupRole").html(html)`

**Fix:** `window.CRM.escapeHtml(i18next.t(role.OptionName))` — the same pattern already used ~20× elsewhere in these files (and modelled at GroupView.js:833).

Line 790 (DataTable regex filter — not a DOM sink) is intentionally untouched.