### PR TITLE
security: fix GHSA-frj8-mpcx-44g9 — stored XSS via unescaped tel: href in family/person custom fields

### DIFF
--- a/src/ChurchCRM/dto/PeopleCustomField.php
+++ b/src/ChurchCRM/dto/PeopleCustomField.php
@@ -39,7 +39,11 @@ class PeopleCustomField
         } elseif ($masterField->getTypeId() == 11) {
             //$custom_Special = $sPhoneCountry;
             $this->icon = 'fa fa-phone';
-            $this->link = 'tel:' . $this->value;
+            // Sanitize to only phone-safe characters before building the tel: URI.
+            // This protects against already-stored malicious values that pre-date
+            // input-side sanitization (fix for GHSA-frj8-mpcx-44g9).
+            $safePhone = preg_replace('/[^0-9+\-().\sxX#*]/', '', $this->value);
+            $this->link = 'tel:' . $safePhone;
         } elseif ($masterField->getTypeId() == 12) {
             $customOption = ListOptionQuery::create()->filterById($masterField->getCustomSpecial())->filterByOptionId($this->value)->findOne();
             if ($customOption !== null) {

--- a/src/ChurchCRM/utils/CustomFieldUtils.php
+++ b/src/ChurchCRM/utils/CustomFieldUtils.php
@@ -323,6 +323,12 @@ class CustomFieldUtils
                 }
                 break;
 
+            case 11:
+                // Phone field: strip any character that is not valid in a phone number
+                // or a tel: URI to prevent storage of XSS payloads (GHSA-frj8-mpcx-44g9).
+                $data = preg_replace('/[^0-9+\-().\sxX#*]/', '', $data);
+                break;
+
             default:
                 break;
         }

--- a/src/people/views/family-view.php
+++ b/src/people/views/family-view.php
@@ -515,15 +515,15 @@ $canEditRecords = AuthenticationManager::getCurrentUser()->isEditRecordsEnabled(
                     <ul class="list-unstyled mb-0">
                         <?php foreach ($familyCustom as $customField) { ?>
                             <li class="mb-1">
-                                <i class="<?= $customField->getIcon() ?> me-2 text-body-secondary" style="width: 1rem; text-align: center;"></i><?= $customField->getDisplayValue() ?>:
+                                <i class="<?= InputUtils::escapeAttribute($customField->getIcon()) ?> me-2 text-body-secondary" style="width: 1rem; text-align: center;"></i><?= InputUtils::escapeHTML($customField->getDisplayValue()) ?>:
                                 <?php if ($customField->getLink()) { ?>
-                                    <a href="<?= $customField->getLink() ?>"><?= $customField->getFormattedValue() ?></a>
+                                    <a href="<?= InputUtils::escapeAttribute($customField->getLink()) ?>"><?= InputUtils::escapeHTML($customField->getFormattedValue()) ?></a>
                                 <?php } else {
                                     $val = $customField->getFormattedValue();
                                     if (strlen($val) > 40) { ?>
-                                        <span class="d-block text-body-secondary text-truncate" title="<?= InputUtils::escapeAttribute($val) ?>"><?= $val ?></span>
+                                        <span class="d-block text-body-secondary text-truncate" title="<?= InputUtils::escapeAttribute($val) ?>"><?= InputUtils::escapeHTML($val) ?></span>
                                     <?php } else { ?>
-                                        <span><?= $val ?></span>
+                                        <span><?= InputUtils::escapeHTML($val) ?></span>
                                     <?php }
                                 } ?>
                             </li>

--- a/src/people/views/person-view.php
+++ b/src/people/views/person-view.php
@@ -242,13 +242,13 @@ $fam_Longitude      = (float) ($personData['fam_Longitude'] ?? 0);
                         } elseif ((int)$type_ID === 11) {
                             $custom_Special = null;
                             $displayIcon = "fa-solid fa-phone";
-                            // Sanitize phone number for tel: URI
-                            $sanitizedPhone = preg_replace('/[^0-9+\-()e]/', '', $currentData);
+                            // Sanitize phone number for tel: URI (aligned with GHSA-frj8-mpcx-44g9 allowlist)
+                            $sanitizedPhone = preg_replace('/[^0-9+\-().\sxX#*]/', '', $currentData);
                             $displayLink = "tel:" . $sanitizedPhone;
                         }
                         $customFieldsHtml .= '<li class="mb-2">';
                         $customFieldsHtml .= '<i class="' . $displayIcon . ' me-2 text-body-secondary"></i>';
-                        $temp_string = nl2br(CustomFieldUtils::display($type_ID, $currentData, $custom_Special));
+                        $temp_string = nl2br(InputUtils::escapeHTML(CustomFieldUtils::display($type_ID, $currentData, $custom_Special)));
                         if ($displayLink) {
                             $customFieldsHtml .= '<strong>' . InputUtils::escapeHTML($custom_Name) . ':</strong> <a href="' . InputUtils::escapeAttribute($displayLink) . '">' . $temp_string . '</a>';
                         } else {
@@ -605,7 +605,7 @@ $fam_Longitude      = (float) ($personData['fam_Longitude'] ?? 0);
                                                             if ((int)$type_ID === 11) {
                                                                 $prop_Special = null;
                                                             }
-                                                            echo '<br><small class="text-body-secondary"><strong>' . InputUtils::escapeHTML($prop_Name) . '</strong>: ' . CustomFieldUtils::display($type_ID, $currentData, $prop_Special) . '</small>';
+                                                            echo '<br><small class="text-body-secondary"><strong>' . InputUtils::escapeHTML($prop_Name) . '</strong>: ' . InputUtils::escapeHTML(CustomFieldUtils::display($type_ID, $currentData, $prop_Special)) . '</small>';
                                                         }
                                                     }
                                                 } ?>


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Fixes stored XSS reported in GHSA-frj8-mpcx-44g9.

**Root cause:** Phone-type (type_ID 11) custom-field values had no character restriction at storage time and were echoed raw into `href` and element-content in `family-view.php` and `person-view.php`.

**Changes (4 files):**

- `src/people/views/family-view.php` — wrap the custom-fields card href with `InputUtils::escapeAttribute()`, all display echoes with `InputUtils::escapeHTML()`, and `getIcon()` with `InputUtils::escapeAttribute()` (convention fix)
- `src/people/views/person-view.php` — escape `CustomFieldUtils::display()` output via `InputUtils::escapeHTML()` in both the custom-fields card (`$temp_string`) and the group-properties panel; align phone regex allowlist with the canonical set
- `src/ChurchCRM/dto/PeopleCustomField.php` — sanitize the raw value to phone-safe chars before building the `tel:` URI, protecting against already-stored malicious values
- `src/ChurchCRM/utils/CustomFieldUtils.php` — add `case 11` in `validate()` to strip non-phone characters by reference, so the sanitized value reaches `buildSql()` via `$aCustomData` in `FamilyEditor`, `PersonEditor`, and `GroupPropsEditor`

**Testing:** `npm run lint` (0 errors), `npm run build:php` (all 571 files pass). Independent reviewer: approved.
