### PR TITLE
security: fix GHSA-mrr9-jxqx-xv62 — escape person name inputs in FamilyEditor

### DIFF
--- a/src/FamilyEditor.php
+++ b/src/FamilyEditor.php
@@ -792,19 +792,19 @@ require_once __DIR__ . '/Include/Header.php';
                                             <tr>
                                                 <td>
                                                     <input type="hidden" name="PersonID<?= $iCount ?>" value="<?= $aPersonIDs[$iCount] ?>">
-                                                    <input name="FirstName<?= $iCount ?>" type="text" value="<?= $aFirstNames[$iCount] ?>" class="form-control form-control-sm">
+                                                    <input name="FirstName<?= $iCount ?>" type="text" value="<?= InputUtils::escapeAttribute($aFirstNames[$iCount]) ?>" class="form-control form-control-sm">
                                                     <?php if (array_key_exists($iCount, $aFirstNameError)) { ?>
                                                     <span class="text-danger small"><?= $aFirstNameError[$iCount] ?></span>
                                                     <?php } ?>
                                                 </td>
                                                 <td>
-                                                    <input name="MiddleName<?= $iCount ?>" type="text" value="<?= $aMiddleNames[$iCount] ?>" class="form-control form-control-sm">
+                                                    <input name="MiddleName<?= $iCount ?>" type="text" value="<?= InputUtils::escapeAttribute($aMiddleNames[$iCount]) ?>" class="form-control form-control-sm">
                                                 </td>
                                                 <td>
-                                                    <input name="LastName<?= $iCount ?>" type="text" value="<?= $aLastNames[$iCount] ?>" class="form-control form-control-sm">
+                                                    <input name="LastName<?= $iCount ?>" type="text" value="<?= InputUtils::escapeAttribute($aLastNames[$iCount]) ?>" class="form-control form-control-sm">
                                                 </td>
                                                 <td>
-                                                    <input name="Suffix<?= $iCount ?>" type="text" value="<?= $aSuffix[$iCount] ?>" class="form-control form-control-sm" maxlength="50">
+                                                    <input name="Suffix<?= $iCount ?>" type="text" value="<?= InputUtils::escapeAttribute($aSuffix[$iCount]) ?>" class="form-control form-control-sm" maxlength="50">
                                                 </td>
                                                 <td>
                                                     <select name="Gender<?= $iCount ?>" class="form-select form-select-sm">


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

## Summary
Fixes stored XSS (GHSA-mrr9-jxqx-xv62): the four member-row name inputs in the Family Editor echoed raw database values into HTML `value` attributes, enabling injection via the `autofocus onfocus` vector that auto-executes on page load.

## Changes
- Wrap `$aFirstNames[$iCount]` in `InputUtils::escapeAttribute()` (line 795)
- Wrap `$aMiddleNames[$iCount]` in `InputUtils::escapeAttribute()` (line 801)
- Wrap `$aLastNames[$iCount]` in `InputUtils::escapeAttribute()` (line 804)
- Wrap `$aSuffix[$iCount]` in `InputUtils::escapeAttribute()` (line 807)

## Why
The family Name field at line 548 already used `escapeAttribute()` correctly. The four member-row name inputs were the only remaining sinks that didn't. `InputUtils::escapeAttribute()` applies `htmlspecialchars(stripslashes(), ENT_QUOTES, 'UTF-8')`, which correctly encodes `"` and `'` in both the DB-load and POST-error-rerender code paths.

## Files Changed
- `src/FamilyEditor.php` — 4 insertions, 4 deletions (wrapping only; no logic change)

## Testing
- ✅ `php -l src/FamilyEditor.php` → no syntax errors
- ✅ Independent code review: all four XSS sinks covered; PersonID/BirthYear are integer-typed and correctly left unwrapped
- No regression: zero logic changes, only output escaping added

## Notes
The reviewer identified a pre-existing low-severity issue (L954–956: `json_encode()` without `JSON_HEX_TAG` inside a `<script>` block for admin-controlled role/classification lists). That is out of scope for this advisory fix and can be tracked separately.

## Related Issues
Fixes GHSA-mrr9-jxqx-xv62