### PR TITLE
Fix flaky attendance-stat-total assertions in Cypress spec

### DIFF
--- a/.agents/skills/churchcrm/cypress-testing.md
+++ b/.agents/skills/churchcrm/cypress-testing.md
@@ -852,6 +852,32 @@ Rule of thumb: if the URL substring you are asserting was **already** in the URL
 
 ---
 
+### 8. `cy.wait("@alias")` Does Not Wait For The App's Post-Response JS <!-- learned: 2026-07-19 -->
+
+`cy.wait("@alias")` resolves as soon as the intercepted network response is received — it says nothing about whether the app's `fetch().then()` / `.catch()` handler has finished running and updated the DOM. If the very next command reads element state with a one-shot `.invoke("text").then((text) => expect(...))`, there is a real race window: the assertion can run against the pre-fetch placeholder before the async render lands, producing a nonsensical failure (e.g. `expected NaN to equal 0` when a stat tile still shows its `—` placeholder).
+
+Confirmed via a CI failure screenshot on `person.attendance.spec.js` (`shows zero total events`): the *final* DOM state in the screenshot (captured after the assertion had already failed) showed the correct `0` — proving the render did complete, just not before the one-shot read.
+
+```javascript
+// ❌ WRONG — invoke().then() reads text exactly once; no retry if the DOM hasn't updated yet
+cy.wait("@emptyAttendance");
+cy.get("#attendance-tab .attendance-stat-total")
+    .invoke("text")
+    .then((text) => {
+        expect(parseInt(text.trim(), 10)).to.equal(0);
+    });
+
+// ✅ CORRECT — .should(($el) => {...}) is retried by Cypress until it passes or times out
+cy.wait("@emptyAttendance");
+cy.get("#attendance-tab .attendance-stat-total").should(($el) => {
+    expect(parseInt($el.text().trim(), 10)).to.equal(0);
+});
+```
+
+**Rule:** any assertion on content that is populated by JS *after* a `cy.wait()`-awaited network call must use a retrying `.should()` callback, not `.invoke().then()` with a plain `expect`. This applies even when a preceding `cy.wait("@alias")` looks like sufficient synchronization — it only synchronizes on the network layer, not on the app's async response handling.
+
+---
+
 ### Flakiness Prevention Checklist (for every new test that saves/loads state)
 
 Before marking a test complete, verify:
@@ -863,6 +889,7 @@ Before marking a test complete, verify:
 - [ ] `cy.contains()` is scoped to a container, not used globally
 - [ ] API-only tests (those that only assert against `cy.request()`) establish the session via `POST /session/begin` — not UI login
 - [ ] No `cy.url().should('include', ...)` assertions where the substring is already present pre-action (tautology)
+- [ ] Assertions on JS-rendered content after `cy.wait("@alias")` use a retrying `.should(($el) => {...})`, not `.invoke().then()` with a plain `expect`
 
 ---
 

--- a/cypress/e2e/ui/people/person.attendance.spec.js
+++ b/cypress/e2e/ui/people/person.attendance.spec.js
@@ -108,11 +108,14 @@ describe("Person Attendance History Tab", () => {
 
         it("shows a non-zero total events stat", () => {
             cy.wait("@attendanceApi");
-            cy.get("#attendance-tab .attendance-stat-total")
-                .invoke("text")
-                .then((text) => {
-                    expect(parseInt(text.trim(), 10)).to.be.at.least(1);
-                });
+            // cy.wait() only confirms the network response arrived — it does not wait
+            // for the fetch().then() callback in attendance-history.ts to run and update
+            // the DOM. Use a retrying .should() (not .invoke().then()) so Cypress keeps
+            // re-reading the text until the async render lands instead of reading the
+            // initial "—" placeholder once and failing with NaN.
+            cy.get("#attendance-tab .attendance-stat-total").should(($el) => {
+                expect(parseInt($el.text().trim(), 10)).to.be.at.least(1);
+            });
         });
 
         it("shows the filter controls", () => {
@@ -163,11 +166,11 @@ describe("Person Attendance History Tab", () => {
 
         it("shows zero total events", () => {
             cy.wait("@emptyAttendance");
-            cy.get("#attendance-tab .attendance-stat-total")
-                .invoke("text")
-                .then((text) => {
-                    expect(parseInt(text.trim(), 10)).to.equal(0);
-                });
+            // See the comment on "shows a non-zero total events stat" above — same
+            // race between cy.wait() (network only) and the async DOM render.
+            cy.get("#attendance-tab .attendance-stat-total").should(($el) => {
+                expect(parseInt($el.text().trim(), 10)).to.equal(0);
+            });
         });
 
         it("shows an empty table with no rows", () => {


### PR DESCRIPTION
## Summary
- Fixes a flaky Cypress test in `person.attendance.spec.js` (`Person Attendance History Tab > Person with no attendance records > shows zero total events`), which failed in CI on [PR #9188](https://github.com/ChurchCRM/CRM/actions/runs/29692090864?pr=9188#user-content-tr-ebiIYA-r32s3) with `AssertionError: expected NaN to equal 0`.

## Changes
- Replaced the one-shot `.invoke("text").then((text) => expect(...))` reads of `#attendance-tab .attendance-stat-total` with retrying `.should(($el) => {...})` callbacks in both `"shows a non-zero total events stat"` and `"shows zero total events"`.
- Documented the root cause as a new flakiness pattern (#8) in [`cypress-testing.md`](.agents/skills/churchcrm/cypress-testing.md), with a checklist entry.

## Why
`cy.wait("@alias")` only confirms the network response arrived — it does not wait for the app's `fetch().then()` handler (`attendance-history.ts`) to finish updating the DOM. The one-shot `.invoke("text").then()` read could execute before that async render completed, reading the initial `—` placeholder and producing `NaN`.

This was confirmed as a test-only race, not a product bug: the CI failure screenshot showed the *final* DOM state (captured after the assertion had already failed) correctly displaying `0` total events and an empty attendance table — proving the render did complete, just not before the assertion ran.

## Files Changed
- `cypress/e2e/ui/people/person.attendance.spec.js` — retry-safe assertions
- `.agents/skills/churchcrm/cypress-testing.md` — new flakiness pattern documented

## Testing
- `npm run lint` — passed
- Cypress cannot be run from this sandbox (Electron requires Docker/CI per project convention); the fix is grounded in the CI failure screenshot evidence showing the correct final DOM state. CI on this PR will confirm the fix.