### PR TITLE
security: audit custom-field output encoding — codify plain-text contract (issue #9199)

### DIFF
--- a/src/ChurchCRM/dto/PeopleCustomField.php
+++ b/src/ChurchCRM/dto/PeopleCustomField.php
@@ -55,9 +55,36 @@ class PeopleCustomField
     }
 
     /**
-     * @return mixed
+     * Returns the display-ready value for this custom field.
+     *
+     * **Security contract (issue #9199 audit):**
+     * For every supported type_ID (1–12) this method returns PLAIN, unescaped
+     * text — never HTML markup:
+     *
+     *  type 1  (True/False)          → raw stored value ('true'/'false'/'')
+     *  type 2  (Date)                → raw stored date string
+     *  type 3  (Text 50 char)        → raw stored value
+     *  type 4  (Text 100 char)       → raw stored value
+     *  type 5  (Text long)           → raw stored value
+     *  type 6  (Year)                → raw stored value
+     *  type 7  (Season)              → raw stored value
+     *  type 8  (Number)              → raw stored value
+     *  type 9  (Person from Group)   → Person::getFullName() — plain text
+     *  type 10 (Money)               → raw stored value
+     *  type 11 (Phone)               → raw stored value; hyperlink via getLink()
+     *  type 12 (Custom Drop-Down)    → ListOption::getOptionName() — plain text
+     *
+     * Links (person profile URL, tel: href) are exposed separately via
+     * {@see getLink()} and MUST be escaped with InputUtils::escapeAttribute().
+     *
+     * **Callers rendering to an HTML/browser context MUST wrap this value
+     * in InputUtils::escapeHTML() before output.** Do NOT escape inside this
+     * method: the same value also feeds CSV and PDF contexts where HTML
+     * encoding is wrong.
+     *
+     * @return string
      */
-    public function getFormattedValue()
+    public function getFormattedValue(): string
     {
         return $this->formattedValue;
     }
@@ -86,9 +113,16 @@ class PeopleCustomField
     }
 
     /**
-     * @return mixed
+     * Returns the human-readable label (field name) for this custom field.
+     *
+     * **Security contract (issue #9199 audit):**
+     * Always returns the admin-configured field name as PLAIN, unescaped text.
+     * Callers rendering to an HTML/browser context MUST wrap the return value
+     * in InputUtils::escapeHTML() before output.
+     *
+     * @return string
      */
-    public function getDisplayValue()
+    public function getDisplayValue(): string
     {
         return $this->displayValue;
     }

