### PR TITLE
Security: escape Person name/role/title in person & family views (GHSA-5g9h-6xrp-gpqq)

### DIFF
--- a/src/people/views/family-view.php
+++ b/src/people/views/family-view.php
@@ -175,7 +175,7 @@ $canEditRecords = AuthenticationManager::getCurrentUser()->isEditRecordsEnabled(
                     <button class="dropdown-item AddToCart" data-cart-id="<?= $person->getId() ?>" data-cart-type="person"><i class="fa-solid fa-cart-plus me-2"></i><?= gettext('Add to Cart') ?></button>
                     <?php if (AuthenticationManager::getCurrentUser()->isDeleteRecordsEnabled()): ?>
                     <div class="dropdown-divider"></div>
-                    <button class="dropdown-item text-danger delete-person" data-person_name="<?= $person->getFullName() ?>" data-person_id="<?= $person->getId() ?>" data-view="family"><i class="fa-solid fa-trash-can me-2"></i><?= gettext('Delete') ?></button>
+                    <button class="dropdown-item text-danger delete-person" data-person_name="<?= InputUtils::escapeAttribute($person->getFullName()) ?>" data-person_id="<?= $person->getId() ?>" data-view="family"><i class="fa-solid fa-trash-can me-2"></i><?= gettext('Delete') ?></button>
                     <?php endif; ?>
                 </div>
             </div>
@@ -203,11 +203,11 @@ $canEditRecords = AuthenticationManager::getCurrentUser()->isEditRecordsEnabled(
                                     <td>
                                         <div class="d-flex align-items-center">
                                             <img data-image-entity-type="person" data-image-entity-id="<?= $person->getId() ?>" class="avatar avatar-sm me-2">
-                                            <a href="<?= $person->getViewURI() ?>"><?= $person->getTitle() ?> <?= $person->getFullName() ?></a>
+                                            <a href="<?= $person->getViewURI() ?>"><?= InputUtils::escapeHTML($person->getTitle()) ?> <?= InputUtils::escapeHTML($person->getFullName()) ?></a>
                                         </div>
                                     </td>
                                     <td class="text-center">
-                                        <span class="badge bg-secondary-lt text-secondary"><?= $person->getFamilyRoleName() ?></span>
+                                        <span class="badge bg-secondary-lt text-secondary"><?= InputUtils::escapeHTML($person->getFamilyRoleName()) ?></span>
                                     </td>
                                     <td><?= $person->getFormattedBirthDate() ?></td>
                                     <td>
@@ -279,7 +279,7 @@ $canEditRecords = AuthenticationManager::getCurrentUser()->isEditRecordsEnabled(
                                     <td>
                                         <div class="d-flex align-items-center">
                                             <img data-image-entity-type="person" data-image-entity-id="<?= $person->getId() ?>" class="avatar avatar-sm me-2">
-                                            <a href="<?= $person->getViewURI() ?>"><?= $person->getTitle() ?> <?= $person->getFullName() ?></a>
+                                            <a href="<?= $person->getViewURI() ?>"><?= InputUtils::escapeHTML($person->getTitle()) ?> <?= InputUtils::escapeHTML($person->getFullName()) ?></a>
                                         </div>
                                     </td>
                                     <td><?= $person->getFormattedBirthDate() ?></td>

--- a/src/people/views/person-view.php
+++ b/src/people/views/person-view.php
@@ -371,7 +371,7 @@ $fam_Longitude      = (float) ($personData['fam_Longitude'] ?? 0);
                     <?php } ?>
                     <?php if ($bOkToEdit && $fam_ID !== '') { ?>
                         <a class="dropdown-item" href="<?= SystemURLs::getRootPath() ?>/FamilyEditor.php?FamilyID=<?= $fam_ID ?>"><i class="fa-solid fa-people-roof me-2"></i><?= gettext("Edit Family") ?></a>
-                        <a class="dropdown-item" id="edit-role-btn" data-person_id="<?= $person->getId() ?>" data-family_role="<?= $person->getFamilyRoleName() ?>" data-family_role_id="<?= $person->getFmrId() ?>"><i class="fa-solid fa-user-tag me-2"></i><?= gettext("Change Family Role") ?></a>
+                        <a class="dropdown-item" id="edit-role-btn" data-person_id="<?= $person->getId() ?>" data-family_role="<?= InputUtils::escapeAttribute($person->getFamilyRoleName()) ?>" data-family_role_id="<?= $person->getFmrId() ?>"><i class="fa-solid fa-user-tag me-2"></i><?= gettext("Change Family Role") ?></a>
                     <?php } ?>
                     <?php if (AuthenticationManager::getCurrentUser()->isManageGroupsEnabled()) { ?>
                         <a class="dropdown-item" id="addGroup"><i class="fa-solid fa-users me-2"></i><?= gettext("Assign New Group") ?></a>
@@ -387,7 +387,7 @@ $fam_Longitude      = (float) ($personData['fam_Longitude'] ?? 0);
                     <?php } ?>
                     <?php if (AuthenticationManager::getCurrentUser()->isDeleteRecordsEnabled()) { ?>
                         <div class="dropdown-divider"></div>
-                        <a class="dropdown-item text-danger delete-person" id="deletePersonBtn" data-person_name="<?= $person->getFullName() ?>" data-person_id="<?= $iPersonID ?>"><i class="fa-solid fa-trash-can me-2"></i><?= gettext("Delete Person") ?></a>
+                        <a class="dropdown-item text-danger delete-person" id="deletePersonBtn" data-person_name="<?= InputUtils::escapeAttribute($person->getFullName()) ?>" data-person_id="<?= $iPersonID ?>"><i class="fa-solid fa-trash-can me-2"></i><?= gettext("Delete Person") ?></a>
                     <?php } ?>
                 </div>
             </div>
@@ -426,15 +426,15 @@ $fam_Longitude      = (float) ($personData['fam_Longitude'] ?? 0);
                                     <div class="d-flex align-items-center">
                                         <img data-image-entity-type="person" data-image-entity-id="<?= $familyMember->getId() ?>" class="avatar avatar-sm me-2">
                                         <?php if ($isSelf) { ?>
-                                            <span class="fw-bold"><?= $familyMember->getFullName() ?></span>
+                                            <span class="fw-bold"><?= InputUtils::escapeHTML($familyMember->getFullName()) ?></span>
                                             <i class="fa-solid fa-circle-user text-primary ms-2" title="<?= gettext('Current person') ?>"></i>
                                         <?php } else { ?>
-                                            <a href="<?= $familyMember->getViewURI() ?>"><?= $familyMember->getFullName() ?></a>
+                                            <a href="<?= $familyMember->getViewURI() ?>"><?= InputUtils::escapeHTML($familyMember->getFullName()) ?></a>
                                         <?php } ?>
                                     </div>
                                 </td>
                                 <td class="text-center">
-                                    <span class="badge bg-secondary-lt text-secondary"><?= $familyMember->getFamilyRoleName() ?></span>
+                                    <span class="badge bg-secondary-lt text-secondary"><?= InputUtils::escapeHTML($familyMember->getFamilyRoleName()) ?></span>
                                 </td>
                                 <td><?= $familyMember->getFormattedBirthDate(); ?></td>
                                 <td>
@@ -454,7 +454,7 @@ $fam_Longitude      = (float) ($personData['fam_Longitude'] ?? 0);
                                             <button class="dropdown-item AddToCart" data-cart-id="<?= $tmpPersonId ?>" data-cart-type="person"><i class="fa-solid fa-cart-plus me-2"></i><?= gettext('Add to Cart') ?></button>
                                             <?php if ($bOkToEdit) { ?>
                                             <div class="dropdown-divider"></div>
-                                            <button class="dropdown-item text-danger delete-person" data-person_name="<?= $familyMember->getFullName() ?>" data-person_id="<?= $familyMember->getId() ?>" data-view="family"><i class="fa-solid fa-trash-can me-2"></i><?= gettext('Delete') ?></button>
+                                            <button class="dropdown-item text-danger delete-person" data-person_name="<?= InputUtils::escapeAttribute($familyMember->getFullName()) ?>" data-person_id="<?= $familyMember->getId() ?>" data-view="family"><i class="fa-solid fa-trash-can me-2"></i><?= gettext('Delete') ?></button>
                                             <?php } ?>
                                         </div>
                                     </div>


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Fixes stored XSS reported in GHSA-5g9h-6xrp-gpqq. Unescaped `Person::getFullName()` echoed into `data-person_name` HTML attributes allows attribute breakout via a crafted last name (e.g. `onmouseover=alert(1)`).

**Three advisory sinks fixed + adjacent sibling echoes of the same user-controlled data:**

| File | Line | Context | Fix |
|------|------|---------|-----|
| person-view.php | 374 | `data-family_role` attribute | `escapeAttribute(getFamilyRoleName())` |
| person-view.php | 390 | `data-person_name` attribute ⚠️ | `escapeAttribute(getFullName())` |
| person-view.php | 429 | name in `<span>` text | `escapeHTML(getFullName())` |
| person-view.php | 432 | name in `<a>` text | `escapeHTML(getFullName())` |
| person-view.php | 437 | role badge text | `escapeHTML(getFamilyRoleName())` |
| person-view.php | 457 | `data-person_name` attribute ⚠️ | `escapeAttribute(getFullName())` |
| family-view.php | 178 | `data-person_name` attribute ⚠️ | `escapeAttribute(getFullName())` |
| family-view.php | 206 | name in `<a>` text | `escapeHTML(getTitle())` + `escapeHTML(getFullName())` |
| family-view.php | 210 | role badge text | `escapeHTML(getFamilyRoleName())` |
| family-view.php | 282 | name in `<a>` text | `escapeHTML(getTitle())` + `escapeHTML(getFullName())` |

⚠️ = advisory sinks. Rows without ⚠️ are audit-driven additions (same data source, same XSS class).

`InputUtils` already imported in both files — no import changes.

JS-side equivalent in `CRMJSOM.js:414,473` already uses `window.CRM.escapeHtml()` — no change needed there.

**Known follow-up (out of scope):** `family-view.php` custom-field card (lines 518–524) echoes `getFormattedValue()` / `getDisplayValue()` / `getIcon()` unescaped. These are deferred because `getFormattedValue()` may intentionally return HTML for some field types — needs separate investigation to avoid breaking formatted output.

**Testing:** `php -l` passes on both files. No functional logic changed — only output encoding wrappers added.