### PR TITLE
Add Obsidian knowledge vault and standardize skill frontmatter

### DIFF
--- a/.agents/skills/churchcrm/SKILL.md
+++ b/.agents/skills/churchcrm/SKILL.md
@@ -34,8 +34,9 @@ Project-specific skills for AI agents and developers working on ChurchCRM. Each 
 
 ## Frontend & UI
 
-> **Any time you add or edit a table with row actions — read [`table-action-menu.md`](./table-action-menu.md) first.**
-> **Any time you add settings/config to a page — read [`frontend-development.md`](./frontend-development.md) (System Settings Panel section) for the gold-standard pattern from Finance Dashboard.**
+> [!IMPORTANT] Read first
+> Any time you add or edit a table with row actions — read [`table-action-menu.md`](./table-action-menu.md) first.
+> Any time you add settings/config to a page — read [`frontend-development.md`](./frontend-development.md) (System Settings Panel section) for the gold-standard pattern from Finance Dashboard.
 
 | Skill | When to Use |
 |-------|------------|

--- a/.agents/skills/churchcrm/admin-mvc-migration.md
+++ b/.agents/skills/churchcrm/admin-mvc-migration.md
@@ -2,7 +2,7 @@
 title: "Admin MVC Module Migration"
 intent: "Patterns and steps to migrate legacy pages into the Admin MVC structure"
 tags: ["admin","mvc","migration","slim"]
-prereqs: ["service-layer.md","php-best-practices.md"]
+prereqs: ["[[service-layer]]","[[php-best-practices]]"]
 complexity: "intermediate"
 ---
 - **Routes**: `src/admin/routes/[feature].php` - Define route endpoints
@@ -269,7 +269,8 @@ $typeId  = (int) ($params['typeId'] ?? 0);
 
 ## Middleware Order (CRITICAL) <!-- learned: 2026-04-07 -->
 
-> **Full reference:** [`slim-4-best-practices.md` → Middleware Order](./slim-4-best-practices.md)
+> [!NOTE] Full reference
+> [`slim-4-best-practices.md` → Middleware Order](./slim-4-best-practices.md)
 
 For MVC modules, use `MvcAppFactory::create()` which handles all ordering automatically:
 
