### PR TITLE
feat(events): add quick Activate/Deactivate button to event view page

### DIFF
--- a/src/event/views/view.php
+++ b/src/event/views/view.php
@@ -83,6 +83,15 @@ $inactive = (int) $event->getInActive() === 1;
             </a>
           <?php endif; ?>
           <?php if ($canEditEvents): ?>
+            <?php if ($inactive): ?>
+              <button type="button" class="btn btn-outline-success activate-event" data-event_id="<?= $eventId ?>">
+                <i class="ti ti-circle-check me-1"></i><?= gettext('Activate') ?>
+              </button>
+            <?php else: ?>
+              <button type="button" class="btn btn-outline-secondary deactivate-event" data-event_id="<?= $eventId ?>">
+                <i class="ti ti-circle-x me-1"></i><?= gettext('Deactivate') ?>
+              </button>
+            <?php endif; ?>
             <a href="<?= $sRootPath ?>/event/editor/<?= $eventId ?>" class="btn btn-primary">
               <i class="ti ti-pencil me-1"></i><?= gettext('Edit') ?>
             </a>


### PR DESCRIPTION
## Summary
Adds a one-click Activate/Deactivate button to the event detail page (`/event/view/{id}`) so admins can toggle an event's status without opening the editor.

## Changes
- Event view card footer now shows **Deactivate** (active events) or **Activate** (inactive events) next to Edit, visible only to users with the AddEvents role
- Reuses the existing global `.activate-event` / `.deactivate-event` delegated handlers in `CRMJSOM.js`, which call `POST /api/calendar/events/{id}/status` and reload — no new JavaScript, no CSP-inline handlers

## Why
Deactivating an event previously required opening the full editor (or finding the row's ⋮ menu on the dashboard). The detail page is where admins land when reviewing an event, so the toggle belongs there too.

## Files Changed
- `src/event/views/view.php` — +9 lines (button markup in card footer)

## Testing
- `npm run lint` — clean; `npm run build:php` — all files pass
- Manual: open any event's View page as an admin → Deactivate → page reloads with Inactive badge and an Activate button; toggle back. As a user without AddEvents, neither button renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)