### PR TITLE
Fix CI: reorder attendance-tab API seeding before session login

### DIFF
--- a/.agents/skills/churchcrm/cypress-testing.md
+++ b/.agents/skills/churchcrm/cypress-testing.md
@@ -326,6 +326,24 @@ beforeEach(() => {
 });
 ```
 
+### Recurrence: brand-new specs keep reintroducing this bug — grep before writing `beforeEach` <!-- learned: 2026-07-19 -->
+
+This exact anti-pattern reappeared in `cypress/e2e/ui/people/person.attendance.spec.js`
+(added by the per-person attendance-history feature, #8649) despite being documented above
+since 2026-03-27. Its `beforeEach` hooks did `cy.setupAdminSession()` → `cy.makePrivateAdminAPICall("POST", ".../checkin", ...)` → `cy.visit(...)`, which clobbered the cached admin
+session's PHP session data. Because `cy.session()`'s cache validator only checks that a
+`CRM-` cookie exists (not that the session behind it still works), the corruption silently
+carried forward into **every later context in the same file** — including ones that made no
+API call at all — since they all reused the same poisoned `cy.session('admin-session')`
+cache. In CI this surfaced as `cy.get('#nav-item-attendance')` timing out (the page was
+silently redirecting to the login screen), which looks nothing like a session bug at first
+glance. Fixed by moving the API call before `freshAdminLogin()` per the pattern above.
+
+**Before adding any new UI spec that seeds data via `makePrivateAdminAPICall` /
+`makePrivateUserAPICall`, grep the file for `cy.setupAdminSession()` appearing before an API
+call in the same hook** — that ordering is the bug. The API call must come first, and the
+hook must call `freshAdminLogin()` (not `cy.setupAdminSession()`) afterward, every time.
+
 **API-only tests need no login at all.** `makePrivateAdminAPICall` / `makePrivateUserAPICall`
 authenticate via the `x-api-key` header — no session or cookies. Never put
 `cy.setupAdminSession()` in `beforeEach` of a pure API spec; it is a wasted login per test.

--- a/.agents/skills/churchcrm/frontend-development.md
+++ b/.agents/skills/churchcrm/frontend-development.md
@@ -884,6 +884,29 @@ A classic bug: the "Refresh Coordinates" button is shown when a family has no co
 
 **Rule:** JS bundles that contain event handlers must always be loaded. Use `if (!config) return;` guards inside the JS, not PHP conditionals wrapping the `<script>` tag.
 
+### Recurrence: same bug, person-view page this time <!-- learned: 2026-07-19 -->
+
+Found again in `src/people/views/person-view.php`: `<script src=".../people-person-view.min.js">`
+(which bundles `initAttendanceHistory()`, `initGroupManager()`, `initTimelineFilter()`, and the
+person-map init) was nested two levels deep — inside `<?php if ($fam_ID !== '' && $person->getFamily() !== null) { ?>`
+*and* `<?php if (!empty($formattedMailingAddress)) : ?>`. For any person without a family (or
+with a family but no mailing address — e.g. the "Church Admin" placeholder record at `per_ID=1`,
+used as the admin user's own person record), the bundle never loaded at all. Every feature it
+powers silently no-op'd: clicking the Attendance tab never fired its lazy-load fetch, group
+add/remove/change-role never worked, the timeline filter chips never applied.
+
+This was invisible in manual testing and in most Cypress specs because almost every test fixture
+person has a family with an address. It only surfaced once a test visited the admin's own
+profile (`/people/view/1`) — a person view that's easy to forget exists as a distinct, real state
+(no family, no address) precisely because you rarely navigate there intentionally.
+
+**Rule reinforced:** when adding any new script-driven feature (tab, button, filter) to
+`person-view.php` or `family-view.php`, verify the `<script>` tag for its bundle sits outside
+*every* conditional that isn't the bundle's own load-order requirement — and specifically test
+against a fixture person/family with no address and no coordinates, not just the happy-path
+fixture. `grep -n 'people-person-view.min.js\|people-family-view.min.js'` the view file and
+trace every enclosing `<?php if` before adding markup near it.
+
 ## importDemoData.js — Demo Data Trigger <!-- learned: 2026-03-19 -->
 
 `src/skin/js/importDemoData.js` listens on these selectors and shows the import overlay:

--- a/cypress/e2e/ui/people/person.attendance.spec.js
+++ b/cypress/e2e/ui/people/person.attendance.spec.js
@@ -3,18 +3,41 @@
 /**
  * UI spec for the Attendance History tab on the Person view page.
  *
- * Seeding strategy: person 2 (Mathew Campbell) is checked into event 1 in
- * the beforeEach() of contexts that need attendance data — AFTER
- * setupAdminSession() has established auth. The checkin call accepts both 200
- * (freshly checked in) and 409 (already checked in from a previous test run)
- * so duplicate checkins are silently tolerated.
+ * Seeding strategy: person 2 (Mathew Campbell) is checked into event 1 via
+ * cy.makePrivateAdminAPICall() in the beforeEach() of contexts that need
+ * attendance data. Per `.agents/skills/churchcrm/cypress-testing.md` →
+ * "UI Tests Must Not Call APIs After Login": cy.request() (which
+ * makePrivateAdminAPICall uses) sends and receives cookies for the app's
+ * own origin regardless of `withCredentials`, so any API-key call made
+ * while a UI session cookie is already present clobbers that browser
+ * session's PHP session data. `cy.setupAdminSession()` afterward is NOT
+ * a reliable fix — its cache validator only checks that a session cookie
+ * exists, not that the underlying PHP session is still alive — so contexts
+ * that mix an API call with a browser visit use the local freshAdminLogin()
+ * helper (real clear + form login) AFTER the API call instead, exactly as
+ * documented in the skill. The checkin call accepts both 200 (freshly
+ * checked in) and 409 (already checked in from a previous test run) so
+ * duplicate checkins are silently tolerated.
  *
- * The after() cleanup runs as admin (cy.session is still alive after the last
- * beforeEach of the suite) to remove the attendance record.
+ * The after() cleanup is a pure API call (checkout) and needs no browser
+ * session at all — makePrivateAdminAPICall authenticates via x-api-key only.
  *
  * cy.intercept uses double-star ("**") glob patterns so intercepts work when
  * ChurchCRM is deployed under a subdirectory path.
  */
+
+// Local helper — NOT a cy.* command (see cypress-testing.md). Clears cookies and
+// does a direct form login, discarding any dead PHP session left by a prior
+// cy.request() / makePrivateAdminAPICall() call. Required after any API call
+// that precedes a cy.visit() — cy.setupAdminSession() is not reliable here.
+function freshAdminLogin() {
+    cy.clearCookies();
+    cy.visit("/session/begin");
+    cy.get("input[name=User]").type(Cypress.env("admin.username"));
+    cy.get("input[name=Password]").type(Cypress.env("admin.password") + "{enter}");
+    cy.url().should("not.include", "/session/begin");
+}
+
 describe("Person Attendance History Tab", () => {
     const PERSON_WITH_ATTENDANCE = 2;
     const PERSON_WITHOUT_ATTENDANCE = 1;
@@ -22,8 +45,8 @@ describe("Person Attendance History Tab", () => {
 
     after(() => {
         // Cleanup: check person 2 out of event 1.
-        // cy.session from the last beforeEach is still valid here.
-        cy.setupAdminSession();
+        // makePrivateAdminAPICall() authenticates via x-api-key alone — it needs no
+        // browser session, so no login call here (see file header).
         cy.makePrivateAdminAPICall("POST", `/api/events/${EVENT_ID}/checkout`, { personId: PERSON_WITH_ATTENDANCE }, 200);
     });
 
@@ -45,15 +68,16 @@ describe("Person Attendance History Tab", () => {
 
     context("Lazy load on tab activation — person with attendance", () => {
         beforeEach(() => {
-            // Auth FIRST, then seed — before() fires before any auth is set up
-            cy.setupAdminSession();
-            // Accept 200 (fresh checkin) or 409 (already checked in) — tolerate duplicates
+            // API setup FIRST, then freshAdminLogin() — NOT cy.setupAdminSession(),
+            // see file header. Accept 200 (fresh checkin) or 409 (already checked
+            // in) — tolerate duplicates.
             cy.makePrivateAdminAPICall(
                 "POST",
                 `/api/events/${EVENT_ID}/checkin`,
                 { personId: PERSON_WITH_ATTENDANCE },
                 [200, 409],
             );
+            freshAdminLogin();
             cy.visit(`/people/view/${PERSON_WITH_ATTENDANCE}`);
             // Use **/api/** glob so intercepts work under a subdirectory deployment
             cy.intercept("GET", `**/api/attendance/person/${PERSON_WITH_ATTENDANCE}`).as("attendanceApi");
@@ -147,13 +171,15 @@ describe("Person Attendance History Tab", () => {
 
     context("Filter controls", () => {
         beforeEach(() => {
-            cy.setupAdminSession();
+            // API setup FIRST, then freshAdminLogin() — NOT cy.setupAdminSession(),
+            // see file header.
             cy.makePrivateAdminAPICall(
                 "POST",
                 `/api/events/${EVENT_ID}/checkin`,
                 { personId: PERSON_WITH_ATTENDANCE },
                 [200, 409],
             );
+            freshAdminLogin();
             cy.visit(`/people/view/${PERSON_WITH_ATTENDANCE}`);
             cy.intercept("GET", `**/api/attendance/person/${PERSON_WITH_ATTENDANCE}`).as("attendanceApi");
             cy.get("#nav-item-attendance").click();

--- a/cypress/e2e/ui/people/person.attendance.spec.js
+++ b/cypress/e2e/ui/people/person.attendance.spec.js
@@ -198,11 +198,12 @@ describe("Person Attendance History Tab", () => {
         });
 
         it("clear button resets filters and shows all records", () => {
-            // Set a future date that excludes all records. .clear() first — matches
-            // the working pattern used elsewhere for native date inputs (e.g.
-            // tax-report-pdf.spec.js) and ensures the "change" event that
-            // attendance-history.ts listens on actually fires.
-            cy.get("#attendance-tab .attendance-filter-from").clear().type("2099-01-01");
+            // Set a future date that excludes all records. attendance-history.ts
+            // applies the filter on the "change" event, which native date inputs
+            // only fire on blur — .type() alone doesn't blur the field, and the
+            // very next command here is a read-only assertion (no click to move
+            // focus elsewhere), so an explicit .blur() is required to trigger it.
+            cy.get("#attendance-tab .attendance-filter-from").clear().type("2099-01-01").blur();
             cy.get("#attendance-tab .attendance-tbody tr").should("have.length", 0);
 
             // Clear the filter

--- a/cypress/e2e/ui/people/person.attendance.spec.js
+++ b/cypress/e2e/ui/people/person.attendance.spec.js
@@ -191,8 +191,11 @@ describe("Person Attendance History Tab", () => {
         });
 
         it("clear button resets filters and shows all records", () => {
-            // Set a future date that excludes all records
-            cy.get("#attendance-tab .attendance-filter-from").type("2099-01-01");
+            // Set a future date that excludes all records. .clear() first — matches
+            // the working pattern used elsewhere for native date inputs (e.g.
+            // tax-report-pdf.spec.js) and ensures the "change" event that
+            // attendance-history.ts listens on actually fires.
+            cy.get("#attendance-tab .attendance-filter-from").clear().type("2099-01-01");
             cy.get("#attendance-tab .attendance-tbody tr").should("have.length", 0);
 
             // Clear the filter

--- a/cypress/e2e/ui/people/person.attendance.spec.js
+++ b/cypress/e2e/ui/people/person.attendance.spec.js
@@ -6,15 +6,17 @@
  * Seeding strategy: person 2 (Mathew Campbell) is checked into event 1 via
  * cy.makePrivateAdminAPICall() in the beforeEach() of contexts that need
  * attendance data. Per `.agents/skills/churchcrm/cypress-testing.md` →
- * "UI Tests Must Not Call APIs After Login": cy.request() (which
- * makePrivateAdminAPICall uses) sends and receives cookies for the app's
- * own origin regardless of `withCredentials`, so any API-key call made
- * while a UI session cookie is already present clobbers that browser
- * session's PHP session data. `cy.setupAdminSession()` afterward is NOT
- * a reliable fix — its cache validator only checks that a session cookie
- * exists, not that the underlying PHP session is still alive — so contexts
- * that mix an API call with a browser visit use the local freshAdminLogin()
- * helper (real clear + form login) AFTER the API call instead, exactly as
+ * "UI Tests Must Not Call APIs After Login": `makePrivateAdminAPICall` does
+ * set `withCredentials: false` on its cy.request() call (see
+ * cypress/support/api-commands.js), but CI has repeatedly confirmed that
+ * alone is NOT sufficient to stop the browser's session cookie from being
+ * shared with the request — so an API-key call made while a UI session
+ * cookie is already present still clobbers that browser session's PHP
+ * session data. `cy.setupAdminSession()` afterward is NOT a reliable fix
+ * either — its cache validator only checks that a session cookie exists,
+ * not that the underlying PHP session is still alive — so contexts that mix
+ * an API call with a browser visit use the local freshAdminLogin() helper
+ * (real clear + form login) AFTER the API call instead, exactly as
  * documented in the skill. The checkin call accepts both 200 (freshly
  * checked in) and 409 (already checked in from a previous test run) so
  * duplicate checkins are silently tolerated.
@@ -35,7 +37,12 @@ function freshAdminLogin() {
     cy.visit("/session/begin");
     cy.get("input[name=User]").type(Cypress.env("admin.username"));
     cy.get("input[name=Password]").type(Cypress.env("admin.password") + "{enter}");
+    // Navigating away from /session/begin alone doesn't prove authentication
+    // succeeded (a 500 or an error page would also satisfy it) — confirm a
+    // real CRM session cookie was actually issued, same check cy.session()'s
+    // own validate() callback uses in cypress/support/ui-commands.js.
     cy.url().should("not.include", "/session/begin");
+    cy.getCookies().should("satisfy", (cookies) => cookies.some((cookie) => cookie.name.startsWith("CRM-")));
 }
 
 describe("Person Attendance History Tab", () => {

--- a/src/people/views/person-view.php
+++ b/src/people/views/person-view.php
@@ -504,19 +504,29 @@ $fam_Longitude      = (float) ($personData['fam_Longitude'] ?? 0);
                         <?php endif; ?>
                     </div>
                 </div>
-                <?php if ($personMapConfig !== null) : ?>
-                <div class="mt-2">
-                    <div id="person-map" style="height: 150px; border-radius: 4px;"></div>
-                </div>
-                <script nonce="<?= SystemURLs::getCSPNonce() ?>">
-                    window.CRM = window.CRM || {};
-                    window.CRM.personMapConfig = <?= json_encode($personMapConfig, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
-                </script>
-                <?php endif; ?>
             </div>
             <?php endif; ?>
         </div>
         <?php } ?>
+
+        <!--
+            Map config + container — unconditional on family/address presence (only
+            gated on $personMapConfig !== null), since it must render both for a
+            family's stored coordinates AND for a family-less person's own address
+            (the $fam_ID === '' branch above) — neither of which requires a family.
+            Previously this lived inside the "has family" card footer above, so the
+            family-less-with-own-address case never got a map despite the PHP setting
+            $personMapConfig for it.
+        -->
+        <?php if ($personMapConfig !== null) : ?>
+        <div class="mb-3">
+            <div id="person-map" style="height: 150px; border-radius: 4px;"></div>
+        </div>
+        <script nonce="<?= SystemURLs::getCSPNonce() ?>">
+            window.CRM = window.CRM || {};
+            window.CRM.personMapConfig = <?= json_encode($personMapConfig, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
+        </script>
+        <?php endif; ?>
 
         <!--
             person-view.js bundle (map, refresh-coordinates, group manager, timeline
@@ -524,9 +534,7 @@ $fam_Longitude      = (float) ($personData['fam_Longitude'] ?? 0);
             nested inside the "has family" / "has mailing address" blocks above:
             group management, the timeline filter, and the attendance history tab
             are all needed regardless of whether the person has a family or address
-            (e.g. the admin's own "Church Admin" placeholder person has neither),
-            and personMapConfig can also be set for a family-less person with their
-            own address (see the $fam_ID === '' branch above).
+            (e.g. the admin's own "Church Admin" placeholder person has neither).
         -->
         <link rel="stylesheet" href="<?= SystemURLs::assetVersioned('/skin/external/leaflet/leaflet.css') ?>">
         <script src="<?= SystemURLs::assetVersioned('/skin/external/leaflet/leaflet.js') ?>"></script>

--- a/src/people/views/person-view.php
+++ b/src/people/views/person-view.php
@@ -504,7 +504,6 @@ $fam_Longitude      = (float) ($personData['fam_Longitude'] ?? 0);
                         <?php endif; ?>
                     </div>
                 </div>
-                <link rel="stylesheet" href="<?= SystemURLs::assetVersioned('/skin/external/leaflet/leaflet.css') ?>">
                 <?php if ($personMapConfig !== null) : ?>
                 <div class="mt-2">
                     <div id="person-map" style="height: 150px; border-radius: 4px;"></div>
@@ -514,12 +513,24 @@ $fam_Longitude      = (float) ($personData['fam_Longitude'] ?? 0);
                     window.CRM.personMapConfig = <?= json_encode($personMapConfig, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
                 </script>
                 <?php endif; ?>
-                <script src="<?= SystemURLs::assetVersioned('/skin/external/leaflet/leaflet.js') ?>"></script>
-                <script src="<?= SystemURLs::assetVersioned('/skin/v2/people-person-view.min.js') ?>"></script>
             </div>
             <?php endif; ?>
         </div>
         <?php } ?>
+
+        <!--
+            person-view.js bundle (map, refresh-coordinates, group manager, timeline
+            filter, attendance history) — loaded unconditionally. It must NOT be
+            nested inside the "has family" / "has mailing address" blocks above:
+            group management, the timeline filter, and the attendance history tab
+            are all needed regardless of whether the person has a family or address
+            (e.g. the admin's own "Church Admin" placeholder person has neither),
+            and personMapConfig can also be set for a family-less person with their
+            own address (see the $fam_ID === '' branch above).
+        -->
+        <link rel="stylesheet" href="<?= SystemURLs::assetVersioned('/skin/external/leaflet/leaflet.css') ?>">
+        <script src="<?= SystemURLs::assetVersioned('/skin/external/leaflet/leaflet.js') ?>"></script>
+        <script src="<?= SystemURLs::assetVersioned('/skin/v2/people-person-view.min.js') ?>"></script>
 
         <!-- Tabbed Content -->
         <div class="card">


### PR DESCRIPTION
## What Changed

The root failure: `cypress/e2e/ui/people/person.attendance.spec.js` mixed `cy.makePrivateAdminAPICall()` (API-key auth) with an already-authenticated `cy.setupAdminSession()` browser session. Cypress's `cy.request()` always sends the app's same-origin cookies regardless of `withCredentials`, so the API-key call carried the browser's session cookie alongside `x-api-key`. The server's `AuthMiddleware` treats any `x-api-key` request as re-authenticating whatever session that cookie points to via the (session-less) `APITokenAuthentication` provider, which always reports the session as inactive — silently breaking the browser's session for the rest of the test file.

Fixing that surfaced two further, real application bugs that had been masked by it (not introduced by this PR, just previously untestable):

1. **`person-view.php` never loaded its own JS bundle for family-less people.** `<script src=".../people-person-view.min.js">` (attendance tab, group manager, timeline filter, person map) was nested inside a "person has a family" conditional *and* a "has mailing address" conditional. The admin's own "Church Admin" placeholder person record (`per_ID=1`, no family, no address) never got the bundle at all — every feature it powers silently no-op'd there. This is the same bug class already documented in `frontend-development.md` for `family-view.php` (2026-03-07); it had recurred on the person-view page.
2. **`window.CRM.personMapConfig` was still only emitted inside the family-card footer** even after (1)'s fix — so a family-less person with their *own* address (a separate, real PHP branch that sets `$personMapConfig`) got the bundle loaded but no config/container to use it with. Caught by review.

## Changes

- Reordered each `beforeEach`/`after` hook in `person.attendance.spec.js` to fire the API-key seeding call first, then re-authenticate via the `freshAdminLogin()` helper (a real clear + form login) — not `cy.setupAdminSession()` — before visiting the page, per the pattern already documented in `.agents/skills/churchcrm/cypress-testing.md`.
- Strengthened `freshAdminLogin()` to assert a real `CRM-` session cookie was issued, not just that the URL moved off `/session/begin`.
- Hoisted `person-view.php`'s `people-person-view.min.js`/`leaflet.js` script tags out of the family/address conditionals so they always load.
- Hoisted the `window.CRM.personMapConfig` script + `#person-map` container out of the family-card footer to render unconditionally whenever `$personMapConfig !== null`, fixing the map for family-less people with their own address too.
- Fixed the "clear button resets filters" test: `attendance-history.ts` applies date filters on the `change` event, which native date inputs only fire on blur; the test's next command was a read-only assertion with no click to force that blur, so added an explicit `.blur()`.
- Documented the recurrence in `cypress-testing.md` and `frontend-development.md` so both bug classes are easier to catch next time a script-driven feature is added to these pages/specs.

## Type
- [x] 🐛 Bug fix

## Testing
- `npm run lint` — 0 errors (2 pre-existing, unrelated warnings in `webpack/event-form.js` and `webpack/localization.js`)
- `npm run build:php` — 575 files, all pass syntax validation
- `node --check` on the modified spec file — syntax OK
- Verified against actual CI runs on this branch: all `person.attendance.spec.js` contexts (Tab navigation, Lazy load, Person with no attendance, Filter controls) now pass in `test-root`/`test-subdir` UI jobs; iterated through 3 rounds of real CI failures to get here, each traced to its actual root cause via job logs rather than guessed at

## Pre-Merge
- [x] No new warnings
- [x] Build passes (lint + PHP syntax validation)
- [x] Backward compatible — the person-view.php changes only *add* previously-dead code paths (bundle/map now load where they silently didn't before); no existing behavior for people who do have a family + address changes


---
_Generated by [Claude Code](https://claude.ai/code/session_01VawThYn8EhvWAquxcLcJrY)_