### PR TITLE
feat(finance): apply CurrencyFormatter to dashboard & finance pages

### DIFF
--- a/.agents/skills/churchcrm/currency-localization.md
+++ b/.agents/skills/churchcrm/currency-localization.md
@@ -97,7 +97,9 @@ Location: `src/ChurchCRM/Utils/CurrencyFormatter.php`
 use ChurchCRM\Utils\CurrencyFormatter;
 
 CurrencyFormatter::formatHtml(1234.5);    // "$1,234.50" — HTML-escaped, null-safe; for <?= ?> in templates
+CurrencyFormatter::formatHtml("1234.50"); // "$1,234.50" — numeric strings OK (Propel DECIMAL/SUM returns string)
 CurrencyFormatter::formatHtml(null);      // ""          — null in, empty string out (no bogus $0.00)
+CurrencyFormatter::formatHtml("N/A");     // ""          — non-numeric string → '' + warning log (never $0.00)
 CurrencyFormatter::format(1234.5);        // "$1,234.50" — raw string; for APIs, PDFs, further processing
 CurrencyFormatter::format(1234.5, 0);     // "$1,235"
 CurrencyFormatter::symbol();              // "$"
@@ -109,7 +111,7 @@ CurrencyFormatter::toArray();             // ['symbol' => ..., 'position' => ...
 
 | Context | Method |
 |---------|--------|
-| PHP template `<?= ?>` output | `formatHtml()` (escaped, accepts nullable Propel DECIMAL getters) |
+| PHP template `<?= ?>` output | `formatHtml()` (escaped, accepts `float\|string\|null`) |
 | API payload / PDF / string building | `format()` |
 | JS (DataTables, Chart.js, DOM) | `window.CRM.currency.format()` |
 
@@ -128,6 +130,26 @@ prevent line-wrapping on narrow screens.
 
 Never concatenate the symbol yourself; the helper applies the configured
 position and separators for you.
+
+### Never pre-cast `(float)` before `formatHtml()` <!-- learned: 2026-07-18 -->
+
+`formatHtml()` takes `float|string|null` and validates internally. A caller-side
+`(float)` cast silently launders `null`/garbage into `$0.00` on finance reports —
+exactly what the signature is designed to prevent. Pass the raw value; use `?? 0`
+only when a blank truly should display as zero (e.g. an unguarded SUM total).
+
+```php
+// ❌ WRONG — blind cast turns NULL/garbage into a legit-looking $0.00
+<?= CurrencyFormatter::formatHtml((float) $deposit->getVirtualColumn('totalAmount')) ?>
+<?= is_numeric($v) ? CurrencyFormatter::formatHtml((float) $v) : '' ?>  // redundant guard
+
+// ✅ CORRECT — formatter handles string|null; '' for null/non-numeric (logged)
+<?= CurrencyFormatter::formatHtml($pledge['pledge_amount']) ?>
+<?= CurrencyFormatter::formatHtml($deposit->getVirtualColumn('totalAmount') ?? 0) ?>  // intentional $0.00
+```
+
+`format()` stays strict (`float`) — API/PDF code should hold real numbers already;
+convert explicitly there.
 
 ---
 

--- a/src/ChurchCRM/utils/CurrencyFormatter.php
+++ b/src/ChurchCRM/utils/CurrencyFormatter.php
@@ -38,15 +38,21 @@ class CurrencyFormatter
      * Use this in PHP templates; use format() in PHP code that further processes the string
      * (e.g. API payload building, PDF generation).
      *
-     * Accepts null (e.g. from nullable Propel DECIMAL getters) and returns an empty string
-     * so callers do not need to pre-cast to float and risk turning NULL into $0.00.
+     * Accepts null and numeric strings (Propel returns DECIMAL columns as string|null) so
+     * callers do not need to pre-cast — a blind (float) cast would turn NULL and garbage
+     * into $0.00. Null, empty, and non-numeric values render as an empty string; the
+     * non-numeric case is logged.
      */
