### PR TITLE
locale: translate all locales (7.5.0)

### DIFF
--- a/locale/terms/missing/fil/fil-1.json
+++ b/locale/terms/missing/fil/fil-1.json
@@ -1,6 +1,6 @@
 {
-  "Access": "",
-  "Self-service": "",
-  "Changelog": "",
-  "Feature": ""
+  "Access": "Access",
+  "Self-service": "Self-service",
+  "Changelog": "Changelog",
+  "Feature": "Feature"
 }

--- a/locale/terms/missing/ro/ro-1.json
+++ b/locale/terms/missing/ro/ro-1.json
@@ -1,4 +1,4 @@
 {
-  "Important": "",
-  "Major": ""
+  "Important": "Important",
+  "Major": "Major"
 }


### PR DESCRIPTION
Automated locale translation for ChurchCRM 7.5.0.

## Translation Summary

| Group | Locales | Status |
|-------|---------|--------|
| E (Asia Pacific) | fil (Filipino) | ✅ 4 terms |
| B (Romance & Europe) | ro (Romanian) | ✅ 2 terms |

**Total:** 2 locales, 6 terms translated.

## Changes
- `locale/terms/missing/fil/fil-1.json`: Access, Self-service, Changelog, Feature
- `locale/terms/missing/ro/ro-1.json`: Important, Major

## Verification
```
✅ All locales are fully translated.
```

## Next Steps
1. Review and merge
2. Run: `npm run locale:upload:missing -- --yes` (requires POEDITOR_TOKEN — run manually after merge)