### PR TITLE
fix: use Person view URI for Did Not Attend links on event detail page

### DIFF
--- a/cypress/e2e/ui/people/standard.person.groups.spec.js
+++ b/cypress/e2e/ui/people/standard.person.groups.spec.js
@@ -1,7 +1,7 @@
 /// <reference types="cypress" />
 
 /**
- * UI tests for Person Group Interactions on PersonView.php.
+ * UI tests for Person Group Interactions on the person view page (/people/view/{id}).
  *
  * Uses API calls to ensure person 2 is in a known group before each test.
  * Depends on seed-data group "Church Board" (ID 9) existing.

--- a/src/event/views/view.php
+++ b/src/event/views/view.php
@@ -199,7 +199,7 @@ $inactive = (int) $event->getInActive() === 1;
                 <?php foreach ($nonAttendees as $na): ?>
                   <tr>
                     <td>
-                      <a href="<?= $sRootPath ?>/PersonView.php?PersonID=<?= (int) $na['personId'] ?>">
+                      <a href="<?= Person::getViewURIForId($na['personId']) ?>">
                         <?= InputUtils::escapeHTML($na['fullName']) ?>
                       </a>
                     </td>

--- a/src/people/routes/view.php
+++ b/src/people/routes/view.php
@@ -162,7 +162,7 @@ $app->get('/view/{personID:[0-9]+}', function (Request $request, Response $respo
         ->orderByOrder()
         ->find();
 
-    // ── Properties (ORM via PropertyService — mirrors master's PersonView.php) ─
+    // ── Properties (ORM via PropertyService) ─
     $assignedPersonProperties = PropertyService::getAssigned($person);
     $allPersonProperties      = PropertyService::getAll($person);
 

--- a/webpack/people/person-group-manager.js
+++ b/webpack/people/person-group-manager.js
@@ -1,5 +1,5 @@
 /**
- * Group interaction manager for PersonView.php
+ * Group interaction manager for the person view page (/people/view/{id})
  *
  * Handles:
  * - Add person to a group (searchable TomSelect dropdown + role)

--- a/webpack/people/person-view.js
+++ b/webpack/people/person-view.js
@@ -1,5 +1,5 @@
 /**
- * Leaflet map initialisation for the person detail view (PersonView.php).
+ * Leaflet map initialisation for the person detail view (/people/view/{id}).
  *
  * PHP injects window.CRM.personMapConfig with one of two shapes:
  *   { lat, lng }   — family has stored geocoded coordinates (used directly)


### PR DESCRIPTION
## Summary
The Did Not Attend table on the event detail page (added in #8994) linked person names to the deleted legacy `PersonView.php?PersonID=` URL, producing broken links. Fixes it to use `Person::getViewURIForId()` like the attendance roster above it, and removes the remaining stale `PersonView.php` doc comments codebase-wide.

## Changes
- `src/event/views/view.php` — Did Not Attend person link now uses `Person::getViewURIForId()`
- Comment-only cleanups (no behavior change): `src/people/routes/view.php`, `webpack/people/person-view.js`, `webpack/people/person-group-manager.js`, `cypress/e2e/ui/people/standard.person.groups.spec.js` — references to the deleted `PersonView.php` updated to `/people/view/{id}`

## Why
`src/PersonView.php` was deleted in the people MVC migration; this was the last live link to it (verified via repo-wide grep — remaining `PersonID=` hits target legacy pages that still exist).

## Testing
- `npm run lint`, `npm run build:webpack`, `npm run build:php` — all pass
- Manual: open an ended, group-linked event's detail page → Did Not Attend name links now resolve to `/people/view/{id}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)