### PR TITLE
chore: remove dead buildRenderEmail() unescaped email code (#9201)

### DIFF
--- a/src/skin/js/MainDashboard.js
+++ b/src/skin/js/MainDashboard.js
@@ -596,13 +596,6 @@ export function initializeMainDashboard() {
     }
   }
 
-  function buildRenderEmail(email) {
-    if (email) {
-      return "<a href='mailto:" + email + "' target='_blank' rel='noopener noreferrer'>" + email + "</a>";
-    }
-    return "";
-  }
-
   // Today's Events widget
   if ($("#todayEventsDashboardItem").length > 0) {
     const todayEventsConfig = {


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Removes the dead `buildRenderEmail()` helper from `src/skin/js/MainDashboard.js`.

The function was never called anywhere in the codebase (confirmed by grep across all `src/` files). It concatenated a raw email string into a `mailto:` href without escaping — a latent XSS risk flagged in the security review of PR #9200. Since it is entirely unreachable, deletion is the correct fix.

**Changes:** 7 lines deleted, one file, zero behaviour change.

Fixes #9201.