### PR TITLE
chore: remove or fix dead buildRenderEmail() code in MainDashboard.js

### DIFF
--- a/src/skin/js/MainDashboard.js
+++ b/src/skin/js/MainDashboard.js
@@ -596,13 +596,6 @@ export function initializeMainDashboard() {
     }
   }
 
-  function buildRenderEmail(email) {
-    if (email) {
-      return "<a href='mailto:" + email + "' target='_blank' rel='noopener noreferrer'>" + email + "</a>";
-    }
-    return "";
-  }
-
   // Today's Events widget
   if ($("#todayEventsDashboardItem").length > 0) {
     const todayEventsConfig = {


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Fixes #9201

## Summary
`buildRenderEmail()` in `src/skin/js/MainDashboard.js` was dead code — defined once but never called anywhere in the file or the repo. It concatenated an unescaped email address directly into an `href` attribute, making it a latent XSS risk if ever wired up.

## Changes
- Deleted the 6-line `buildRenderEmail()` function and its trailing blank line

## Why
Code search confirmed zero call sites. Fix Option 1 from issue #9201 applies: remove dead code entirely rather than patching a function that is never executed.

## Testing
No functional change. `node --check` confirms the file remains syntactically valid after removal.