-    public static function formatHtml(?float $amount, int $decimals = 2): string
+    public static function formatHtml(float|string|null $amount, int $decimals = 2): string
     {
-        if ($amount === null) {
+        if ($amount === null || $amount === '') {
             return '';
         }
-        return htmlspecialchars(self::format($amount, $decimals), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        if (is_string($amount) && !is_numeric($amount)) {
+            LoggerUtils::getAppLogger()->warning('Non-numeric amount passed to CurrencyFormatter::formatHtml', ['amount' => $amount]);
+            return '';
+        }
+        return htmlspecialchars(self::format((float) $amount, $decimals), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
     }
 
     /**

--- a/src/DepositSlipEditor.php
+++ b/src/DepositSlipEditor.php
@@ -171,7 +171,7 @@ require_once __DIR__ . '/Include/Header.php';
         <div class="col-12 mb-3">
           <div class="stat-card text-center py-4 border-0 shadow-sm" style="background: linear-gradient(135deg, #0d6efd 0%, #0b5ed7 100%);">
             <div style="font-size: 3rem; font-weight: 700; color: white; letter-spacing: -1px;">
-              <?= CurrencyFormatter::formatHtml((float) $thisDeposit->getVirtualColumn('totalAmount')); ?>
+              <?= CurrencyFormatter::formatHtml($thisDeposit->getVirtualColumn('totalAmount') ?? 0); ?>
             </div>
             <div class="text-white-50 text-uppercase small fw-bold mt-2" style="letter-spacing: 1px;"><?= gettext('Total Deposit'); ?></div>
           </div>
@@ -183,7 +183,7 @@ require_once __DIR__ . '/Include/Header.php';
             <?php if ($thisDeposit->getCountCash()): ?>
             <div class="mb-3">
               <i class="fa-solid fa-money-bill fa-2x text-success mb-2"></i>
-              <div class="fw-bold h5 text-success"><?= CurrencyFormatter::formatHtml((float) $thisDeposit->getTotalCash()); ?></div>
+              <div class="fw-bold h5 text-success"><?= CurrencyFormatter::formatHtml($thisDeposit->getTotalCash()); ?></div>
               <div class="small text-body-secondary"><?= gettext('Cash'); ?> (<?= $thisDeposit->getCountCash(); ?>)</div>
             </div>
             <?php endif; ?>
@@ -201,7 +201,7 @@ require_once __DIR__ . '/Include/Header.php';
             <?php if ($thisDeposit->getCountChecks()): ?>
             <div class="mb-3">
               <i class="fa-solid fa-money-check fa-2x text-info mb-2"></i>
-              <div class="fw-bold h5 text-info"><?= CurrencyFormatter::formatHtml((float) $thisDeposit->getTotalChecks()); ?></div>
+              <div class="fw-bold h5 text-info"><?= CurrencyFormatter::formatHtml($thisDeposit->getTotalChecks()); ?></div>
               <div class="small text-body-secondary"><?= gettext('Checks'); ?> (<?= $thisDeposit->getCountChecks(); ?>)</div>
             </div>
             <?php endif; ?>

--- a/src/DepositSlipEditor.php
+++ b/src/DepositSlipEditor.php
@@ -8,6 +8,7 @@ use ChurchCRM\dto\SystemURLs;
 use ChurchCRM\model\ChurchCRM\Deposit;
 use ChurchCRM\view\PageHeader;
 use ChurchCRM\model\ChurchCRM\DepositQuery;
+use ChurchCRM\Utils\CurrencyFormatter;
 use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Utils\RedirectUtils;
 
@@ -170,7 +171,7 @@ require_once __DIR__ . '/Include/Header.php';
         <div class="col-12 mb-3">
           <div class="stat-card text-center py-4 border-0 shadow-sm" style="background: linear-gradient(135deg, #0d6efd 0%, #0b5ed7 100%);">
             <div style="font-size: 3rem; font-weight: 700; color: white; letter-spacing: -1px;">
-              $<?= number_format($thisDeposit->getVirtualColumn('totalAmount'), 2); ?>
+              <?= CurrencyFormatter::formatHtml((float) $thisDeposit->getVirtualColumn('totalAmount')); ?>
             </div>
             <div class="text-white-50 text-uppercase small fw-bold mt-2" style="letter-spacing: 1px;"><?= gettext('Total Deposit'); ?></div>
           </div>
@@ -182,7 +183,7 @@ require_once __DIR__ . '/Include/Header.php';
             <?php if ($thisDeposit->getCountCash()): ?>
             <div class="mb-3">
               <i class="fa-solid fa-money-bill fa-2x text-success mb-2"></i>
-              <div class="fw-bold h5 text-success">$<?= number_format($thisDeposit->getTotalCash(), 2); ?></div>
+              <div class="fw-bold h5 text-success"><?= CurrencyFormatter::formatHtml((float) $thisDeposit->getTotalCash()); ?></div>
               <div class="small text-body-secondary"><?= gettext('Cash'); ?> (<?= $thisDeposit->getCountCash(); ?>)</div>
             </div>
             <?php endif; ?>
@@ -200,7 +201,7 @@ require_once __DIR__ . '/Include/Header.php';
             <?php if ($thisDeposit->getCountChecks()): ?>
             <div class="mb-3">
               <i class="fa-solid fa-money-check fa-2x text-info mb-2"></i>
-              <div class="fw-bold h5 text-info">$<?= number_format($thisDeposit->getTotalChecks(), 2); ?></div>
+              <div class="fw-bold h5 text-info"><?= CurrencyFormatter::formatHtml((float) $thisDeposit->getTotalChecks()); ?></div>
               <div class="small text-body-secondary"><?= gettext('Checks'); ?> (<?= $thisDeposit->getCountChecks(); ?>)</div>
             </div>
             <?php endif; ?>

--- a/src/DepositSlipEditor.php
+++ b/src/DepositSlipEditor.php
@@ -171,7 +171,7 @@ require_once __DIR__ . '/Include/Header.php';
         <div class="col-12 mb-3">
           <div class="stat-card text-center py-4 border-0 shadow-sm" style="background: linear-gradient(135deg, #0d6efd 0%, #0b5ed7 100%);">
             <div style="font-size: 3rem; font-weight: 700; color: white; letter-spacing: -1px;">
-              <?= CurrencyFormatter::formatHtml((float) $thisDeposit->getVirtualColumn('totalAmount')); ?>
+              <?= CurrencyFormatter::formatHtml($thisDeposit->getVirtualColumn('totalAmount') ?? 0); ?>
             </div>
             <div class="text-white-50 text-uppercase small fw-bold mt-2" style="letter-spacing: 1px;"><?= gettext('Total Deposit'); ?></div>
           </div>
@@ -183,7 +183,7 @@ require_once __DIR__ . '/Include/Header.php';
             <?php if ($thisDeposit->getCountCash()): ?>
             <div class="mb-3">
               <i class="fa-solid fa-money-bill fa-2x text-success mb-2"></i>
-              <div class="fw-bold h5 text-success"><?= CurrencyFormatter::formatHtml((float) $thisDeposit->getTotalCash()); ?></div>
+              <div class="fw-bold h5 text-success"><?= CurrencyFormatter::formatHtml($thisDeposit->getTotalCash() ?? 0); ?></div>
               <div class="small text-body-secondary"><?= gettext('Cash'); ?> (<?= $thisDeposit->getCountCash(); ?>)</div>
             </div>
             <?php endif; ?>
@@ -201,7 +201,7 @@ require_once __DIR__ . '/Include/Header.php';
             <?php if ($thisDeposit->getCountChecks()): ?>
             <div class="mb-3">
               <i class="fa-solid fa-money-check fa-2x text-info mb-2"></i>
-              <div class="fw-bold h5 text-info"><?= CurrencyFormatter::formatHtml((float) $thisDeposit->getTotalChecks()); ?></div>
+              <div class="fw-bold h5 text-info"><?= CurrencyFormatter::formatHtml($thisDeposit->getTotalChecks() ?? 0); ?></div>
               <div class="small text-body-secondary"><?= gettext('Checks'); ?> (<?= $thisDeposit->getCountChecks(); ?>)</div>
             </div>
             <?php endif; ?>

--- a/src/finance/views/dashboard.php
+++ b/src/finance/views/dashboard.php
@@ -4,6 +4,7 @@ use ChurchCRM\Authentication\AuthenticationManager;
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\dto\SystemURLs;
 use ChurchCRM\Service\FinancialService;
+use ChurchCRM\Utils\CurrencyFormatter;
 use ChurchCRM\Utils\InputUtils;
 
 require SystemURLs::getDocumentRoot() . '/Include/Header.php';
@@ -56,7 +57,7 @@ $sRootPath = SystemURLs::getRootPath();
                             </span>
                         </div>
                         <div class="col">
-                            <div class="fw-medium">$<?= number_format($ytdPaymentTotal ?? 0, 2) ?></div>
+                            <div class="fw-medium"><?= CurrencyFormatter::formatHtml((float) ($ytdPaymentTotal ?? 0)) ?></div>
                             <div class="text-body-secondary"><?= gettext('YTD Payments') ?></div>
                         </div>
                     </div>
@@ -73,7 +74,7 @@ $sRootPath = SystemURLs::getRootPath();
                             </span>
                         </div>
                         <div class="col">
-                            <div class="fw-medium">$<?= number_format($ytdPledgeTotal ?? 0, 2) ?></div>
+                            <div class="fw-medium"><?= CurrencyFormatter::formatHtml((float) ($ytdPledgeTotal ?? 0)) ?></div>
                             <div class="text-body-secondary"><?= gettext('YTD Pledges') ?></div>
                         </div>
                     </div>
@@ -308,7 +309,7 @@ $sRootPath = SystemURLs::getRootPath();
                                     <td><?= $deposit->getDate('M j, Y') ?></td>
                                     <td><span class="badge bg-blue-lt text-blue"><?= $deposit->getType() ?></span></td>
                                     <td class="text-truncate finance-truncate"><?= InputUtils::escapeHTML($deposit->getComment() ?? '') ?></td>
-                                    <td class="text-end fw-bold">$<?= number_format($deposit->getVirtualColumn('totalAmount') ?? 0, 2) ?></td>
+                                    <td class="text-end fw-bold"><?= CurrencyFormatter::formatHtml((float) ($deposit->getVirtualColumn('totalAmount') ?? 0)) ?></td>
                                     <td>
                                         <?php if ($deposit->getClosed()): ?>
                                         <span class="badge bg-green-lt text-green"><?= gettext('Closed') ?></span>
@@ -362,7 +363,7 @@ $sRootPath = SystemURLs::getRootPath();
                     </div>
                     <hr>
                     <div class="text-center mb-3">
-                        <div class="h3 text-success mb-0">$<?= number_format($currentDeposit->getVirtualColumn('totalAmount') ?? 0, 2) ?></div>
+                        <div class="h3 text-success mb-0"><?= CurrencyFormatter::formatHtml((float) ($currentDeposit->getVirtualColumn('totalAmount') ?? 0)) ?></div>
                         <small class="text-body-secondary"><?= gettext('Total Amount') ?></small>
                     </div>
                     <a href="<?= $sRootPath ?>/DepositSlipEditor.php?DepositSlipID=<?= $currentDeposit->getId() ?>" class="btn btn-primary w-100">

--- a/src/finance/views/dashboard.php
+++ b/src/finance/views/dashboard.php
@@ -57,7 +57,7 @@ $sRootPath = SystemURLs::getRootPath();
                             </span>
                         </div>
                         <div class="col">
-                            <div class="fw-medium"><?= CurrencyFormatter::formatHtml((float) ($ytdPaymentTotal ?? 0)) ?></div>
+                            <div class="fw-medium"><?= CurrencyFormatter::formatHtml($ytdPaymentTotal ?? 0) ?></div>
                             <div class="text-body-secondary"><?= gettext('YTD Payments') ?></div>
                         </div>
                     </div>
@@ -74,7 +74,7 @@ $sRootPath = SystemURLs::getRootPath();
                             </span>
                         </div>
                         <div class="col">
-                            <div class="fw-medium"><?= CurrencyFormatter::formatHtml((float) ($ytdPledgeTotal ?? 0)) ?></div>
+                            <div class="fw-medium"><?= CurrencyFormatter::formatHtml($ytdPledgeTotal ?? 0) ?></div>
                             <div class="text-body-secondary"><?= gettext('YTD Pledges') ?></div>
                         </div>
                     </div>
@@ -309,7 +309,7 @@ $sRootPath = SystemURLs::getRootPath();
                                     <td><?= $deposit->getDate('M j, Y') ?></td>
                                     <td><span class="badge bg-blue-lt text-blue"><?= $deposit->getType() ?></span></td>
                                     <td class="text-truncate finance-truncate"><?= InputUtils::escapeHTML($deposit->getComment() ?? '') ?></td>
-                                    <td class="text-end fw-bold"><?= CurrencyFormatter::formatHtml((float) ($deposit->getVirtualColumn('totalAmount') ?? 0)) ?></td>
+                                    <td class="text-end fw-bold"><?= CurrencyFormatter::formatHtml($deposit->getVirtualColumn('totalAmount') ?? 0) ?></td>
                                     <td>
                                         <?php if ($deposit->getClosed()): ?>
                                         <span class="badge bg-green-lt text-green"><?= gettext('Closed') ?></span>
@@ -363,7 +363,7 @@ $sRootPath = SystemURLs::getRootPath();
                     </div>
                     <hr>
                     <div class="text-center mb-3">
-                        <div class="h3 text-success mb-0"><?= CurrencyFormatter::formatHtml((float) ($currentDeposit->getVirtualColumn('totalAmount') ?? 0)) ?></div>
+                        <div class="h3 text-success mb-0"><?= CurrencyFormatter::formatHtml($currentDeposit->getVirtualColumn('totalAmount') ?? 0) ?></div>
                         <small class="text-body-secondary"><?= gettext('Total Amount') ?></small>
                     </div>
                     <a href="<?= $sRootPath ?>/DepositSlipEditor.php?DepositSlipID=<?= $currentDeposit->getId() ?>" class="btn btn-primary w-100">

--- a/src/finance/views/pledges/family-summary.php
+++ b/src/finance/views/pledges/family-summary.php
@@ -88,7 +88,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
                                                 <?php endif; ?>
                                                 <td><?= InputUtils::escapeHTML($pledge['fund_name']) ?></td>
                                                 <td class="text-end">
-                                                    <?= CurrencyFormatter::formatHtml((float) $pledge['pledge_amount']) ?>
+                                                    <?= CurrencyFormatter::formatHtml($pledge['pledge_amount']) ?>
                                                 </td>
                                             </tr>
                                         <?php endforeach; ?>

--- a/src/finance/views/pledges/family-summary.php
+++ b/src/finance/views/pledges/family-summary.php
@@ -2,6 +2,7 @@
 
 use ChurchCRM\dto\SystemURLs;
 use ChurchCRM\dto\SystemConfig;
+use ChurchCRM\Utils\CurrencyFormatter;
 use ChurchCRM\Utils\InputUtils;
 
 require SystemURLs::getDocumentRoot() . '/Include/Header.php';
@@ -87,7 +88,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
                                                 <?php endif; ?>
                                                 <td><?= InputUtils::escapeHTML($pledge['fund_name']) ?></td>
                                                 <td class="text-end">
-                                                    <?= number_format($pledge['pledge_amount'], 2) ?>
+                                                    <?= CurrencyFormatter::formatHtml((float) $pledge['pledge_amount']) ?>
                                                 </td>
                                             </tr>
                                         <?php endforeach; ?>

--- a/src/finance/views/pledges/family-summary.php
+++ b/src/finance/views/pledges/family-summary.php
@@ -88,7 +88,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
                                                 <?php endif; ?>
                                                 <td><?= InputUtils::escapeHTML($pledge['fund_name']) ?></td>
                                                 <td class="text-end">
-                                                    <?= CurrencyFormatter::formatHtml((float) $pledge['pledge_amount']) ?>
+                                                    <?= CurrencyFormatter::formatHtml($pledge['pledge_amount'] ?? 0) ?>
                                                 </td>
                                             </tr>
                                         <?php endforeach; ?>

--- a/src/finance/views/reports/pledge-dashboard.php
+++ b/src/finance/views/reports/pledge-dashboard.php
@@ -46,7 +46,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
             <div class="card finance-card shadow-sm border-0 h-100">
                 <div class="card-body text-center py-4 finance-metric-card metric-pledges">
                     <div class="finance-metric-value">
-                        <?= CurrencyFormatter::formatHtml((float) $totalPledges) ?>
+                        <?= CurrencyFormatter::formatHtml($totalPledges ?? 0) ?>
                     </div>
                     <div class="text-white-50 text-uppercase small fw-bold mt-2 finance-metric-label">
                         <?= gettext('Total Pledges') ?>
@@ -64,7 +64,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
             <div class="card finance-card shadow-sm border-0 h-100">
                 <div class="card-body text-center py-4 finance-metric-card metric-payments">
                     <div class="finance-metric-value">
-                        <?= CurrencyFormatter::formatHtml((float) $totalPayments) ?>
+                        <?= CurrencyFormatter::formatHtml($totalPayments ?? 0) ?>
                     </div>
                     <div class="text-white-50 text-uppercase small fw-bold mt-2 finance-metric-label">
                         <?= gettext('Total Payments') ?>
@@ -91,10 +91,10 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
                         </div>
                         <div class="card-body">
                             <div class="h5 mb-1 fw-bold text-dark">
-                                <?= CurrencyFormatter::formatHtml((float) $fundTotal['total_paid']) ?>
+                                <?= CurrencyFormatter::formatHtml($fundTotal['total_paid'] ?? 0) ?>
                             </div>
                             <div class="text-body-secondary small mb-2">
-                                <?= gettext('of') ?> <?= CurrencyFormatter::formatHtml((float) $fundTotal['total_pledged']) ?>
+                                <?= gettext('of') ?> <?= CurrencyFormatter::formatHtml($fundTotal['total_pledged'] ?? 0) ?>
                                 (<?= number_format($fundPercent, 0) ?>%)
                             </div>
                             <div class="text-body-secondary small mb-2">
@@ -169,10 +169,10 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
                                                 <?php endif; ?>
                                                 <td><?= InputUtils::escapeHTML($pledge['fund_name']) ?></td>
                                                 <td class="text-end fw-bold">
-                                                    <?= CurrencyFormatter::formatHtml((float) $pledge['pledge_amount']) ?>
+                                                    <?= CurrencyFormatter::formatHtml($pledge['pledge_amount'] ?? 0) ?>
                                                 </td>
                                                 <td class="text-end">
-                                                    <?= CurrencyFormatter::formatHtml((float) $pledge['payment_amount']) ?>
+                                                    <?= CurrencyFormatter::formatHtml($pledge['payment_amount'] ?? 0) ?>
                                                 </td>
                                                 <?php
                                                 $remaining = $pledge['pledge_amount'] - $pledge['payment_amount'];
@@ -188,7 +188,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
                                                 }
                                                 ?>
                                                 <td class="text-end <?= $statusClass ?>">
-                                                    <?= CurrencyFormatter::formatHtml((float) $remaining) ?>
+                                                    <?= CurrencyFormatter::formatHtml($remaining ?? 0) ?>
                                                     <small class="d-block text-body-secondary"><?= number_format($percentComplete, 0) ?>%</small>
                                                 </td>
                                             </tr>

--- a/src/finance/views/reports/pledge-dashboard.php
+++ b/src/finance/views/reports/pledge-dashboard.php
@@ -46,7 +46,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
             <div class="card finance-card shadow-sm border-0 h-100">
                 <div class="card-body text-center py-4 finance-metric-card metric-pledges">
                     <div class="finance-metric-value">
-                        <?= CurrencyFormatter::formatHtml((float) $totalPledges) ?>
+                        <?= CurrencyFormatter::formatHtml($totalPledges) ?>
                     </div>
                     <div class="text-white-50 text-uppercase small fw-bold mt-2 finance-metric-label">
                         <?= gettext('Total Pledges') ?>
@@ -64,7 +64,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
             <div class="card finance-card shadow-sm border-0 h-100">
                 <div class="card-body text-center py-4 finance-metric-card metric-payments">
                     <div class="finance-metric-value">
-                        <?= CurrencyFormatter::formatHtml((float) $totalPayments) ?>
+                        <?= CurrencyFormatter::formatHtml($totalPayments) ?>
                     </div>
                     <div class="text-white-50 text-uppercase small fw-bold mt-2 finance-metric-label">
                         <?= gettext('Total Payments') ?>
@@ -91,10 +91,10 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
                         </div>
                         <div class="card-body">
                             <div class="h5 mb-1 fw-bold text-dark">
-                                <?= CurrencyFormatter::formatHtml((float) $fundTotal['total_paid']) ?>
+                                <?= CurrencyFormatter::formatHtml($fundTotal['total_paid']) ?>
                             </div>
                             <div class="text-body-secondary small mb-2">
-                                <?= gettext('of') ?> <?= CurrencyFormatter::formatHtml((float) $fundTotal['total_pledged']) ?>
+                                <?= gettext('of') ?> <?= CurrencyFormatter::formatHtml($fundTotal['total_pledged']) ?>
                                 (<?= number_format($fundPercent, 0) ?>%)
                             </div>
                             <div class="text-body-secondary small mb-2">
@@ -169,10 +169,10 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
                                                 <?php endif; ?>
                                                 <td><?= InputUtils::escapeHTML($pledge['fund_name']) ?></td>
                                                 <td class="text-end fw-bold">
-                                                    <?= CurrencyFormatter::formatHtml((float) $pledge['pledge_amount']) ?>
+                                                    <?= CurrencyFormatter::formatHtml($pledge['pledge_amount']) ?>
                                                 </td>
                                                 <td class="text-end">
-                                                    <?= CurrencyFormatter::formatHtml((float) $pledge['payment_amount']) ?>
+                                                    <?= CurrencyFormatter::formatHtml($pledge['payment_amount']) ?>
                                                 </td>
                                                 <?php
                                                 $remaining = $pledge['pledge_amount'] - $pledge['payment_amount'];
@@ -188,7 +188,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
                                                 }
                                                 ?>
                                                 <td class="text-end <?= $statusClass ?>">
-                                                    <?= CurrencyFormatter::formatHtml((float) $remaining) ?>
+                                                    <?= CurrencyFormatter::formatHtml($remaining) ?>
                                                     <small class="d-block text-body-secondary"><?= number_format($percentComplete, 0) ?>%</small>
                                                 </td>
                                             </tr>

--- a/src/finance/views/reports/pledge-dashboard.php
+++ b/src/finance/views/reports/pledge-dashboard.php
@@ -3,6 +3,7 @@
 use ChurchCRM\dto\SystemURLs;
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\Service\FinancialService;
+use ChurchCRM\Utils\CurrencyFormatter;
 use ChurchCRM\Utils\InputUtils;
 
 require SystemURLs::getDocumentRoot() . '/Include/Header.php';
@@ -45,7 +46,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
             <div class="card finance-card shadow-sm border-0 h-100">
                 <div class="card-body text-center py-4 finance-metric-card metric-pledges">
                     <div class="finance-metric-value">
-                        $<?= number_format($totalPledges, 2) ?>
+                        <?= CurrencyFormatter::formatHtml((float) $totalPledges) ?>
                     </div>
                     <div class="text-white-50 text-uppercase small fw-bold mt-2 finance-metric-label">
                         <?= gettext('Total Pledges') ?>
@@ -63,7 +64,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
             <div class="card finance-card shadow-sm border-0 h-100">
                 <div class="card-body text-center py-4 finance-metric-card metric-payments">
                     <div class="finance-metric-value">
-                        $<?= number_format($totalPayments, 2) ?>
+                        <?= CurrencyFormatter::formatHtml((float) $totalPayments) ?>
                     </div>
                     <div class="text-white-50 text-uppercase small fw-bold mt-2 finance-metric-label">
                         <?= gettext('Total Payments') ?>
@@ -90,10 +91,10 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
                         </div>
                         <div class="card-body">
                             <div class="h5 mb-1 fw-bold text-dark">
-                                $<?= number_format($fundTotal['total_paid'], 2) ?>
+                                <?= CurrencyFormatter::formatHtml((float) $fundTotal['total_paid']) ?>
                             </div>
                             <div class="text-body-secondary small mb-2">
-                                <?= gettext('of') ?> $<?= number_format($fundTotal['total_pledged'], 2) ?>
+                                <?= gettext('of') ?> <?= CurrencyFormatter::formatHtml((float) $fundTotal['total_pledged']) ?>
                                 (<?= number_format($fundPercent, 0) ?>%)
                             </div>
                             <div class="text-body-secondary small mb-2">
@@ -168,10 +169,10 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
                                                 <?php endif; ?>
                                                 <td><?= InputUtils::escapeHTML($pledge['fund_name']) ?></td>
                                                 <td class="text-end fw-bold">
-                                                    $<?= number_format($pledge['pledge_amount'], 2) ?>
+                                                    <?= CurrencyFormatter::formatHtml((float) $pledge['pledge_amount']) ?>
                                                 </td>
                                                 <td class="text-end">
-                                                    $<?= number_format($pledge['payment_amount'], 2) ?>
+                                                    <?= CurrencyFormatter::formatHtml((float) $pledge['payment_amount']) ?>
                                                 </td>
                                                 <?php
                                                 $remaining = $pledge['pledge_amount'] - $pledge['payment_amount'];
@@ -187,7 +188,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
                                                 }
                                                 ?>
                                                 <td class="text-end <?= $statusClass ?>">
-                                                    $<?= number_format($remaining, 2) ?>
+                                                    <?= CurrencyFormatter::formatHtml((float) $remaining) ?>
                                                     <small class="d-block text-body-secondary"><?= number_format($percentComplete, 0) ?>%</small>
                                                 </td>
                                             </tr>

--- a/src/fundraiser/views/fundraiser-editor.php
+++ b/src/fundraiser/views/fundraiser-editor.php
@@ -119,10 +119,10 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
                 <?php endif; ?>
               </td>
               <td><?= InputUtils::escapeHTML($item->getTitle()) ?></td>
-              <td class="text-end"><?= is_numeric($item->getSellprice()) ? CurrencyFormatter::formatHtml((float) $item->getSellprice()) : '' ?></td>
-              <td class="text-end"><?= is_numeric($item->getEstprice()) ? CurrencyFormatter::formatHtml((float) $item->getEstprice()) : '' ?></td>
-              <td class="text-end"><?= is_numeric($item->getMaterialValue()) ? CurrencyFormatter::formatHtml((float) $item->getMaterialValue()) : '' ?></td>
-              <td class="text-end"><?= is_numeric($item->getMinimum()) ? CurrencyFormatter::formatHtml((float) $item->getMinimum()) : '' ?></td>
+              <td class="text-end"><?= CurrencyFormatter::formatHtml($item->getSellprice()) ?></td>
+              <td class="text-end"><?= CurrencyFormatter::formatHtml($item->getEstprice()) ?></td>
+              <td class="text-end"><?= CurrencyFormatter::formatHtml($item->getMaterialValue()) ?></td>
+              <td class="text-end"><?= CurrencyFormatter::formatHtml($item->getMinimum()) ?></td>
               <td class="w-1">
                 <div class="dropdown">
                   <button class="btn btn-sm btn-ghost-secondary" type="button" data-bs-toggle="dropdown" data-bs-display="static" aria-expanded="false">


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *original implementation by the implementer bot from Docker Agentic Platform; follow-up commits by maintainer session*

## Summary
Applies `CurrencyFormatter::formatHtml()` to all dashboard and finance HTML pages that previously hard-coded a US dollar sign next to `number_format()`, then widens `formatHtml()` to accept `float|string|null` so call sites no longer need `(float)` pre-casts. Part of epic #8459 (currency localisation).

## Changes
- Replace hardcoded `$` + `number_format()` with `CurrencyFormatter::formatHtml()` across finance dashboard, pledge dashboard, family pledge summary, and deposit slip editor
- Widen `formatHtml()` signature to `float|string|null`: numeric strings (Propel DECIMAL/SUM returns) are converted internally; null/empty render as `''`; non-numeric strings render as `''` with a warning log instead of a silent `$0.00`
- Drop all 19 caller-side `(float)` casts (a blind cast launders NULL/garbage into a legit-looking `$0.00` on finance reports); keep `?? 0` only where a blank should intentionally display as zero (unguarded SUM totals)
- Simplify `fundraiser-editor.php` `is_numeric(...) ? formatHtml((float)...) : ''` ternaries to plain `formatHtml()` calls — the formatter's null/non-numeric handling replaces the guards
- `format()` stays strictly `float` for API/PDF code
- Document the no-pre-cast rule in `.agents/skills/churchcrm/currency-localization.md`

## Why
- Centralises string→float conversion with validation at the formatter boundary instead of scattering unchecked casts across templates
- `family-summary.php` now shows a currency symbol where previously there was none — intended behaviour per the currency-localization skill

## Files Changed
- `src/ChurchCRM/utils/CurrencyFormatter.php` — signature widening + validation
- `src/finance/views/dashboard.php`, `src/finance/views/reports/pledge-dashboard.php`, `src/finance/views/pledges/family-summary.php`, `src/DepositSlipEditor.php`, `src/fundraiser/views/fundraiser-editor.php` — call-site cleanup
- `.agents/skills/churchcrm/currency-localization.md` — skill update

## Testing
- `npm run lint` — clean
- `npm run build:php` — all 757 PHP files pass syntax validation

**Percentage and count `number_format()` calls are intentionally left unchanged.** PDF-generating reports (`src/Reports/`) get a separate rewrite per the epic.

Skill: `.agents/skills/churchcrm/currency-localization.md`
Epic: #8459

🤖 Generated with [Claude Code](https://claude.com/claude-code)