### PR TITLE
Fix upgrade wizard parsererror caused by stray PHP output

### DIFF
--- a/src/ChurchCRM/dto/ChurchCRMReleaseManager.php
+++ b/src/ChurchCRM/dto/ChurchCRMReleaseManager.php
@@ -367,6 +367,12 @@ class ChurchCRMReleaseManager
             $logger = LoggerUtils::getAppLogger();
             $logger->warning('Maximum execution time threshold exceeded: ' . ini_get('max_execution_time'));
 
+            // Discard any output already buffered (e.g. by the do-upgrade route's
+            // output-buffering guard) so this is the only thing in the response body.
+            while (ob_get_level() > 0) {
+                ob_end_clean();
+            }
+
             echo \json_encode([
                 'code'    => 500,
                 'message' => 'Maximum execution time threshold exceeded: ' . ini_get('max_execution_time') . '.  This ChurchCRM installation may now be in an unstable state.  Please review the Documentation at https://docs.churchcrm.io/administration/troubleshooting',
@@ -377,10 +383,17 @@ class ChurchCRMReleaseManager
     public static function doUpgrade(string $zipFilename, string $sha1): void
     {
         self::$isUpgradeInProgress = true;
-        // temporarily disable PHP's error display so that
-        // our custom timeout handler can display parsable JSON
-        // in the event this upgrade job times-out the
-        // PHP instance's max_execution_time
+        // Disable PHP's error display for the entire upgrade (code deploy +
+        // database migration + cleanup), not just the code-deploy phase. This
+        // is what lets our custom timeout handler (preShutdown()) emit clean,
+        // parsable JSON if this job times out, and it also stops any stray
+        // PHP warning/notice/deprecation from the database migration step
+        // (UpgradeService runs legacy .sql/.php upgrade scripts) from being
+        // echoed directly into the HTTP response body ahead of the JSON the
+        // wizard's AJAX call expects — which corrupts the response and
+        // surfaces client-side as a "parsererror" even though the upgrade
+        // itself succeeded. Restored exactly once, in the finally block
+        // below, regardless of outcome.
         $displayErrors = ini_get('display_errors');
         ini_set('display_errors', 0);
         ini_set('max_execution_time', 50_000);
@@ -390,220 +403,211 @@ class ChurchCRMReleaseManager
         $logger->info('Beginning upgrade process');
         $logger->info('PHP max_execution_time is now: ' . ini_get('max_execution_time'));
 
-        // Pre-flight validation: Check if we can create the Upgrade directory
-        $docRoot = SystemURLs::getDocumentRoot();
-        $upgradeDir = $docRoot . '/Upgrade';
-        $logger->info('Document root: ' . $docRoot);
-        $logger->info('Upgrade directory will be: ' . $upgradeDir);
+        try {
+            // Pre-flight validation: Check if we can create the Upgrade directory
+            $docRoot = SystemURLs::getDocumentRoot();
+            $upgradeDir = $docRoot . '/Upgrade';
+            $logger->info('Document root: ' . $docRoot);
+            $logger->info('Upgrade directory will be: ' . $upgradeDir);
 
-        // Check if document root is writable
-        if (!is_writable($docRoot)) {
-            self::$isUpgradeInProgress = false;
-            ini_set('display_errors', $displayErrors);
-
-            // Safely determine the directory owner name, handling environments
-            // where POSIX functions or lookups may fail.
-            $ownerName = 'N/A';
-            if (function_exists('posix_getpwuid')) {
-                $fileOwner = @fileowner($docRoot);
-                if ($fileOwner !== false) {
-                    $ownerInfo = @posix_getpwuid($fileOwner);
-                    if (is_array($ownerInfo) && isset($ownerInfo['name'])) {
-                        $ownerName = $ownerInfo['name'];
+            // Check if document root is writable
+            if (!is_writable($docRoot)) {
+                // Safely determine the directory owner name, handling environments
+                // where POSIX functions or lookups may fail.
+                $ownerName = 'N/A';
+                if (function_exists('posix_getpwuid')) {
+                    $fileOwner = @fileowner($docRoot);
+                    if ($fileOwner !== false) {
+                        $ownerInfo = @posix_getpwuid($fileOwner);
+                        if (is_array($ownerInfo) && isset($ownerInfo['name'])) {
+                            $ownerName = $ownerInfo['name'];
+                        } else {
+                            $ownerName = 'unknown';
+                        }
                     } else {
                         $ownerName = 'unknown';
                     }
-                } else {
-                    $ownerName = 'unknown';
                 }
+
+                $logger->error('Cannot write to ChurchCRM installation directory', [
+                    'docRoot' => $docRoot,
+                    'isWritable' => false,
+                    'permissions' => substr(sprintf('%o', fileperms($docRoot)), -4),
+                    'owner' => $ownerName,
+                ]);
+                throw new \Exception(gettext('Cannot write to ChurchCRM installation directory. Please check that the web server has write permissions.'));
             }
 
-            $logger->error('Cannot write to ChurchCRM installation directory', [
-                'docRoot' => $docRoot,
-                'isWritable' => false,
-                'permissions' => substr(sprintf('%o', fileperms($docRoot)), -4),
-                'owner' => $ownerName,
-            ]);
-            throw new \Exception(gettext('Cannot write to ChurchCRM installation directory. Please check that the web server has write permissions.'));
-        }
-
-        // Create Upgrade directory if it doesn't exist
-        if (!is_dir($upgradeDir)) {
-            $logger->info('Creating Upgrade directory: ' . $upgradeDir);
-            if (!@mkdir($upgradeDir, 0755, true)) {
-                self::$isUpgradeInProgress = false;
-                ini_set('display_errors', $displayErrors);
-                $error = error_get_last();
-                $logger->error('Failed to create Upgrade directory', [
-                    'upgradeDir' => $upgradeDir,
-                    'lastError' => $error,
-                ]);
-                throw new \Exception(gettext('Failed to create Upgrade directory. Please check file permissions.'));
-            }
-        }
-
-        $logger->info('Beginning hash validation on ' . $zipFilename);
-
-        // Log detailed file information before attempting hash
-        $fileExists = file_exists($zipFilename);
-        $isReadable = is_readable($zipFilename);
-        $fileSize = $fileExists ? filesize($zipFilename) : -1;
-        $perms = $fileExists ? @fileperms($zipFilename) : false;
-        $filePerms = ($perms !== false) ? substr(sprintf('%o', $perms), -4) : 'N/A';
-        $currentUser = get_current_user();
-        $fileOwner = 'unknown';
-        // Only call posix_getpwuid if the function exists (not available on Windows)
-        if ($fileExists && function_exists('posix_getpwuid')) {
-            $pwuid = @posix_getpwuid(fileowner($zipFilename));
-            $fileOwner = ($pwuid !== false && isset($pwuid['name'])) ? $pwuid['name'] : 'unknown';
-        }
-        $logger->debug('File pre-flight check', [
-            'zipFilename' => $zipFilename,
-            'fileExists' => $fileExists,
-            'isReadable' => $isReadable,
-            'fileSize' => $fileSize,
-            'filePerms' => $filePerms,
-            'fileOwner' => $fileOwner,
-            'currentUser' => $currentUser,
-            'currentUserId' => function_exists('posix_getuid') ? posix_getuid() : 'N/A',
-            'fileOwnerId' => $fileExists ? fileowner($zipFilename) : -1,
-        ]);
-
-        $actualSha1 = sha1_file($zipFilename);
-        
-        // If sha1_file() returned false, log detailed diagnostic info
-        if ($actualSha1 === false) {
-            $lastError = error_get_last();
-            $logger->error(
-                'sha1_file() returned false - hash calculation failed',
-                [
-                    'zipFilename' => $zipFilename,
-                    'expectedHash' => $sha1,
-                    'actualHash' => false,
-                    'fileExists' => $fileExists,
-                    'isReadable' => $isReadable,
-                    'fileSize' => $fileSize,
-                    'filePerms' => $filePerms,
-                    'fileOwner' => $fileOwner,
-                    'currentUser' => $currentUser,
-                    'lastError' => $lastError['message'] ?? 'none',
-                    'lastErrorType' => $lastError['type'] ?? 'none',
-                    'openBasedir' => ini_get('open_basedir') ?: 'not set',
-                    'disabledFunctions' => ini_get('disable_functions') ?: 'none',
-                    'memoryLimit' => ini_get('memory_limit'),
-                    'uploadTmpDir' => ini_get('upload_tmp_dir') ?: sys_get_temp_dir(),
-                ]
-            );
-        }
-        
-        if ($sha1 !== $actualSha1) {
-            self::$isUpgradeInProgress = false;
-            ini_set('display_errors', $displayErrors);
-            $message = 'hash validation failure';
-            $logger->error(
-                $message,
-                [
-                    'zipFilename' => $zipFilename,
-                    'expectedHash' => $sha1,
-                    'actualHash' => $actualSha1,
-                ]
-            );
-
-            throw new \Exception($message);
-        }
-
-        $logger->info('Hash validation succeeded on ' . $zipFilename . ' Got: ' . $actualSha1);
-
-        $zip = new \ZipArchive();
-        $codeDeploySuccessful = false;
-
-        $openResult = $zip->open($zipFilename);
-        if ($openResult === true) {
-            $logger->info('Extracting ' . $zipFilename . ' to: ' . $upgradeDir);
-
-            $executionTime = new ExecutionTime();
-            $isSuccessful = $zip->extractTo($upgradeDir);
-            if (!$isSuccessful) {
-                self::$isUpgradeInProgress = false;
-                ini_set('display_errors', $displayErrors);
-                $logger->error('Failed to extract upgrade archive', [
-                    'zipFilename' => $zipFilename,
-                    'upgradeDir' => $upgradeDir,
-                    'diskFreeSpace' => disk_free_space($docRoot),
-                ]);
-                $zip->close();
-                throw new \Exception(gettext('Failed to extract upgrade archive. Please check disk space and file permissions.'));
-            }
-
-            $zip->close();
-
-            $logger->info('Extraction completed.  Took:' . $executionTime->getMilliseconds());
-
-            // Verify the extracted directory exists
-            $extractedChurchCRM = $upgradeDir . '/churchcrm';
-            if (!is_dir($extractedChurchCRM)) {
-                self::$isUpgradeInProgress = false;
-                ini_set('display_errors', $displayErrors);
-                $logger->error('Extraction completed but expected directory not found', [
-                    'upgradeDir' => $upgradeDir,
-                    'expectedDir' => $extractedChurchCRM,
-                    'upgradeDirContents' => @scandir($upgradeDir),
-                ]);
-                throw new \Exception(gettext('Extraction completed but upgrade files not found. The upgrade archive may be corrupted.'));
-            }
-
-            $logger->info('Moving extracted zip into place');
-
-            $executionTime = new ExecutionTime();
-
-            FileSystemUtils::moveDir($extractedChurchCRM, $docRoot);
-            $codeDeploySuccessful = true;
-            $logger->info('Move completed.  Took:' . $executionTime->getMilliseconds());
-        } else {
-            // ZipArchive::open() failed - log the error code and throw
-            self::$isUpgradeInProgress = false;
-            ini_set('display_errors', $displayErrors);
-            $logger->error('Failed to open upgrade archive', [
-                'zipFilename' => $zipFilename,
-                'errorCode' => $openResult,
-            ]);
-            throw new \Exception(gettext('Failed to open upgrade archive. The downloaded file may be corrupted.'));
-        }
-        $logger->info('Deleting zip archive: ' . $zipFilename);
-        unlink($zipFilename);
-
-        $logger->info('Upgrade process complete');
-        ini_set('display_errors', $displayErrors);
-        // Only attempt to upgrade the database if the code deploy/move completed successfully
-        if ($codeDeploySuccessful) {
-            try {
-                $logger->info('Attempting automatic database upgrade post code-deploy');
-                UpgradeService::upgradeDatabaseVersion();
-                $logger->info('Automatic database upgrade completed successfully');
-                
-                // After successful database upgrade, clean up orphaned files
-                $logger->info('Beginning automatic orphaned file cleanup');
-                $cleanupResult = AppIntegrityService::deleteOrphanedFiles();
-                $logger->info('Orphaned file cleanup completed', [
-                    'deleted' => count($cleanupResult['deleted']),
-                    'failed' => count($cleanupResult['failed']),
-                ]);
-                
-                if (!empty($cleanupResult['failed'])) {
-                    $logger->warning('Some orphaned files could not be deleted', [
-                        'failedFiles' => $cleanupResult['failed'],
-                        'errors' => $cleanupResult['errors'],
+            // Create Upgrade directory if it doesn't exist
+            if (!is_dir($upgradeDir)) {
+                $logger->info('Creating Upgrade directory: ' . $upgradeDir);
+                if (!@mkdir($upgradeDir, 0755, true)) {
+                    $error = error_get_last();
+                    $logger->error('Failed to create Upgrade directory', [
+                        'upgradeDir' => $upgradeDir,
+                        'lastError' => $error,
                     ]);
+                    throw new \Exception(gettext('Failed to create Upgrade directory. Please check file permissions.'));
                 }
-            } catch (\Exception $e) {
-                $logger->error('Automatic database upgrade failed: ' . $e->getMessage(), ['exception' => $e]);
-                // rethrow so the API caller is made aware of the failure
-                throw $e;
             }
-        } else {
-            $logger->warning('Skipping automatic database upgrade because code deployment did not complete successfully');
+
+            $logger->info('Beginning hash validation on ' . $zipFilename);
+
+            // Log detailed file information before attempting hash
+            $fileExists = file_exists($zipFilename);
+            $isReadable = is_readable($zipFilename);
+            $fileSize = $fileExists ? filesize($zipFilename) : -1;
+            $perms = $fileExists ? @fileperms($zipFilename) : false;
+            $filePerms = ($perms !== false) ? substr(sprintf('%o', $perms), -4) : 'N/A';
+            $currentUser = get_current_user();
+            $fileOwner = 'unknown';
+            // Only call posix_getpwuid if the function exists (not available on Windows)
+            if ($fileExists && function_exists('posix_getpwuid')) {
+                $pwuid = @posix_getpwuid(fileowner($zipFilename));
+                $fileOwner = ($pwuid !== false && isset($pwuid['name'])) ? $pwuid['name'] : 'unknown';
+            }
+            $logger->debug('File pre-flight check', [
+                'zipFilename' => $zipFilename,
+                'fileExists' => $fileExists,
+                'isReadable' => $isReadable,
+                'fileSize' => $fileSize,
+                'filePerms' => $filePerms,
+                'fileOwner' => $fileOwner,
+                'currentUser' => $currentUser,
+                'currentUserId' => function_exists('posix_getuid') ? posix_getuid() : 'N/A',
+                'fileOwnerId' => $fileExists ? fileowner($zipFilename) : -1,
+            ]);
+
+            $actualSha1 = sha1_file($zipFilename);
+
+            // If sha1_file() returned false, log detailed diagnostic info
+            if ($actualSha1 === false) {
+                $lastError = error_get_last();
+                $logger->error(
+                    'sha1_file() returned false - hash calculation failed',
+                    [
+                        'zipFilename' => $zipFilename,
+                        'expectedHash' => $sha1,
+                        'actualHash' => false,
+                        'fileExists' => $fileExists,
+                        'isReadable' => $isReadable,
+                        'fileSize' => $fileSize,
+                        'filePerms' => $filePerms,
+                        'fileOwner' => $fileOwner,
+                        'currentUser' => $currentUser,
+                        'lastError' => $lastError['message'] ?? 'none',
+                        'lastErrorType' => $lastError['type'] ?? 'none',
+                        'openBasedir' => ini_get('open_basedir') ?: 'not set',
+                        'disabledFunctions' => ini_get('disable_functions') ?: 'none',
+                        'memoryLimit' => ini_get('memory_limit'),
+                        'uploadTmpDir' => ini_get('upload_tmp_dir') ?: sys_get_temp_dir(),
+                    ]
+                );
+            }
+
+            if ($sha1 !== $actualSha1) {
+                $message = 'hash validation failure';
+                $logger->error(
+                    $message,
+                    [
+                        'zipFilename' => $zipFilename,
+                        'expectedHash' => $sha1,
+                        'actualHash' => $actualSha1,
+                    ]
+                );
+
+                throw new \Exception($message);
+            }
+
+            $logger->info('Hash validation succeeded on ' . $zipFilename . ' Got: ' . $actualSha1);
+
+            $zip = new \ZipArchive();
+            $codeDeploySuccessful = false;
+
+            $openResult = $zip->open($zipFilename);
+            if ($openResult === true) {
+                $logger->info('Extracting ' . $zipFilename . ' to: ' . $upgradeDir);
+
+                $executionTime = new ExecutionTime();
+                $isSuccessful = $zip->extractTo($upgradeDir);
+                if (!$isSuccessful) {
+                    $logger->error('Failed to extract upgrade archive', [
+                        'zipFilename' => $zipFilename,
+                        'upgradeDir' => $upgradeDir,
+                        'diskFreeSpace' => disk_free_space($docRoot),
+                    ]);
+                    $zip->close();
+                    throw new \Exception(gettext('Failed to extract upgrade archive. Please check disk space and file permissions.'));
+                }
+
+                $zip->close();
+
+                $logger->info('Extraction completed.  Took:' . $executionTime->getMilliseconds());
+
+                // Verify the extracted directory exists
+                $extractedChurchCRM = $upgradeDir . '/churchcrm';
+                if (!is_dir($extractedChurchCRM)) {
+                    $logger->error('Extraction completed but expected directory not found', [
+                        'upgradeDir' => $upgradeDir,
+                        'expectedDir' => $extractedChurchCRM,
+                        'upgradeDirContents' => @scandir($upgradeDir),
+                    ]);
+                    throw new \Exception(gettext('Extraction completed but upgrade files not found. The upgrade archive may be corrupted.'));
+                }
+
+                $logger->info('Moving extracted zip into place');
+
+                $executionTime = new ExecutionTime();
+
+                FileSystemUtils::moveDir($extractedChurchCRM, $docRoot);
+                $codeDeploySuccessful = true;
+                $logger->info('Move completed.  Took:' . $executionTime->getMilliseconds());
+            } else {
+                // ZipArchive::open() failed - log the error code and throw
+                $logger->error('Failed to open upgrade archive', [
+                    'zipFilename' => $zipFilename,
+                    'errorCode' => $openResult,
+                ]);
+                throw new \Exception(gettext('Failed to open upgrade archive. The downloaded file may be corrupted.'));
+            }
+            $logger->info('Deleting zip archive: ' . $zipFilename);
+            unlink($zipFilename);
+
+            $logger->info('Upgrade process complete');
+
+            // Only attempt to upgrade the database if the code deploy/move completed successfully
+            if ($codeDeploySuccessful) {
+                try {
+                    $logger->info('Attempting automatic database upgrade post code-deploy');
+                    UpgradeService::upgradeDatabaseVersion();
+                    $logger->info('Automatic database upgrade completed successfully');
+
+                    // After successful database upgrade, clean up orphaned files
+                    $logger->info('Beginning automatic orphaned file cleanup');
+                    $cleanupResult = AppIntegrityService::deleteOrphanedFiles();
+                    $logger->info('Orphaned file cleanup completed', [
+                        'deleted' => count($cleanupResult['deleted']),
+                        'failed' => count($cleanupResult['failed']),
+                    ]);
+
+                    if (!empty($cleanupResult['failed'])) {
+                        $logger->warning('Some orphaned files could not be deleted', [
+                            'failedFiles' => $cleanupResult['failed'],
+                            'errors' => $cleanupResult['errors'],
+                        ]);
+                    }
+                } catch (\Exception $e) {
+                    $logger->error('Automatic database upgrade failed: ' . $e->getMessage(), ['exception' => $e]);
+                    // rethrow so the API caller is made aware of the failure
+                    throw $e;
+                }
+            } else {
+                $logger->warning('Skipping automatic database upgrade because code deployment did not complete successfully');
+            }
+        } finally {
+            ini_set('display_errors', $displayErrors);
+            self::$isUpgradeInProgress = false;
         }
-        self::$isUpgradeInProgress = false;
     }
 
     /**

--- a/src/admin/routes/api/upgrade.php
+++ b/src/admin/routes/api/upgrade.php
@@ -2,6 +2,7 @@
 
 use ChurchCRM\Service\UpgradeAPIService;
 use ChurchCRM\Slim\SlimUtils;
+use ChurchCRM\Utils\LoggerUtils;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Routing\RouteCollectorProxy;
@@ -115,7 +116,20 @@ $app->group('/api/upgrade', function (RouteCollectorProxy $group): void {
             if ($realPath === false || $tempDir === false || !str_starts_with($realPath, $tempDir . DIRECTORY_SEPARATOR)) {
                 return SlimUtils::renderErrorJSON($response, gettext('Invalid file path'), [], 400, null, $request);
             }
-            UpgradeAPIService::doUpgrade($realPath, $sha1);
+            // Guard against stray PHP output (warnings/notices from the legacy
+            // migration scripts the upgrade runs) leaking into the response body
+            // ahead of the JSON, which corrupts it and surfaces client-side as a
+            // "parsererror" even though the upgrade itself succeeded. Anything
+            // captured here is logged, never sent to the client.
+            ob_start();
+            try {
+                UpgradeAPIService::doUpgrade($realPath, $sha1);
+            } finally {
+                $strayOutput = ob_get_clean();
+                if ($strayOutput !== false && trim($strayOutput) !== '') {
+                    LoggerUtils::getAppLogger()->warning('Discarded unexpected output during upgrade apply', ['output' => $strayOutput]);
+                }
+            }
             return SlimUtils::renderSuccessJSON($response);
         } catch (\Throwable $e) {
             // Return a localized, user-safe error message and log full details server-side


### PR DESCRIPTION
## Summary
- Fixes a bug in the upgrade wizard where the "Apply Update Now" step can fail with `Upgrade failed. 200: parsererror` even though the upgrade itself succeeded server-side.

## Changes
- `ChurchCRMReleaseManager::doUpgrade()`: `display_errors` was being re-enabled right after the code-deploy phase, before the database migration phase (`UpgradeService::upgradeDatabaseVersion()`, which runs legacy SQL/PHP migration scripts) ran. Restructured the method into `try { ... } finally { ... }` so `display_errors` stays suppressed for the entire upgrade and is restored exactly once, regardless of outcome.
- `preShutdown()` (the max-execution-time timeout handler): now discards any already-buffered output before echoing its own JSON, so a mid-upgrade timeout can't produce mixed/corrupted output either.
- `POST /admin/api/upgrade/do-upgrade` route: wrapped the `doUpgrade()` call in an `ob_start()`/`ob_get_clean()` guard as defense-in-depth — any stray output is now captured, logged, and discarded instead of leaking into the JSON response.

## Why
- If any PHP warning/notice/deprecation was emitted during the database migration phase (very plausible on servers with `display_errors=On`, given the legacy migration scripts involved), it was echoed directly into the HTTP response body ahead of the JSON payload. The HTTP status stayed 200 (nothing ever set it otherwise), but the body was no longer valid JSON.
- Client-side, `AdminAPIRequest` forces `dataType: "json"` for POST requests, so jQuery's automatic JSON parsing failed. jQuery sets its internal `textStatus` to `"parsererror"` while leaving `jqXHR.status` at 200, producing the exact `"200: parsererror"` message shown in the wizard's error banner — even though the upgrade had actually completed.

## Files Changed
- `src/ChurchCRM/dto/ChurchCRMReleaseManager.php`
- `src/admin/routes/api/upgrade.php`

## Testing
- ✅ `php -l` on both changed files
- ✅ `npm run lint` (Biome) — 0 errors
- ✅ `npm run build:php` — full PHP syntax validation (760 files) passed

## Related Issues
None filed yet — reported directly via a user-supplied screenshot of the wizard's "Download & Apply" step.