### PR TITLE
locale: translate all locales (7.5.0)

### DIFF
--- a/locale/terms/missing/fil/fil-1.json
+++ b/locale/terms/missing/fil/fil-1.json
@@ -1,6 +1,6 @@
 {
-  "Access": "",
-  "Self-service": "",
-  "Changelog": "",
-  "Feature": ""
+  "Access": "Access",
+  "Self-service": "Self-service",
+  "Changelog": "Changelog",
+  "Feature": "Tampok"
 }

--- a/locale/terms/missing/ro/ro-1.json
+++ b/locale/terms/missing/ro/ro-1.json
@@ -1,4 +1,4 @@
 {
-  "Important": "",
-  "Major": ""
+  "Important": "Important",
+  "Major": "Major"
 }


### PR DESCRIPTION
Automated locale translation for ChurchCRM 7.5.0.

## Translation Summary

| Group | Locales | Terms | Status |
|-------|---------|-------|--------|
| E (Asia Pacific) | fil (Filipino) | 4 | ✅ |
| B (Romance & Europe) | ro (Romanian) | 2 | ✅ |

**Total: 2 locales, 6 terms**

All other locales were already fully translated — only `fil` and `ro` had outstanding terms this run.

## Translations Applied

### Filipino (fil) — Evangelical
| Term | Translation |
|------|-------------|
| Access | Access |
| Self-service | Self-service |
| Changelog | Changelog |
| Feature | Tampok |

### Romanian (ro) — Catholic
| Term | Translation |
|------|-------------|
| Important | Important |
| Major | Major |

## Verification
```
node locale/scripts/locale-translate.js --list
✅ All locales are fully translated.
```

## Next Steps
1. Review and merge
2. Run: `npm run locale:upload:missing -- --yes`
