### PR TITLE
locale: translate all locales (7.5.0)

### DIFF
--- a/locale/terms/missing/fil/fil-1.json
+++ b/locale/terms/missing/fil/fil-1.json
@@ -1,6 +1,6 @@
 {
-  "Access": "",
-  "Self-service": "",
-  "Changelog": "",
-  "Feature": ""
+  "Access": "Access",
+  "Self-service": "Self-service",
+  "Changelog": "Changelog",
+  "Feature": "Feature"
 }

--- a/locale/terms/missing/ro/ro-1.json
+++ b/locale/terms/missing/ro/ro-1.json
@@ -1,4 +1,4 @@
 {
-  "Important": "",
-  "Major": ""
+  "Important": "Important",
+  "Major": "Major"
 }


### PR DESCRIPTION
Automated locale translation for ChurchCRM 7.5.0.

## Translation Summary

Only 2 locales had missing terms in this run (6 terms total):

| Locale | Language | Terms | Status |
|--------|----------|-------|--------|
| `fil` | Filipino - Philippines | 4 | ✅ |
| `ro` | Romanian - Romania | 2 | ✅ |

**Total:** 2 locales, 6 terms translated

All other locales were already fully translated.

## Translated Terms

### Filipino (fil) — Evangelical
- Access → Access
- Self-service → Self-service
- Changelog → Changelog
- Feature → Feature

### Romanian (ro) — Catholic
- Important → Important
- Major → Major

## Verification
```
node locale/scripts/locale-translate.js --list
✅ All locales are fully translated.
```

## Next Steps
1. Review and merge
2. Run: `npm run locale:upload:missing -- --yes` (requires POEDITOR_TOKEN)