--- a/src/ChurchCRM/dto/PeopleCustomField.php
+++ b/src/ChurchCRM/dto/PeopleCustomField.php
@@ -10,10 +10,10 @@ class PeopleCustomField
 {
     private $name;
     private string $value;
-    private $formattedValue;
+    private string $formattedValue;
     private ?string $link = null;
     private string $icon = 'fa fa-tag';
-    private $displayValue;
+    private string $displayValue;
 
     /**
      * PeopleCustomField constructor.
@@ -61,7 +61,7 @@ class PeopleCustomField
      * For every supported type_ID (1–12) this method returns PLAIN, unescaped
      * text — never HTML markup:
      *
-     *  type 1  (True/False)          → raw stored value ('true'/'false'/'')
+     *  type 1  (True/False)          → raw stored value ('true'/'false'); '' when unset
      *  type 2  (Date)                → raw stored date string
      *  type 3  (Text 50 char)        → raw stored value
      *  type 4  (Text 100 char)       → raw stored value

--- a/src/ChurchCRM/utils/CustomFieldUtils.php
+++ b/src/ChurchCRM/utils/CustomFieldUtils.php
@@ -39,6 +39,34 @@ class CustomFieldUtils
     /**
      * Formats custom field data for display-only (read-only) output.
      * Migrated from displayCustomField() in Functions.php.
+     *
+     * **Security contract (issue #9199 audit):**
+     * Returns PLAIN, unescaped text for every supported type_ID. No case
+     * produces HTML markup:
+     *
+     *  type 1  (True/False)        → gettext('Yes') / gettext('No') / ''
+     *  type 2  (Date)              → DateTimeUtils::formatDate() — plain text
+     *  type 3  (Text 50 char)      → raw $data
+     *  type 4  (Text 100 char)     → raw $data
+     *  type 5  (Text long)         → raw $data
+     *  type 6  (Year)              → raw $data
+     *  type 7  (Season)            → ucfirst($data) — plain text
+     *  type 8  (Number)            → raw $data
+     *  type 9  (Person from Group) → Person::getFullName() — plain text
+     *  type 10 (Money)             → raw $data
+     *  type 11 (Phone)             → raw $data
+     *  type 12 (Custom Drop-Down)  → ListOption::getOptionName() — plain text
+     *  default                     → gettext('Invalid Editor ID!')
+     *
+     * **Output encoding is deliberately kept at each call site**, not here,
+     * because the same method feeds multiple output contexts:
+     *   - HTML views        → InputUtils::escapeHTML()  (required)
+     *   - HTML attributes   → InputUtils::escapeAttribute()  (required)
+     *   - CSV rows          → no HTML escaping (CSVCreateFile.php)
+     *   - PDF (TCPDF)       → no HTML escaping (PdfDirectory.php)
+     *   - Plain-text reports → no escaping (GroupReport.php)
+     *
+     * HTML/browser-context callers MUST escape the return value.
      */
     public static function display($type, ?string $data, $special)
     {

--- a/src/ChurchCRM/utils/CustomFieldUtils.php
+++ b/src/ChurchCRM/utils/CustomFieldUtils.php
@@ -44,7 +44,7 @@ class CustomFieldUtils
      * Returns PLAIN, unescaped text for every supported type_ID. No case
      * produces HTML markup:
      *
-     *  type 1  (True/False)        → gettext('Yes') / gettext('No') / ''
+     *  type 1  (True/False)        → gettext('Yes') / gettext('No') / '' (empty when data is unset)
      *  type 2  (Date)              → DateTimeUtils::formatDate() — plain text
      *  type 3  (Text 50 char)      → raw $data
      *  type 4  (Text 100 char)     → raw $data
@@ -77,7 +77,7 @@ class CustomFieldUtils
                 } elseif ($data === 'false') {
                     return gettext('No');
                 }
-                break;
+                return '';
 
             case 2:
                 return DateTimeUtils::formatDate($data);


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

## What Changed

Completes the audit requested in #9199: enumerates all 12 custom-field type_IDs, confirms none return HTML, and codifies this as an enforceable security contract on the three accessor methods. Also fixes a latent `null` return in `CustomFieldUtils::display()` case 1, and adds `string` type declarations to two untyped backing properties in `PeopleCustomField`.

Fixes #9199

## Audit Result

| type_ID | Label | Return value | HTML? |
|--------|-------|-------------|-------|
| 1 | True / False | `gettext('Yes')` / `gettext('No')` / `''` (unset) | No |
| 2 | Date | `DateTimeUtils::formatDate()` — formatted date string | No |
| 3 | Text (50 char) | raw `$data` | No |
| 4 | Text (100 char) | raw `$data` | No |
| 5 | Text (long) | raw `$data` | No |
| 6 | Year | raw `$data` | No |
| 7 | Season | `ucfirst($data)` | No |
| 8 | Number | raw `$data` | No |
| 9 | Person from Group | `Person::getFullName()` (plain text); profile URI via `getLink()` | No |
| 10 | Money | raw `$data` | No |
| 11 | Phone | raw `$data`; `tel:` URI via `getLink()` (sanitised by #9202) | No |
| 12 | Custom Drop-Down | `ListOption::getOptionName()` (plain text) | No |

**Conclusion:** No type returns HTML markup. Runtime escaping (applied in `family-view.php` and `person-view.php` by PR #9202) is the correct layer. Output encoding is deliberately NOT centralised into the accessor methods because the same methods also feed CSV (`CSVCreateFile.php`), PDF/TCPDF (`PdfDirectory.php`), and plain-text report (`GroupReport.php`) contexts where HTML encoding would corrupt output.

## Changes

- **`src/ChurchCRM/dto/PeopleCustomField.php`**
  - `getFormattedValue()`: replace vague `@return mixed` with a per-type security contract; add `@return string` docblock and `: string` PHP return type hint.
  - `getDisplayValue()`: same treatment.
  - Backing properties `$formattedValue` and `$displayValue`: `private $x` → `private string $x` to match the typed getters and sibling properties.

- **`src/ChurchCRM/utils/CustomFieldUtils.php`**
  - `display()`: augment docblock with per-type audit table, list of caller output contexts, and escaping requirement for HTML callers.
  - `case 1`: replace `break` with `return ''` to eliminate the latent implicit-`null` return when `$data` is neither `'true'` nor `'false'` (all current callers guard with non-empty checks, so this is unreachable in practice, but the previous behaviour violated the documented `''` contract and could have caused a `TypeError` in `escapeHTML()` if any guard were relaxed).

## Type
- [x] 🔒 Security

## Testing

No PHP unit tests exist in this project (Cypress e2e only). Manual validation:

1. `grep -rn "getFormattedValue\|getDisplayValue\|CustomFieldUtils::display" src/ --include=*.php` — confirm all HTML render sites use `InputUtils::escapeHTML()` / `escapeAttribute()`.
2. Load a family or person view with custom fields populated — verify no display regression.
3. Export a CSV and confirm custom-field columns are not HTML-encoded.

## Screenshots
_N/A — no UI change._

## Pre-Merge
- [x] Tested locally
- [x] No new warnings
- [x] Build passes
- [x] Backward compatible (or migration documented)
