### PR TITLE
security: fix GHSA-jx45-q5vj-h2wm — reflected XSS via Return param in MemberRoleChange.php

### DIFF
--- a/src/MemberRoleChange.php
+++ b/src/MemberRoleChange.php
@@ -26,8 +26,8 @@ $iGroupID = (int)InputUtils::legacyFilterInput($_GET['GroupID'], 'int');
 // Get the PersonID from the querystring
 $iPersonID = (int)InputUtils::legacyFilterInput($_GET['PersonID'], 'int');
 
-// Get the return location flag from the querystring
-$iReturn = $_GET['Return'];
+// Get the return location flag from the querystring (int-cast prevents XSS; GHSA-jx45-q5vj-h2wm)
+$iReturn = (int) ($_GET['Return'] ?? 0);
 
 // Was the form submitted?
 if (isset($_POST['Submit'])) {


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Fixes reflected XSS via the `Return` query parameter in `MemberRoleChange.php`.

**Root cause:** `$_GET['Return']` was read raw at line 30 (no InputUtils filtering, no cast) and echoed unescaped into the form `action` attribute at line 91. A payload like `"><script>alert(1)</script>` closes the attribute and injects executable script.

**Fix:** One-line int-cast with null-coalesce:
```php
// Before
$iReturn = $_GET['Return'];

// After
$iReturn = (int) ($_GET['Return'] ?? 0);
```

`Return` is only ever used as a boolean flag (lines 48, 91, 126), so `(int)` is semantically equivalent and eliminates the XSS vector entirely. The `?? 0` bonus also prevents the pre-existing PHP "Undefined index" notice when `Return` is absent.

Fixes GHSA-jx45-q5vj-h2wm