@@ -283,7 +284,8 @@ $app = MvcAppFactory::create('/admin', [
 
 ## Entry Point Error Handling
 
-> **Full reference:** [`slim-4-best-practices.md` → Error Handler Architecture](./slim-4-best-practices.md)
+> [!NOTE] Full reference
+> [`slim-4-best-practices.md` → Error Handler Architecture](./slim-4-best-practices.md)
 
 For MVC modules use `MvcAppFactory`. For non-MVC entry points (API, external, session),
 add error middleware manually — always AFTER `addRoutingMiddleware()`.

--- a/.agents/skills/churchcrm/api-compatibility-and-deprecation.md
+++ b/.agents/skills/churchcrm/api-compatibility-and-deprecation.md
@@ -2,7 +2,7 @@
 title: "API Compatibility & Deprecation"
 intent: "Patterns for maintaining backward compatibility, adding shims, and deprecation timelines"
 tags: ["api","compatibility","deprecation","shims"]
-prereqs: ["api-development.md","routing-architecture.md"]
+prereqs: ["[[api-development]]","[[routing-architecture]]"]
 complexity: "intermediate"
 ---
 

--- a/.agents/skills/churchcrm/api-development.md
+++ b/.agents/skills/churchcrm/api-development.md
@@ -2,7 +2,7 @@
 title: "API Development"
 intent: "Patterns for creating and maintaining API endpoints using Slim and service layer"
 tags: ["api","slim","routes","security"]
-prereqs: ["slim-4-best-practices.md","php-best-practices.md"]
+prereqs: ["[[slim-4-best-practices]]","[[php-best-practices]]"]
 complexity: "intermediate"
 ---
 
@@ -155,7 +155,8 @@ var errorText = error.message || error.error || error.msg || i18next.t("Unknown 
 
 ## Middleware Order (CRITICAL - Slim 4 uses LIFO) <!-- learned: 2026-04-07 -->
 
-> **Full reference:** [`slim-4-best-practices.md` → Middleware Order](./slim-4-best-practices.md)
+> [!NOTE] Full reference
+> [`slim-4-best-practices.md` → Middleware Order](./slim-4-best-practices.md)
 
 **TL;DR:** `addErrorMiddleware()` MUST be called AFTER `addRoutingMiddleware()`. Wrong order → raw 500 on 404s.
 

--- a/.agents/skills/churchcrm/authorization-security.md
+++ b/.agents/skills/churchcrm/authorization-security.md
@@ -2,7 +2,7 @@
 title: "Authorization & Security"
 intent: "Authorization patterns, RedirectUtils, input sanitization, and security guidance"
 tags: ["security","auth","redirects","xss"]
-prereqs: ["php-best-practices.md"]
+prereqs: ["[[php-best-practices]]"]
 complexity: "intermediate"
 ---
 

--- a/.agents/skills/churchcrm/bootstrap-5-migration.md
+++ b/.agents/skills/churchcrm/bootstrap-5-migration.md
@@ -2,7 +2,7 @@
 title: "Bootstrap 4 to Bootstrap 5 Migration Reference"
 intent: "Complete migration guide for converting Bootstrap 4.6.2 to Bootstrap 5.3 in a large PHP application"
 tags: ["frontend", "bootstrap", "migration", "css", "javascript"]
-prereqs: ["frontend-development.md"]
+prereqs: ["[[frontend-development]]"]
 complexity: "advanced"
 ---
 
@@ -188,7 +188,8 @@ grep -rl 'data-offset=' src/ | xargs sed -i 's/data-offset=/data-bs-offset=/g'
 # CAUTION: data-offset on scrollspy should become data-bs-root-margin (manual review needed)
 ```
 
-> **WARNING**: Run `data-slide=` replacement AFTER `data-slide-to=` to avoid double-replacing.
+> [!WARNING]
+> Run `data-slide=` replacement AFTER `data-slide-to=` to avoid double-replacing.
 
 ---
 

--- a/.agents/skills/churchcrm/code-standards.md
+++ b/.agents/skills/churchcrm/code-standards.md
@@ -2,7 +2,7 @@
 title: "Code Standards"
 intent: "Coding conventions, PR checklist, and pre-commit guidance"
 tags: ["standards","code-quality","pr"]
-prereqs: ["php-best-practices.md"]
+prereqs: ["[[php-best-practices]]"]
 complexity: "beginner"
 ---
 

--- a/.agents/skills/churchcrm/configuration-management.md
+++ b/.agents/skills/churchcrm/configuration-management.md
@@ -1,3 +1,10 @@
+---
+title: "Configuration Management"
+intent: "Guide to managing SystemConfig, asset paths, settings panels, and configuration best practices"
+tags: ["configuration", "settings", "systemconfig", "admin"]
+prereqs: ["[[php-best-practices]]"]
+complexity: "beginner"
+---
 # Configuration Management
 
 Guide to managing SystemConfig, asset paths, settings panels, and configuration best practices.

--- a/.agents/skills/churchcrm/currency-localization.md
+++ b/.agents/skills/churchcrm/currency-localization.md
@@ -2,7 +2,7 @@
 title: "Currency Localization"
 intent: "Render money values with a configurable symbol, position, and separators across PHP, JS, DataTables, Chart.js, CSS, and PDFs"
 tags: ["i18n", "localization", "currency", "money", "finance", "systemconfig"]
-prereqs: ["configuration-management.md", "i18n-localization.md", "frontend-development.md"]
+prereqs: ["[[configuration-management]]", "[[i18n-localization]]", "[[frontend-development]]"]
 complexity: "beginner"
 ---
 

--- a/.agents/skills/churchcrm/cypress-testing.md
+++ b/.agents/skills/churchcrm/cypress-testing.md
@@ -1,3 +1,10 @@
+---
+title: "Cypress Testing"
+intent: "Test organization, session management, API helpers, and best practices for writing reliable Cypress tests"
+tags: ["testing", "cypress", "e2e", "ci"]
+prereqs: []
+complexity: "intermediate"
+---
 # Skill: Cypress Testing
 
 ## Context
@@ -280,11 +287,12 @@ Check the actual route implementation before choosing `allowedStatuses`.
 
 ### `freshAdminLogin` is still required — `withCredentials: false` is not sufficient in CI <!-- learned: 2026-07-12 -->
 
-> ⚠️ A 2026-07-11 update claimed `freshAdminLogin()` was deleted because `makePrivateAPICall`
-> sets `withCredentials: false`, preventing the API key from clobbering `$_SESSION`.
-> **That claim was wrong in practice.** CI runs (both `test-root` and `test-subdir`) confirmed
-> that PHP session clobbering still occurs in the browser environment despite the header.
-> `freshAdminLogin()` has been restored in all 4 affected UI specs.
+> [!WARNING] A 2026-07-11 update claimed `freshAdminLogin()` was deleted
+> The reasoning was that `makePrivateAPICall` sets `withCredentials: false`, preventing the
+> API key from clobbering `$_SESSION`. **That claim was wrong in practice.** CI runs (both
+> `test-root` and `test-subdir`) confirmed that PHP session clobbering still occurs in the
+> browser environment despite the header. `freshAdminLogin()` has been restored in all 4
+> affected UI specs.
 
 `makePrivateAPICall` does set `withCredentials: false` (see `support/api-commands.js`), but
 this alone is not sufficient to protect the PHP session in the Cypress/CI browser environment.

--- a/.agents/skills/churchcrm/database-operations.md
+++ b/.agents/skills/churchcrm/database-operations.md
@@ -1,3 +1,10 @@
+---
+title: "Database Operations"
+intent: "Core patterns for database access using Perpl ORM (actively maintained fork of Propel2)"
+tags: ["database", "perpl", "orm", "php"]
+prereqs: ["[[php-best-practices]]"]
+complexity: "beginner"
+---
 # Skill: Database Operations with Perpl ORM
 
 ## Context

--- a/.agents/skills/churchcrm/db-schema-migration.md
+++ b/.agents/skills/churchcrm/db-schema-migration.md
@@ -2,7 +2,7 @@
 title: "DB Schema Migration"
 intent: "Safe procedures for database schema changes and versioning"
 tags: ["database","migration","schema","backup"]
-prereqs: ["database-operations.md","development-workflows.md"]
+prereqs: ["[[database-operations]]","[[development-workflows]]"]
 complexity: "advanced"
 ---
 

--- a/.agents/skills/churchcrm/development-workflows.md
+++ b/.agents/skills/churchcrm/development-workflows.md
@@ -2,7 +2,7 @@
 title: "Development Workflows"
 intent: "Setup, build, Docker, and testing workflows for development and CI"
 tags: ["devops","workflows","docker","testing"]
-prereqs: ["testing.md"]
+prereqs: ["[[testing]]"]
 complexity: "beginner"
 ---
 

--- a/.agents/skills/churchcrm/error-reporting.md
+++ b/.agents/skills/churchcrm/error-reporting.md
@@ -1,3 +1,10 @@
+---
+title: "Error Reporting & Issue Filing"
+intent: "Shared Tabler-styled error pages wired to the Issue Reporter workflow for consistent UX and GitHub issue pre-fill"
+tags: ["frontend", "tabler", "error-handling", "testing"]
+prereqs: ["[[tabler-components]]"]
+complexity: "intermediate"
+---
 # Error Reporting & Issue Filing
 
 This skill documents the new shared Tabler-styled error pages and how to wire them to the existing Issue Reporter workflow so error pages across the app are consistent and can open a GitHub issue pre-filled with the current page URL and system info.

--- a/.agents/skills/churchcrm/frontend-development.md
+++ b/.agents/skills/churchcrm/frontend-development.md
@@ -2,7 +2,7 @@
 title: "Frontend Development"
 intent: "Guidance for frontend work, vanilla JS/TypeScript, and asset management"
 tags: ["frontend","webpack","i18n"]
-prereqs: ["webpack-typescript.md","i18n-localization.md"]
+prereqs: ["[[webpack-typescript]]","[[i18n-localization]]"]
 complexity: "intermediate"
 ---
 

--- a/.agents/skills/churchcrm/git-workflow.md
+++ b/.agents/skills/churchcrm/git-workflow.md
@@ -1,3 +1,10 @@
+---
+title: "Git Workflow & Development Standards"
+intent: "Branching, commits, PRs, and pre-commit validation to maintain code quality"
+tags: ["workflow", "pr", "review", "standards"]
+prereqs: ["[[code-standards]]"]
+complexity: "beginner"
+---
 # Git Workflow & Development Standards
 
 Guidelines for branching, commits, PRs, and pre-commit validation to maintain code quality.

--- a/.agents/skills/churchcrm/github-interaction.md
+++ b/.agents/skills/churchcrm/github-interaction.md
@@ -1,3 +1,10 @@
+---
+title: "GitHub Interaction — Concise Checklist"
+intent: "Practical, step-by-step actions for handling reviews, commits, and PRs — companion to git-workflow.md"
+tags: ["workflow", "pr", "review", "github"]
+prereqs: ["[[git-workflow]]"]
+complexity: "beginner"
+---
 # Skill: GitHub Interaction — concise checklist
 
 Purpose: practical, step-by-step actions for handling reviews, commits, and PRs. This file is an actionable companion to the canonical `git-workflow.md` (policy) and the `gh-cli` skill (commands).

--- a/.agents/skills/churchcrm/groups-mvc-guidelines.md
+++ b/.agents/skills/churchcrm/groups-mvc-guidelines.md
@@ -2,7 +2,7 @@
 title: "Groups MVC Guidelines"
 intent: "Design and implementation patterns for Groups MVC apps (SundaySchool, Congregation)"
 tags: ["groups","mvc","routing","service-layer"]
-prereqs: ["routing-architecture.md","service-layer.md","php-best-practices.md"]
+prereqs: ["[[routing-architecture]]","[[service-layer]]","[[php-best-practices]]"]
 complexity: "intermediate"
 ---
 

--- a/.agents/skills/churchcrm/i18n-localization.md
+++ b/.agents/skills/churchcrm/i18n-localization.md
@@ -18,8 +18,8 @@ ChurchCRM supports 45+ languages through gettext (PHP) and i18next (JavaScript).
 
 **Key Principle:** Every translatable term added = 45+ translations needed (one per language). Consolidate compound terms to reduce this burden.
 
-> **Scope note — this skill is for the CORE `messages` domain only.** Community
-> plugins do **not** go through POeditor and do **not** contribute strings to
+> [!NOTE] Scope — CORE `messages` domain only
+> Community plugins do **not** go through POeditor and do **not** contribute strings to
 > `locale/messages.po` or `locale/i18n/*.json`. Plugin authors ship their
 > translations inside the plugin directory and ChurchCRM loads them via
 > `PluginLocalization`. See
@@ -199,8 +199,7 @@ This applies to all inline scripts in PHP templates that use `i18next.t()`. Webp
 
 ## Adding New UI Terms
 
-> ## ⛔ NEVER run `npm run locale:build` <!-- learned: 2026-07-11 -->
->
+> [!WARNING] NEVER run `npm run locale:build` <!-- learned: 2026-07-11 -->
 > Term extraction and `locale/terms/messages.po` updates are **automated outside
 > this repo** (POEditor sync). Do not run `locale:build`, and do not hand-edit or
 > commit `messages.po` or the generated locale JSON files. Running it locally only
@@ -1085,7 +1084,8 @@ $localeInfo = Bootstrapper::getCurrentLocale();
 
 ### Extracting and Uploading New Terms
 
-> **Not a developer task.** Extraction (`locale:build`) and the POEditor upload are
+> [!WARNING] Not a developer task
+> Extraction (`locale:build`) and the POEditor upload are
 > run by the **release/locale automation**, not by hand during feature work. The
 > steps below document what that automation does — they are not a checklist to
 > follow when you add a `gettext()` string. See

--- a/.agents/skills/churchcrm/locale-translation-workflow.md
+++ b/.agents/skills/churchcrm/locale-translation-workflow.md
@@ -2,6 +2,7 @@
 title: "Locale Translation Workflow"
 intent: "Complete guide for translating missing UI strings across 40+ locales with cloud-safe durability and impact-based prioritization"
 tags: ["i18n", "localization", "translation", "release"]
+prereqs: ["[[i18n-localization]]"]
 complexity: "intermediate"
 ---
 

--- a/.agents/skills/churchcrm/modern-php-frameworks.md
+++ b/.agents/skills/churchcrm/modern-php-frameworks.md
@@ -1,3 +1,10 @@
+---
+title: "Modern PHP 8.4+ & Framework Best Practices"
+intent: "Security hardening and framework-level best practices for the PHP 8.4+ / Slim stack"
+tags: ["php", "security", "slim"]
+prereqs: ["[[php-best-practices]]"]
+complexity: "intermediate"
+---
 # Modern PHP 8.4+ & Framework Best Practices
 
 ChurchCRM requires PHP >=8.4 (defined in composer.json) with the following framework stack:
@@ -140,7 +147,8 @@ allow_url_include = 0
 
 ## Slim 4 Framework Best Practices
 
-> **Canonical reference:** [`slim-4-best-practices.md`](./slim-4-best-practices.md) is the single source of truth
+> [!NOTE] Canonical reference
+> [`slim-4-best-practices.md`](./slim-4-best-practices.md) is the single source of truth
 > for Slim 4 middleware ordering, error handling, DI, and response patterns.
 > Consult that file for all Slim 4 questions. This section covers only PHP-level patterns.
 

--- a/.agents/skills/churchcrm/observability-logging-metrics.md
+++ b/.agents/skills/churchcrm/observability-logging-metrics.md
@@ -2,7 +2,7 @@
 title: "Observability, Logging & Metrics"
 intent: "Guidance for logging, metrics, and monitoring for new MVCs and APIs"
 tags: ["logging","monitoring","metrics","observability"]
-prereqs: ["code-standards.md","development-workflows.md"]
+prereqs: ["[[code-standards]]","[[development-workflows]]"]
 complexity: "intermediate"
 ---
 

--- a/.agents/skills/churchcrm/performance-optimization.md
+++ b/.agents/skills/churchcrm/performance-optimization.md
@@ -2,7 +2,7 @@
 title: "Performance Optimization & Best Practices"
 intent: "Patterns for improving query performance, caching, and frontend optimization"
 tags: ["performance","database","caching"]
-prereqs: ["database-operations.md","service-layer.md"]
+prereqs: ["[[database-operations]]","[[service-layer]]"]
 complexity: "advanced"
 ---
 

--- a/.agents/skills/churchcrm/plugin-compliance.md
+++ b/.agents/skills/churchcrm/plugin-compliance.md
@@ -2,13 +2,14 @@
 title: "Plugin Compliance — Admin Audit Guide"
 intent: "Checklist a ChurchCRM admin follows to vet, audit, and scan community plugins on their own server"
 tags: ["plugins","security","admin","audit","compliance"]
-prereqs: ["plugin-system.md"]
+prereqs: ["[[plugin-system]]"]
 complexity: "beginner"
 ---
 
 # Plugin Compliance — Admin Audit Guide <!-- learned: 2026-04-13 -->
 
-> **Audience:** ChurchCRM site administrators (not plugin developers and
+> [!NOTE] Audience
+> ChurchCRM site administrators (not plugin developers and
 > not ChurchCRM maintainers). If you are a developer submitting a plugin
 > for review, read [`plugin-security-scan.md`](./plugin-security-scan.md)
 > instead. If you are a ChurchCRM maintainer reviewing a community plugin

--- a/.agents/skills/churchcrm/plugin-create.md
+++ b/.agents/skills/churchcrm/plugin-create.md
@@ -2,13 +2,14 @@
 title: "Plugin Create — Community Plugin Quickstart & Submission"
 intent: "Step-by-step flow for building a new community plugin from scratch and getting it added to the approved allowlist"
 tags: ["plugins","community","create","submission","security"]
-prereqs: ["plugin-development.md","plugin-security-scan.md"]
+prereqs: ["[[plugin-development]]","[[plugin-security-scan]]"]
 complexity: "intermediate"
 ---
 
 # Plugin Create — Community Plugin Quickstart <!-- learned: 2026-04-13 -->
 
-> **Scope — community plugins only.** This skill is the create-from-scratch
+> [!NOTE] Scope — community plugins only
+> This skill is the create-from-scratch
 > walkthrough for third-party plugins that will be installed into
 > `src/plugins/community/` via the URL installer. If you are updating a
 > plugin shipped in `src/plugins/core/`, read
@@ -77,7 +78,8 @@ A full-featured plugin might also add:
 Keep it minimal. The fewer files you ship, the faster the review and
 the smaller the attack surface.
 
-> **Don't want to use the scaffolder?** Fork
+> [!TIP] Don't want to use the scaffolder?
+> Fork
 > [ChurchCRM/community-plugin-hello-world](https://github.com/ChurchCRM/community-plugin-hello-world)
 > directly and rename the identifiers. The scaffolder is a
 > convenience, not a requirement.

--- a/.agents/skills/churchcrm/plugin-development.md
+++ b/.agents/skills/churchcrm/plugin-development.md
@@ -1,6 +1,13 @@
+---
+title: "Plugin Development"
+intent: "Building a ChurchCRM plugin end-to-end — allowed/forbidden capabilities, hooks, sandboxed config, and plugin-local translations"
+tags: ["plugins", "security", "i18n"]
+prereqs: ["[[plugin-system]]", "[[plugin-security-scan]]"]
+complexity: "intermediate"
+---
 # Skill: Plugin Development
 
-> ## ⚠️ Before you write a single line of plugin code — read this <!-- learned: 2026-04-13 -->
+> [!IMPORTANT] Before you write a single line of plugin code — read this <!-- learned: 2026-04-13 -->
 >
 > **Every community plugin must pass [`plugin-security-scan.md`](./plugin-security-scan.md) before it can be approved for the URL installer.** That checklist is not a post-hoc review — it's the spec you are building against. Read it first, then come back here.
 >
@@ -464,7 +471,8 @@ PluginManager::disablePlugin('mailchimp');
 
 Plugin entry points create their own Slim app instance.
 
-> **Full reference:** [`slim-4-best-practices.md` → Middleware Order](./slim-4-best-practices.md)
+> [!NOTE] Full reference
+> [`slim-4-best-practices.md` → Middleware Order](./slim-4-best-practices.md)
 
 **TL;DR:** `addErrorMiddleware()` MUST be called AFTER `addRoutingMiddleware()`. Wrong order → raw 500 on 404s.
 

--- a/.agents/skills/churchcrm/plugin-migration.md
+++ b/.agents/skills/churchcrm/plugin-migration.md
@@ -2,13 +2,14 @@
 title: "Core Plugin Migration Guidelines"
 intent: "Checklist for updating the core plugins shipped in src/plugins/core/ when core ChurchCRM APIs, routes, or conventions change"
 tags: ["plugins","migration","core","compatibility"]
-prereqs: ["plugin-system.md","api-compatibility-and-deprecation.md"]
+prereqs: ["[[plugin-system]]","[[api-compatibility-and-deprecation]]"]
 complexity: "intermediate"
 ---
 
 # Core Plugin Migration Guidelines <!-- learned: 2026-04-13 -->
 
-> **Scope — core plugins only.** This skill covers the plugins shipped
+> [!NOTE] Scope — core plugins only
+> This skill covers the plugins shipped
 > in `src/plugins/core/` (mailchimp, vonage, gravatar, openlp,
 > google-analytics, external-backup, custom-links) and any future
 > plugin maintained in this repository. **Community plugins do not

--- a/.agents/skills/churchcrm/plugin-security-scan.md
+++ b/.agents/skills/churchcrm/plugin-security-scan.md
@@ -1,3 +1,10 @@
+---
+title: "Plugin Security Scan"
+intent: "Required review checklist before approving a community plugin for approved-plugins.json — intake, static analysis, risk classification"
+tags: ["plugins", "security", "audit", "compliance"]
+prereqs: ["[[plugin-system]]"]
+complexity: "intermediate"
+---
 # Plugin Security Scan <!-- learned: 2026-04-13 -->
 
 Use this skill every time a new community plugin is proposed for
@@ -5,7 +12,8 @@ Use this skill every time a new community plugin is proposed for
 zip before it is published to end users. No plugin enters the approved list
 until every section below is signed off and documented in the PR.
 
-> **Why this exists:** ChurchCRM now supports URL-based plugin installs
+> [!NOTE] Why this exists
+> ChurchCRM now supports URL-based plugin installs
 > (see `PluginInstaller::installFromUrl`). The installer refuses anything
 > that isn't in `approved-plugins.json`, so that file is the only supply
 > chain gate between third-party code and a production parish server. Treat

--- a/.agents/skills/churchcrm/plugin-system.md
+++ b/.agents/skills/churchcrm/plugin-system.md
@@ -1,3 +1,10 @@
+---
+title: "Plugin System & Extensibility"
+intent: "Runtime architecture — PluginManager, hooks, install flow, and plugin-local localization loader"
+tags: ["plugins", "architecture", "core"]
+prereqs: []
+complexity: "intermediate"
+---
 # Plugin System & Extensibility
 
 Comprehensive guide to ChurchCRM's WordPress-style plugin architecture. Plugins enable core functionality extension without modifying source code.

--- a/.agents/skills/churchcrm/pr-review.md
+++ b/.agents/skills/churchcrm/pr-review.md
@@ -2,7 +2,7 @@
 title: "PR Review"
 intent: "Full pull request review workflow: fetch changes, validate standards, check docs/wiki, identify manual testing, address comments, and capture learnings"
 tags: ["pr","review","code-quality","standards","workflow"]
-prereqs: ["code-standards.md","git-workflow.md","github-interaction.md"]
+prereqs: ["[[code-standards]]","[[git-workflow]]","[[github-interaction]]"]
 complexity: "intermediate"
 ---
 
@@ -484,11 +484,13 @@ When a PR review reveals a pattern or mistake that isn't yet documented:
 
 ### Example — capturing a learning
 
-> **Scenario:** A PR review comment flags that `SystemConfig::getValue()` was used for a boolean check instead of `SystemConfig::getBooleanValue()`.
+> [!NOTE] Scenario
+> A PR review comment flags that `SystemConfig::getValue()` was used for a boolean check instead of `SystemConfig::getBooleanValue()`.
 
 Add to `development-workflows.md` (already documented there — no change needed).
 
-> **Scenario:** A PR adds a Tabler card component but uses inline `style` attributes instead of utility classes.
+> [!NOTE] Scenario
+> A PR adds a Tabler card component but uses inline `style` attributes instead of utility classes.
 
 Add to `tabler-components.md` under a "Cards" section:
 

--- a/.agents/skills/churchcrm/refactor.md
+++ b/.agents/skills/churchcrm/refactor.md
@@ -2,7 +2,7 @@
 title: "Refactor Patterns"
 intent: "Guidance for refactoring legacy code to services and MVC structure"
 tags: ["refactor","service-layer","mvc"]
-prereqs: ["php-best-practices.md","service-layer.md"]
+prereqs: ["[[php-best-practices]]","[[service-layer]]"]
 complexity: "intermediate"
 ---
 

--- a/.agents/skills/churchcrm/release-notes.md
+++ b/.agents/skills/churchcrm/release-notes.md
@@ -1,3 +1,10 @@
+---
+title: "Release Notes Authoring"
+intent: "Generate polished, end-user-focused GitHub release notes for a ChurchCRM version"
+tags: ["release", "documentation", "workflow"]
+prereqs: ["[[github-interaction]]"]
+complexity: "beginner"
+---
 # Skill: Release Notes Authoring
 
 ## Purpose

--- a/.agents/skills/churchcrm/responsive-design-guidelines.md
+++ b/.agents/skills/churchcrm/responsive-design-guidelines.md
@@ -2,7 +2,7 @@
 title: "Responsive Design Guidelines"
 intent: "Canonical guidance for mobile, tablet, and laptop/desktop layouts across ChurchCRM"
 tags: ["frontend","responsive","bootstrap","tabler","mobile","tablet"]
-prereqs: ["frontend-development.md","bootstrap-5-migration.md","tabler-components.md"]
+prereqs: ["[[frontend-development]]","[[bootstrap-5-migration]]","[[tabler-components]]"]
 complexity: "intermediate"
 ---
 
@@ -30,7 +30,8 @@ codebase:
 | **Tablet** | 768px | 1199.98px | `md`, `lg` | Tablets, small laptops, split-screen windows |
 | **Laptop/Desktop** | 1200px | ∞ | `xl`, `xxl` | Laptops, desktop monitors, kiosks |
 
-> **Why the split is at 768 and 1200 and not 576/992:** The vertical Tabler
+> [!NOTE] Why the split is at 768 and 1200 and not 576/992
+> The vertical Tabler
 > sidebar in `src/Include/Header.php:176` is `navbar-vertical navbar-expand-xl`,
 > which means the **permanent left sidebar only appears at ≥1200px**. Below that
 > the nav collapses to a hamburger. The 768px boundary is where column layouts
@@ -86,7 +87,8 @@ codebase:
 - Dense card tabs become full labels (`d-none d-xl-inline`)
 - Multi-column forms OK: `col-lg-4` or `col-lg-3`
 
-> **Note:** We use `col-lg-*` at 992px (not 1200px) for the 8/4 split because
+> [!NOTE]
+> We use `col-lg-*` at 992px (not 1200px) for the 8/4 split because
 > the 992–1199 band still benefits from side-by-side content even though the
 > sidebar hasn't appeared yet. `col-lg-*` = "start being wide at 992px".
 
@@ -97,7 +99,8 @@ codebase:
 The project standard is **`col-6 col-lg-3`** for 4 stat cards, or **`col-6 col-lg`**
 (auto-equal) for 5+ stat cards.
 
-> **Heads-up on the breakpoint vs the form-factor model:** Bootstrap's `lg`
+> [!WARNING] Heads-up on the breakpoint vs the form-factor model
+> Bootstrap's `lg`
 > breakpoint activates at **992px**, which sits *inside* the Tablet form
 > factor (768–1199.98px) defined above — it is not the same as the 1200px
 > Laptop boundary. So `col-6 col-lg-3` actually goes:
@@ -173,7 +176,7 @@ On mobile and tablet they stack automatically (both become `col-12`).
 
 ### Tables must be wrapped — but NOT with `.table-responsive` if the rows have action dropdowns <!-- learned: 2026-04-09 -->
 
-> **⚠️ Critical conflict with [`table-action-menu.md`](./table-action-menu.md):**
+> [!WARNING] Critical conflict with [`table-action-menu.md`](./table-action-menu.md)
 > `.table-responsive` sets `overflow-x: auto`, which (per CSS spec) forces
 > `overflow-y: auto` as well — and that **clips absolutely-positioned row
 > dropdowns on their last rows**. For tables that have per-row action menus

--- a/.agents/skills/churchcrm/routing-architecture.md
+++ b/.agents/skills/churchcrm/routing-architecture.md
@@ -2,7 +2,7 @@
 title: "Routing & Project Architecture"
 intent: "Organization patterns for routes, modules, and menus"
 tags: ["routing","architecture","mvc","admin","api"]
-prereqs: ["slim-4-best-practices.md"]
+prereqs: ["[[slim-4-best-practices]]"]
 complexity: "intermediate"
 ---
 

--- a/.agents/skills/churchcrm/security-advisory-review.md
+++ b/.agents/skills/churchcrm/security-advisory-review.md
@@ -1,3 +1,10 @@
+---
+title: "Security Advisory Review Process"
+intent: "How to access, analyze, and respond to GitHub security advisories for ChurchCRM"
+tags: ["security", "audit", "github"]
+prereqs: ["[[security-best-practices]]", "[[github-interaction]]"]
+complexity: "advanced"
+---
 # Security Advisory Review Process
 
 This skill documents how to access, analyze, and respond to GitHub security advisories for ChurchCRM.

--- a/.agents/skills/churchcrm/security-best-practices.md
+++ b/.agents/skills/churchcrm/security-best-practices.md
@@ -1,3 +1,10 @@
+---
+title: "Security Best Practices"
+intent: "HTML sanitization, XSS prevention, TLS/SSL, authorization, and vulnerability handling"
+tags: ["security", "xss", "auth"]
+prereqs: ["[[php-best-practices]]"]
+complexity: "intermediate"
+---
 # Security Best Practices
 
 Comprehensive security guidelines including HTML sanitization, XSS prevention, TLS/SSL, authorization, and vulnerability handling.

--- a/.agents/skills/churchcrm/service-layer.md
+++ b/.agents/skills/churchcrm/service-layer.md
@@ -2,7 +2,7 @@
 title: "Service Layer"
 intent: "Guidance for creating service classes and performance best practices"
 tags: ["service","performance","architecture"]
-prereqs: ["php-best-practices.md","database-operations.md"]
+prereqs: ["[[php-best-practices]]","[[database-operations]]"]
 complexity: "intermediate"
 ---
 

--- a/.agents/skills/churchcrm/slim-4-best-practices.md
+++ b/.agents/skills/churchcrm/slim-4-best-practices.md
@@ -2,7 +2,7 @@
 title: "Slim 4 Best Practices"
 intent: "Guidance for Slim 4 app setup, routing, middleware, and error handling"
 tags: ["slim","middleware","routing","api","error-handling"]
-prereqs: ["php-best-practices.md","routing-architecture.md"]
+prereqs: ["[[php-best-practices]]","[[routing-architecture]]"]
 complexity: "intermediate"
 ---
 

--- a/.agents/skills/churchcrm/slim-mvc-skill.md
+++ b/.agents/skills/churchcrm/slim-mvc-skill.md
@@ -2,7 +2,7 @@
 title: "Slim MVCs — Routes, Uses, Security & Migration Guidance"
 intent: "Inventory Slim MVCs and provide migration guidance for group apps"
 tags: ["slim","mvc","routing","migration","security"]
-prereqs: ["routing-architecture.md","slim-4-best-practices.md"]
+prereqs: ["[[routing-architecture]]","[[slim-4-best-practices]]"]
 complexity: "intermediate"
 ---
 

--- a/.agents/skills/churchcrm/social-media-release.md
+++ b/.agents/skills/churchcrm/social-media-release.md
@@ -1,3 +1,10 @@
+---
+title: "Social Media Release Posts"
+intent: "Generate platform-optimized social media posts for every ChurchCRM release"
+tags: ["release", "social-media", "workflow"]
+prereqs: ["[[release-notes]]"]
+complexity: "beginner"
+---
 # Skill: Social Media Release Posts
 
 ## Purpose

--- a/.agents/skills/churchcrm/tabler-components.md
+++ b/.agents/skills/churchcrm/tabler-components.md
@@ -2,7 +2,7 @@
 title: "Tabler UI Component Reference"
 intent: "Complete reference for Tabler framework layout, cards, tables, forms, navigation, and utility components used in ChurchCRM"
 tags: ["frontend", "tabler", "bootstrap5", "ui", "components"]
-prereqs: ["bootstrap-5-migration.md", "frontend-development.md"]
+prereqs: ["[[bootstrap-5-migration]]", "[[frontend-development]]"]
 complexity: "intermediate"
 ---
 
@@ -1327,8 +1327,7 @@ Do NOT add `autofocus` to the search results page input — it prevents the `?` 
 
 ## Standard Table Action Dropdown <!-- learned: 2026-03-23 -->
 
-> **See the dedicated skill: [`table-action-menu.md`](./table-action-menu.md)**
->
+> [!NOTE] See the dedicated skill: [`table-action-menu.md`](./table-action-menu.md)
 > That file has the complete pattern (PHP + JS), full rules table, overflow/clipping fixes, cart button pattern, order/sort actions, and a pre-commit checklist. Always read it when adding or editing any table with row-level actions.
 
 ---

--- a/.agents/skills/churchcrm/tabler-library-replacement.md
+++ b/.agents/skills/churchcrm/tabler-library-replacement.md
@@ -2,7 +2,7 @@
 title: "Tabler Library Replacement Guide"
 intent: "Which 3rd-party UI libraries to replace with Tabler built-ins, how to do it via webpack, and which to keep"
 tags: ["frontend", "tabler", "webpack", "migration", "libraries"]
-prereqs: ["tabler-components.md", "webpack-typescript.md", "bootstrap-5-migration.md"]
+prereqs: ["[[tabler-components]]", "[[webpack-typescript]]", "[[bootstrap-5-migration]]"]
 complexity: "advanced"
 ---
 
@@ -73,7 +73,8 @@ SCSS → churchcrm.min.css  (all CSS combined)
 |---------|-------------|--------|
 | **select2-bootstrap4-theme** | `@ttskch/select2-bootstrap4-theme@^1.5.2` | Obsolete with Select2 removal. |
 
-> **Status update (2026-04-06):** React fully removed (react, react-dom, react-bootstrap, react-datepicker, react-select). `@ttskch/select2-bootstrap4-theme` already removed. DataTables BS4→BS5 upgrade is **complete**.
+> [!NOTE] Status update (2026-04-06)
+> React fully removed (react, react-dom, react-bootstrap, react-datepicker, react-select). `@ttskch/select2-bootstrap4-theme` already removed. DataTables BS4→BS5 upgrade is **complete**.
 
 ---
 

--- a/.agents/skills/churchcrm/tabler-migration-playbook.md
+++ b/.agents/skills/churchcrm/tabler-migration-playbook.md
@@ -2,7 +2,7 @@
 title: "Tabler Migration Playbook"
 intent: "Step-by-step playbook for migrating ChurchCRM pages from AdminLTE/BS4 to Tabler/BS5, with full codebase audit inventory and phased execution plan"
 tags: ["frontend", "tabler", "migration", "bootstrap5", "playbook"]
-prereqs: ["tabler-components.md", "tabler-library-replacement.md", "bootstrap-5-migration.md"]
+prereqs: ["[[tabler-components]]", "[[tabler-library-replacement]]", "[[bootstrap-5-migration]]"]
 complexity: "advanced"
 ---
 

--- a/.agents/skills/churchcrm/testing-migration-e2e.md
+++ b/.agents/skills/churchcrm/testing-migration-e2e.md
@@ -2,7 +2,7 @@
 title: "Testing Migration & E2E"
 intent: "Testing strategy for migrating endpoints and UI flows (Cypress + integration tests)"
 tags: ["testing","cypress","e2e","migration"]
-prereqs: ["testing.md","cypress-testing.md","api-development.md"]
+prereqs: ["[[testing]]","[[cypress-testing]]","[[api-development]]"]
 complexity: "intermediate"
 ---
 

--- a/.agents/skills/churchcrm/testing.md
+++ b/.agents/skills/churchcrm/testing.md
@@ -2,7 +2,7 @@
 title: "Testing"
 intent: "Guidance for Cypress, unit/integration tests, and test workflows"
 tags: ["testing","cypress","ci"]
-prereqs: ["cypress-testing.md"]
+prereqs: ["[[cypress-testing]]"]
 complexity: "intermediate"
 ---
 

--- a/.agents/skills/churchcrm/timezone-handling.md
+++ b/.agents/skills/churchcrm/timezone-handling.md
@@ -1,3 +1,10 @@
+---
+title: "Timezone Handling"
+intent: "End-to-end timezone conventions for events, calendars, kiosks, and any datetime-aware feature"
+tags: ["timezone", "frontend", "database"]
+prereqs: ["[[frontend-development]]"]
+complexity: "advanced"
+---
 # Timezone Handling — ChurchCRM
 
 End-to-end timezone conventions for events, calendars, kiosks, and any other church-time-aware feature. Built from the PR #8806 timezone refactor. **Read this before touching any datetime in the editor, calendar, kiosk, or related JS.**

--- a/.agents/skills/churchcrm/webpack-typescript.md
+++ b/.agents/skills/churchcrm/webpack-typescript.md
@@ -1,3 +1,10 @@
+---
+title: "Webpack & TypeScript Development"
+intent: "Entry points, API utilities, type safety, and best practices for building modern webpack modules"
+tags: ["frontend", "webpack", "javascript"]
+prereqs: []
+complexity: "intermediate"
+---
 # Skill: Webpack & TypeScript Development
 
 ## Context
@@ -9,7 +16,8 @@ ChurchCRM uses Webpack to bundle frontend JavaScript/TypeScript and CSS. This sk
 - `webpack-cli` 7.0.2
 - `ts-loader` 9.5.4
 
-> **Note:** React was removed in 7.2.0. All interactive UI uses vanilla JS + Bootstrap 5.
+> [!NOTE]
+> React was removed in 7.2.0. All interactive UI uses vanilla JS + Bootstrap 5.
 
 ---
 

--- a/.agents/skills/churchcrm/wiki-documentation.md
+++ b/.agents/skills/churchcrm/wiki-documentation.md
@@ -1,3 +1,10 @@
+---
+title: "Creating Wiki Documentation"
+intent: "When to create GitHub Wiki articles and how to structure them for complex documentation and admin guides"
+tags: ["documentation", "workflow"]
+prereqs: []
+complexity: "beginner"
+---
 # Skill: Creating Wiki Documentation
 
 ## Context

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ cy.log
 knowledge-vault/.obsidian/workspace.json
 knowledge-vault/.obsidian/workspace-mobile.json
 knowledge-vault/.obsidian/plugins/
+/.obsidian

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,8 @@ cypress.env.json
 
 .claude/settings.json
 cy.log
+
+# Obsidian machine-local workspace state (not shared config)
+knowledge-vault/.obsidian/workspace.json
+knowledge-vault/.obsidian/workspace-mobile.json
+knowledge-vault/.obsidian/plugins/

--- a/knowledge-vault/.obsidian/app.json
+++ b/knowledge-vault/.obsidian/app.json
@@ -1,0 +1,5 @@
+{
+  "newFileLocation": "root",
+  "alwaysUpdateLinks": true,
+  "useMarkdownLinks": true
+}

--- a/knowledge-vault/.obsidian/core-plugins.json
+++ b/knowledge-vault/.obsidian/core-plugins.json
@@ -1,0 +1,16 @@
+[
+  "file-explorer",
+  "global-search",
+  "switcher",
+  "graph",
+  "backlink",
+  "outgoing-link",
+  "tag-pane",
+  "page-preview",
+  "note-composer",
+  "command-palette",
+  "editor-status",
+  "outline",
+  "word-count",
+  "file-recovery"
+]

--- a/knowledge-vault/.obsidian/graph.json
+++ b/knowledge-vault/.obsidian/graph.json
@@ -1,0 +1,22 @@
+{
+  "collapse-filter": true,
+  "search": "",
+  "showTags": false,
+  "showAttachments": false,
+  "hideUnresolved": false,
+  "showOrphans": true,
+  "collapse-color-groups": true,
+  "colorGroups": [],
+  "collapse-display": true,
+  "showArrow": false,
+  "textFadeMultiplier": 0,
+  "nodeSizeMultiplier": 1,
+  "lineSizeMultiplier": 1,
+  "collapse-forces": true,
+  "centerStrength": 0.5,
+  "repelStrength": 10,
+  "linkStrength": 1,
+  "linkDistance": 250,
+  "scale": 1,
+  "close": false
+}

--- a/knowledge-vault/CLAUDE.md
+++ b/knowledge-vault/CLAUDE.md
@@ -1,0 +1,1 @@
+../CLAUDE.md

--- a/knowledge-vault/README.md
+++ b/knowledge-vault/README.md
@@ -1,0 +1,26 @@
+---
+title: "ChurchCRM Knowledge Vault"
+tags: ["documentation", "vault-guide"]
+---
+
+# ChurchCRM Knowledge Vault
+
+An [Obsidian](https://obsidian.md) vault for browsing ChurchCRM's development docs with backlinks and a graph view.
+
+**Open this folder (`knowledge-vault/`) as a vault in Obsidian** — that's the only setup step.
+
+## What's in here
+
+- [`skills/`](./skills/) — symlink to [`.agents/skills/`](../.agents/skills/), the actual skill files Claude Code reads. Start at [`skills/churchcrm/SKILL.md`](./skills/churchcrm/SKILL.md), the task-based index.
+- [`CLAUDE.md`](./CLAUDE.md) — symlink to the repo's [`CLAUDE.md`](../CLAUDE.md).
+
+Nothing here is a copy. Every note is a symlink into the real files, so editing a note in Obsidian edits the source file directly — there's no second copy to keep in sync, and Claude Code's context still comes from `.agents/skills/` exactly as before.
+
+## What this is (and isn't) for
+
+- **Is for:** human browsing — graph view, backlinks, quick navigation across the ~50 skill files without opening each one in an editor.
+- **Isn't:** a change to how Claude Code loads context. The task-based lookup table in `CLAUDE.md` and `skills/churchcrm/SKILL.md` already ensures a session only reads the skills relevant to its task — that's what keeps sessions token-efficient, and this vault doesn't alter it.
+
+## Adding new notes
+
+Don't add new `.md` files directly under `knowledge-vault/` — add them to `.agents/skills/churchcrm/` (or the repo root, for things like `CLAUDE.md`) so they stay under version control as the source of truth, and they'll show up here automatically through the symlink.

--- a/knowledge-vault/skills
+++ b/knowledge-vault/skills
@@ -1,0 +1,1 @@
+../.agents/skills


### PR DESCRIPTION
## Summary
- Adds `knowledge-vault/` — an Obsidian vault symlinked over `.agents/skills/` for human browsing with backlinks and graph view. `.agents/skills/` remains the single source of truth Claude Code reads; nothing is duplicated.
- Standardizes YAML frontmatter (`title`/`intent`/`tags`/`prereqs`/`complexity`) across all 50 skill files (was present on 33/50).
- Converts every `prereqs` entry from a plain filename string to a `[[wikilink]]` so dependency chains resolve as real graph/backlink edges instead of inert text.
- Converts genuine warning/important/tip blockquotes to `[!WARNING]` / `[!IMPORTANT]` / `[!TIP]` / `[!NOTE]` callouts, using GitHub's alert vocabulary so they render correctly both on GitHub and in Obsidian.

## Changes
- `knowledge-vault/README.md`, `knowledge-vault/.obsidian/*.json` — new vault + config
- `knowledge-vault/skills`, `knowledge-vault/CLAUDE.md` — symlinks into existing repo files (no duplication)
- `.agents/skills/churchcrm/*.md` (48 files) — frontmatter added/standardized, `prereqs` wikilinked, 26 blockquotes converted to callouts
- `.gitignore` — excludes Obsidian's machine-local workspace state (`workspace.json`, installed plugins) under `knowledge-vault/.obsidian/`

## Why
- The skill system already keeps Claude Code sessions token-efficient via the task-based lookup table in `CLAUDE.md`/`SKILL.md` — this PR doesn't change that.
- What it adds: structured, queryable metadata (tags, complexity, real prereq edges) instead of prose-only docs, plus a human-browsable graph view. This is groundwork for things like a filterable skills dashboard (Obsidian Bases) and any future agent/skill-router tooling that wants to query "which skills are relevant" rather than grep 50 files.
- Deliberately did **not** convert body cross-reference links (`[text](./file.md)`) to wikilinks, since those need to keep rendering correctly on GitHub and in VS Code, not just Obsidian.

## Testing
- `npm run lint` — clean (Biome only scans `src/`/`webpack/`, unaffected by this change)
- No PHP/JS touched — no build step applicable
- Verified all 50 skill files parse with valid YAML frontmatter and all `prereqs` wikilinks resolve to existing files in the vault