### PR TITLE
feat: in-app email composer replacing mailto: links (closes #8433)

### DIFF
--- a/cypress/e2e/api/private/standard/private.email-endpoints.spec.js
+++ b/cypress/e2e/api/private/standard/private.email-endpoints.spec.js
@@ -1,0 +1,259 @@
+/// <reference types="cypress" />
+
+/**
+ * API specs for email-list endpoints introduced in the in-app email composer PR.
+ *
+ * Covered endpoints:
+ *   GET /api/people/emails        — all active-family people mailing list
+ *   GET /api/cart/emails          — people currently in the session cart
+ *   GET /api/groups/:id/emails    — members of a specific group
+ *
+ * All three require Email role permission (bEmailMailto=1). In the seed
+ * data all API-key users have email enabled, so we use the admin key for
+ * happy-path tests and an unauthenticated request for 401.
+ *
+ * Canonical response shape: { emails: string[], byRole?: Record<string, string[]> }
+ */
+
+// ──────────────────────────────────────────────────────
+//  GET /api/people/emails
+// ──────────────────────────────────────────────────────
+describe("GET /api/people/emails", () => {
+    context("authenticated admin", () => {
+        beforeEach(() => {
+            cy.makePrivateAdminAPICall("GET", "/api/people/emails", "", 200).as("resp");
+        });
+
+        it("returns 200 with emails array and byRole object", () => {
+            cy.get("@resp").then((response) => {
+                expect(response.status).to.eq(200);
+                expect(response.body).to.have.property("emails").that.is.an("array");
+                expect(response.body).to.have.property("byRole").that.is.an("object");
+            });
+        });
+
+        it("emails array is non-empty (seed data has people with emails)", () => {
+            cy.get("@resp").then((response) => {
+                expect(response.body.emails.length).to.be.at.least(1);
+            });
+        });
+
+        it("every email in the flat list is a non-empty string", () => {
+            cy.get("@resp").then((response) => {
+                response.body.emails.forEach((email) => {
+                    expect(email).to.be.a("string").and.not.be.empty;
+                });
+            });
+        });
+
+        it("byRole values are arrays of strings", () => {
+            cy.get("@resp").then((response) => {
+                for (const [, roleEmails] of Object.entries(response.body.byRole)) {
+                    expect(roleEmails).to.be.an("array");
+                    roleEmails.forEach((email) => {
+                        expect(email).to.be.a("string").and.not.be.empty;
+                    });
+                }
+            });
+        });
+
+        it("no duplicate emails in the flat list (case-insensitive)", () => {
+            cy.get("@resp").then((response) => {
+                const seen = new Set();
+                for (const email of response.body.emails) {
+                    const lower = email.toLowerCase();
+                    expect(seen.has(lower), `duplicate email: ${email}`).to.be.false;
+                    seen.add(lower);
+                }
+            });
+        });
+    });
+
+    context("unauthenticated request", () => {
+        it("returns 401 without an API key", () => {
+            cy.request({
+                method: "GET",
+                url: "/api/people/emails",
+                failOnStatusCode: false,
+            }).then((response) => {
+                expect(response.status).to.eq(401);
+            });
+        });
+    });
+
+    context("user without email permission", () => {
+        it("returns 403 for plainauth user (no bEmailMailto row in userconfig_ucfg)", () => {
+            // User 900 (john.plainauth) has no bEmailMailto entry in userconfig_ucfg,
+            // so isEnabledSecurity('bEmailMailto') returns false → isEmailEnabled() = false.
+            cy.makePrivatePlainAuthAPICall("GET", "/api/people/emails", "", 403);
+        });
+    });
+});
+
+// ──────────────────────────────────────────────────────
+//  GET /api/cart/emails
+// ──────────────────────────────────────────────────────
+describe("GET /api/cart/emails", () => {
+    // Seed: add person 2 (Mathew Campbell) to the cart so we get a non-empty result.
+    before(() => {
+        cy.makePrivateAdminAPICall("POST", "/api/cart/add/2", "", 200);
+    });
+
+    after(() => {
+        cy.makePrivateAdminAPICall("DELETE", "/api/cart/remove/2", "", 200);
+    });
+
+    context("authenticated admin — non-empty cart", () => {
+        beforeEach(() => {
+            cy.makePrivateAdminAPICall("GET", "/api/cart/emails", "", 200).as("resp");
+        });
+
+        it("returns 200 with emails array", () => {
+            cy.get("@resp").then((response) => {
+                expect(response.status).to.eq(200);
+                expect(response.body).to.have.property("emails").that.is.an("array");
+            });
+        });
+
+        it("emails array is non-empty when cart has people with emails", () => {
+            cy.get("@resp").then((response) => {
+                // Person 2 (Mathew Campbell) has an email in seed data
+                expect(response.body.emails.length).to.be.at.least(1);
+            });
+        });
+
+        it("every email is a non-empty string", () => {
+            cy.get("@resp").then((response) => {
+                response.body.emails.forEach((email) => {
+                    expect(email).to.be.a("string").and.not.be.empty;
+                });
+            });
+        });
+
+        it("no duplicate emails in the list (case-insensitive)", () => {
+            cy.get("@resp").then((response) => {
+                const seen = new Set();
+                for (const email of response.body.emails) {
+                    const lower = email.toLowerCase();
+                    expect(seen.has(lower), `duplicate email: ${email}`).to.be.false;
+                    seen.add(lower);
+                }
+            });
+        });
+    });
+
+    context("authenticated admin — empty cart", () => {
+        before(() => {
+            // Empty the cart so we get the zero-email path
+            cy.makePrivateAdminAPICall("DELETE", "/api/cart/remove/2", "", 200);
+        });
+
+        after(() => {
+            // Restore for the after() in the outer context
+            cy.makePrivateAdminAPICall("POST", "/api/cart/add/2", "", 200);
+        });
+
+        it("returns 200 with empty emails array when cart is empty", () => {
+            cy.makePrivateAdminAPICall("GET", "/api/cart/emails", "", 200).then((response) => {
+                expect(response.body).to.have.property("emails").that.is.an("array");
+                expect(response.body.emails).to.deep.equal([]);
+            });
+        });
+    });
+
+    context("unauthenticated request", () => {
+        it("returns 401 without an API key", () => {
+            cy.request({
+                method: "GET",
+                url: "/api/cart/emails",
+                failOnStatusCode: false,
+            }).then((response) => {
+                expect(response.status).to.eq(401);
+            });
+        });
+    });
+
+    context("user without email permission", () => {
+        it("returns 403 for plainauth user", () => {
+            cy.makePrivatePlainAuthAPICall("GET", "/api/cart/emails", "", 403);
+        });
+    });
+});
+
+// ──────────────────────────────────────────────────────
+//  GET /api/groups/:id/emails
+// ──────────────────────────────────────────────────────
+describe("GET /api/groups/:id/emails", () => {
+    // Group 10 "Worship Service" is seeded and has members with emails.
+    const GROUP_WITH_MEMBERS = 10;
+    const NONEXISTENT_GROUP = 99999;
+
+    context("authenticated admin — group with members", () => {
+        beforeEach(() => {
+            cy.makePrivateAdminAPICall(
+                "GET",
+                `/api/groups/${GROUP_WITH_MEMBERS}/emails`,
+                "",
+                200,
+            ).as("resp");
+        });
+
+        it("returns 200 with emails array and byRole object", () => {
+            cy.get("@resp").then((response) => {
+                expect(response.status).to.eq(200);
+                expect(response.body).to.have.property("emails").that.is.an("array");
+                expect(response.body).to.have.property("byRole").that.is.an("object");
+            });
+        });
+
+        it("every email in the flat list is a non-empty string", () => {
+            cy.get("@resp").then((response) => {
+                response.body.emails.forEach((email) => {
+                    expect(email).to.be.a("string").and.not.be.empty;
+                });
+            });
+        });
+
+        it("no duplicate emails in the flat list (case-insensitive)", () => {
+            cy.get("@resp").then((response) => {
+                const seen = new Set();
+                for (const email of response.body.emails) {
+                    const lower = email.toLowerCase();
+                    expect(seen.has(lower), `duplicate email: ${email}`).to.be.false;
+                    seen.add(lower);
+                }
+            });
+        });
+    });
+
+    context("non-existent group", () => {
+        it("returns 404 for a group that does not exist", () => {
+            cy.makePrivateAdminAPICall(
+                "GET",
+                `/api/groups/${NONEXISTENT_GROUP}/emails`,
+                "",
+                404,
+            ).then((response) => {
+                expect(response.status).to.eq(404);
+            });
+        });
+    });
+
+    context("unauthenticated request", () => {
+        it("returns 401 without an API key", () => {
+            cy.request({
+                method: "GET",
+                url: `/api/groups/${GROUP_WITH_MEMBERS}/emails`,
+                failOnStatusCode: false,
+            }).then((response) => {
+                expect(response.status).to.eq(401);
+            });
+        });
+    });
+
+    context("user without email permission", () => {
+        it("returns 403 for plainauth user", () => {
+            cy.makePrivatePlainAuthAPICall("GET", `/api/groups/${GROUP_WITH_MEMBERS}/emails`, "", 403);
+        });
+    });
+});

--- a/cypress/e2e/api/private/standard/private.email-endpoints.spec.js
+++ b/cypress/e2e/api/private/standard/private.email-endpoints.spec.js
@@ -13,6 +13,12 @@
  * happy-path tests and an unauthenticated request for 401.
  *
  * Canonical response shape: { emails: string[], byRole?: Record<string, string[]> }
+ *
+ * NOTE on cart tests: the cart is stored in $_SESSION['aPeopleCart'], which is
+ * session-scoped. cy.makePrivateAdminAPICall() sets withCredentials:false (no
+ * cookies) so each call starts a fresh PHP session — cart state would be empty.
+ * Cart state tests instead use cy.setupAdminSession() to establish a login session
+ * and cy.request() (with the session cookie) to seed and read the cart.
  */
 
 // ──────────────────────────────────────────────────────
@@ -94,39 +100,70 @@ describe("GET /api/people/emails", () => {
 //  GET /api/cart/emails
 // ──────────────────────────────────────────────────────
 describe("GET /api/cart/emails", () => {
-    // Seed: add person 2 (Mathew Campbell) to the cart so we get a non-empty result.
-    // Real endpoint: POST /api/person/{id}/addToCart (not /api/cart/add/{id})
+    // Cart state is session-scoped ($_SESSION['aPeopleCart']).
+    // makePrivateAdminAPICall uses withCredentials:false (no cookies) so each
+    // call would get a fresh PHP session with an empty cart. Instead, we use
+    // cy.setupAdminSession() + cy.request() (which sends the session cookie)
+    // for cart-state-dependent tests so state persists across calls.
+
     before(() => {
-        cy.makePrivateAdminAPICall("POST", "/api/person/2/addToCart", "", 200);
+        // Establish admin login session so cy.request() sends the session cookie.
+        cy.setupAdminSession();
+        // Add person 2 (Mathew Campbell) to the admin's cart using the session cookie.
+        cy.request({
+            method: "POST",
+            url: "/api/person/2/addToCart",
+            failOnStatusCode: false,
+        });
     });
 
-    // Remove person 2 from cart after the suite.
-    // Real endpoint: DELETE /api/cart/ with JSON body {Persons: [id]}
     after(() => {
-        cy.makePrivateAdminAPICall("DELETE", "/api/cart/", { Persons: [2] }, 200);
+        // Restore session and clean up the cart
+        cy.setupAdminSession();
+        cy.request({
+            method: "DELETE",
+            url: "/api/cart/",
+            headers: { "Content-Type": "application/json" },
+            body: { Persons: [2] },
+            failOnStatusCode: false,
+        });
     });
 
     context("authenticated admin — non-empty cart", () => {
+        // Re-establish session before each test so the session cookie is fresh.
         beforeEach(() => {
-            cy.makePrivateAdminAPICall("GET", "/api/cart/emails", "", 200).as("resp");
+            cy.setupAdminSession();
         });
 
         it("returns 200 with emails array", () => {
-            cy.get("@resp").then((response) => {
+            cy.request({
+                method: "GET",
+                url: "/api/cart/emails",
+                failOnStatusCode: false,
+            }).then((response) => {
                 expect(response.status).to.eq(200);
                 expect(response.body).to.have.property("emails").that.is.an("array");
             });
         });
 
         it("emails array is non-empty when cart has people with emails", () => {
-            cy.get("@resp").then((response) => {
-                // Person 2 (Mathew Campbell) has an email in seed data
+            // Person 2 (Mathew Campbell) has an email in seed data
+            cy.request({
+                method: "GET",
+                url: "/api/cart/emails",
+                failOnStatusCode: false,
+            }).then((response) => {
+                expect(response.status).to.eq(200);
                 expect(response.body.emails.length).to.be.at.least(1);
             });
         });
 
         it("every email is a non-empty string", () => {
-            cy.get("@resp").then((response) => {
+            cy.request({
+                method: "GET",
+                url: "/api/cart/emails",
+                failOnStatusCode: false,
+            }).then((response) => {
                 response.body.emails.forEach((email) => {
                     expect(email).to.be.a("string").and.not.be.empty;
                 });
@@ -134,7 +171,11 @@ describe("GET /api/cart/emails", () => {
         });
 
         it("no duplicate emails in the list (case-insensitive)", () => {
-            cy.get("@resp").then((response) => {
+            cy.request({
+                method: "GET",
+                url: "/api/cart/emails",
+                failOnStatusCode: false,
+            }).then((response) => {
                 const seen = new Set();
                 for (const email of response.body.emails) {
                     const lower = email.toLowerCase();
@@ -148,16 +189,34 @@ describe("GET /api/cart/emails", () => {
     context("authenticated admin — empty cart", () => {
         before(() => {
             // Empty the cart so we get the zero-email path
-            cy.makePrivateAdminAPICall("DELETE", "/api/cart/", { Persons: [2] }, 200);
+            cy.setupAdminSession();
+            cy.request({
+                method: "DELETE",
+                url: "/api/cart/",
+                headers: { "Content-Type": "application/json" },
+                body: { Persons: [2] },
+                failOnStatusCode: false,
+            });
         });
 
         after(() => {
-            // Restore person 2 so the outer after() cleanup has something to remove
-            cy.makePrivateAdminAPICall("POST", "/api/person/2/addToCart", "", 200);
+            // Restore person 2 so the outer after() cleanup can confirm it worked
+            cy.setupAdminSession();
+            cy.request({
+                method: "POST",
+                url: "/api/person/2/addToCart",
+                failOnStatusCode: false,
+            });
         });
 
         it("returns 200 with empty emails array when cart is empty", () => {
-            cy.makePrivateAdminAPICall("GET", "/api/cart/emails", "", 200).then((response) => {
+            cy.setupAdminSession();
+            cy.request({
+                method: "GET",
+                url: "/api/cart/emails",
+                failOnStatusCode: false,
+            }).then((response) => {
+                expect(response.status).to.eq(200);
                 expect(response.body).to.have.property("emails").that.is.an("array");
                 expect(response.body.emails).to.deep.equal([]);
             });
@@ -170,6 +229,7 @@ describe("GET /api/cart/emails", () => {
                 method: "GET",
                 url: "/api/cart/emails",
                 failOnStatusCode: false,
+                withCredentials: false,
             }).then((response) => {
                 expect(response.status).to.eq(401);
             });
@@ -248,6 +308,7 @@ describe("GET /api/groups/:id/emails", () => {
                 method: "GET",
                 url: `/api/groups/${GROUP_WITH_MEMBERS}/emails`,
                 failOnStatusCode: false,
+                withCredentials: false,
             }).then((response) => {
                 expect(response.status).to.eq(401);
             });

--- a/cypress/e2e/api/private/standard/private.email-endpoints.spec.js
+++ b/cypress/e2e/api/private/standard/private.email-endpoints.spec.js
@@ -113,8 +113,7 @@ describe("GET /api/cart/emails", () => {
         cy.request({
             method: "POST",
             url: "/api/person/2/addToCart",
-            failOnStatusCode: false,
-        });
+        }).then((resp) => expect(resp.status).to.equal(200));
     });
 
     after(() => {
@@ -125,7 +124,6 @@ describe("GET /api/cart/emails", () => {
             url: "/api/cart/",
             headers: { "Content-Type": "application/json" },
             body: { Persons: [2] },
-            failOnStatusCode: false,
         });
     });
 
@@ -195,7 +193,6 @@ describe("GET /api/cart/emails", () => {
                 url: "/api/cart/",
                 headers: { "Content-Type": "application/json" },
                 body: { Persons: [2] },
-                failOnStatusCode: false,
             });
         });
 
@@ -205,7 +202,6 @@ describe("GET /api/cart/emails", () => {
             cy.request({
                 method: "POST",
                 url: "/api/person/2/addToCart",
-                failOnStatusCode: false,
             });
         });
 

--- a/cypress/e2e/api/private/standard/private.email-endpoints.spec.js
+++ b/cypress/e2e/api/private/standard/private.email-endpoints.spec.js
@@ -14,6 +14,10 @@
  *
  * Canonical response shape: { emails: string[], byRole?: Record<string, string[]> }
  *
+ * `emails`/`byRole` contain member recipients only. The church default address
+ * (sToEmailAddress) is a system setting the composer adds from the button at render
+ * time — it is never returned by these endpoints.
+ *
  * NOTE on cart tests: the cart is stored in $_SESSION['aPeopleCart'], which is
  * session-scoped. cy.makePrivateAdminAPICall() sets withCredentials:false (no
  * cookies) so each call starts a fresh PHP session — cart state would be empty.

--- a/cypress/e2e/api/private/standard/private.email-endpoints.spec.js
+++ b/cypress/e2e/api/private/standard/private.email-endpoints.spec.js
@@ -95,12 +95,15 @@ describe("GET /api/people/emails", () => {
 // ──────────────────────────────────────────────────────
 describe("GET /api/cart/emails", () => {
     // Seed: add person 2 (Mathew Campbell) to the cart so we get a non-empty result.
+    // Real endpoint: POST /api/person/{id}/addToCart (not /api/cart/add/{id})
     before(() => {
-        cy.makePrivateAdminAPICall("POST", "/api/cart/add/2", "", 200);
+        cy.makePrivateAdminAPICall("POST", "/api/person/2/addToCart", "", 200);
     });
 
+    // Remove person 2 from cart after the suite.
+    // Real endpoint: DELETE /api/cart/ with JSON body {Persons: [id]}
     after(() => {
-        cy.makePrivateAdminAPICall("DELETE", "/api/cart/remove/2", "", 200);
+        cy.makePrivateAdminAPICall("DELETE", "/api/cart/", { Persons: [2] }, 200);
     });
 
     context("authenticated admin — non-empty cart", () => {
@@ -145,12 +148,12 @@ describe("GET /api/cart/emails", () => {
     context("authenticated admin — empty cart", () => {
         before(() => {
             // Empty the cart so we get the zero-email path
-            cy.makePrivateAdminAPICall("DELETE", "/api/cart/remove/2", "", 200);
+            cy.makePrivateAdminAPICall("DELETE", "/api/cart/", { Persons: [2] }, 200);
         });
 
         after(() => {
-            // Restore for the after() in the outer context
-            cy.makePrivateAdminAPICall("POST", "/api/cart/add/2", "", 200);
+            // Restore person 2 so the outer after() cleanup has something to remove
+            cy.makePrivateAdminAPICall("POST", "/api/person/2/addToCart", "", 200);
         });
 
         it("returns 200 with empty emails array when cart is empty", () => {
@@ -184,8 +187,8 @@ describe("GET /api/cart/emails", () => {
 //  GET /api/groups/:id/emails
 // ──────────────────────────────────────────────────────
 describe("GET /api/groups/:id/emails", () => {
-    // Group 10 "Worship Service" is seeded and has members with emails.
-    const GROUP_WITH_MEMBERS = 10;
+    // Group 11 "Clergy" is seeded and has members with emails (persons 2 and 26).
+    const GROUP_WITH_MEMBERS = 11;
     const NONEXISTENT_GROUP = 99999;
 
     context("authenticated admin — group with members", () => {

--- a/cypress/e2e/api/private/standard/private.people.groups.communication.spec.js
+++ b/cypress/e2e/api/private/standard/private.people.groups.communication.spec.js
@@ -41,17 +41,17 @@ describe("API Group Communication Endpoints", () => {
     });
 
     describe("GET /groups/{groupID}/emails", () => {
-        it("returns email list with all and roles", () => {
+        it("returns email list with emails array and byRole object", () => {
             cy.makePrivateAdminAPICall(
                 "GET",
                 `/api/groups/${groupID}/emails`,
                 null,
                 200,
             ).then((resp) => {
-                expect(resp.body).to.have.property("all");
-                expect(resp.body).to.have.property("roles");
-                expect(resp.body.all).to.be.a("string");
-                expect(resp.body.roles).to.be.an("object");
+                expect(resp.body).to.have.property("emails");
+                expect(resp.body).to.have.property("byRole");
+                expect(resp.body.emails).to.be.an("array");
+                expect(resp.body.byRole).to.be.an("object");
             });
         });
 

--- a/cypress/e2e/ui/communication/communication.dashboard.spec.js
+++ b/cypress/e2e/ui/communication/communication.dashboard.spec.js
@@ -88,23 +88,26 @@ describe("Communication Menu and Dashboards", () => {
 describe("Group Contact Dropdowns", () => {
     beforeEach(() => cy.setupAdminSession());
 
-    it("Group view has Email and Text dropdowns", () => {
+    it("Group view has Email and Text buttons", () => {
         cy.visit("groups/view/9");
         cy.get("#group-view-toolbar").within(() => {
-            cy.contains("Email").should("exist");
+            // Email is now a composer button (no dropdown)
+            cy.get("[data-email-composer]").contains("Email").should("exist");
+            // Text is still a dropdown
             cy.contains("Text").should("exist");
         });
     });
 
-    it("Email dropdown populates on click", () => {
+    it("Email composer button opens modal with Copy and Client actions", () => {
         cy.visit("groups/view/9");
-        cy.get("#emailDropdownBtn").click();
-        // Should show loading then populate
-        cy.get("#emailDropdownMenu", { timeout: 10000 }).within(() => {
-            cy.contains("Copy All Emails").should("exist");
-            cy.contains("Email All").should("exist");
-            cy.contains("BCC All").should("exist");
-        });
+        cy.intercept("GET", "**/api/groups/9/emails").as("groupEmails");
+        // Click the email composer button (replaces old dropdown)
+        cy.get("[data-email-composer]").click();
+        cy.wait("@groupEmails");
+        // Modal should appear with Copy Addresses and Open in Email Client buttons
+        cy.get("#crm-email-composer-modal").should("be.visible");
+        cy.get("#crm-email-copy-btn").should("exist");
+        cy.get("#crm-email-client-btn").should("exist");
     });
 
     it("Text dropdown populates on click", () => {

--- a/cypress/e2e/ui/communication/communication.dashboard.spec.js
+++ b/cypress/e2e/ui/communication/communication.dashboard.spec.js
@@ -89,7 +89,7 @@ describe("Group Contact Dropdowns", () => {
     beforeEach(() => cy.setupAdminSession());
 
     it("Group view has Email and Text buttons", () => {
-        cy.visit("groups/view/9");
+        cy.visit("/groups/view/9");
         cy.get("#group-view-toolbar").within(() => {
             // Email is now a composer button (no dropdown)
             cy.get("[data-email-composer]").contains("Email").should("exist");
@@ -99,7 +99,7 @@ describe("Group Contact Dropdowns", () => {
     });
 
     it("Email composer button opens modal with Copy and Client actions", () => {
-        cy.visit("groups/view/9");
+        cy.visit("/groups/view/9");
         cy.intercept("GET", "**/api/groups/9/emails").as("groupEmails");
         // Click the email composer button (replaces old dropdown)
         cy.get("[data-email-composer]").click();
@@ -111,7 +111,7 @@ describe("Group Contact Dropdowns", () => {
     });
 
     it("Text dropdown populates on click", () => {
-        cy.visit("groups/view/9");
+        cy.visit("/groups/view/9");
         cy.get("#textDropdownBtn").click();
         cy.get("#textDropdownMenu", { timeout: 10000 }).within(() => {
             // Either shows phone options or "No phone numbers"

--- a/cypress/e2e/ui/email/email.cart.spec.js
+++ b/cypress/e2e/ui/email/email.cart.spec.js
@@ -1,0 +1,77 @@
+/// <reference types="cypress" />
+
+/**
+ * Cart view — email composer button integration tests.
+ *
+ * The old To/BCC mailto: btn-group has been replaced by a single "Email"
+ * button that opens the in-app email composer modal via /api/cart/emails.
+ * This spec verifies the new behaviour:
+ *  - The composer button is rendered (no old-style mailto links).
+ *  - Clicking it opens the modal and waits for the API response.
+ *  - The modal shows a recipient count badge and Copy/Open action buttons.
+ *
+ * Seed: person 2 (Mathew Campbell) is added to the cart in before()
+ * so the API returns at least one recipient.
+ */
+
+describe("Cart view — email composer button", () => {
+    before(() => {
+        // Add person 2 to the cart so /api/cart/emails returns recipients
+        cy.request({
+            method: "POST",
+            url: "/api/person/2/addToCart",
+            headers: { "x-api-key": Cypress.env("CRM_ADMIN_API_KEY") ?? "" },
+        });
+    });
+
+    after(() => {
+        // Clean up: remove person 2 from cart
+        cy.request({
+            method: "DELETE",
+            url: "/api/cart/",
+            headers: { "x-api-key": Cypress.env("CRM_ADMIN_API_KEY") ?? "" },
+            body: { Persons: [2] },
+        });
+    });
+
+    beforeEach(() => cy.setupAdminSession());
+
+    it("shows a single 'Email' composer button (not a mailto: link)", () => {
+        cy.visit("/v2/cart");
+        cy.get("[data-email-composer][data-email-endpoint='cart/emails']").should("be.visible");
+        // No old-style mailto To/BCC btn-group
+        cy.get("a[href^='mailto:']").should("not.exist");
+    });
+
+    it("clicking Email opens the composer modal with recipients", () => {
+        cy.visit("/v2/cart");
+
+        cy.intercept("GET", "**/api/cart/emails").as("cartEmailsApi");
+
+        cy.get("[data-email-composer][data-email-endpoint='cart/emails']").click();
+
+        cy.wait("@cartEmailsApi").its("response.statusCode").should("eq", 200);
+
+        // Modal appears
+        cy.get("#crm-email-composer-modal").should("be.visible");
+
+        // Title and action buttons are visible
+        cy.get("#crm-email-composer-modal .modal-title").should("contain.text", "Email");
+        cy.get("#crm-email-copy-btn").should("be.visible");
+        cy.get("#crm-email-client-btn").should("be.visible");
+    });
+
+    it("modal shows a positive recipient count badge", () => {
+        cy.visit("/v2/cart");
+        cy.intercept("GET", "**/api/cart/emails").as("cartEmailsApi");
+
+        cy.get("[data-email-composer][data-email-endpoint='cart/emails']").click();
+        cy.wait("@cartEmailsApi");
+
+        cy.get("#crm-email-composer-modal .modal-title .badge")
+            .invoke("text")
+            .then((text) => {
+                expect(parseInt(text.trim(), 10)).to.be.at.least(1);
+            });
+    });
+});

--- a/cypress/e2e/ui/email/email.cart.spec.js
+++ b/cypress/e2e/ui/email/email.cart.spec.js
@@ -3,38 +3,52 @@
 /**
  * Cart view — email composer button integration tests.
  *
+ * Key design rule: cart setup MUST use the browser's session cookie, NOT X-API-Key.
+ * The cart is stored in $_SESSION['aPeopleCart']; requests made with X-API-Key and
+ * withCredentials:false populate a *different* PHP session than the one the browser
+ * holds, so the UI cart would always appear empty.
+ * Pattern follows cypress/e2e/ui/people/standard.cart-to-family.spec.js.
+ *
  * The old To/BCC mailto: btn-group has been replaced by a single "Email"
  * button that opens the in-app email composer modal via /api/cart/emails.
- * This spec verifies the new behaviour:
- *  - The composer button is rendered (no old-style mailto links).
- *  - Clicking it opens the modal and waits for the API response.
- *  - The modal shows a recipient count badge and Copy/Open action buttons.
- *
- * Seed: person 2 (Mathew Campbell) is added to the cart in before()
- * so the API returns at least one recipient.
  */
 
+/** Add persons to the cart using the browser's session cookie (no API key). */
+const addToCart = (personIds) =>
+    cy.request({
+        method: "POST",
+        url: "/api/cart/",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ Persons: personIds }),
+        failOnStatusCode: false,
+    }).then((resp) => expect(resp.status).to.equal(200));
+
+/** Empty the cart using the browser's session cookie. */
+const emptyCart = () =>
+    cy.request({
+        method: "DELETE",
+        url: "/api/cart/",
+        headers: { "content-type": "application/json" },
+        body: {},
+        failOnStatusCode: false,
+    });
+
 describe("Cart view — email composer button", () => {
-    before(() => {
-        // Add person 2 to the cart so /api/cart/emails returns recipients
-        cy.request({
-            method: "POST",
-            url: "/api/person/2/addToCart",
-            headers: { "x-api-key": Cypress.env("CRM_ADMIN_API_KEY") ?? "" },
-        });
+    beforeEach(() => {
+        // setupAdminSession() restores a cached browser session with the correct
+        // PHP session cookie. All subsequent cy.request() calls without an API key
+        // will share this session, so cart state is consistent with what the
+        // browser sees when cy.visit() is called.
+        cy.setupAdminSession();
+        // Empty the cart so each test starts clean, then add person 2 (Mathew Campbell).
+        emptyCart();
+        addToCart([2]);
     });
 
-    after(() => {
-        // Clean up: remove person 2 from cart
-        cy.request({
-            method: "DELETE",
-            url: "/api/cart/",
-            headers: { "x-api-key": Cypress.env("CRM_ADMIN_API_KEY") ?? "" },
-            body: { Persons: [2] },
-        });
+    afterEach(() => {
+        // Clean up the cart after each test for isolation.
+        emptyCart();
     });
-
-    beforeEach(() => cy.setupAdminSession());
 
     it("shows a single 'Email' composer button (not a mailto: link)", () => {
         cy.visit("/v2/cart");

--- a/cypress/e2e/ui/groups/standard.email.spec.js
+++ b/cypress/e2e/ui/groups/standard.email.spec.js
@@ -1,0 +1,64 @@
+/// <reference types="cypress" />
+
+/**
+ * Group view — email composer button integration tests.
+ *
+ * The old email dropdown (which lazy-loaded via ajax) has been replaced by
+ * a single "Email" button that opens the in-app email composer modal via
+ * /api/groups/{id}/emails. This spec verifies the new behaviour:
+ *  - The composer button is present in the group toolbar.
+ *  - Clicking it opens the modal and fetches recipients.
+ *  - The modal shows a recipient count badge and action buttons.
+ *
+ * Group 11 (Clergy) is used — persons 2 and 26 are seeded members
+ * (confirmed in person2group2role_p2g2r seed data).
+ */
+
+describe("Group view — email composer button", () => {
+    const CLERGY_GROUP_ID = 11;
+
+    beforeEach(() => cy.setupAdminSession());
+
+    it("shows an 'Email' composer button in the group toolbar", () => {
+        cy.visit(`/groups/view/${CLERGY_GROUP_ID}`);
+        cy.get(
+            `[data-email-composer][data-email-endpoint='groups/${CLERGY_GROUP_ID}/emails']`,
+        ).should("be.visible");
+    });
+
+    it("clicking Email opens the composer modal with recipients", () => {
+        cy.visit(`/groups/view/${CLERGY_GROUP_ID}`);
+
+        cy.intercept("GET", `**/api/groups/${CLERGY_GROUP_ID}/emails`).as("groupEmailsApi");
+
+        cy.get(
+            `[data-email-composer][data-email-endpoint='groups/${CLERGY_GROUP_ID}/emails']`,
+        ).click();
+
+        cy.wait("@groupEmailsApi").its("response.statusCode").should("eq", 200);
+
+        // Modal appears
+        cy.get("#crm-email-composer-modal").should("be.visible");
+
+        // Title and action buttons are visible
+        cy.get("#crm-email-composer-modal .modal-title").should("contain.text", "Email");
+        cy.get("#crm-email-copy-btn").should("be.visible");
+        cy.get("#crm-email-client-btn").should("be.visible");
+    });
+
+    it("modal shows a positive recipient count badge (group has seeded members)", () => {
+        cy.visit(`/groups/view/${CLERGY_GROUP_ID}`);
+        cy.intercept("GET", `**/api/groups/${CLERGY_GROUP_ID}/emails`).as("groupEmailsApi");
+
+        cy.get(
+            `[data-email-composer][data-email-endpoint='groups/${CLERGY_GROUP_ID}/emails']`,
+        ).click();
+        cy.wait("@groupEmailsApi");
+
+        cy.get("#crm-email-composer-modal .modal-title .badge")
+            .invoke("text")
+            .then((text) => {
+                expect(parseInt(text.trim(), 10)).to.be.at.least(1);
+            });
+    });
+});

--- a/cypress/e2e/ui/people/people.dashboard.email.spec.js
+++ b/cypress/e2e/ui/people/people.dashboard.email.spec.js
@@ -9,8 +9,9 @@
  *  - The composer button is rendered when email is enabled.
  *  - Clicking it opens the modal (waits for the /api/people/emails fetch).
  *  - The modal shows a recipient count and action buttons.
- *  - sToEmailAddress dedup logic is tested via the /api/people/emails API
- *    (see private.email-endpoints.spec.js for the API spec).
+ *  - The church default address (sToEmailAddress) is exposed once via
+ *    window.CRM.comm.defaultEmailToAddress and offered by the composer as a removable
+ *    recipient (see private.email-endpoints.spec.js for the API spec).
  */
 
 describe("People Dashboard — email composer button", () => {

--- a/cypress/e2e/ui/people/people.dashboard.email.spec.js
+++ b/cypress/e2e/ui/people/people.dashboard.email.spec.js
@@ -1,151 +1,61 @@
 /// <reference types="cypress" />
 
 /**
- * Regression tests for the People Dashboard email-recipient-list assembly
- * introduced in chore/remove-email-delimiter-user-settings (#9250).
+ * People Dashboard — email composer button integration tests.
  *
- * Covers:
- *  - Email All / Email BCC dropdowns render when person emails exist.
- *  - "All People" mailto: / mailto:?bcc= hrefs are well-formed (no
- *    double-comma, no leading/trailing comma after decoding).
- *  - sToEmailAddress is appended to the recipient list exactly once.
- *  - Case-insensitive dedup: sToEmailAddress whose case differs from a
- *    person's email is still recognised as a duplicate and not added twice.
+ * The old mailto: dropdown links have been replaced by a single
+ * "Email All" button that opens the in-app email composer modal.
+ * This spec verifies the new behaviour:
+ *  - The composer button is rendered when email is enabled.
+ *  - Clicking it opens the modal (waits for the /api/people/emails fetch).
+ *  - The modal shows a recipient count and action buttons.
+ *  - sToEmailAddress dedup logic is tested via the /api/people/emails API
+ *    (see private.email-endpoints.spec.js for the API spec).
  */
 
-/** Toggle a system config value via the admin config API.
- *  Requires an active admin session cookie (call cy.setupAdminSession() first).
- *  Pattern matches external.calendar.spec.js. */
-function setSystemConfig(name, value) {
-    cy.request({
-        method: "POST",
-        url: `/admin/api/system/config/${name}`,
-        body: { value },
-        headers: { "Content-Type": "application/json" },
-    });
-}
-
-/**
- * Decode a rawurlencode()-produced mailto: href attribute into the plain
- * comma-separated recipient string for assertion.
- *  - "mailto:a%40x.com%2Cb%40x.com"  → "a@x.com,b@x.com"
- *  - "mailto:?bcc=a%40x.com%2Cb%40x.com" → "a@x.com,b@x.com"
- */
-function decodeMailtoHref(href) {
-    return decodeURIComponent(
-        href.replace(/^mailto:(\?bcc=)?/, ""),
-    );
-}
-
-describe("People Dashboard — email recipient list", () => {
+describe("People Dashboard — email composer button", () => {
     beforeEach(() => cy.setupAdminSession());
 
-    after(() => {
-        // Restore sToEmailAddress so other specs are not affected.
-        cy.setupAdminSession();
-        setSystemConfig("sToEmailAddress", "");
+    it("shows a single 'Email All' button (not a dropdown) when email is enabled", () => {
+        cy.visit("/people/dashboard");
+        // The button has the data-email-composer attribute
+        cy.get("[data-email-composer][data-email-endpoint='people/emails']").should("be.visible");
+        // No old-style dropdown toggles for email
+        cy.contains(".dropdown-toggle", "Email All").should("not.exist");
+        cy.contains(".dropdown-toggle", "Email BCC").should("not.exist");
     });
 
-    // ── Basic rendering ───────────────────────────────────────────────────
-
-    it("shows Email All and Email BCC dropdowns when person emails exist", () => {
+    it("clicking Email All opens the composer modal with recipients", () => {
         cy.visit("/people/dashboard");
-        cy.contains(".dropdown-toggle", "Email All").should("be.visible");
-        cy.contains(".dropdown-toggle", "Email BCC").should("be.visible");
+
+        // Intercept the API call
+        cy.intercept("GET", "**/api/people/emails").as("emailsApi");
+
+        cy.get("[data-email-composer][data-email-endpoint='people/emails']").click();
+
+        cy.wait("@emailsApi").its("response.statusCode").should("eq", 200);
+
+        // Modal should appear
+        cy.get("#crm-email-composer-modal").should("be.visible");
+
+        // Should show the modal title and action buttons
+        cy.get("#crm-email-composer-modal .modal-title").should("contain.text", "Email");
+        cy.get("#crm-email-copy-btn").should("be.visible");
+        cy.get("#crm-email-client-btn").should("be.visible");
     });
 
-    // ── Href structure: Email All ─────────────────────────────────────────
-
-    it("Email All — All People link is a well-formed mailto: with comma-separated addresses", () => {
+    it("modal shows a recipient count badge when people have emails", () => {
         cy.visit("/people/dashboard");
+        cy.intercept("GET", "**/api/people/emails").as("emailsApi");
 
-        cy.contains(".dropdown-toggle", "Email All").click();
+        cy.get("[data-email-composer][data-email-endpoint='people/emails']").click();
+        cy.wait("@emailsApi");
 
-        cy.contains(".dropdown-toggle", "Email All")
-            .closest(".dropdown")
-            .contains("a.dropdown-item", "All People")
-            .invoke("attr", "href")
-            .then((href) => {
-                expect(href, "starts with mailto:").to.match(/^mailto:/);
-                expect(href, "is not a bcc link").not.to.include("?bcc=");
-
-                const decoded = decodeMailtoHref(href);
-                expect(decoded, "contains at least one @").to.match(/@/);
-                expect(decoded, "no double-comma (empty slot)").not.to.include(",,");
-                expect(decoded, "no leading comma").not.to.match(/^,/);
-                expect(decoded, "no trailing comma").not.to.match(/,$/);
+        // The badge should show a positive number
+        cy.get("#crm-email-composer-modal .modal-title .badge")
+            .invoke("text")
+            .then((text) => {
+                expect(parseInt(text.trim(), 10)).to.be.at.least(1);
             });
-    });
-
-    // ── Href structure: Email BCC ─────────────────────────────────────────
-
-    it("Email BCC — All People link is a well-formed mailto:?bcc= with comma-separated addresses", () => {
-        cy.visit("/people/dashboard");
-
-        cy.contains(".dropdown-toggle", "Email BCC").click();
-
-        cy.contains(".dropdown-toggle", "Email BCC")
-            .closest(".dropdown")
-            .contains("a.dropdown-item", "All People")
-            .invoke("attr", "href")
-            .then((href) => {
-                expect(href, "starts with mailto:?bcc=").to.match(/^mailto:\?bcc=/);
-
-                const decoded = decodeMailtoHref(href);
-                expect(decoded, "contains at least one @").to.match(/@/);
-                expect(decoded, "no double-comma (empty slot)").not.to.include(",,");
-                expect(decoded, "no leading comma").not.to.match(/^,/);
-                expect(decoded, "no trailing comma").not.to.match(/,$/);
-            });
-    });
-
-    // ── sToEmailAddress dedup ─────────────────────────────────────────────
-
-    it("sToEmailAddress is appended to Email All recipients exactly once", () => {
-        const defaultTo = "default-to@cypress.example";
-        setSystemConfig("sToEmailAddress", defaultTo);
-
-        cy.visit("/people/dashboard");
-        cy.contains(".dropdown-toggle", "Email All").click();
-
-        cy.contains(".dropdown-toggle", "Email All")
-            .closest(".dropdown")
-            .contains("a.dropdown-item", "All People")
-            .invoke("attr", "href")
-            .then((href) => {
-                const decoded = decodeMailtoHref(href);
-                const occurrences = decoded.toLowerCase().split(defaultTo.toLowerCase()).length - 1;
-                expect(occurrences, `'${defaultTo}' appears exactly once in: ${decoded}`)
-                    .to.equal(1);
-                expect(decoded, "no double-comma").not.to.include(",,");
-            });
-
-        setSystemConfig("sToEmailAddress", "");
-    });
-
-    it("sToEmailAddress is not duplicated when it matches a person email (case-insensitive)", () => {
-        // "lady@nower.com" is a known person email in the seed fixture.
-        // Use a differently-cased variant to verify the case-insensitive
-        // dedup path in $joinEmails (in_array + strtolower).
-        const knownPersonEmail = "lady@nower.com";
-        const caseVariant = "Lady@Nower.Com";
-        setSystemConfig("sToEmailAddress", caseVariant);
-
-        cy.visit("/people/dashboard");
-        cy.contains(".dropdown-toggle", "Email All").click();
-
-        cy.contains(".dropdown-toggle", "Email All")
-            .closest(".dropdown")
-            .contains("a.dropdown-item", "All People")
-            .invoke("attr", "href")
-            .then((href) => {
-                const decoded = decodeMailtoHref(href).toLowerCase();
-                const occurrences = decoded.split(knownPersonEmail).length - 1;
-                expect(occurrences, `'${knownPersonEmail}' should appear exactly once (case-insensitive dedup)`)
-                    .to.equal(1);
-                expect(decoded, "no double-comma").not.to.include(",,");
-            });
-
-        setSystemConfig("sToEmailAddress", "");
     });
 });

--- a/cypress/e2e/ui/reports/confirm-reports.spec.js
+++ b/cypress/e2e/ui/reports/confirm-reports.spec.js
@@ -12,12 +12,24 @@
  * to demo data (family 1) rather than fetched via API calls before PDF tests.
  */
 describe("Confirmation Reports - ConfirmReport & ConfirmReportEmail", () => {
+    /**
+     * Direct form login — clears existing cookies and authenticates as admin
+     * via the real ChurchCRM login page (/session/begin). More reliable than
+     * cy.setupAdminSession() for pages that require specific role flags
+     * (MenuOptions), because it guarantees a fresh PHP session without any
+     * contamination from prior tests.
+     * Pattern follows cypress/e2e/ui/people/standard.cart-to-family.spec.js.
+     */
+    function freshAdminLogin() {
+        cy.clearCookies();
+        cy.visit("/session/begin");
+        cy.get("input[name=User]").type(Cypress.env("admin.username"));
+        cy.get("input[name=Password]").type(Cypress.env("admin.password") + "{enter}");
+        cy.url().should("not.include", "/session/begin");
+    }
+
     beforeEach(() => {
-        // forceLogin:true ensures a fresh admin session on every test,
-        // preventing session contamination from earlier tests in the run
-        // (the admin must have MenuOptions to access LettersAndLabels.php).
-        cy.setupAdminSession({ forceLogin: true });
-        // Leading '/' makes the URL explicit for both root and subdir deployments.
+        freshAdminLogin();
         cy.visit("/LettersAndLabels.php");
     });
 

--- a/cypress/e2e/ui/reports/confirm-reports.spec.js
+++ b/cypress/e2e/ui/reports/confirm-reports.spec.js
@@ -13,9 +13,12 @@
  */
 describe("Confirmation Reports - ConfirmReport & ConfirmReportEmail", () => {
     beforeEach(() => {
-        cy.setupAdminSession();
-        // Establish browser context so session cookies are in scope for PDF navigation
-        cy.visit("LettersAndLabels.php");
+        // forceLogin:true ensures a fresh admin session on every test,
+        // preventing session contamination from earlier tests in the run
+        // (the admin must have MenuOptions to access LettersAndLabels.php).
+        cy.setupAdminSession({ forceLogin: true });
+        // Leading '/' makes the URL explicit for both root and subdir deployments.
+        cy.visit("/LettersAndLabels.php");
     });
 
     describe("ConfirmReport - PDF Generation", () => {

--- a/src/ChurchCRM/Service/PersonService.php
+++ b/src/ChurchCRM/Service/PersonService.php
@@ -129,8 +129,10 @@ class PersonService
 
     /**
      * Returns mailing email lists for all active-family people, grouped by classification role.
-     * Respects the iDoNotEmailPropertyId exclusion setting and appends sToEmailAddress
-     * only when configured and at least one recipient email was found.
+     * Respects the iDoNotEmailPropertyId exclusion setting.
+     *
+     * Member recipients only. The church default address (sToEmailAddress) is a system
+     * setting handled by the composer at render time, not returned here.
      *
      * @return array{emails: string[], byRole: array<string, string[]>}
      */
@@ -172,22 +174,16 @@ class PersonService
             $byRole[$roleName][] = $email;
         }
 
-        $defaultTo = (string) SystemConfig::getValue('sToEmailAddress');
-        if ($defaultTo !== '' && !empty($emails) && !isset($emailsSeen[strtolower($defaultTo)])) {
-            $emails[] = $defaultTo;
-            // Also inject into byRole so the UI modal's visible list
-            // stays in sync with the Copy payload and badge count.
-            $byRole[gettext('System')][] = $defaultTo;
-        }
-
         return ['emails' => $emails, 'byRole' => $byRole];
     }
 
     /**
      * Returns mailing email addresses for all members of a specific group,
      * grouped by their group role.
-     * Respects the iDoNotEmailPropertyId exclusion setting and appends sToEmailAddress
-     * only when configured and at least one recipient email was found.
+     * Respects the iDoNotEmailPropertyId exclusion setting.
+     *
+     * Member recipients only. The church default address (sToEmailAddress) is a system
+     * setting handled by the composer at render time, not returned here.
      *
      * @param \ChurchCRM\model\ChurchCRM\Group $group The Group object (already loaded by GroupMiddleware)
      * @return array{emails: string[], byRole: array<string, string[]>}
@@ -238,14 +234,6 @@ class PersonService
 
             $roleName = $roleNameMap[(int) $membership->getRoleId()] ?? gettext('Member');
             $byRole[$roleName][] = $email;
-        }
-
-        $defaultTo = (string) SystemConfig::getValue('sToEmailAddress');
-        if ($defaultTo !== '' && !empty($emails) && !isset($emailsSeen[strtolower($defaultTo)])) {
-            $emails[] = $defaultTo;
-            // Also inject into byRole so the UI modal's visible list
-            // stays in sync with the Copy payload and badge count.
-            $byRole[gettext('System')][] = $defaultTo;
         }
 
         return ['emails' => $emails, 'byRole' => $byRole];

--- a/src/ChurchCRM/Service/PersonService.php
+++ b/src/ChurchCRM/Service/PersonService.php
@@ -204,7 +204,8 @@ class PersonService
             }
         }
 
-        $doNotEmailSet = $this->buildDoNotEmailSet($personIds);
+        // Short-circuit: no members → nothing to exclude (avoids a full RecordProperty scan)
+        $doNotEmailSet = $personIds !== [] ? $this->buildDoNotEmailSet($personIds) : [];
 
         $roleNameMap = [];
         $group = GroupQuery::create()->findPk($groupId);

--- a/src/ChurchCRM/Service/PersonService.php
+++ b/src/ChurchCRM/Service/PersonService.php
@@ -110,7 +110,7 @@ class PersonService
      *                         When empty, checks all records for the property.
      * @return array<int, true> Map of personId → true
      */
-    private function buildDoNotEmailSet(array $personIds = []): array
+    public function buildDoNotEmailSet(array $personIds = []): array
     {
         $propId = (int) SystemConfig::getValue('iDoNotEmailPropertyId');
         if ($propId <= 0) {

--- a/src/ChurchCRM/Service/PersonService.php
+++ b/src/ChurchCRM/Service/PersonService.php
@@ -130,7 +130,8 @@ class PersonService
 
     /**
      * Returns mailing email lists for all active-family people, grouped by classification role.
-     * Respects the iDoNotEmailPropertyId exclusion setting and appends sToEmailAddress when configured.
+     * Respects the iDoNotEmailPropertyId exclusion setting and appends sToEmailAddress
+     * only when configured and at least one recipient email was found.
      *
      * @return array{emails: string[], byRole: array<string, string[]>}
      */
@@ -185,7 +186,8 @@ class PersonService
     /**
      * Returns mailing email addresses for all members of a specific group,
      * grouped by their group role.
-     * Respects the iDoNotEmailPropertyId exclusion setting and appends sToEmailAddress when configured.
+     * Respects the iDoNotEmailPropertyId exclusion setting and appends sToEmailAddress
+     * only when configured and at least one recipient email was found.
      *
      * @return array{emails: string[], byRole: array<string, string[]>}
      */

--- a/src/ChurchCRM/Service/PersonService.php
+++ b/src/ChurchCRM/Service/PersonService.php
@@ -161,7 +161,7 @@ class PersonService
             if (isset($doNotEmailSet[(int) $person->getId()])) {
                 continue;
             }
-            $email = (string) $person->getEmail();
+            $email = trim((string) $person->getEmail());
             if ($email === '' || isset($emailsSeen[strtolower($email)])) {
                 continue;
             }
@@ -229,7 +229,7 @@ class PersonService
             if (isset($doNotEmailSet[(int) $person->getId()])) {
                 continue;
             }
-            $email = (string) $person->getEmail();
+            $email = trim((string) $person->getEmail());
             if ($email === '' || isset($emailsSeen[strtolower($email)])) {
                 continue;
             }

--- a/src/ChurchCRM/Service/PersonService.php
+++ b/src/ChurchCRM/Service/PersonService.php
@@ -173,7 +173,7 @@ class PersonService
         }
 
         $defaultTo = (string) SystemConfig::getValue('sToEmailAddress');
-        if ($defaultTo !== '' && !isset($emailsSeen[strtolower($defaultTo)])) {
+        if ($defaultTo !== '' && !empty($emails) && !isset($emailsSeen[strtolower($defaultTo)])) {
             $emails[] = $defaultTo;
             // sToEmailAddress is appended only to the flat list;
             // role groups already contain their own member emails.
@@ -239,7 +239,7 @@ class PersonService
         }
 
         $defaultTo = (string) SystemConfig::getValue('sToEmailAddress');
-        if ($defaultTo !== '' && !isset($emailsSeen[strtolower($defaultTo)])) {
+        if ($defaultTo !== '' && !empty($emails) && !isset($emailsSeen[strtolower($defaultTo)])) {
             $emails[] = $defaultTo;
         }
 

--- a/src/ChurchCRM/Service/PersonService.php
+++ b/src/ChurchCRM/Service/PersonService.php
@@ -4,7 +4,6 @@ namespace ChurchCRM\Service;
 
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\model\ChurchCRM\FamilyQuery;
-use ChurchCRM\model\ChurchCRM\GroupQuery;
 use ChurchCRM\model\ChurchCRM\ListOptionQuery;
 use ChurchCRM\model\ChurchCRM\Person2group2roleP2g2rQuery;
 use ChurchCRM\model\ChurchCRM\PersonQuery;
@@ -176,8 +175,9 @@ class PersonService
         $defaultTo = (string) SystemConfig::getValue('sToEmailAddress');
         if ($defaultTo !== '' && !empty($emails) && !isset($emailsSeen[strtolower($defaultTo)])) {
             $emails[] = $defaultTo;
-            // sToEmailAddress is appended only to the flat list;
-            // role groups already contain their own member emails.
+            // Also inject into byRole so the UI modal's visible list
+            // stays in sync with the Copy payload and badge count.
+            $byRole[gettext('System')][] = $defaultTo;
         }
 
         return ['emails' => $emails, 'byRole' => $byRole];
@@ -189,10 +189,12 @@ class PersonService
      * Respects the iDoNotEmailPropertyId exclusion setting and appends sToEmailAddress
      * only when configured and at least one recipient email was found.
      *
+     * @param \ChurchCRM\model\ChurchCRM\Group $group The Group object (already loaded by GroupMiddleware)
      * @return array{emails: string[], byRole: array<string, string[]>}
      */
-    public function getGroupMailingEmails(int $groupId): array
+    public function getGroupMailingEmails(\ChurchCRM\model\ChurchCRM\Group $group): array
     {
+        $groupId = (int) $group->getId();
         $memberships = Person2group2roleP2g2rQuery::create()
             ->filterByGroupId($groupId)
             ->innerJoinWithPerson()
@@ -209,12 +211,10 @@ class PersonService
         // Short-circuit: no members → nothing to exclude (avoids a full RecordProperty scan)
         $doNotEmailSet = $personIds !== [] ? $this->buildDoNotEmailSet($personIds) : [];
 
+        // Build role name map from the already-loaded Group (avoids an extra DB query)
         $roleNameMap = [];
-        $group = GroupQuery::create()->findPk($groupId);
-        if ($group !== null) {
-            foreach (ListOptionQuery::create()->filterById((int) $group->getRoleListId())->find() as $opt) {
-                $roleNameMap[(int) $opt->getOptionId()] = $opt->getOptionName();
-            }
+        foreach (ListOptionQuery::create()->filterById((int) $group->getRoleListId())->find() as $opt) {
+            $roleNameMap[(int) $opt->getOptionId()] = $opt->getOptionName();
         }
 
         $emails = [];
@@ -243,6 +243,9 @@ class PersonService
         $defaultTo = (string) SystemConfig::getValue('sToEmailAddress');
         if ($defaultTo !== '' && !empty($emails) && !isset($emailsSeen[strtolower($defaultTo)])) {
             $emails[] = $defaultTo;
+            // Also inject into byRole so the UI modal's visible list
+            // stays in sync with the Copy payload and badge count.
+            $byRole[gettext('System')][] = $defaultTo;
         }
 
         return ['emails' => $emails, 'byRole' => $byRole];

--- a/src/ChurchCRM/Service/PersonService.php
+++ b/src/ChurchCRM/Service/PersonService.php
@@ -2,11 +2,15 @@
 
 namespace ChurchCRM\Service;
 
+use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\model\ChurchCRM\FamilyQuery;
+use ChurchCRM\model\ChurchCRM\GroupQuery;
 use ChurchCRM\model\ChurchCRM\ListOptionQuery;
+use ChurchCRM\model\ChurchCRM\Person2group2roleP2g2rQuery;
 use ChurchCRM\model\ChurchCRM\PersonQuery;
 use ChurchCRM\model\ChurchCRM\PersonVolunteerOpportunity;
 use ChurchCRM\model\ChurchCRM\PersonVolunteerOpportunityQuery;
+use ChurchCRM\model\ChurchCRM\RecordPropertyQuery;
 use Propel\Runtime\ActiveQuery\Criteria;
 
 class PersonService
@@ -97,6 +101,148 @@ class PersonService
         }
 
         return $result;
+    }
+
+    /**
+     * Build the set of person IDs that should be excluded from mailing lists
+     * because the configured "Do Not Email" property is assigned to them.
+     *
+     * @param int[] $personIds Optional subset of person IDs to check (for efficiency).
+     *                         When empty, checks all records for the property.
+     * @return array<int, true> Map of personId → true
+     */
+    private function buildDoNotEmailSet(array $personIds = []): array
+    {
+        $propId = (int) SystemConfig::getValue('iDoNotEmailPropertyId');
+        if ($propId <= 0) {
+            return [];
+        }
+        $query = RecordPropertyQuery::create()->filterByPropertyId($propId);
+        if (!empty($personIds)) {
+            $query->filterByRecordId($personIds);
+        }
+        $set = [];
+        foreach ($query->find() as $r) {
+            $set[(int) $r->getRecordId()] = true;
+        }
+        return $set;
+    }
+
+    /**
+     * Returns mailing email lists for all active-family people, grouped by classification role.
+     * Respects the iDoNotEmailPropertyId exclusion setting and appends sToEmailAddress when configured.
+     *
+     * @return array{emails: string[], byRole: array<string, string[]>}
+     */
+    public function getMailingEmails(): array
+    {
+        $doNotEmailSet = $this->buildDoNotEmailSet();
+
+        $roleNameMap = [];
+        foreach (ListOptionQuery::create()->filterById(1)->find() as $opt) {
+            $roleNameMap[(int) $opt->getOptionId()] = $opt->getOptionName();
+        }
+
+        $persons = PersonQuery::create()
+            ->filterByFamId(null, Criteria::ISNOTNULL)
+            ->filterByFamId(0, Criteria::NOT_EQUAL)
+            ->leftJoinWithFamily()
+            ->useQuery('Family')
+                ->filterByDateDeactivated(null)
+            ->endUse()
+            ->filterByEmail('', Criteria::NOT_EQUAL)
+            ->find();
+
+        $emails = [];
+        $byRole = [];
+        $emailsSeen = [];
+
+        foreach ($persons as $person) {
+            if (isset($doNotEmailSet[(int) $person->getId()])) {
+                continue;
+            }
+            $email = (string) $person->getEmail();
+            if ($email === '' || isset($emailsSeen[strtolower($email)])) {
+                continue;
+            }
+            $emailsSeen[strtolower($email)] = true;
+            $emails[] = $email;
+
+            $roleName = $roleNameMap[(int) $person->getClsId()] ?? gettext('Member');
+            $byRole[$roleName][] = $email;
+        }
+
+        $defaultTo = (string) SystemConfig::getValue('sToEmailAddress');
+        if ($defaultTo !== '' && !isset($emailsSeen[strtolower($defaultTo)])) {
+            $emails[] = $defaultTo;
+            // sToEmailAddress is appended only to the flat list;
+            // role groups already contain their own member emails.
+        }
+
+        return ['emails' => $emails, 'byRole' => $byRole];
+    }
+
+    /**
+     * Returns mailing email addresses for all members of a specific group,
+     * grouped by their group role.
+     * Respects the iDoNotEmailPropertyId exclusion setting and appends sToEmailAddress when configured.
+     *
+     * @return array{emails: string[], byRole: array<string, string[]>}
+     */
+    public function getGroupMailingEmails(int $groupId): array
+    {
+        $memberships = Person2group2roleP2g2rQuery::create()
+            ->filterByGroupId($groupId)
+            ->innerJoinWithPerson()
+            ->find();
+
+        $personIds = [];
+        foreach ($memberships as $m) {
+            $person = $m->getPerson();
+            if ($person !== null) {
+                $personIds[] = (int) $person->getId();
+            }
+        }
+
+        $doNotEmailSet = $this->buildDoNotEmailSet($personIds);
+
+        $roleNameMap = [];
+        $group = GroupQuery::create()->findPk($groupId);
+        if ($group !== null) {
+            foreach (ListOptionQuery::create()->filterById((int) $group->getRoleListId())->find() as $opt) {
+                $roleNameMap[(int) $opt->getOptionId()] = $opt->getOptionName();
+            }
+        }
+
+        $emails = [];
+        $byRole = [];
+        $emailsSeen = [];
+
+        foreach ($memberships as $membership) {
+            $person = $membership->getPerson();
+            if ($person === null) {
+                continue;
+            }
+            if (isset($doNotEmailSet[(int) $person->getId()])) {
+                continue;
+            }
+            $email = (string) $person->getEmail();
+            if ($email === '' || isset($emailsSeen[strtolower($email)])) {
+                continue;
+            }
+            $emailsSeen[strtolower($email)] = true;
+            $emails[] = $email;
+
+            $roleName = $roleNameMap[(int) $membership->getRoleId()] ?? gettext('Member');
+            $byRole[$roleName][] = $email;
+        }
+
+        $defaultTo = (string) SystemConfig::getValue('sToEmailAddress');
+        if ($defaultTo !== '' && !isset($emailsSeen[strtolower($defaultTo)])) {
+            $emails[] = $defaultTo;
+        }
+
+        return ['emails' => $emails, 'byRole' => $byRole];
     }
 
     /**

--- a/src/ChurchCRM/dto/Cart.php
+++ b/src/ChurchCRM/dto/Cart.php
@@ -276,8 +276,8 @@ class Cart
             if (isset($doNotEmailSet[(int) $cartPerson->getId()])) {
                 continue;
             }
-            $email = (string) $cartPerson->getEmail();
-            if (!isset($emailsSeen[strtolower($email)])) {
+            $email = trim((string) $cartPerson->getEmail());
+            if ($email !== '' && !isset($emailsSeen[strtolower($email)])) {
                 $emailsSeen[strtolower($email)] = true;
                 $emails[] = $email;
             }

--- a/src/ChurchCRM/dto/Cart.php
+++ b/src/ChurchCRM/dto/Cart.php
@@ -2,10 +2,13 @@
 
 namespace ChurchCRM\dto;
 
+use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\model\ChurchCRM\Person2group2roleP2g2r;
 use ChurchCRM\model\ChurchCRM\Person2group2roleP2g2rQuery;
 use ChurchCRM\model\ChurchCRM\PersonQuery;
+use ChurchCRM\model\ChurchCRM\RecordPropertyQuery;
 use ChurchCRM\Service\GroupService;
+use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\Connection\ConnectionInterface;
 use Propel\Runtime\Propel;
 
@@ -245,26 +248,55 @@ class Cart
             ->find();
     }
 
-    public static function getEmailLink(): string
+    /**
+     * Returns unique email addresses for all people in the cart, plus sToEmailAddress if configured.
+     * Respects the iDoNotEmailPropertyId exclusion setting.
+     *
+     * @return string[]
+     */
+    public static function getEmails(): array
     {
-        /* @var $cartPerson ChurchCRM\Person */
-        $people = Cart::getCartPeople();
-        $emailAddressArray = [];
-        foreach ($people as $cartPerson) {
-            if (!empty($cartPerson->getEmail())) {
-                $emailAddressArray[] = $cartPerson->getEmail();
+        self::checkCart();
+        $cartIds = array_values(array_filter(array_map('intval', $_SESSION['aPeopleCart']), fn ($id) => $id > 0));
+        if (empty($cartIds)) {
+            return [];
+        }
+
+        $doNotEmailSet = [];
+        $doNotEmailPropId = (int) SystemConfig::getValue('iDoNotEmailPropertyId');
+        if ($doNotEmailPropId > 0) {
+            foreach (RecordPropertyQuery::create()
+                ->filterByPropertyId($doNotEmailPropId)
+                ->filterByRecordId($cartIds)
+                ->find() as $r) {
+                $doNotEmailSet[(int) $r->getRecordId()] = true;
             }
         }
-        // RFC 6068: comma is the standard email-list delimiter.
-        // Use an array-based membership check (case-insensitive) to decide
-        // whether to append sToEmailAddress — avoids the stristr() false-positive
-        // where e.g. 'admin@x.com' would match inside 'superadmin@x.com'.
-        $emails    = array_values(array_unique(array_filter($emailAddressArray)));
+
+        $emails = [];
+        $emailsSeen = [];
+        // No per_fam_ID filter here: the cart may intentionally contain persons
+        // with per_fam_ID=0 (unassigned). We email whoever is in the cart.
+        foreach (PersonQuery::create()
+            ->filterById($cartIds)
+            ->filterByEmail('', Criteria::NOT_EQUAL)
+            ->find() as $cartPerson) {
+            if (isset($doNotEmailSet[(int) $cartPerson->getId()])) {
+                continue;
+            }
+            $email = (string) $cartPerson->getEmail();
+            if (!isset($emailsSeen[strtolower($email)])) {
+                $emailsSeen[strtolower($email)] = true;
+                $emails[] = $email;
+            }
+        }
+
         $defaultTo = (string) SystemConfig::getValue('sToEmailAddress');
-        if ($emails !== [] && $defaultTo !== '' && !in_array(strtolower($defaultTo), array_map('strtolower', $emails))) {
+        if ($defaultTo !== '' && !isset($emailsSeen[strtolower($defaultTo)])) {
             $emails[] = $defaultTo;
         }
-        return implode(',', $emails);
+
+        return $emails;
     }
 
     public static function getSMSLink(): string

--- a/src/ChurchCRM/dto/Cart.php
+++ b/src/ChurchCRM/dto/Cart.php
@@ -292,7 +292,7 @@ class Cart
         }
 
         $defaultTo = (string) SystemConfig::getValue('sToEmailAddress');
-        if ($defaultTo !== '' && !isset($emailsSeen[strtolower($defaultTo)])) {
+        if ($defaultTo !== '' && !empty($emails) && !isset($emailsSeen[strtolower($defaultTo)])) {
             $emails[] = $defaultTo;
         }
 

--- a/src/ChurchCRM/dto/Cart.php
+++ b/src/ChurchCRM/dto/Cart.php
@@ -6,8 +6,8 @@ use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\model\ChurchCRM\Person2group2roleP2g2r;
 use ChurchCRM\model\ChurchCRM\Person2group2roleP2g2rQuery;
 use ChurchCRM\model\ChurchCRM\PersonQuery;
-use ChurchCRM\model\ChurchCRM\RecordPropertyQuery;
 use ChurchCRM\Service\GroupService;
+use ChurchCRM\Service\PersonService;
 use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\Connection\ConnectionInterface;
 use Propel\Runtime\Propel;
@@ -262,16 +262,8 @@ class Cart
             return [];
         }
 
-        $doNotEmailSet = [];
-        $doNotEmailPropId = (int) SystemConfig::getValue('iDoNotEmailPropertyId');
-        if ($doNotEmailPropId > 0) {
-            foreach (RecordPropertyQuery::create()
-                ->filterByPropertyId($doNotEmailPropId)
-                ->filterByRecordId($cartIds)
-                ->find() as $r) {
-                $doNotEmailSet[(int) $r->getRecordId()] = true;
-            }
-        }
+        // Delegate to PersonService to avoid duplicating the DoNotEmail exclusion logic
+        $doNotEmailSet = (new PersonService())->buildDoNotEmailSet($cartIds);
 
         $emails = [];
         $emailsSeen = [];

--- a/src/ChurchCRM/dto/Cart.php
+++ b/src/ChurchCRM/dto/Cart.php
@@ -2,7 +2,6 @@
 
 namespace ChurchCRM\dto;
 
-use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\model\ChurchCRM\Person2group2roleP2g2r;
 use ChurchCRM\model\ChurchCRM\Person2group2roleP2g2rQuery;
 use ChurchCRM\model\ChurchCRM\PersonQuery;
@@ -249,8 +248,12 @@ class Cart
     }
 
     /**
-     * Returns unique email addresses for all people in the cart, plus sToEmailAddress if configured.
+     * Returns unique email addresses for all people in the cart.
      * Respects the iDoNotEmailPropertyId exclusion setting.
+     *
+     * The configured sToEmailAddress is intentionally NOT included here; it is a system
+     * setting the composer reads from window.CRM.comm.defaultEmailToAddress and offers as a
+     * removable default recipient.
      *
      * @return string[]
      */
@@ -281,11 +284,6 @@ class Cart
                 $emailsSeen[strtolower($email)] = true;
                 $emails[] = $email;
             }
-        }
-
-        $defaultTo = (string) SystemConfig::getValue('sToEmailAddress');
-        if ($defaultTo !== '' && !empty($emails) && !isset($emailsSeen[strtolower($defaultTo)])) {
-            $emails[] = $defaultTo;
         }
 
         return $emails;

--- a/src/Include/Header.php
+++ b/src/Include/Header.php
@@ -123,6 +123,9 @@ $MenuFirst = 1;
           comm: {
             smtpConfigured: <?= json_encode(SystemConfig::hasValidMailServerSettings()) ?>,
             vonageEnabled: <?= json_encode(PluginManager::getPlugin('vonage')?->isConfigured() ?? false) ?>,
+            // Church default "to" address (sToEmailAddress); exposed only to email-enabled
+            // users. The email composer offers it as a removable default recipient.
+            defaultEmailToAddress: <?= AuthenticationManager::getCurrentUser()->isEmailEnabled() ? SystemConfig::getValueForJs('sToEmailAddress') : json_encode('') ?>,
           },
           // Plugin configs from active plugins (via getClientConfig())
           plugins: <?= json_encode(PluginManager::getPluginsClientConfig(), JSON_FORCE_OBJECT) ?>,

--- a/src/api/routes/cart.php
+++ b/src/api/routes/cart.php
@@ -16,7 +16,7 @@ use Slim\Routing\RouteCollectorProxy;
  *     @OA\Response(response=200, description="Email list for the current cart",
  *         @OA\JsonContent(
  *             @OA\Property(property="emails", type="array", @OA\Items(type="string"),
- *                 description="Unique email addresses (sToEmailAddress appended only when configured and the list has at least one recipient)")
+ *                 description="Unique cart member email addresses (does not include sToEmailAddress, which the composer adds from the setting)")
  *         )
  *     ),
  *     @OA\Response(response=401, description="Unauthorized"),

--- a/src/api/routes/cart.php
+++ b/src/api/routes/cart.php
@@ -1,10 +1,35 @@
 <?php
 
 use ChurchCRM\dto\Cart;
+use ChurchCRM\Slim\Middleware\Request\Auth\EmailRoleAuthMiddleware;
 use ChurchCRM\Slim\SlimUtils;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Routing\RouteCollectorProxy;
+
+/**
+ * @OA\Get(
+ *     path="/cart/emails",
+ *     summary="Get email addresses for all people currently in the session cart",
+ *     tags={"Cart"},
+ *     security={{"ApiKeyAuth":{}}},
+ *     @OA\Response(response=200, description="Email list for the current cart",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="emails", type="array", @OA\Items(type="string"),
+ *                 description="Unique email addresses (including sToEmailAddress if configured)")
+ *         )
+ *     ),
+ *     @OA\Response(response=401, description="Unauthorized"),
+ *     @OA\Response(response=403, description="Email permission required")
+ * )
+ */
+$app->get('/cart/emails', function (Request $request, Response $response): Response {
+    try {
+        return SlimUtils::renderJSON($response, ['emails' => Cart::getEmails()]);
+    } catch (\Throwable $e) {
+        return SlimUtils::renderErrorJSON($response, gettext('Failed to retrieve cart email addresses'), [], 500, $e, $request);
+    }
+})->add(EmailRoleAuthMiddleware::class);
 
 $app->group('/cart', function (RouteCollectorProxy $group): void {
     /**

--- a/src/api/routes/cart.php
+++ b/src/api/routes/cart.php
@@ -16,7 +16,7 @@ use Slim\Routing\RouteCollectorProxy;
  *     @OA\Response(response=200, description="Email list for the current cart",
  *         @OA\JsonContent(
  *             @OA\Property(property="emails", type="array", @OA\Items(type="string"),
- *                 description="Unique email addresses (including sToEmailAddress if configured)")
+ *                 description="Unique email addresses (sToEmailAddress appended only when configured and the list has at least one recipient)")
  *         )
  *     ),
  *     @OA\Response(response=401, description="Unauthorized"),

--- a/src/api/routes/people/people-groups.php
+++ b/src/api/routes/people/people-groups.php
@@ -446,7 +446,12 @@ $app->group('/groups', function (RouteCollectorProxy $group): void {
      *                 description="All unique email addresses (sToEmailAddress appended only when configured and the list has at least one recipient)"),
      *             @OA\Property(property="byRole", type="object",
      *                 description="Emails grouped by group role name",
-     *                 @OA\AdditionalProperties(type="array", @OA\Items(type="string")))
+     *                 @OA\AdditionalProperties(type="array", @OA\Items(type="string"))),
+     *             @OA\Property(property="all", type="string", deprecated=true,
+     *                 description="Deprecated: comma-separated string of all emails (legacy format, will be removed in a future release)"),
+     *             @OA\Property(property="roles", type="object", deprecated=true,
+     *                 description="Deprecated: map of role name to comma-separated emails (legacy format, will be removed in a future release)",
+     *                 @OA\AdditionalProperties(type="string"))
      *         )
      *     ),
      *     @OA\Response(response=401, description="Unauthorized"),
@@ -458,7 +463,16 @@ $app->group('/groups', function (RouteCollectorProxy $group): void {
         try {
             $groupID = (int) $args['groupID'];
             $personService = new PersonService();
-            return SlimUtils::renderJSON($response, $personService->getGroupMailingEmails($groupID));
+            $result = $personService->getGroupMailingEmails($groupID);
+            // Backward-compatible shim: include legacy CSV keys alongside new array keys
+            // so existing callers/plugins continue to work during the deprecation window.
+            $legacyRoles = [];
+            foreach ($result['byRole'] as $role => $roleEmails) {
+                $legacyRoles[$role] = implode(',', $roleEmails);
+            }
+            $result['all'] = implode(',', $result['emails']);
+            $result['roles'] = $legacyRoles;
+            return SlimUtils::renderJSON($response, $result);
         } catch (\Throwable $e) {
             return SlimUtils::renderErrorJSON($response, gettext('Failed to retrieve email addresses'), [], 500, $e, $request);
         }

--- a/src/api/routes/people/people-groups.php
+++ b/src/api/routes/people/people-groups.php
@@ -461,9 +461,10 @@ $app->group('/groups', function (RouteCollectorProxy $group): void {
      */
     $group->get('/{groupID:[0-9]+}/emails', function (Request $request, Response $response, array $args): Response {
         try {
-            $groupID = (int) $args['groupID'];
+            // GroupMiddleware already loaded and validated the Group — reuse it to avoid an extra DB query.
+            $groupEntity = $request->getAttribute('group');
             $personService = new PersonService();
-            $result = $personService->getGroupMailingEmails($groupID);
+            $result = $personService->getGroupMailingEmails($groupEntity);
             // Backward-compatible shim: include legacy CSV keys alongside new array keys
             // so existing callers/plugins continue to work during the deprecation window.
             $legacyRoles = [];

--- a/src/api/routes/people/people-groups.php
+++ b/src/api/routes/people/people-groups.php
@@ -436,22 +436,17 @@ $app->group('/groups', function (RouteCollectorProxy $group): void {
      * @OA\Get(
      *     path="/groups/{groupID}/emails",
      *     summary="Get mailing email addresses for group members grouped by role",
-     *     description="Returns email addresses for all group members, excluding those with the DoNotEmail property. Includes sToEmailAddress only when configured and at least one recipient email was found.",
+     *     description="Returns member email addresses for all group members, excluding those with the DoNotEmail property. sToEmailAddress is a system setting added by the composer, not returned here.",
      *     tags={"Groups"},
      *     security={{"ApiKeyAuth":{}}},
      *     @OA\Parameter(name="groupID", in="path", required=true, @OA\Schema(type="integer")),
      *     @OA\Response(response=200, description="Email addresses for the group",
      *         @OA\JsonContent(
      *             @OA\Property(property="emails", type="array", @OA\Items(type="string"),
-     *                 description="All unique email addresses (sToEmailAddress appended only when configured and the list has at least one recipient)"),
+     *                 description="All unique member email addresses (does not include sToEmailAddress)"),
      *             @OA\Property(property="byRole", type="object",
      *                 description="Emails grouped by group role name",
-     *                 @OA\AdditionalProperties(type="array", @OA\Items(type="string"))),
-     *             @OA\Property(property="all", type="string", deprecated=true,
-     *                 description="Deprecated: comma-separated string of all emails (legacy format, will be removed in a future release)"),
-     *             @OA\Property(property="roles", type="object", deprecated=true,
-     *                 description="Deprecated: map of role name to comma-separated emails (legacy format, will be removed in a future release)",
-     *                 @OA\AdditionalProperties(type="string"))
+     *                 @OA\AdditionalProperties(type="array", @OA\Items(type="string")))
      *         )
      *     ),
      *     @OA\Response(response=401, description="Unauthorized"),
@@ -464,19 +459,7 @@ $app->group('/groups', function (RouteCollectorProxy $group): void {
             // GroupMiddleware already loaded and validated the Group — reuse it to avoid an extra DB query.
             $groupEntity = $request->getAttribute('group');
             $personService = new PersonService();
-            $result = $personService->getGroupMailingEmails($groupEntity);
-            // Backward-compatible shim: include legacy CSV keys alongside new array keys
-            // so existing callers/plugins continue to work during the deprecation window.
-            // The `all` and `roles` keys are marked deprecated:true in the OA schema.
-            // NOTE: This shim also covers the sToEmailAddress 'System' bucket that
-            // PersonService injects into byRole, so the legacy CSV captures it too.
-            $legacyRoles = [];
-            foreach ($result['byRole'] as $role => $roleEmails) {
-                $legacyRoles[$role] = implode(',', $roleEmails);
-            }
-            $result['all'] = implode(',', $result['emails']);
-            $result['roles'] = $legacyRoles;
-            return SlimUtils::renderJSON($response, $result);
+            return SlimUtils::renderJSON($response, $personService->getGroupMailingEmails($groupEntity));
         } catch (\Throwable $e) {
             return SlimUtils::renderErrorJSON($response, gettext('Failed to retrieve email addresses'), [], 500, $e, $request);
         }

--- a/src/api/routes/people/people-groups.php
+++ b/src/api/routes/people/people-groups.php
@@ -477,7 +477,7 @@ $app->group('/groups', function (RouteCollectorProxy $group): void {
         } catch (\Throwable $e) {
             return SlimUtils::renderErrorJSON($response, gettext('Failed to retrieve email addresses'), [], 500, $e, $request);
         }
-    })->add(EmailRoleAuthMiddleware::class)->add(GroupMiddleware::class);
+    })->add(GroupMiddleware::class)->add(EmailRoleAuthMiddleware::class);
 
     /**
      * @OA\Get(

--- a/src/api/routes/people/people-groups.php
+++ b/src/api/routes/people/people-groups.php
@@ -467,6 +467,9 @@ $app->group('/groups', function (RouteCollectorProxy $group): void {
             $result = $personService->getGroupMailingEmails($groupEntity);
             // Backward-compatible shim: include legacy CSV keys alongside new array keys
             // so existing callers/plugins continue to work during the deprecation window.
+            // The `all` and `roles` keys are marked deprecated:true in the OA schema.
+            // NOTE: This shim also covers the sToEmailAddress 'System' bucket that
+            // PersonService injects into byRole, so the legacy CSV captures it too.
             $legacyRoles = [];
             foreach ($result['byRole'] as $role => $roleEmails) {
                 $legacyRoles[$role] = implode(',', $roleEmails);

--- a/src/api/routes/people/people-groups.php
+++ b/src/api/routes/people/people-groups.php
@@ -436,14 +436,14 @@ $app->group('/groups', function (RouteCollectorProxy $group): void {
      * @OA\Get(
      *     path="/groups/{groupID}/emails",
      *     summary="Get mailing email addresses for group members grouped by role",
-     *     description="Returns email addresses for all group members, excluding those with the DoNotEmail property. Includes sToEmailAddress when configured.",
+     *     description="Returns email addresses for all group members, excluding those with the DoNotEmail property. Includes sToEmailAddress only when configured and at least one recipient email was found.",
      *     tags={"Groups"},
      *     security={{"ApiKeyAuth":{}}},
      *     @OA\Parameter(name="groupID", in="path", required=true, @OA\Schema(type="integer")),
      *     @OA\Response(response=200, description="Email addresses for the group",
      *         @OA\JsonContent(
      *             @OA\Property(property="emails", type="array", @OA\Items(type="string"),
-     *                 description="All unique email addresses (including sToEmailAddress if configured)"),
+     *                 description="All unique email addresses (sToEmailAddress appended only when configured and the list has at least one recipient)"),
      *             @OA\Property(property="byRole", type="object",
      *                 description="Emails grouped by group role name",
      *                 @OA\AdditionalProperties(type="array", @OA\Items(type="string")))

--- a/src/api/routes/people/people-groups.php
+++ b/src/api/routes/people/people-groups.php
@@ -22,6 +22,7 @@ use ChurchCRM\Service\SundaySchoolService;
 use ChurchCRM\Slim\Middleware\Api\GroupMiddleware;
 use ChurchCRM\Slim\Middleware\Api\PersonMiddleware;
 use ChurchCRM\Slim\Middleware\InputSanitizationMiddleware;
+use ChurchCRM\Slim\Middleware\Request\Auth\EmailRoleAuthMiddleware;
 use ChurchCRM\Slim\Middleware\Request\Auth\ManageGroupRoleAuthMiddleware;
 use ChurchCRM\Slim\Middleware\Request\Setting\SundaySchoolEnabledMiddleware;
 use ChurchCRM\Slim\SlimUtils;
@@ -434,67 +435,34 @@ $app->group('/groups', function (RouteCollectorProxy $group): void {
     /**
      * @OA\Get(
      *     path="/groups/{groupID}/emails",
-     *     summary="Get email addresses for group members (respects Do Not Email)",
+     *     summary="Get mailing email addresses for group members grouped by role",
+     *     description="Returns email addresses for all group members, excluding those with the DoNotEmail property. Includes sToEmailAddress when configured.",
      *     tags={"Groups"},
      *     security={{"ApiKeyAuth":{}}},
      *     @OA\Parameter(name="groupID", in="path", required=true, @OA\Schema(type="integer")),
-     *     @OA\Response(response=200, description="Email contact info for the group")
+     *     @OA\Response(response=200, description="Email addresses for the group",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="emails", type="array", @OA\Items(type="string"),
+     *                 description="All unique email addresses (including sToEmailAddress if configured)"),
+     *             @OA\Property(property="byRole", type="object",
+     *                 description="Emails grouped by group role name",
+     *                 @OA\AdditionalProperties(type="array", @OA\Items(type="string")))
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=403, description="Email permission required"),
+     *     @OA\Response(response=404, description="Group not found")
      * )
      */
     $group->get('/{groupID:[0-9]+}/emails', function (Request $request, Response $response, array $args): Response {
         try {
             $groupID = (int) $args['groupID'];
-            $doNotEmailSet = _getExcludedPersonIdSet('iDoNotEmailPropertyId');
-
-            $memberships = Person2group2roleP2g2rQuery::create()
-                ->filterByGroupId($groupID)
-                ->innerJoinWithPerson()
-                ->find();
-
-            $group = $request->getAttribute('group');
-            $roleNameMap = [];
-            foreach (ListOptionQuery::create()->filterById($group->getRoleListId())->find() as $opt) {
-                $roleNameMap[(int) $opt->getOptionId()] = $opt->getOptionName();
-            }
-
-            $allEmails = [];
-            $roleEmails = [];
-            foreach ($memberships as $membership) {
-                $person = $membership->getPerson();
-                if ($person === null) {
-                    continue;
-                }
-                if (isset($doNotEmailSet[(int) $person->getId()])) {
-                    continue;
-                }
-                $email = (string) $person->getEmail();
-                if (empty($email) || isset($allEmails[$email])) {
-                    continue;
-                }
-                $allEmails[$email] = true;
-                $roleName = $roleNameMap[(int) $membership->getRoleId()] ?? gettext('Member');
-                $roleEmails[$roleName][] = $email;
-            }
-
-            $systemEmail = (string) SystemConfig::getValue('sToEmailAddress');
-            $allList = array_keys($allEmails);
-            if (!empty($systemEmail) && !isset($allEmails[$systemEmail])) {
-                $allList[] = $systemEmail;
-            }
-
-            $roles = [];
-            foreach ($roleEmails as $name => $emails) {
-                $roles[$name] = implode(',', $emails);
-            }
-
-            return SlimUtils::renderJSON($response, [
-                'all'       => implode(',', $allList),
-                'roles'     => $roles,
-            ]);
+            $personService = new PersonService();
+            return SlimUtils::renderJSON($response, $personService->getGroupMailingEmails($groupID));
         } catch (\Throwable $e) {
             return SlimUtils::renderErrorJSON($response, gettext('Failed to retrieve email addresses'), [], 500, $e, $request);
         }
-    })->add(GroupMiddleware::class);
+    })->add(EmailRoleAuthMiddleware::class)->add(GroupMiddleware::class);
 
     /**
      * @OA\Get(

--- a/src/api/routes/people/people-groups.php
+++ b/src/api/routes/people/people-groups.php
@@ -528,7 +528,23 @@ $app->group('/groups', function (RouteCollectorProxy $group): void {
             // Merge and dedup across segments for 'all'
             $allEmails = array_values(array_unique(array_merge($teacherEmails, $parentEmails, $kidEmails)));
 
+            // New array-shape response (used by email-composer modal)
+            $byRole = [];
+            if (!empty($teacherEmails)) {
+                $byRole[gettext('Teachers')] = $teacherEmails;
+            }
+            if (!empty($parentEmails)) {
+                $byRole[gettext('Parents')] = $parentEmails;
+            }
+            if (!empty($kidEmails)) {
+                $byRole[gettext('Kids')] = $kidEmails;
+            }
+
             return SlimUtils::renderJSON($response, [
+                // New canonical shape consumed by the email-composer modal
+                'emails' => $allEmails,
+                'byRole' => $byRole,
+                // Legacy CSV fields retained for backward compatibility
                 'all'      => implode(',', $allEmails),
                 'teachers' => implode(',', $teacherEmails),
                 'parents'  => implode(',', $parentEmails),

--- a/src/api/routes/people/people-persons.php
+++ b/src/api/routes/people/people-persons.php
@@ -474,13 +474,13 @@ function buildFormattedPersonList(Collection $people): array
  * @OA\Get(
  *     path="/people/emails",
  *     summary="Get mailing email addresses grouped by classification role",
- *     description="Returns email addresses for all active-family people, excluding those with the DoNotEmail property. Includes sToEmailAddress when configured.",
+ *     description="Returns email addresses for all active-family people, excluding those with the DoNotEmail property. Includes sToEmailAddress only when configured and at least one recipient email was found.",
  *     tags={"People"},
  *     security={{"ApiKeyAuth":{}}},
  *     @OA\Response(response=200, description="Email addresses for all people and per role",
  *         @OA\JsonContent(
  *             @OA\Property(property="emails", type="array", @OA\Items(type="string"),
- *                 description="All unique email addresses (including sToEmailAddress if configured)"),
+ *                 description="All unique email addresses (sToEmailAddress appended only when configured and the list has at least one recipient)"),
  *             @OA\Property(property="byRole", type="object",
  *                 description="Emails grouped by classification role name",
  *                 @OA\AdditionalProperties(type="array", @OA\Items(type="string")))

--- a/src/api/routes/people/people-persons.php
+++ b/src/api/routes/people/people-persons.php
@@ -5,7 +5,9 @@ use ChurchCRM\model\ChurchCRM\FamilyQuery;
 use ChurchCRM\model\ChurchCRM\ListOptionQuery;
 use ChurchCRM\model\ChurchCRM\Person;
 use ChurchCRM\model\ChurchCRM\PersonQuery;
+use ChurchCRM\Service\PersonService;
 use ChurchCRM\Slim\Middleware\Request\Auth\EditRecordsRoleAuthMiddleware;
+use ChurchCRM\Slim\Middleware\Request\Auth\EmailRoleAuthMiddleware;
 use ChurchCRM\Slim\SlimUtils;
 use ChurchCRM\Utils\DateTimeUtils;
 use Propel\Runtime\ActiveQuery\Criteria;
@@ -467,3 +469,32 @@ function buildFormattedPersonList(Collection $people): array
 
     return ['people' => $formattedList];
 }
+
+/**
+ * @OA\Get(
+ *     path="/people/emails",
+ *     summary="Get mailing email addresses grouped by classification role",
+ *     description="Returns email addresses for all active-family people, excluding those with the DoNotEmail property. Includes sToEmailAddress when configured.",
+ *     tags={"People"},
+ *     security={{"ApiKeyAuth":{}}},
+ *     @OA\Response(response=200, description="Email addresses for all people and per role",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="emails", type="array", @OA\Items(type="string"),
+ *                 description="All unique email addresses (including sToEmailAddress if configured)"),
+ *             @OA\Property(property="byRole", type="object",
+ *                 description="Emails grouped by classification role name",
+ *                 @OA\AdditionalProperties(type="array", @OA\Items(type="string")))
+ *         )
+ *     ),
+ *     @OA\Response(response=401, description="Unauthorized"),
+ *     @OA\Response(response=403, description="Email permission required")
+ * )
+ */
+$app->get('/people/emails', function (Request $request, Response $response): Response {
+    try {
+        $personService = new PersonService();
+        return SlimUtils::renderJSON($response, $personService->getMailingEmails());
+    } catch (\Throwable $e) {
+        return SlimUtils::renderErrorJSON($response, gettext('Failed to retrieve email addresses'), [], 500, $e, $request);
+    }
+})->add(EmailRoleAuthMiddleware::class);

--- a/src/api/routes/people/people-persons.php
+++ b/src/api/routes/people/people-persons.php
@@ -474,13 +474,13 @@ function buildFormattedPersonList(Collection $people): array
  * @OA\Get(
  *     path="/people/emails",
  *     summary="Get mailing email addresses grouped by classification role",
- *     description="Returns email addresses for all active-family people, excluding those with the DoNotEmail property. Includes sToEmailAddress only when configured and at least one recipient email was found.",
+ *     description="Returns member email addresses for all active-family people, excluding those with the DoNotEmail property. sToEmailAddress is a system setting added by the composer, not returned here.",
  *     tags={"People"},
  *     security={{"ApiKeyAuth":{}}},
  *     @OA\Response(response=200, description="Email addresses for all people and per role",
  *         @OA\JsonContent(
  *             @OA\Property(property="emails", type="array", @OA\Items(type="string"),
- *                 description="All unique email addresses (sToEmailAddress appended only when configured and the list has at least one recipient)"),
+ *                 description="All unique member email addresses (does not include sToEmailAddress)"),
  *             @OA\Property(property="byRole", type="object",
  *                 description="Emails grouped by classification role name",
  *                 @OA\AdditionalProperties(type="array", @OA\Items(type="string")))

--- a/src/groups/views/group-view.php
+++ b/src/groups/views/group-view.php
@@ -135,14 +135,12 @@ if ($bCanManageGroups) {
             </a>
             <?php endif; ?>
             <?php if ($bEmailEnabled): ?>
-            <div class="dropdown">
-                <button class="btn btn-ghost-secondary dropdown-toggle" data-bs-toggle="dropdown" data-bs-display="static" id="emailDropdownBtn">
-                    <i class="fa-solid fa-paper-plane me-1"></i><?= gettext('Email') ?>
-                </button>
-                <div class="dropdown-menu" id="emailDropdownMenu">
-                    <div class="text-center py-2 text-body-secondary"><i class="fa-solid fa-spinner fa-spin me-1"></i><?= gettext('Loading...') ?></div>
-                </div>
-            </div>
+            <button class="btn btn-ghost-secondary"
+                    data-email-composer
+                    data-email-endpoint="groups/<?= (int) $iGroupID ?>/emails"
+                    data-email-title="<?= htmlspecialchars(gettext('Email') . ' ' . $thisGroup->getName(), ENT_QUOTES) ?>">
+                <i class="fa-solid fa-paper-plane me-1"></i><?= gettext('Email') ?>
+            </button>
             <?php endif; ?>
             <div class="dropdown">
                 <button class="btn btn-ghost-secondary dropdown-toggle" data-bs-toggle="dropdown" data-bs-display="static" id="textDropdownBtn">
@@ -362,6 +360,9 @@ if ($bCanManageGroups) {
     window.CRM.groupPhoneNumbers = <?= json_encode($sPhoneLink, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
 </script>
 <script src="<?= $sRootPath ?>/skin/js/GroupView.js?v=<?= filemtime(SystemURLs::getDocumentRoot() . '/skin/js/GroupView.js') ?>"></script>
+<?php if ($bEmailEnabled): ?>
+<script src="<?= SystemURLs::assetVersioned('/skin/v2/email-composer.min.js') ?>" defer nonce="<?= SystemURLs::getCSPNonce() ?>"></script>
+<?php endif; ?>
 
 <?php
 require SystemURLs::getDocumentRoot() . '/Include/Footer.php';

--- a/src/groups/views/group-view.php
+++ b/src/groups/views/group-view.php
@@ -138,7 +138,7 @@ if ($bCanManageGroups) {
             <button class="btn btn-ghost-secondary"
                     data-email-composer
                     data-email-endpoint="groups/<?= (int) $iGroupID ?>/emails"
-                    data-email-title="<?= htmlspecialchars(gettext('Email') . ' ' . $thisGroup->getName(), ENT_QUOTES) ?>">
+                    data-email-title="<?= htmlspecialchars(gettext('Email') . ' ' . $thisGroup->getName(), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>">
                 <i class="fa-solid fa-paper-plane me-1"></i><?= gettext('Email') ?>
             </button>
             <?php endif; ?>

--- a/src/groups/views/group-view.php
+++ b/src/groups/views/group-view.php
@@ -111,7 +111,7 @@ if ($bCanManageGroups) {
                 <i class="fa-solid fa-pen me-1"></i><?= gettext('Edit') ?>
             </a>
             <?php endif; ?>
-            <button class="btn btn-ghost-secondary" id="printGroup" title="<?= gettext('Print') ?>">
+            <button type="button" class="btn btn-ghost-secondary" id="printGroup" title="<?= gettext('Print') ?>">
                 <i class="fa-solid fa-print me-1"></i><?= gettext('Print') ?>
             </button>
             <div class="dropdown">

--- a/src/groups/views/group-view.php
+++ b/src/groups/views/group-view.php
@@ -135,10 +135,10 @@ if ($bCanManageGroups) {
             </a>
             <?php endif; ?>
             <?php if ($bEmailEnabled): ?>
-            <button class="btn btn-ghost-secondary"
+            <button type="button" class="btn btn-ghost-secondary"
                     data-email-composer
                     data-email-endpoint="groups/<?= (int) $iGroupID ?>/emails"
-                    data-email-title="<?= htmlspecialchars(gettext('Email') . ' ' . $thisGroup->getName(), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>">
+                    data-email-title="<?= InputUtils::escapeAttribute(gettext('Email') . ' ' . $thisGroup->getName()) ?>">
                 <i class="fa-solid fa-paper-plane me-1"></i><?= gettext('Email') ?>
             </button>
             <?php endif; ?>

--- a/src/groups/views/sundayschool/class-view.php
+++ b/src/groups/views/sundayschool/class-view.php
@@ -123,14 +123,12 @@ if ($bCanManageGroups) {
                 <i class="fa-solid fa-map-location-dot me-1"></i><?= gettext('Map') ?>
             </a>
             <?php if ($canEmail): ?>
-            <div class="dropdown">
-                <button class="btn btn-ghost-secondary dropdown-toggle" data-bs-toggle="dropdown" data-bs-display="static" id="ssEmailDropdownBtn">
-                    <i class="fa-solid fa-paper-plane me-1"></i><?= gettext('Email') ?>
-                </button>
-                <div class="dropdown-menu" id="ssEmailDropdownMenu">
-                    <div class="text-center py-2 text-body-secondary"><i class="fa-solid fa-spinner fa-spin me-1"></i><?= gettext('Loading...') ?></div>
-                </div>
-            </div>
+            <button type="button" class="btn btn-ghost-secondary"
+                    data-email-composer
+                    data-email-endpoint="groups/<?= (int) $iGroupId ?>/sundayschool/emails"
+                    data-email-title="<?= htmlspecialchars(gettext('Email') . ' ' . $iGroupName, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>">
+                <i class="fa-solid fa-paper-plane me-1"></i><?= gettext('Email') ?>
+            </button>
             <?php endif; ?>
             <div class="dropdown">
                 <button class="btn btn-ghost-secondary dropdown-toggle" data-bs-toggle="dropdown" data-bs-display="static" id="ssTextDropdownBtn">
@@ -619,5 +617,8 @@ if ($bCanManageGroups) {
 </script>
 <script src="<?= $sRootPath ?>/skin/js/sundayschool-actions.js?v=<?= filemtime(SystemURLs::getDocumentRoot() . '/skin/js/sundayschool-actions.js') ?>"></script>
 <script src="<?= SystemURLs::getRootPath() ?>/skin/v2/groups-sundayschool-class-view.min.js"></script>
+<?php if ($canEmail): ?>
+<script src="<?= SystemURLs::assetVersioned('/skin/v2/email-composer.min.js') ?>" defer nonce="<?= SystemURLs::getCSPNonce() ?>"></script>
+<?php endif; ?>
 
 <?php require SystemURLs::getDocumentRoot() . '/Include/Footer.php'; ?>

--- a/src/mysql/upgrade.json
+++ b/src/mysql/upgrade.json
@@ -76,9 +76,14 @@
     "scripts": ["/mysql/upgrade/7.5.0-fundraiser-fields.sql"],
     "dbVersion": "7.5.0"
   },
-  "current": {
+  "pre-7.5.1": {
     "versions": ["7.5.0"],
-    "scripts": ["/mysql/upgrade/7.5.1-remove-email-delimiter-user-settings.sql"],
+    "scripts": ["/mysql/upgrade/7.5.1-remove-sMailtoDelimiter.sql"],
+    "dbVersion": "7.5.1"
+  },
+  "current": {
+    "versions": [],
+    "scripts": [],
     "dbVersion": "7.5.1"
   }
 }

--- a/src/mysql/upgrade/7.5.1-remove-sMailtoDelimiter.sql
+++ b/src/mysql/upgrade/7.5.1-remove-sMailtoDelimiter.sql
@@ -5,9 +5,9 @@
 --   sMailtoDelimiter (userconfig_ucfg) stored a per-user choice of delimiter
 --   character for mailto: links. ui.email.delimiter (user_settings) was its
 --   successor key introduced in the pre-6.0.0 consolidated migration. Both are
---   now obsolete: email delimiters always use the RFC 6068 comma format, and
---   the PHP code that read these settings has been updated to use ',' directly.
+--   now obsolete: email lists are handled via API endpoints that return arrays,
+--   and the PHP code that read these settings has been removed.
 --
 -- Idempotent: safe to re-run; rows already absent are silently skipped.
-DELETE FROM `userconfig_ucfg` WHERE `ucfg_name` = 'sMailtoDelimiter';
-DELETE FROM `user_settings` WHERE `setting_name` = 'ui.email.delimiter';
+DELETE FROM userconfig_ucfg WHERE ucfg_name = 'sMailtoDelimiter';
+DELETE FROM user_settings WHERE setting_name = 'ui.email.delimiter';

--- a/src/mysql/upgrade/pre-6.0.0-consolidated.sql
+++ b/src/mysql/upgrade/pre-6.0.0-consolidated.sql
@@ -509,7 +509,8 @@ INSERT IGNORE INTO user_settings SELECT usr_per_ID, 'finance.show.pledges',     
 INSERT IGNORE INTO user_settings SELECT usr_per_ID, 'finance.show.payments',    usr_showPayments FROM user_usr;
 INSERT IGNORE INTO user_settings SELECT usr_per_ID, 'finance.show.since',       usr_showSince    FROM user_usr;
 INSERT IGNORE INTO user_settings SELECT usr_per_ID, 'finance.FY',               usr_defaultFY    FROM user_usr;
-INSERT IGNORE INTO user_settings SELECT ucfg_per_id, 'ui.email.delimiter',      ucfg_value       FROM userconfig_ucfg WHERE ucfg_name = 'sMailtoDelimiter';
+-- sMailtoDelimiter migration omitted: the 7.5.1 migration deletes ui.email.delimiter from
+-- user_settings for all upgrade paths, so inserting it here is always redundant.
 
 
 -- ===== from 4.4.0-FB.sql =====

--- a/src/people/routes/dashboard.php
+++ b/src/people/routes/dashboard.php
@@ -1,13 +1,9 @@
 <?php
 
 use ChurchCRM\Authentication\AuthenticationManager;
-use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\dto\SystemURLs;
 use ChurchCRM\Service\DashboardService;
 use ChurchCRM\view\PageHeader;
-use ChurchCRM\model\ChurchCRM\Base\ListOptionQuery;
-use ChurchCRM\model\ChurchCRM\PersonQuery;
-use ChurchCRM\model\ChurchCRM\RecordPropertyQuery;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Views\PhpRenderer;
@@ -35,65 +31,8 @@ $app->get('/dashboard', function (Request $request, Response $response): Respons
     $ageGroupStats       = $dashboardStats['ageGroupStats'];
     $familyRoleStats     = $dashboardStats['familyRoleStats'];
 
-    // Build email list grouped by role (active families, excluding "Do Not Email" property)
-    $currentUser        = AuthenticationManager::getCurrentUser();
-    $isAdmin            = $currentUser->isAdmin();
-    // Recipient lists collected as arrays; joined into RFC 6068 comma strings below.
-    $sEmailList         = [];
-    $roleEmails         = [];
-
-    // Build exclusion set from configured "Do Not Email" property
-    $doNotEmailSet = [];
-    $doNotEmailPropId = (int) SystemConfig::getValue('iDoNotEmailPropertyId');
-    if ($doNotEmailPropId > 0) {
-        foreach (RecordPropertyQuery::create()->filterByPropertyId($doNotEmailPropId)->find() as $r) {
-            $doNotEmailSet[(int) $r->getRecordId()] = true;
-        }
-    }
-
-    // Role name map: classification ID → label
-    $roleNameMap = [];
-    foreach (ListOptionQuery::create()->filterById(1)->find() as $opt) {
-        $roleNameMap[(int) $opt->getOptionId()] = $opt->getOptionName();
-    }
-
-    $persons = PersonQuery::create()
-        ->leftJoinWithFamily()
-        ->useQuery('Family')
-            ->filterByDateDeactivated(null)
-        ->endUse()
-        ->find();
-
-    $emailsSeen = [];
-    foreach ($persons as $person) {
-        $personId = (int) $person->getId();
-        if (isset($doNotEmailSet[$personId])) {
-            continue;
-        }
-        $email = (string) $person->getEmail();
-        if (empty($email) || isset($emailsSeen[$email])) {
-            continue;
-        }
-        $emailsSeen[$email] = true;
-        $sEmailList[] = $email;
-
-        $roleName = $roleNameMap[(int) $person->getClsId()] ?? gettext('Member');
-        $roleEmails[$roleName][] = $email;
-    }
-
-    // Join addresses into an RFC 6068 comma string, adding the default "to"
-    // once when configured.  Case-insensitive check (in_array + strtolower)
-    // prevents adding sToEmailAddress when a person email matches it only by
-    // case (e.g. "Admin@church.org" vs "admin@church.org").  $defaultTo is
-    // omitted entirely when $emails is empty so the dashboard dropdowns stay
-    // hidden when there are no reachable person recipients.
-    $defaultTo = SystemConfig::getValue('sToEmailAddress');
-    $joinEmails = static fn(array $emails): string => implode(
-        ',',
-        $defaultTo === '' || $emails === [] || in_array(strtolower($defaultTo), array_map('strtolower', $emails))
-            ? array_unique($emails)
-            : array_unique([...$emails, $defaultTo]),
-    );
+    $currentUser = AuthenticationManager::getCurrentUser();
+    $isAdmin     = $currentUser->isAdmin();
 
     $pageArgs = [
         'sRootPath'          => SystemURLs::getRootPath(),
@@ -116,8 +55,6 @@ $app->get('/dashboard', function (Request $request, Response $response): Respons
         'simpleGenderStats'  => $simpleGenderStats,
         'ageGroupStats'      => $ageGroupStats,
         'familyRoleStats'    => $familyRoleStats,
-        'sEmailLink'         => $joinEmails($sEmailList),
-        'roleEmails'         => array_map($joinEmails, $roleEmails),
         'isAdmin'            => $isAdmin,
         'canEmail'           => $currentUser->isEmailEnabled(),
     ];

--- a/src/people/views/dashboard.php
+++ b/src/people/views/dashboard.php
@@ -3,7 +3,6 @@
 use ChurchCRM\Authentication\AuthenticationManager;
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\dto\SystemURLs;
-use ChurchCRM\Utils\InputUtils;
 
 require SystemURLs::getDocumentRoot() . '/Include/Header.php';
 
@@ -109,35 +108,13 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
                 <a href="<?= $sRootPath ?>/people/verify" class="btn btn-outline-info">
                     <i class="fa-solid fa-clipboard-check me-1"></i><?= gettext('Verify People') ?>
                 </a>
-                <?php if ($sEmailLink && $canEmail):
-                    // Recipients are data; "to" vs "bcc" is delivery mode — keep them separate.
-                    $mailto = static fn(string $recipients, bool $bcc = false): string =>
-                        InputUtils::escapeAttribute('mailto:' . ($bcc ? '?bcc=' : '') . rawurlencode($recipients));
-                    ?>
-                    <div class="dropdown">
-                        <button class="btn btn-outline-primary dropdown-toggle" type="button" data-bs-toggle="dropdown">
-                            <i class="fa-solid fa-envelope me-1"></i><?= gettext('Email All') ?>
-                        </button>
-                        <div class="dropdown-menu">
-                            <a class="dropdown-item" href="<?= $mailto($sEmailLink) ?>" target="_blank" rel="noopener noreferrer"><?= gettext('All People') ?></a>
-                            <div class="dropdown-divider"></div>
-                            <?php foreach ($roleEmails as $role => $roleEmail): ?>
-                                <a class="dropdown-item" href="<?= $mailto($roleEmail) ?>" target="_blank" rel="noopener noreferrer"><?= InputUtils::escapeHTML($role) ?></a>
-                            <?php endforeach; ?>
-                        </div>
-                    </div>
-                    <div class="dropdown">
-                        <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown">
-                            <i class="fa-solid fa-user-secret me-1"></i><?= gettext('Email BCC') ?>
-                        </button>
-                        <div class="dropdown-menu">
-                            <a class="dropdown-item" href="<?= $mailto($sEmailLink, true) ?>" target="_blank" rel="noopener noreferrer"><?= gettext('All People') ?></a>
-                            <div class="dropdown-divider"></div>
-                            <?php foreach ($roleEmails as $role => $roleEmail): ?>
-                                <a class="dropdown-item" href="<?= $mailto($roleEmail, true) ?>" target="_blank" rel="noopener noreferrer"><?= InputUtils::escapeHTML($role) ?></a>
-                            <?php endforeach; ?>
-                        </div>
-                    </div>
+                <?php if ($canEmail): ?>
+                    <button class="btn btn-outline-primary"
+                            data-email-composer
+                            data-email-endpoint="people/emails"
+                            data-email-title="<?= htmlspecialchars(gettext('Email All Members'), ENT_QUOTES) ?>">
+                        <i class="fa-solid fa-envelope me-1"></i><?= gettext('Email All') ?>
+                    </button>
                 <?php endif; ?>
             </div>
         </div>
@@ -378,6 +355,10 @@ $(document).ready(function () {
     });
 });
 </script>
+<?php endif; ?>
+
+<?php if ($canEmail): ?>
+<script src="<?= SystemURLs::assetVersioned('/skin/v2/email-composer.min.js') ?>" defer nonce="<?= SystemURLs::getCSPNonce() ?>"></script>
 <?php endif; ?>
 
 <?php require SystemURLs::getDocumentRoot() . '/Include/Footer.php'; ?>

--- a/src/people/views/dashboard.php
+++ b/src/people/views/dashboard.php
@@ -112,7 +112,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
                     <button type="button" class="btn btn-outline-primary"
                             data-email-composer
                             data-email-endpoint="people/emails"
-                            data-email-title="<?= htmlspecialchars(gettext('Email All Members'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>">
+                            data-email-title="<?= gettext('Email All Members') ?>">
                         <i class="fa-solid fa-envelope me-1"></i><?= gettext('Email All') ?>
                     </button>
                 <?php endif; ?>

--- a/src/people/views/dashboard.php
+++ b/src/people/views/dashboard.php
@@ -112,7 +112,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
                     <button class="btn btn-outline-primary"
                             data-email-composer
                             data-email-endpoint="people/emails"
-                            data-email-title="<?= htmlspecialchars(gettext('Email All Members'), ENT_QUOTES) ?>">
+                            data-email-title="<?= htmlspecialchars(gettext('Email All Members'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>">
                         <i class="fa-solid fa-envelope me-1"></i><?= gettext('Email All') ?>
                     </button>
                 <?php endif; ?>

--- a/src/people/views/dashboard.php
+++ b/src/people/views/dashboard.php
@@ -3,6 +3,7 @@
 use ChurchCRM\Authentication\AuthenticationManager;
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\dto\SystemURLs;
+use ChurchCRM\Utils\InputUtils;
 
 require SystemURLs::getDocumentRoot() . '/Include/Header.php';
 
@@ -112,7 +113,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
                     <button type="button" class="btn btn-outline-primary"
                             data-email-composer
                             data-email-endpoint="people/emails"
-                            data-email-title="<?= gettext('Email All Members') ?>">
+                            data-email-title="<?= InputUtils::escapeAttribute(gettext('Email All Members')) ?>">
                         <i class="fa-solid fa-envelope me-1"></i><?= gettext('Email All') ?>
                     </button>
                 <?php endif; ?>

--- a/src/people/views/dashboard.php
+++ b/src/people/views/dashboard.php
@@ -109,7 +109,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
                     <i class="fa-solid fa-clipboard-check me-1"></i><?= gettext('Verify People') ?>
                 </a>
                 <?php if ($canEmail): ?>
-                    <button class="btn btn-outline-primary"
+                    <button type="button" class="btn btn-outline-primary"
                             data-email-composer
                             data-email-endpoint="people/emails"
                             data-email-title="<?= htmlspecialchars(gettext('Email All Members'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>">

--- a/src/skin/js/GroupView.js
+++ b/src/skin/js/GroupView.js
@@ -277,81 +277,8 @@ function initializeGroupView() {
     });
   });
 
-  // ------------------------------------------------------------------ //
-  // Email dropdown: populate on first open, then handle clicks
-  // ------------------------------------------------------------------ //
-  var emailLoaded = false;
-  $("#emailDropdownBtn")
-    .parent()
-    .on("show.bs.dropdown", () => {
-      if (emailLoaded) return;
-      emailLoaded = true;
-      window.CRM.APIRequest({
-        method: "GET",
-        path: "groups/" + window.CRM.currentGroup + "/emails",
-      }).done((data) => {
-        var menu = $("#emailDropdownMenu");
-        menu.empty();
-        if (!data.all) {
-          menu.html('<span class="dropdown-item text-muted">' + i18next.t("No email addresses available") + "</span>");
-          return;
-        }
-        // All section
-        menu.append(
-          '<button class="dropdown-item" data-action="copy-emails" data-emails="' +
-            window.CRM.escapeHtml(data.all) +
-            '"><i class="fa-solid fa-copy me-2"></i>' +
-            i18next.t("Copy All Emails") +
-            "</button>",
-        );
-        menu.append(
-          '<button class="dropdown-item" data-action="mailto" data-emails="' +
-            window.CRM.escapeHtml(data.all) +
-            '"><i class="fa-solid fa-envelope me-2"></i>' +
-            i18next.t("Email All") +
-            "</button>",
-        );
-        menu.append(
-          '<button class="dropdown-item" data-action="bcc" data-emails="' +
-            window.CRM.escapeHtml(data.all) +
-            '"><i class="fa-solid fa-user-secret me-2"></i>' +
-            i18next.t("BCC All") +
-            "</button>",
-        );
-        // Per-role sections
-        if (data.roles && Object.keys(data.roles).length > 0) {
-          $.each(data.roles, (roleName, emails) => {
-            menu.append('<div class="dropdown-divider"></div>');
-            menu.append('<h6 class="dropdown-header">' + window.CRM.escapeHtml(roleName) + "</h6>");
-            menu.append(
-              '<button class="dropdown-item" data-action="copy-emails" data-emails="' +
-                window.CRM.escapeHtml(emails) +
-                '"><i class="fa-solid fa-copy me-2"></i>' +
-                i18next.t("Copy") +
-                "</button>",
-            );
-            menu.append(
-              '<button class="dropdown-item" data-action="mailto" data-emails="' +
-                window.CRM.escapeHtml(emails) +
-                '"><i class="fa-solid fa-envelope me-2"></i>' +
-                i18next.t("Email") +
-                "</button>",
-            );
-          });
-        }
-      });
-    });
-
-  // Handle email actions (delegated from dynamic items)
-  $("#group-view-toolbar").on("click", "[data-action='copy-emails']", function () {
-    window.CRM.comm.copyEmails($(this).data("emails"));
-  });
-  $("#group-view-toolbar").on("click", "[data-action='mailto']", function () {
-    window.CRM.comm.openMailto($(this).data("emails"));
-  });
-  $("#group-view-toolbar").on("click", "[data-action='bcc']", function () {
-    window.CRM.comm.openBcc($(this).data("emails"));
-  });
+  // Note: email action is handled by the email-composer.min.js bundle
+  // which auto-wires the [data-email-composer] button on the toolbar.
 
   // ------------------------------------------------------------------ //
   // Text dropdown: populate on first open, then handle clicks

--- a/src/skin/js/sundayschool-actions.js
+++ b/src/skin/js/sundayschool-actions.js
@@ -167,87 +167,8 @@
       window.print();
     });
 
-    // ------------------------------------------------------------------ //
-    // Email dropdown: populate on first open
-    // ------------------------------------------------------------------ //
-    var ssEmailLoaded = false;
-    $("#ssEmailDropdownBtn")
-      .parent()
-      .on("show.bs.dropdown", function () {
-        if (ssEmailLoaded) return;
-        ssEmailLoaded = true;
-        window.CRM.APIRequest({
-          method: "GET",
-          path: "groups/" + window.CRM.currentGroup + "/sundayschool/emails",
-        }).done(function (data) {
-          var menu = $("#ssEmailDropdownMenu");
-          menu.empty();
-          if (!data.all) {
-            menu.html(
-              '<span class="dropdown-item text-muted">' + i18next.t("No email addresses available") + "</span>",
-            );
-            return;
-          }
-          // All section
-          menu.append(
-            '<button class="dropdown-item" data-action="copy-emails" data-emails="' +
-              window.CRM.escapeHtml(data.all) +
-              '"><i class="fa-solid fa-copy me-2"></i>' +
-              i18next.t("Copy All Emails") +
-              "</button>",
-          );
-          menu.append(
-            '<button class="dropdown-item" data-action="mailto" data-emails="' +
-              window.CRM.escapeHtml(data.all) +
-              '"><i class="fa-solid fa-envelope me-2"></i>' +
-              i18next.t("Email All") +
-              "</button>",
-          );
-          menu.append(
-            '<button class="dropdown-item" data-action="bcc" data-emails="' +
-              window.CRM.escapeHtml(data.all) +
-              '"><i class="fa-solid fa-user-secret me-2"></i>' +
-              i18next.t("BCC All") +
-              "</button>",
-          );
-          // Per-role sections (teachers, students, parents)
-          var roleMap = {
-            teachers: { label: i18next.t("Teachers"), icon: "fa-person-chalkboard" },
-            parents: { label: i18next.t("Parents"), icon: "fa-users" },
-            kids: { label: i18next.t("Students"), icon: "fa-child" },
-          };
-          $.each(roleMap, function (key, meta) {
-            if (!data[key]) return;
-            menu.append('<div class="dropdown-divider"></div>');
-            menu.append('<h6 class="dropdown-header">' + meta.label + "</h6>");
-            menu.append(
-              '<button class="dropdown-item" data-action="copy-emails" data-emails="' +
-                window.CRM.escapeHtml(data[key]) +
-                '"><i class="fa-solid fa-copy me-2"></i>' +
-                i18next.t("Copy") +
-                "</button>",
-            );
-            menu.append(
-              '<button class="dropdown-item" data-action="mailto" data-emails="' +
-                window.CRM.escapeHtml(data[key]) +
-                '"><i class="fa-solid fa-envelope me-2"></i>' +
-                i18next.t("Email") +
-                "</button>",
-            );
-          });
-        });
-      });
-
-    // Handle email actions (delegated)
-    $("#ss-action-toolbar").on("click", "[data-action='copy-emails']", function () {
-      window.CRM.comm.copyEmails($(this).data("emails"));
-    });
-    $("#ss-action-toolbar").on("click", "[data-action='mailto']", function () {
-      window.CRM.comm.openMailto($(this).data("emails"));
-    });
-    $("#ss-action-toolbar").on("click", "[data-action='bcc']", function () {
-      window.CRM.comm.openBcc($(this).data("emails"));
-    });
+    // Note: email action is handled by the email-composer.min.js bundle
+    // which auto-wires the [data-email-composer] button on the toolbar.
 
     // ------------------------------------------------------------------ //
     // Text dropdown: populate on first open

--- a/src/v2/routes/cart.php
+++ b/src/v2/routes/cart.php
@@ -31,7 +31,6 @@ function getCartView(Request $request, Response $response, array $args): Respons
         return $renderer->render($response, 'cartempty.php', $pageArgs);
     } else {
         $pageArgs = array_merge($pageArgs, [
-            'sEmailLink'   => Cart::getEmailLink(),
             'iNumFamilies' => Cart::countFamilies(),
             'cartPeople'   => Cart::getCartPeople(),
         ]);

--- a/src/v2/templates/cart/cartview.php
+++ b/src/v2/templates/cart/cartview.php
@@ -2,7 +2,6 @@
 
 use ChurchCRM\Authentication\AuthenticationManager;
 use ChurchCRM\dto\SystemURLs;
-use ChurchCRM\Utils\InputUtils;
 
 require SystemURLs::getDocumentRoot() . '/Include/Header.php';
 
@@ -28,14 +27,12 @@ $ListTitleText = gettext('Your cart contains') . ' ' . count($cartPeople) . ' ' 
       <a href="<?= SystemURLs::getRootPath() ?>/Reports/NameTags.php?labeltype=74536&labelfont=times&labelfontsize=36" class="btn btn-outline-secondary" title="<?= gettext('Print name tags') ?>"><i class="fa-solid fa-file-pdf me-2"></i><?= gettext('Tags') ?></a>
     </div>
     <?php if (AuthenticationManager::getCurrentUser()->isEmailEnabled()) { ?>
-      <div class="btn-group" role="group">
-        <a href="mailto:<?= InputUtils::escapeAttribute($sEmailLink) ?>" class="btn btn-outline-info" title="<?= gettext('Email cart items') ?>" target="_blank" rel="noopener noreferrer">
-          <i class="fa-solid fa-paper-plane me-2"></i><?= gettext('Email') ?>
-        </a>
-        <a href="mailto:?bcc=<?= InputUtils::escapeAttribute($sEmailLink) ?>" class="btn btn-outline-secondary" title="<?= gettext('Email with hidden recipients') ?>" target="_blank" rel="noopener noreferrer">
-          <i class="fa-solid fa-user-secret me-2"></i>BCC
-        </a>
-      </div>
+      <button class="btn btn-outline-info"
+              data-email-composer
+              data-email-endpoint="cart/emails"
+              data-email-title="<?= htmlspecialchars(gettext('Email Cart Members'), ENT_QUOTES) ?>">
+        <i class="fa-solid fa-paper-plane me-2"></i><?= gettext('Email') ?>
+      </button>
     <?php } ?>
     <a href="<?= SystemURLs::getRootPath() ?>/DirectoryReports.php?cartdir=Cart+Directory" class="btn btn-outline-warning" title="<?= gettext('Generate phone directory') ?>">
       <i class="fa-solid fa-book me-2"></i><?= gettext('Directory') ?>
@@ -125,5 +122,8 @@ $ListTitleText = gettext('Your cart contains') . ' ' . count($cartPeople) . ' ' 
     $("#cart-listing-table").DataTable(window.CRM.plugin.dataTable);
   });
 </script>
+<?php if (AuthenticationManager::getCurrentUser()->isEmailEnabled()): ?>
+<script src="<?= SystemURLs::assetVersioned('/skin/v2/email-composer.min.js') ?>" defer nonce="<?= SystemURLs::getCSPNonce() ?>"></script>
+<?php endif; ?>
 <?php
 require SystemURLs::getDocumentRoot() . '/Include/Footer.php';

--- a/src/v2/templates/cart/cartview.php
+++ b/src/v2/templates/cart/cartview.php
@@ -30,7 +30,7 @@ $ListTitleText = gettext('Your cart contains') . ' ' . count($cartPeople) . ' ' 
       <button type="button" class="btn btn-outline-info"
               data-email-composer
               data-email-endpoint="cart/emails"
-              data-email-title="<?= htmlspecialchars(gettext('Email Cart Members'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>">
+              data-email-title="<?= gettext('Email Cart Members') ?>">
         <i class="fa-solid fa-paper-plane me-2"></i><?= gettext('Email') ?>
       </button>
     <?php } ?>

--- a/src/v2/templates/cart/cartview.php
+++ b/src/v2/templates/cart/cartview.php
@@ -30,7 +30,7 @@ $ListTitleText = gettext('Your cart contains') . ' ' . count($cartPeople) . ' ' 
       <button class="btn btn-outline-info"
               data-email-composer
               data-email-endpoint="cart/emails"
-              data-email-title="<?= htmlspecialchars(gettext('Email Cart Members'), ENT_QUOTES) ?>">
+              data-email-title="<?= htmlspecialchars(gettext('Email Cart Members'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>">
         <i class="fa-solid fa-paper-plane me-2"></i><?= gettext('Email') ?>
       </button>
     <?php } ?>

--- a/src/v2/templates/cart/cartview.php
+++ b/src/v2/templates/cart/cartview.php
@@ -2,6 +2,7 @@
 
 use ChurchCRM\Authentication\AuthenticationManager;
 use ChurchCRM\dto\SystemURLs;
+use ChurchCRM\Utils\InputUtils;
 
 require SystemURLs::getDocumentRoot() . '/Include/Header.php';
 
@@ -30,7 +31,7 @@ $ListTitleText = gettext('Your cart contains') . ' ' . count($cartPeople) . ' ' 
       <button type="button" class="btn btn-outline-info"
               data-email-composer
               data-email-endpoint="cart/emails"
-              data-email-title="<?= gettext('Email Cart Members') ?>">
+              data-email-title="<?= InputUtils::escapeAttribute(gettext('Email Cart Members')) ?>">
         <i class="fa-solid fa-paper-plane me-2"></i><?= gettext('Email') ?>
       </button>
     <?php } ?>

--- a/src/v2/templates/cart/cartview.php
+++ b/src/v2/templates/cart/cartview.php
@@ -27,7 +27,7 @@ $ListTitleText = gettext('Your cart contains') . ' ' . count($cartPeople) . ' ' 
       <a href="<?= SystemURLs::getRootPath() ?>/Reports/NameTags.php?labeltype=74536&labelfont=times&labelfontsize=36" class="btn btn-outline-secondary" title="<?= gettext('Print name tags') ?>"><i class="fa-solid fa-file-pdf me-2"></i><?= gettext('Tags') ?></a>
     </div>
     <?php if (AuthenticationManager::getCurrentUser()->isEmailEnabled()) { ?>
-      <button class="btn btn-outline-info"
+      <button type="button" class="btn btn-outline-info"
               data-email-composer
               data-email-endpoint="cart/emails"
               data-email-title="<?= htmlspecialchars(gettext('Email Cart Members'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>">

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,6 +41,7 @@ module.exports = {
     'event-editor': './webpack/event-editor',
     'event-types-list': './webpack/event-types-list',
     'event-cart-to-event': './webpack/event-cart-to-event',
+    'email-composer': './webpack/common/email-composer',
   },
   output: {
     path: path.resolve('./src/skin/v2'),

--- a/webpack/common/email-composer.ts
+++ b/webpack/common/email-composer.ts
@@ -172,6 +172,8 @@ function showCopyFeedback(success: boolean): void {
   copyBtn.disabled = true;
   setTimeout(() => {
     if (!copyBtn) return;
+    // Only re-enable if we are still in a valid state (non-empty recipient list)
+    if (currentEmails.length === 0) return;
     if (icon) icon.className = "fa-solid fa-copy me-1";
     if (label instanceof Text) label.nodeValue = i18next.t("Copy Addresses");
     copyBtn.disabled = false;
@@ -227,6 +229,7 @@ function getModal(): BootstrapModalInstance {
 
 function renderLoading(title: string): void {
   if (!modalTitle || !modalBody) return;
+  currentEmails = []; // clear stale recipients so pending copy-feedback cannot act on them
   modalTitle.textContent = title;
   modalBody.textContent = "";
   const spinner = document.createElement("div");
@@ -249,6 +252,7 @@ function renderLoading(title: string): void {
 
 function renderError(title: string, message: string): void {
   if (!modalTitle || !modalBody) return;
+  currentEmails = []; // clear stale recipients so no button can act on them
   modalTitle.textContent = title;
   const alert = document.createElement("div");
   alert.className = "alert alert-danger mb-0";
@@ -400,7 +404,8 @@ async function openFromEndpoint(endpoint: string, title: string): Promise<void> 
 
 function wireDataAttributes(): void {
   document.addEventListener("click", (e) => {
-    const btn = (e.target as HTMLElement).closest("[data-email-composer]");
+    if (!(e.target instanceof Element)) return;
+    const btn = e.target.closest("[data-email-composer]");
     if (!(btn instanceof HTMLElement)) return;
 
     const endpoint = btn.dataset.emailEndpoint ?? "";
@@ -424,7 +429,6 @@ document.addEventListener("DOMContentLoaded", () => {
   wireDataAttributes();
 
   // Expose on window.CRM for legacy callers (GroupView.js etc.)
-  if (window.CRM) {
-    window.CRM.emailComposer = { open: openEmailComposer };
-  }
+  window.CRM = window.CRM || {};
+  window.CRM.emailComposer = { open: openEmailComposer };
 });

--- a/webpack/common/email-composer.ts
+++ b/webpack/common/email-composer.ts
@@ -421,8 +421,16 @@ async function openFromEndpoint(endpoint: string, title: string): Promise<void> 
     }
     const data = (await res.json()) as EmailListResponse;
     const emails = Array.isArray(data.emails) ? data.emails : [];
-    const byRole = data.byRole && typeof data.byRole === "object" ? data.byRole : {};
-    renderRecipients(title, emails, byRole);
+    const rawByRole = data.byRole && typeof data.byRole === "object" ? data.byRole : {};
+    // Sanitize byRole: keep only entries whose value is a string[], filtering
+    // out non-array values and non-string items within arrays.
+    const safeByRole: Record<string, string[]> = {};
+    for (const [role, val] of Object.entries(rawByRole)) {
+      if (Array.isArray(val)) {
+        safeByRole[role] = val.filter((v): v is string => typeof v === "string");
+      }
+    }
+    renderRecipients(title, emails, safeByRole);
   } catch (err) {
     console.error("[email-composer] fetch failed:", err);
     renderError(title, i18next.t("Failed to load recipients. Please try again."));
@@ -440,7 +448,7 @@ function wireDataAttributes(): void {
     if (!(btn instanceof HTMLElement)) return;
 
     const endpoint = btn.dataset.emailEndpoint ?? "";
-    const title = btn.dataset.emailTitle ?? "Email";
+    const title = btn.dataset.emailTitle ?? i18next.t("Email");
 
     if (!endpoint) {
       console.warn("[email-composer] missing data-email-endpoint on button", btn);

--- a/webpack/common/email-composer.ts
+++ b/webpack/common/email-composer.ts
@@ -210,6 +210,9 @@ function updateBccToggleAppearance(): void {
 
 function updateClientButtonHref(): void {
   if (!clientBtn) return;
+  // Always clear the native disabled attribute first so aria-disabled logic
+  // is the sole authority on interactivity (prevents permanent lock-out).
+  clientBtn.removeAttribute("disabled");
   const tooMany = currentEmails.length > MAX_MAILTO_RECIPIENTS;
   const unavailable = tooMany || currentEmails.length === 0;
   // Use aria-disabled instead of the disabled attribute so the element remains
@@ -234,6 +237,7 @@ function updateClientButtonHref(): void {
 function resetClientButton(): void {
   if (!clientBtn) return;
   clientBtn.disabled = false;
+  clientBtn.removeAttribute("disabled"); // belt-and-suspenders: clear any setAttribute path too
   clientBtn.removeAttribute("aria-disabled");
   clientBtn.classList.remove("disabled");
   clientBtn.title = "";
@@ -323,7 +327,9 @@ function renderRecipients(title: string, emails: string[], byRole: Record<string
     modalBody.appendChild(empty);
     if (copyBtn) copyBtn.disabled = true;
     if (clientBtn) {
-      clientBtn.disabled = true;
+      clientBtn.removeAttribute("disabled");
+      clientBtn.setAttribute("aria-disabled", "true");
+      clientBtn.classList.add("disabled");
       clientBtn.title = "";
     }
     return;

--- a/webpack/common/email-composer.ts
+++ b/webpack/common/email-composer.ts
@@ -301,7 +301,14 @@ function renderError(title: string, message: string): void {
 
 function renderRecipients(title: string, emails: string[], byRole: Record<string, string[]> = {}): void {
   if (!modalTitle || !modalBody) return;
-  currentEmails = emails;
+
+  // When byRole is present, derive the flat list from byRole so that badge
+  // count, Copy payload, and the visible grouped list are always in sync.
+  // Any address that appears only in the flat `emails` but not in byRole
+  // (e.g. sToEmailAddress appended only to the flat list) would create a
+  // hidden discrepancy, so the byRole-derived list is the authoritative one.
+  const hasRoles = Object.keys(byRole).length > 0;
+  currentEmails = hasRoles ? Object.values(byRole).flat() : emails;
 
   // Update title with count badge
   modalTitle.textContent = "";
@@ -309,13 +316,13 @@ function renderRecipients(title: string, emails: string[], byRole: Record<string
   titleSpan.textContent = title;
   const badge = document.createElement("span");
   badge.className = "badge bg-primary-lt text-primary ms-2";
-  badge.textContent = String(emails.length);
+  badge.textContent = String(currentEmails.length);
   modalTitle.appendChild(titleSpan);
   modalTitle.appendChild(badge);
 
   modalBody.textContent = "";
 
-  if (emails.length === 0) {
+  if (currentEmails.length === 0) {
     const empty = document.createElement("div");
     empty.className = "text-center text-body-secondary py-4";
     const emptyIcon = document.createElement("i");
@@ -339,8 +346,8 @@ function renderRecipients(title: string, emails: string[], byRole: Record<string
   const details = document.createElement("details");
   const summary = document.createElement("summary");
   summary.className = "text-body-secondary small mb-2";
-  const recipientWord = emails.length === 1 ? i18next.t("recipient") : i18next.t("recipients");
-  summary.textContent = `${emails.length} ${recipientWord} — ${i18next.t("click to expand")}`;
+  const recipientWord = currentEmails.length === 1 ? i18next.t("recipient") : i18next.t("recipients");
+  summary.textContent = `${currentEmails.length} ${recipientWord} — ${i18next.t("click to expand")}`;
   details.appendChild(summary);
 
   const listWrapper = document.createElement("div");
@@ -373,7 +380,7 @@ function renderRecipients(title: string, emails: string[], byRole: Record<string
   modalBody.appendChild(details);
 
   // Hint for large lists
-  if (emails.length > MAX_MAILTO_RECIPIENTS) {
+  if (currentEmails.length > MAX_MAILTO_RECIPIENTS) {
     const hint = document.createElement("div");
     hint.className = "alert alert-info mt-3 mb-0 small";
     const hintIcon = document.createElement("i");
@@ -382,7 +389,7 @@ function renderRecipients(title: string, emails: string[], byRole: Record<string
     hint.appendChild(
       document.createTextNode(
         i18next.t("This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.", {
-          count: emails.length,
+          count: currentEmails.length,
         }),
       ),
     );

--- a/webpack/common/email-composer.ts
+++ b/webpack/common/email-composer.ts
@@ -48,7 +48,8 @@ let copyBtn: HTMLButtonElement | null = null;
 let clientBtn: HTMLButtonElement | null = null;
 /** Title count badge — kept as a ref so toggling the default recipient can update it in place */
 let countBadge: HTMLElement | null = null;
-/** The too-many-recipients hint — created once and shown/hidden, never recreated */
+/** Hint element showing "too many recipients" alert. Created on first renderRecipients() call per
+ * modal open; reset to null on modal close so it is re-created fresh on the next open. */
 let tooManyHintEl: HTMLElement | null = null;
 
 /** Current resolved email list (member recipients plus the default "to" when included) */

--- a/webpack/common/email-composer.ts
+++ b/webpack/common/email-composer.ts
@@ -10,7 +10,11 @@
  *            data-email-endpoint="cart/emails"
  *            data-email-title="Email Cart Members">Email</button>
  *
- * 2. Programmatic (for legacy JS callers such as GroupView.js):
+ * The church default "to" address (sToEmailAddress) is read from a single config,
+ * window.CRM.comm.defaultEmailToAddress (set once by Header.php for email-enabled users),
+ * and offered as a removable default recipient — pages do not pass it per-button.
+ *
+ * 2. Programmatic (for JS callers that already hold the recipient list):
  *    window.CRM.emailComposer.open({ emails, byRole, title });
  *
  * Features:
@@ -42,9 +46,20 @@ let modalBody: HTMLElement | null = null;
 let bccToggle: HTMLButtonElement | null = null;
 let copyBtn: HTMLButtonElement | null = null;
 let clientBtn: HTMLButtonElement | null = null;
+/** Title count badge — kept as a ref so toggling the default recipient can update it in place */
+let countBadge: HTMLElement | null = null;
 
-/** Current resolved email list */
+/** Current resolved email list (member recipients plus the default "to" when included) */
 let currentEmails: string[] = [];
+/** Member recipients only — excludes the optional church default "to" address */
+let baseRecipients: string[] = [];
+/**
+ * The church default "to" address (sToEmailAddress) offered as a removable recipient.
+ * Empty string means "not offered" (unset, no members, or already among the members).
+ */
+let defaultToAddress = "";
+/** Whether the default "to" address is currently included (user can uncheck to drop it) */
+let includeDefaultTo = true;
 /** Pending timer for copy-feedback reset — stored so it can be cancelled on state transitions */
 let copyFeedbackTimer: ReturnType<typeof setTimeout> | null = null;
 /** Whether the BCC toggle is active */
@@ -325,30 +340,60 @@ function renderError(title: string, message: string): void {
   }
 }
 
-function renderRecipients(title: string, emails: string[], byRole: Record<string, string[]> = {}): void {
+/** Recompute currentEmails from the member list plus the optional default recipient. */
+function recomputeCurrentEmails(): void {
+  currentEmails =
+    defaultToAddress !== "" && includeDefaultTo ? [...baseRecipients, defaultToAddress] : [...baseRecipients];
+}
+
+/** Update the title count badge to match the current recipient total. */
+function updateCountBadge(): void {
+  if (countBadge) countBadge.textContent = String(currentEmails.length);
+}
+
+/** Sync the footer action buttons (Copy / Open in client) with the current recipient total. */
+function updateActionButtons(): void {
+  if (copyBtn) copyBtn.disabled = currentEmails.length === 0;
+  updateClientButtonHref();
+}
+
+function renderRecipients(
+  title: string,
+  emails: string[],
+  byRole: Record<string, string[]> = {},
+  defaultTo = "",
+): void {
   if (!modalTitle || !modalBody) return;
 
-  // When byRole is non-empty, derive currentEmails (badge count + Copy/mailto payload)
-  // from Object.values(byRole).flat() so the visible grouped list and the action
-  // payload are always in sync. The PHP layer injects sToEmailAddress into
-  // byRole['System'] (PersonService, round 9), so it appears in both the
-  // visible list and the Copy payload — no hidden extras.
+  // Member recipients only. When byRole is present, derive the flat list from it so the
+  // visible grouped list and the action payload stay in sync.
   const hasRoles = Object.keys(byRole).length > 0;
-  currentEmails = hasRoles ? Object.values(byRole).flat() : emails;
+  baseRecipients = hasRoles ? Object.values(byRole).flat() : [...emails];
 
-  // Update title with count badge
+  // Offer the church default "to" address (sToEmailAddress) as a removable recipient only
+  // when it is configured, there is at least one member recipient, and it is not already
+  // present among the members (case-insensitive). The composer — not the backend — owns
+  // whether it is actually sent, so the user can uncheck it.
+  const trimmedDefault = defaultTo.trim();
+  const alreadyPresent =
+    trimmedDefault !== "" && baseRecipients.some((e) => e.toLowerCase() === trimmedDefault.toLowerCase());
+  defaultToAddress = trimmedDefault !== "" && baseRecipients.length > 0 && !alreadyPresent ? trimmedDefault : "";
+
+  recomputeCurrentEmails();
+
+  // Update title with count badge (kept as a ref so the toggle can update it in place)
   modalTitle.textContent = "";
   const titleSpan = document.createElement("span");
   titleSpan.textContent = title;
-  const badge = document.createElement("span");
-  badge.className = "badge bg-primary-lt text-primary ms-2";
-  badge.textContent = String(currentEmails.length);
+  countBadge = document.createElement("span");
+  countBadge.className = "badge bg-primary-lt text-primary ms-2";
+  countBadge.textContent = String(currentEmails.length);
   modalTitle.appendChild(titleSpan);
-  modalTitle.appendChild(badge);
+  modalTitle.appendChild(countBadge);
 
   modalBody.textContent = "";
 
-  if (currentEmails.length === 0) {
+  if (baseRecipients.length === 0) {
     const empty = document.createElement("div");
     empty.className = "text-center text-body-secondary py-4";
     const emptyIcon = document.createElement("i");
@@ -368,12 +413,13 @@ function renderRecipients(title: string, emails: string[], byRole: Record<string
     return;
   }
 
-  // Recipient list (collapsible)
+  // Recipient list (collapsible) — shows member recipients only; the default "to" address
+  // is represented by its own checkbox below, not mixed into the role groups.
   const details = document.createElement("details");
   const summary = document.createElement("summary");
   summary.className = "text-body-secondary small mb-2";
-  const recipientWord = currentEmails.length === 1 ? i18next.t("recipient") : i18next.t("recipients");
-  summary.textContent = `${currentEmails.length} ${recipientWord} — ${i18next.t("click to expand")}`;
+  const recipientWord = baseRecipients.length === 1 ? i18next.t("recipient") : i18next.t("recipients");
+  summary.textContent = `${baseRecipients.length} ${recipientWord} — ${i18next.t("click to expand")}`;
   details.appendChild(summary);
 
   const listWrapper = document.createElement("div");
@@ -381,7 +427,7 @@ function renderRecipients(title: string, emails: string[], byRole: Record<string
   listWrapper.style.overflowY = "auto";
   listWrapper.className = "mt-2 border rounded p-2 small font-monospace";
 
-  if (Object.keys(byRole).length > 0) {
+  if (hasRoles) {
     for (const [role, roleEmails] of Object.entries(byRole)) {
       const roleHeader = document.createElement("div");
       roleHeader.className = "text-body-secondary fw-semibold mt-2 mb-1";
@@ -395,7 +441,7 @@ function renderRecipients(title: string, emails: string[], byRole: Record<string
       }
     }
   } else {
-    for (const email of emails) {
+    for (const email of baseRecipients) {
       const line = document.createElement("div");
       line.textContent = email;
       listWrapper.appendChild(line);
@@ -404,6 +450,31 @@ function renderRecipients(title: string, emails: string[], byRole: Record<string
 
   details.appendChild(listWrapper);
   modalBody.appendChild(details);
+
+  // Removable default recipient (church sToEmailAddress). Checked by default; unchecking
+  // drops it from the badge count and the Copy / Open-in-client payloads.
+  if (defaultToAddress !== "") {
+    const check = document.createElement("div");
+    check.className = "form-check mt-3";
+    const input = document.createElement("input");
+    input.className = "form-check-input";
+    input.type = "checkbox";
+    input.id = "crm-email-include-default";
+    input.checked = includeDefaultTo;
+    const label = document.createElement("label");
+    label.className = "form-check-label small";
+    label.setAttribute("for", "crm-email-include-default");
+    label.textContent = i18next.t("Also send to church address ({{email}})", { email: defaultToAddress });
+    input.addEventListener("change", () => {
+      includeDefaultTo = input.checked;
+      recomputeCurrentEmails();
+      updateCountBadge();
+      updateActionButtons();
+    });
+    check.appendChild(input);
+    check.appendChild(label);
+    modalBody.appendChild(check);
+  }
 
   // Hint for large lists
   if (currentEmails.length > MAX_MAILTO_RECIPIENTS) {
@@ -422,8 +493,7 @@ function renderRecipients(title: string, emails: string[], byRole: Record<string
     modalBody.appendChild(hint);
   }
 
-  if (copyBtn) copyBtn.disabled = false;
-  updateClientButtonHref();
+  updateActionButtons();
 }
 
 function escapeHtml(s: string): string {
@@ -434,10 +504,21 @@ function escapeHtml(s: string): string {
 //  Public API
 // ─────────────────────────────────────────────
 
+/**
+ * Single source of truth for the church default "to" address (sToEmailAddress).
+ * Rendered once into window.CRM.comm by Header.php for email-enabled users; empty
+ * string otherwise. The composer offers it as a removable default recipient.
+ */
+function getConfiguredDefaultTo(): string {
+  const v = window.CRM?.comm?.defaultEmailToAddress;
+  return typeof v === "string" ? v : "";
+}
+
 export function openEmailComposer(options: CRMEmailComposerOptions): void {
   ensureModalExists();
   bccMode = false;
   updateBccToggleAppearance();
+  includeDefaultTo = true; // reset: each open starts with the default recipient included
 
   // Sanitize programmatic inputs the same way the fetch path does
   const sanitizedEmails = (options.emails ?? [])
@@ -452,8 +533,10 @@ export function openEmailComposer(options: CRMEmailComposerOptions): void {
         .map((v) => v.trim());
     }
   }
+  // Callers may override, but the default comes from the single window.CRM.comm config.
+  const defaultTo = typeof options.defaultTo === "string" ? options.defaultTo : getConfiguredDefaultTo();
 
-  renderRecipients(options.title, sanitizedEmails, sanitizedByRole);
+  renderRecipients(options.title, sanitizedEmails, sanitizedByRole, defaultTo);
   getModal().show();
 }
 
@@ -461,6 +544,7 @@ async function openFromEndpoint(endpoint: string, title: string): Promise<void> 
   ensureModalExists();
   bccMode = false;
   updateBccToggleAppearance();
+  includeDefaultTo = true; // reset: each open starts with the default recipient included
   renderLoading(title);
   getModal().show();
 
@@ -488,7 +572,9 @@ async function openFromEndpoint(endpoint: string, title: string): Promise<void> 
           .map((v) => v.trim());
       }
     }
-    renderRecipients(title, emails, safeByRole);
+    // The church default address (sToEmailAddress) is a system setting read from the
+    // single window.CRM.comm config, not returned by the email-list API.
+    renderRecipients(title, emails, safeByRole, getConfiguredDefaultTo());
   } catch (err) {
     console.error("[email-composer] fetch failed:", err);
     renderError(title, i18next.t("Failed to load recipients. Please try again."));

--- a/webpack/common/email-composer.ts
+++ b/webpack/common/email-composer.ts
@@ -152,6 +152,9 @@ function ensureModalExists(): void {
 
   // Open in client handler
   clientBtn.addEventListener("click", () => {
+    // Guard aria-disabled: the button stays focusable/hoverable so the tooltip
+    // remains discoverable, so we must block the action in the event handler.
+    if (clientBtn?.getAttribute("aria-disabled") === "true") return;
     if (currentEmails.length === 0) return;
     const encoded = currentEmails.map(encodeURIComponent).join(",");
     const href = bccMode ? `mailto:?bcc=${encoded}` : `mailto:${encoded}`;
@@ -208,7 +211,16 @@ function updateBccToggleAppearance(): void {
 function updateClientButtonHref(): void {
   if (!clientBtn) return;
   const tooMany = currentEmails.length > MAX_MAILTO_RECIPIENTS;
-  clientBtn.disabled = tooMany || currentEmails.length === 0;
+  const unavailable = tooMany || currentEmails.length === 0;
+  // Use aria-disabled instead of the disabled attribute so the element remains
+  // focusable/hoverable and the title tooltip is still discoverable by users.
+  if (unavailable) {
+    clientBtn.setAttribute("aria-disabled", "true");
+    clientBtn.classList.add("disabled");
+  } else {
+    clientBtn.removeAttribute("aria-disabled");
+    clientBtn.classList.remove("disabled");
+  }
   if (tooMany) {
     clientBtn.title = i18next.t(
       "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.",

--- a/webpack/common/email-composer.ts
+++ b/webpack/common/email-composer.ts
@@ -437,7 +437,21 @@ export function openEmailComposer(options: CRMEmailComposerOptions): void {
   bccMode = false;
   updateBccToggleAppearance();
 
-  renderRecipients(options.title, options.emails, options.byRole ?? {});
+  // Sanitize programmatic inputs the same way the fetch path does
+  const sanitizedEmails = (options.emails ?? [])
+    .filter((v): v is string => typeof v === "string" && v.trim() !== "")
+    .map((v) => v.trim());
+  const rawByRole = options.byRole ?? {};
+  const sanitizedByRole = Object.create(null) as Record<string, string[]>;
+  for (const [role, vals] of Object.entries(rawByRole)) {
+    if (Array.isArray(vals)) {
+      sanitizedByRole[role] = vals
+        .filter((v): v is string => typeof v === "string" && v.trim() !== "")
+        .map((v) => v.trim());
+    }
+  }
+
+  renderRecipients(options.title, sanitizedEmails, sanitizedByRole);
   getModal().show();
 }
 

--- a/webpack/common/email-composer.ts
+++ b/webpack/common/email-composer.ts
@@ -1,0 +1,430 @@
+/**
+ * email-composer.ts — reusable in-app email composer modal
+ *
+ * Replaces mailto: links for multi-recipient "email list" actions.
+ *
+ * Usage patterns:
+ *
+ * 1. Data-attribute auto-wire (declarative):
+ *    <button data-email-composer
+ *            data-email-endpoint="cart/emails"
+ *            data-email-title="Email Cart Members">Email</button>
+ *
+ * 2. Programmatic (for legacy JS callers such as GroupView.js):
+ *    window.CRM.emailComposer.open({ emails, byRole, title });
+ *
+ * Features:
+ * - Loading / error states while fetching
+ * - Recipient count badge
+ * - Collapsible recipient list (scrollable for large sets)
+ * - BCC toggle (changes mailto: mode)
+ * - "Copy Addresses" — clipboard (works for any list size)
+ * - "Open in Email Client" — enabled ≤50 recipients; disabled with tooltip otherwise
+ */
+
+import { buildAPIUrl } from "../api-utils";
+
+/** Response shape from /api/people/emails and /api/cart/emails */
+interface EmailListResponse {
+  emails?: string[];
+  byRole?: Record<string, string[]>;
+}
+
+const MAX_MAILTO_RECIPIENTS = 50;
+
+// ─────────────────────────────────────────────
+//  Modal DOM — created once, reused
+// ─────────────────────────────────────────────
+
+let modalEl: HTMLElement | null = null;
+let modalTitle: HTMLElement | null = null;
+let modalBody: HTMLElement | null = null;
+let bccToggle: HTMLButtonElement | null = null;
+let copyBtn: HTMLButtonElement | null = null;
+let clientBtn: HTMLButtonElement | null = null;
+
+/** Current resolved email list */
+let currentEmails: string[] = [];
+/** Whether the BCC toggle is active */
+let bccMode = false;
+
+/** Helper: create an icon+text button element */
+function makeBtn(id: string, cls: string, iconCls: string, label: string): HTMLButtonElement {
+  const btn = document.createElement("button");
+  btn.type = "button";
+  btn.id = id;
+  btn.className = cls;
+  const icon = document.createElement("i");
+  icon.className = `${iconCls} me-1`;
+  btn.appendChild(icon);
+  btn.appendChild(document.createTextNode(label));
+  return btn;
+}
+
+function ensureModalExists(): void {
+  if (modalEl) return;
+
+  // ── Structural shell (no user-visible text here) ──────────────────
+  modalEl = document.createElement("div");
+  modalEl.className = "modal fade";
+  modalEl.id = "crm-email-composer-modal";
+  modalEl.setAttribute("tabindex", "-1");
+  modalEl.setAttribute("role", "dialog");
+  modalEl.setAttribute("aria-modal", "true");
+  modalEl.setAttribute("aria-labelledby", "crm-email-composer-title");
+  // Language: close button aria-label is handled by Bootstrap natively.
+  modalEl.innerHTML = [
+    '<div class="modal-dialog modal-lg modal-dialog-scrollable">',
+    '  <div class="modal-content">',
+    '    <div class="modal-header">',
+    '      <h5 class="modal-title" id="crm-email-composer-title"></h5>',
+    '      <button type="button" class="btn-close" data-bs-dismiss="modal"',
+    `        aria-label="${escapeHtml(i18next.t("Close"))}"></button>`,
+    "    </div>",
+    '    <div class="modal-body" id="crm-email-composer-body"></div>',
+    '    <div class="modal-footer flex-wrap gap-2" id="crm-email-composer-footer">',
+    "    </div>",
+    "  </div>",
+    "</div>",
+  ].join("");
+
+  document.body.appendChild(modalEl);
+
+  modalTitle = document.getElementById("crm-email-composer-title");
+  modalBody = document.getElementById("crm-email-composer-body");
+
+  // ── Footer buttons (text via i18next so they are translatable) ────
+  const footer = document.getElementById("crm-email-composer-footer");
+
+  bccToggle = makeBtn(
+    "crm-email-bcc-toggle",
+    "btn btn-sm btn-outline-secondary me-auto",
+    "fa-solid fa-user-secret",
+    i18next.t("BCC Mode"),
+  );
+
+  copyBtn = makeBtn(
+    "crm-email-copy-btn",
+    "btn btn-sm btn-outline-primary",
+    "fa-solid fa-copy",
+    i18next.t("Copy Addresses"),
+  );
+  copyBtn.disabled = true;
+
+  clientBtn = makeBtn(
+    "crm-email-client-btn",
+    "btn btn-sm btn-primary",
+    "fa-solid fa-paper-plane",
+    i18next.t("Open in Email Client"),
+  );
+  clientBtn.disabled = true;
+
+  const closeBtn = document.createElement("button");
+  closeBtn.type = "button";
+  closeBtn.className = "btn btn-sm btn-secondary";
+  closeBtn.setAttribute("data-bs-dismiss", "modal");
+  closeBtn.textContent = i18next.t("Close");
+
+  footer?.appendChild(bccToggle);
+  footer?.appendChild(copyBtn);
+  footer?.appendChild(clientBtn);
+  footer?.appendChild(closeBtn);
+
+  // BCC toggle handler
+  bccToggle.addEventListener("click", () => {
+    bccMode = !bccMode;
+    updateBccToggleAppearance();
+    updateClientButtonHref();
+  });
+
+  // Copy handler — uses clipboard API, falls back to execCommand
+  copyBtn.addEventListener("click", () => {
+    const csv = currentEmails.join(", ");
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(csv).then(
+        () => showCopyFeedback(true),
+        () => legacyCopy(csv),
+      );
+    } else {
+      legacyCopy(csv);
+    }
+  });
+
+  // Open in client handler
+  clientBtn.addEventListener("click", () => {
+    if (currentEmails.length === 0) return;
+    const encoded = currentEmails.map(encodeURIComponent).join(",");
+    const href = bccMode ? `mailto:?bcc=${encoded}` : `mailto:${encoded}`;
+    window.open(href, "_blank", "noopener,noreferrer");
+  });
+}
+
+function showCopyFeedback(success: boolean): void {
+  if (!copyBtn) return;
+  const icon = copyBtn.querySelector("i");
+  if (icon) {
+    icon.className = success ? "fa-solid fa-check me-1" : "fa-solid fa-triangle-exclamation me-1";
+  }
+  const label = copyBtn.lastChild;
+  if (label instanceof Text) {
+    label.nodeValue = success ? i18next.t("Copied!") : i18next.t("Failed");
+  }
+  copyBtn.disabled = true;
+  setTimeout(() => {
+    if (!copyBtn) return;
+    if (icon) icon.className = "fa-solid fa-copy me-1";
+    if (label instanceof Text) label.nodeValue = i18next.t("Copy Addresses");
+    copyBtn.disabled = false;
+  }, 2000);
+}
+
+function legacyCopy(text: string): void {
+  const ta = document.createElement("textarea");
+  ta.value = text;
+  ta.style.position = "fixed";
+  ta.style.opacity = "0";
+  document.body.appendChild(ta);
+  ta.select();
+  try {
+    const ok = document.execCommand("copy");
+    showCopyFeedback(ok);
+  } catch {
+    showCopyFeedback(false);
+  }
+  document.body.removeChild(ta);
+}
+
+function updateBccToggleAppearance(): void {
+  if (!bccToggle) return;
+  if (bccMode) {
+    bccToggle.classList.replace("btn-outline-secondary", "btn-secondary");
+  } else {
+    bccToggle.classList.replace("btn-secondary", "btn-outline-secondary");
+  }
+}
+
+function updateClientButtonHref(): void {
+  if (!clientBtn) return;
+  const tooMany = currentEmails.length > MAX_MAILTO_RECIPIENTS;
+  clientBtn.disabled = tooMany || currentEmails.length === 0;
+  if (tooMany) {
+    clientBtn.title = i18next.t(
+      "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.",
+      { count: currentEmails.length, max: MAX_MAILTO_RECIPIENTS },
+    );
+  } else {
+    clientBtn.title = "";
+  }
+}
+
+function getModal(): BootstrapModalInstance {
+  return window.bootstrap.Modal.getOrCreateInstance(modalEl as Element);
+}
+
+// ─────────────────────────────────────────────
+//  Render helpers
+// ─────────────────────────────────────────────
+
+function renderLoading(title: string): void {
+  if (!modalTitle || !modalBody) return;
+  modalTitle.textContent = title;
+  modalBody.textContent = "";
+  const spinner = document.createElement("div");
+  spinner.className = "d-flex justify-content-center align-items-center py-4";
+  const spinIcon = document.createElement("span");
+  spinIcon.className = "spinner-border spinner-border-sm me-2";
+  spinIcon.setAttribute("role", "status");
+  spinIcon.setAttribute("aria-hidden", "true");
+  const spinText = document.createElement("span");
+  spinText.textContent = i18next.t("Loading recipients\u2026");
+  spinner.appendChild(spinIcon);
+  spinner.appendChild(spinText);
+  modalBody.appendChild(spinner);
+  if (copyBtn) copyBtn.disabled = true;
+  if (clientBtn) {
+    clientBtn.disabled = true;
+    clientBtn.title = "";
+  }
+}
+
+function renderError(title: string, message: string): void {
+  if (!modalTitle || !modalBody) return;
+  modalTitle.textContent = title;
+  const alert = document.createElement("div");
+  alert.className = "alert alert-danger mb-0";
+  const icon = document.createElement("i");
+  icon.className = "fa-solid fa-triangle-exclamation me-2";
+  alert.appendChild(icon);
+  alert.appendChild(document.createTextNode(message));
+  modalBody.textContent = "";
+  modalBody.appendChild(alert);
+}
+
+function renderRecipients(title: string, emails: string[], byRole: Record<string, string[]> = {}): void {
+  if (!modalTitle || !modalBody) return;
+  currentEmails = emails;
+
+  // Update title with count badge
+  modalTitle.textContent = "";
+  const titleSpan = document.createElement("span");
+  titleSpan.textContent = title;
+  const badge = document.createElement("span");
+  badge.className = "badge bg-primary-lt text-primary ms-2";
+  badge.textContent = String(emails.length);
+  modalTitle.appendChild(titleSpan);
+  modalTitle.appendChild(badge);
+
+  modalBody.textContent = "";
+
+  if (emails.length === 0) {
+    const empty = document.createElement("div");
+    empty.className = "text-center text-body-secondary py-4";
+    const emptyIcon = document.createElement("i");
+    emptyIcon.className = "fa-solid fa-inbox fs-3 d-block mb-2";
+    const emptyText = document.createElement("span");
+    emptyText.textContent = i18next.t("No email addresses found.");
+    empty.appendChild(emptyIcon);
+    empty.appendChild(emptyText);
+    modalBody.appendChild(empty);
+    if (copyBtn) copyBtn.disabled = true;
+    if (clientBtn) {
+      clientBtn.disabled = true;
+      clientBtn.title = "";
+    }
+    return;
+  }
+
+  // Recipient list (collapsible)
+  const details = document.createElement("details");
+  const summary = document.createElement("summary");
+  summary.className = "text-body-secondary small mb-2";
+  const recipientWord = emails.length === 1 ? i18next.t("recipient") : i18next.t("recipients");
+  summary.textContent = `${emails.length} ${recipientWord} — ${i18next.t("click to expand")}`;
+  details.appendChild(summary);
+
+  const listWrapper = document.createElement("div");
+  listWrapper.style.maxHeight = "200px";
+  listWrapper.style.overflowY = "auto";
+  listWrapper.className = "mt-2 border rounded p-2 small font-monospace";
+
+  if (Object.keys(byRole).length > 0) {
+    for (const [role, roleEmails] of Object.entries(byRole)) {
+      const roleHeader = document.createElement("div");
+      roleHeader.className = "text-body-secondary fw-semibold mt-2 mb-1";
+      roleHeader.textContent = role;
+      listWrapper.appendChild(roleHeader);
+      for (const email of roleEmails) {
+        const line = document.createElement("div");
+        line.className = "ps-2";
+        line.textContent = email;
+        listWrapper.appendChild(line);
+      }
+    }
+  } else {
+    for (const email of emails) {
+      const line = document.createElement("div");
+      line.textContent = email;
+      listWrapper.appendChild(line);
+    }
+  }
+
+  details.appendChild(listWrapper);
+  modalBody.appendChild(details);
+
+  // Hint for large lists
+  if (emails.length > MAX_MAILTO_RECIPIENTS) {
+    const hint = document.createElement("div");
+    hint.className = "alert alert-info mt-3 mb-0 small";
+    const hintIcon = document.createElement("i");
+    hintIcon.className = "fa-solid fa-circle-info me-2";
+    hint.appendChild(hintIcon);
+    hint.appendChild(
+      document.createTextNode(
+        i18next.t("This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.", {
+          count: emails.length,
+        }),
+      ),
+    );
+    modalBody.appendChild(hint);
+  }
+
+  if (copyBtn) copyBtn.disabled = false;
+  updateClientButtonHref();
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+// ─────────────────────────────────────────────
+//  Public API
+// ─────────────────────────────────────────────
+
+export function openEmailComposer(options: CRMEmailComposerOptions): void {
+  ensureModalExists();
+  bccMode = false;
+  updateBccToggleAppearance();
+
+  renderRecipients(options.title, options.emails, options.byRole ?? {});
+  getModal().show();
+}
+
+async function openFromEndpoint(endpoint: string, title: string): Promise<void> {
+  ensureModalExists();
+  bccMode = false;
+  updateBccToggleAppearance();
+  renderLoading(title);
+  getModal().show();
+
+  try {
+    const url = buildAPIUrl(endpoint);
+    const res = await fetch(url, { credentials: "same-origin" });
+    if (!res.ok) {
+      const data = (await res.json().catch(() => ({}))) as { message?: string };
+      renderError(title, data.message ?? i18next.t("Request failed ({{status}})", { status: res.status }));
+      return;
+    }
+    const data = (await res.json()) as EmailListResponse;
+    const emails = Array.isArray(data.emails) ? data.emails : [];
+    const byRole = data.byRole && typeof data.byRole === "object" ? data.byRole : {};
+    renderRecipients(title, emails, byRole);
+  } catch (err) {
+    console.error("[email-composer] fetch failed:", err);
+    renderError(title, i18next.t("Failed to load recipients. Please try again."));
+  }
+}
+
+// ─────────────────────────────────────────────
+//  Auto-wire delegated handler for [data-email-composer]
+// ─────────────────────────────────────────────
+
+function wireDataAttributes(): void {
+  document.addEventListener("click", (e) => {
+    const btn = (e.target as HTMLElement).closest("[data-email-composer]");
+    if (!(btn instanceof HTMLElement)) return;
+
+    const endpoint = btn.dataset.emailEndpoint ?? "";
+    const title = btn.dataset.emailTitle ?? "Email";
+
+    if (!endpoint) {
+      console.warn("[email-composer] missing data-email-endpoint on button", btn);
+      return;
+    }
+
+    openFromEndpoint(endpoint, title).catch(console.error);
+  });
+}
+
+// ─────────────────────────────────────────────
+//  Init
+// ─────────────────────────────────────────────
+
+document.addEventListener("DOMContentLoaded", () => {
+  ensureModalExists();
+  wireDataAttributes();
+
+  // Expose on window.CRM for legacy callers (GroupView.js etc.)
+  if (window.CRM) {
+    window.CRM.emailComposer = { open: openEmailComposer };
+  }
+});

--- a/webpack/common/email-composer.ts
+++ b/webpack/common/email-composer.ts
@@ -154,6 +154,7 @@ function ensureModalExists(): void {
   // BCC toggle handler
   bccToggle.addEventListener("click", () => {
     bccMode = !bccMode;
+    bccToggle?.setAttribute("aria-pressed", String(bccMode));
     updateBccToggleAppearance();
     updateClientButtonHref();
   });
@@ -637,6 +638,7 @@ document.addEventListener("DOMContentLoaded", () => {
   if (modalEl) {
     modalEl.addEventListener("hidden.bs.modal", () => {
       tooManyHintEl = null;
+      if (bccToggle) bccToggle.setAttribute("aria-pressed", "false");
     });
   }
 

--- a/webpack/common/email-composer.ts
+++ b/webpack/common/email-composer.ts
@@ -433,7 +433,9 @@ async function openFromEndpoint(endpoint: string, title: string): Promise<void> 
       return;
     }
     const data = (await res.json()) as EmailListResponse;
-    const emails = Array.isArray(data.emails) ? data.emails : [];
+    const emails = Array.isArray(data.emails)
+      ? data.emails.filter((v): v is string => typeof v === "string" && v.trim() !== "")
+      : [];
     const rawByRole = data.byRole && typeof data.byRole === "object" ? data.byRole : {};
     // Sanitize byRole: keep only entries whose value is a string[], filtering
     // out non-array values and non-string items within arrays.

--- a/webpack/common/email-composer.ts
+++ b/webpack/common/email-composer.ts
@@ -45,6 +45,8 @@ let clientBtn: HTMLButtonElement | null = null;
 
 /** Current resolved email list */
 let currentEmails: string[] = [];
+/** Pending timer for copy-feedback reset — stored so it can be cancelled on state transitions */
+let copyFeedbackTimer: ReturnType<typeof setTimeout> | null = null;
 /** Whether the BCC toggle is active */
 let bccMode = false;
 
@@ -175,7 +177,9 @@ function showCopyFeedback(success: boolean): void {
     label.nodeValue = success ? i18next.t("Copied!") : i18next.t("Failed");
   }
   copyBtn.disabled = true;
-  setTimeout(() => {
+  if (copyFeedbackTimer) clearTimeout(copyFeedbackTimer);
+  copyFeedbackTimer = setTimeout(() => {
+    copyFeedbackTimer = null;
     if (!copyBtn) return;
     // Only re-enable if we are still in a valid state (non-empty recipient list)
     if (currentEmails.length === 0) return;
@@ -266,6 +270,10 @@ function getModal(): BootstrapModalInstance {
 function renderLoading(title: string): void {
   if (!modalTitle || !modalBody) return;
   currentEmails = []; // clear stale recipients so pending copy-feedback cannot act on them
+  if (copyFeedbackTimer) {
+    clearTimeout(copyFeedbackTimer);
+    copyFeedbackTimer = null;
+  }
   modalTitle.textContent = title;
   modalBody.textContent = "";
   const spinner = document.createElement("div");
@@ -292,6 +300,10 @@ function renderLoading(title: string): void {
 function renderError(title: string, message: string): void {
   if (!modalTitle || !modalBody) return;
   currentEmails = []; // clear stale recipients so no button can act on them
+  if (copyFeedbackTimer) {
+    clearTimeout(copyFeedbackTimer);
+    copyFeedbackTimer = null;
+  }
   modalTitle.textContent = title;
   const alert = document.createElement("div");
   alert.className = "alert alert-danger mb-0";
@@ -314,11 +326,11 @@ function renderError(title: string, message: string): void {
 function renderRecipients(title: string, emails: string[], byRole: Record<string, string[]> = {}): void {
   if (!modalTitle || !modalBody) return;
 
-  // When byRole is present, derive the flat list from byRole so that badge
-  // count, Copy payload, and the visible grouped list are always in sync.
-  // Any address that appears only in the flat `emails` but not in byRole
-  // (e.g. sToEmailAddress appended only to the flat list) would create a
-  // hidden discrepancy, so the byRole-derived list is the authoritative one.
+  // When byRole is non-empty, derive currentEmails (badge count + Copy/mailto payload)
+  // from Object.values(byRole).flat() so the visible grouped list and the action
+  // payload are always in sync. The PHP layer injects sToEmailAddress into
+  // byRole['System'] (PersonService, round 9), so it appears in both the
+  // visible list and the Copy payload — no hidden extras.
   const hasRoles = Object.keys(byRole).length > 0;
   currentEmails = hasRoles ? Object.values(byRole).flat() : emails;
 

--- a/webpack/common/email-composer.ts
+++ b/webpack/common/email-composer.ts
@@ -428,8 +428,9 @@ async function openFromEndpoint(endpoint: string, title: string): Promise<void> 
     const url = buildAPIUrl(endpoint);
     const res = await fetch(url, { credentials: "same-origin" });
     if (!res.ok) {
-      const data = (await res.json().catch(() => ({}))) as { message?: string };
-      renderError(title, data.message ?? i18next.t("Request failed ({{status}})", { status: res.status }));
+      const body = (await res.json().catch(() => ({}))) as { message?: string; error?: string };
+      const msg = body.message ?? body.error ?? i18next.t("Request failed ({{status}})", { status: res.status });
+      renderError(title, msg);
       return;
     }
     const data = (await res.json()) as EmailListResponse;

--- a/webpack/common/email-composer.ts
+++ b/webpack/common/email-composer.ts
@@ -437,9 +437,9 @@ async function openFromEndpoint(endpoint: string, title: string): Promise<void> 
       ? data.emails.filter((v): v is string => typeof v === "string" && v.trim() !== "")
       : [];
     const rawByRole = data.byRole && typeof data.byRole === "object" ? data.byRole : {};
-    // Sanitize byRole: keep only entries whose value is a string[], filtering
-    // out non-array values and non-string items within arrays.
-    const safeByRole: Record<string, string[]> = {};
+    // Use a null-prototype object to prevent prototype-pollution if a role
+    // name ever matches special keys like '__proto__' or 'constructor'.
+    const safeByRole = Object.create(null) as Record<string, string[]>;
     for (const [role, val] of Object.entries(rawByRole)) {
       if (Array.isArray(val)) {
         safeByRole[role] = val.filter((v): v is string => typeof v === "string");

--- a/webpack/common/email-composer.ts
+++ b/webpack/common/email-composer.ts
@@ -231,6 +231,14 @@ function updateClientButtonHref(): void {
   }
 }
 
+function resetClientButton(): void {
+  if (!clientBtn) return;
+  clientBtn.disabled = false;
+  clientBtn.removeAttribute("aria-disabled");
+  clientBtn.classList.remove("disabled");
+  clientBtn.title = "";
+}
+
 function getModal(): BootstrapModalInstance {
   return window.bootstrap.Modal.getOrCreateInstance(modalEl as Element);
 }
@@ -256,9 +264,12 @@ function renderLoading(title: string): void {
   spinner.appendChild(spinText);
   modalBody.appendChild(spinner);
   if (copyBtn) copyBtn.disabled = true;
+  resetClientButton();
+  // Client button stays disabled until recipients load — updateClientButtonHref
+  // will re-evaluate once renderRecipients() is called with real data.
   if (clientBtn) {
-    clientBtn.disabled = true;
-    clientBtn.title = "";
+    clientBtn.setAttribute("aria-disabled", "true");
+    clientBtn.classList.add("disabled");
   }
 }
 
@@ -274,6 +285,14 @@ function renderError(title: string, message: string): void {
   alert.appendChild(document.createTextNode(message));
   modalBody.textContent = "";
   modalBody.appendChild(alert);
+  // Explicitly reset both footer buttons to a safe inert state so no
+  // stale enabled/disabled styling leaks through from a previous render.
+  if (copyBtn) copyBtn.disabled = true;
+  resetClientButton();
+  if (clientBtn) {
+    clientBtn.setAttribute("aria-disabled", "true");
+    clientBtn.classList.add("disabled");
+  }
 }
 
 function renderRecipients(title: string, emails: string[], byRole: Record<string, string[]> = {}): void {

--- a/webpack/common/email-composer.ts
+++ b/webpack/common/email-composer.ts
@@ -455,7 +455,9 @@ async function openFromEndpoint(endpoint: string, title: string): Promise<void> 
     const safeByRole = Object.create(null) as Record<string, string[]>;
     for (const [role, val] of Object.entries(rawByRole)) {
       if (Array.isArray(val)) {
-        safeByRole[role] = val.filter((v): v is string => typeof v === "string");
+        safeByRole[role] = val
+          .filter((v): v is string => typeof v === "string" && v.trim() !== "")
+          .map((v) => v.trim());
       }
     }
     renderRecipients(title, emails, safeByRole);

--- a/webpack/common/email-composer.ts
+++ b/webpack/common/email-composer.ts
@@ -160,8 +160,10 @@ function ensureModalExists(): void {
     // remains discoverable, so we must block the action in the event handler.
     if (clientBtn?.getAttribute("aria-disabled") === "true") return;
     if (currentEmails.length === 0) return;
-    const encoded = currentEmails.map(encodeURIComponent).join(",");
-    const href = bccMode ? `mailto:?bcc=${encoded}` : `mailto:${encoded}`;
+    // Match CommunicationUtils.openMailto/openBcc: encode the full CSV string so
+    // commas between addresses are percent-encoded (%2C), not left as bare separators.
+    const csv = currentEmails.join(",");
+    const href = bccMode ? `mailto:?bcc=${encodeURIComponent(csv)}` : `mailto:${encodeURIComponent(csv)}`;
     window.open(href, "_blank", "noopener,noreferrer");
   });
 }

--- a/webpack/common/email-composer.ts
+++ b/webpack/common/email-composer.ts
@@ -48,6 +48,8 @@ let copyBtn: HTMLButtonElement | null = null;
 let clientBtn: HTMLButtonElement | null = null;
 /** Title count badge — kept as a ref so toggling the default recipient can update it in place */
 let countBadge: HTMLElement | null = null;
+/** The too-many-recipients hint — created once and shown/hidden, never recreated */
+let tooManyHintEl: HTMLElement | null = null;
 
 /** Current resolved email list (member recipients plus the default "to" when included) */
 let currentEmails: string[] = [];
@@ -355,6 +357,21 @@ function updateCountBadge(): void {
 function updateActionButtons(): void {
   if (copyBtn) copyBtn.disabled = currentEmails.length === 0;
   updateClientButtonHref();
+  // Keep the hint in sync with the button state so they never contradict each other.
+  if (tooManyHintEl) {
+    const tooMany = currentEmails.length > MAX_MAILTO_RECIPIENTS;
+    tooManyHintEl.hidden = !tooMany;
+    if (tooMany) {
+      // Update the count in the hint text when the recipient total changes.
+      const textNode = tooManyHintEl.lastChild;
+      if (textNode instanceof Text) {
+        textNode.nodeValue = i18next.t(
+          "This list has {{count}} recipients \u2014 too many for a mailto: link. Use Copy Addresses instead.",
+          { count: currentEmails.length },
+        );
+      }
+    }
+  }
 }
 
 function renderRecipients(
@@ -476,22 +493,26 @@ function renderRecipients(
     modalBody.appendChild(check);
   }
 
-  // Hint for large lists
-  if (currentEmails.length > MAX_MAILTO_RECIPIENTS) {
-    const hint = document.createElement("div");
-    hint.className = "alert alert-info mt-3 mb-0 small";
+  // Hint for large lists — create once and toggle hidden rather than recreating,
+  // so updateActionButtons() can keep it in sync with the Email Client button state.
+  if (!tooManyHintEl) {
+    tooManyHintEl = document.createElement("div");
+    tooManyHintEl.className = "alert alert-info mt-3 mb-0 small";
     const hintIcon = document.createElement("i");
     hintIcon.className = "fa-solid fa-circle-info me-2";
-    hint.appendChild(hintIcon);
-    hint.appendChild(
-      document.createTextNode(
-        i18next.t("This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.", {
-          count: currentEmails.length,
-        }),
-      ),
-    );
-    modalBody.appendChild(hint);
+    tooManyHintEl.appendChild(hintIcon);
+    tooManyHintEl.appendChild(document.createTextNode(""));
   }
+  const tooManyNow = currentEmails.length > MAX_MAILTO_RECIPIENTS;
+  tooManyHintEl.hidden = !tooManyNow;
+  const tooManyText = tooManyHintEl.lastChild;
+  if (tooManyText instanceof Text) {
+    tooManyText.nodeValue = i18next.t(
+      "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.",
+      { count: currentEmails.length },
+    );
+  }
+  modalBody.appendChild(tooManyHintEl);
 
   updateActionButtons();
 }
@@ -610,6 +631,14 @@ function wireDataAttributes(): void {
 document.addEventListener("DOMContentLoaded", () => {
   ensureModalExists();
   wireDataAttributes();
+
+  // Reset the tooManyHintEl reference when the modal fully hides so it is
+  // re-created fresh on the next open (avoids stale DOM references).
+  if (modalEl) {
+    modalEl.addEventListener("hidden.bs.modal", () => {
+      tooManyHintEl = null;
+    });
+  }
 
   // Expose on window.CRM for legacy callers (GroupView.js etc.)
   window.CRM = window.CRM || {};

--- a/webpack/common/email-composer.ts
+++ b/webpack/common/email-composer.ts
@@ -86,6 +86,8 @@ function ensureModalExists(): void {
     "    </div>",
     "  </div>",
     "</div>",
+    // Visually-hidden span: screen-reader description for disabled Email Client button
+    '<span id="crm-email-client-reason" class="visually-hidden"></span>',
   ].join("");
 
   document.body.appendChild(modalEl);
@@ -225,12 +227,19 @@ function updateClientButtonHref(): void {
     clientBtn.classList.remove("disabled");
   }
   if (tooMany) {
-    clientBtn.title = i18next.t(
+    const reason = i18next.t(
       "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.",
       { count: currentEmails.length, max: MAX_MAILTO_RECIPIENTS },
     );
+    clientBtn.title = reason;
+    clientBtn.setAttribute("aria-describedby", "crm-email-client-reason");
+    const reasonEl = document.getElementById("crm-email-client-reason");
+    if (reasonEl) reasonEl.textContent = reason;
   } else {
     clientBtn.title = "";
+    clientBtn.removeAttribute("aria-describedby");
+    const reasonEl = document.getElementById("crm-email-client-reason");
+    if (reasonEl) reasonEl.textContent = "";
   }
 }
 
@@ -239,8 +248,11 @@ function resetClientButton(): void {
   clientBtn.disabled = false;
   clientBtn.removeAttribute("disabled"); // belt-and-suspenders: clear any setAttribute path too
   clientBtn.removeAttribute("aria-disabled");
+  clientBtn.removeAttribute("aria-describedby");
   clientBtn.classList.remove("disabled");
   clientBtn.title = "";
+  const reasonEl = document.getElementById("crm-email-client-reason");
+  if (reasonEl) reasonEl.textContent = "";
 }
 
 function getModal(): BootstrapModalInstance {

--- a/webpack/common/email-composer.ts
+++ b/webpack/common/email-composer.ts
@@ -72,7 +72,7 @@ function ensureModalExists(): void {
   modalEl.setAttribute("role", "dialog");
   modalEl.setAttribute("aria-modal", "true");
   modalEl.setAttribute("aria-labelledby", "crm-email-composer-title");
-  // Language: close button aria-label is handled by Bootstrap natively.
+  // Set aria-label via i18next since Bootstrap doesn't localize it automatically.
   modalEl.innerHTML = [
     '<div class="modal-dialog modal-lg modal-dialog-scrollable">',
     '  <div class="modal-content">',
@@ -435,7 +435,7 @@ async function openFromEndpoint(endpoint: string, title: string): Promise<void> 
     }
     const data = (await res.json()) as EmailListResponse;
     const emails = Array.isArray(data.emails)
-      ? data.emails.filter((v): v is string => typeof v === "string" && v.trim() !== "")
+      ? data.emails.filter((v): v is string => typeof v === "string" && v.trim() !== "").map((v) => v.trim())
       : [];
     const rawByRole = data.byRole && typeof data.byRole === "object" ? data.byRole : {};
     // Use a null-prototype object to prevent prototype-pollution if a role

--- a/webpack/common/email-composer.ts
+++ b/webpack/common/email-composer.ts
@@ -685,6 +685,8 @@ function getConfiguredDefaultTo(): string {
 
 export function openEmailComposer(options: CRMEmailComposerOptions): void {
   ensureModalExists();
+  fetchController?.abort(); // cancel any in-flight openFromEndpoint fetch
+  fetchController = null;
   bccMode = false;
   updateBccToggleAppearance();
   includeDefaultTo = true; // reset: each open starts with the default recipient included
@@ -796,6 +798,11 @@ document.addEventListener("DOMContentLoaded", () => {
       // Abort any in-flight fetch so it doesn't write to the now-hidden DOM.
       fetchController?.abort();
       fetchController = null;
+      // Cancel any pending copy-feedback timer so it doesn't fire on the next open.
+      if (copyFeedbackTimer) {
+        clearTimeout(copyFeedbackTimer);
+        copyFeedbackTimer = null;
+      }
       tooManyHintEl = null;
       recipientListWrapperEl = null;
       recipientSummaryEl = null;

--- a/webpack/common/email-composer.ts
+++ b/webpack/common/email-composer.ts
@@ -51,6 +51,8 @@ let countBadge: HTMLElement | null = null;
 /** Hint element showing "too many recipients" alert. Created on first renderRecipients() call per
  * modal open; reset to null on modal close so it is re-created fresh on the next open. */
 let tooManyHintEl: HTMLElement | null = null;
+/** The scrollable <div> inside the collapsible recipient list — updated by rebuildRecipientList() */
+let recipientListWrapperEl: HTMLElement | null = null;
 
 /** Current resolved email list (member recipients plus the default "to" when included) */
 let currentEmails: string[] = [];
@@ -383,6 +385,32 @@ function updateCountBadge(): void {
   if (countBadge) countBadge.textContent = String(currentEmails.length);
 }
 
+/**
+ * Rebuild the scrollable recipient list to show only the emails for the
+ * currently active roles. Called after a role checkbox is toggled so the
+ * visible list stays in sync with the Copy/mailto payload.
+ */
+function rebuildRecipientList(): void {
+  if (!recipientListWrapperEl) return;
+  recipientListWrapperEl.textContent = "";
+  if (activeRoles.size > 0) {
+    for (const role of activeRoles) {
+      const roleEmails = byRoleMap[role] ?? [];
+      if (roleEmails.length === 0) continue;
+      const roleHeader = document.createElement("div");
+      roleHeader.className = "text-body-secondary fw-semibold mt-2 mb-1";
+      roleHeader.textContent = role;
+      recipientListWrapperEl.appendChild(roleHeader);
+      for (const email of roleEmails) {
+        const line = document.createElement("div");
+        line.className = "ps-2";
+        line.textContent = email;
+        recipientListWrapperEl.appendChild(line);
+      }
+    }
+  }
+}
+
 /** Sync the footer action buttons (Copy / Open in client) with the current recipient total. */
 function updateActionButtons(): void {
   if (copyBtn) copyBtn.disabled = currentEmails.length === 0;
@@ -477,7 +505,7 @@ function renderRecipients(
       const roleEmails = byRoleMap[role] ?? [];
       const check = document.createElement("div");
       check.className = "form-check form-check-inline mb-0";
-      const cbId = `crm-role-cb-${role.replace(/\s+/g, "-").toLowerCase()}`;
+      const cbId = `crm-role-cb-${role.replace(/[^a-z0-9]/g, "-").toLowerCase()}`;
       const cb = document.createElement("input");
       cb.type = "checkbox";
       cb.className = "form-check-input";
@@ -493,6 +521,7 @@ function renderRecipients(
         recomputeCurrentEmails();
         updateCountBadge();
         updateActionButtons();
+        rebuildRecipientList();
       });
       const lbl = document.createElement("label");
       lbl.className = "form-check-label small";
@@ -539,9 +568,17 @@ function renderRecipients(
   listWrapper.style.maxHeight = "200px";
   listWrapper.style.overflowY = "auto";
   listWrapper.className = "mt-2 border rounded p-2 small font-monospace";
+  // Store module-level reference so rebuildRecipientList() can update
+  // the visible list when role checkboxes are toggled.
+  recipientListWrapperEl = listWrapper;
 
   if (hasRoles) {
-    for (const [role, roleEmails] of Object.entries(byRole)) {
+    // Render only the active roles — initially all roles are active, and
+    // rebuildRecipientList() keeps this in sync with the checkboxes.
+    const rolesToRender = showRoleFilter ? activeRoles : new Set(Object.keys(byRole));
+    for (const role of rolesToRender) {
+      const roleEmails = byRoleMap[role] ?? [];
+      if (roleEmails.length === 0) continue;
       const roleHeader = document.createElement("div");
       roleHeader.className = "text-body-secondary fw-semibold mt-2 mb-1";
       roleHeader.textContent = role;
@@ -733,6 +770,7 @@ document.addEventListener("DOMContentLoaded", () => {
   if (modalEl) {
     modalEl.addEventListener("hidden.bs.modal", () => {
       tooManyHintEl = null;
+      recipientListWrapperEl = null;
       byRoleMap = {};
       activeRoles = new Set();
       if (bccToggle) bccToggle.setAttribute("aria-pressed", "false");

--- a/webpack/common/email-composer.ts
+++ b/webpack/common/email-composer.ts
@@ -348,9 +348,16 @@ function renderError(title: string, message: string): void {
   }
 }
 
-/** Recompute baseRecipients from the active roles (or the full set when no role filter is shown). */
+/** Recompute baseRecipients from the currently active roles.
+ * Only called when the role-filter UI is shown (byRole has ≥2 keys).
+ * When all checkboxes are unchecked (activeRoles.size === 0) the payload
+ * must be empty so Copy/mailto don't use a stale previous list. */
 function recomputeBaseRecipients(): void {
-  if (activeRoles.size === 0) return; // no role filter UI — baseRecipients set in renderRecipients
+  if (activeRoles.size === 0) {
+    // User unchecked every role checkbox — payload must be empty, not stale.
+    baseRecipients = [];
+    return;
+  }
   const seen = new Set<string>();
   baseRecipients = [];
   for (const role of activeRoles) {

--- a/webpack/common/email-composer.ts
+++ b/webpack/common/email-composer.ts
@@ -388,8 +388,10 @@ function recomputeCurrentEmails(): void {
 function updateCountBadge(): void {
   if (countBadge) countBadge.textContent = String(currentEmails.length);
   if (recipientSummaryEl) {
-    const word = currentEmails.length === 1 ? i18next.t("recipient") : i18next.t("recipients");
-    recipientSummaryEl.textContent = `${currentEmails.length} ${word} \u2014 ${i18next.t("click to expand")}`;
+    // Use baseRecipients.length (not currentEmails.length) — the expandable
+    // list shows member emails only; defaultToAddress has its own checkbox.
+    const word = baseRecipients.length === 1 ? i18next.t("recipient") : i18next.t("recipients");
+    recipientSummaryEl.textContent = `${baseRecipients.length} ${word} \u2014 ${i18next.t("click to expand")}`;
   }
 }
 

--- a/webpack/common/email-composer.ts
+++ b/webpack/common/email-composer.ts
@@ -67,6 +67,10 @@ let baseRecipients: string[] = [];
 let defaultToAddress = "";
 /** Whether the default "to" address is currently included (user can uncheck to drop it) */
 let includeDefaultTo = true;
+/** AbortController for the in-flight /api fetch inside openFromEndpoint().
+ * Aborted and replaced each time a new endpoint open is requested, preventing
+ * a stale response from overwriting fresher modal state. */
+let fetchController: AbortController | null = null;
 /** Full byRole map stored so role checkboxes can recompute baseRecipients */
 let byRoleMap: Record<string, string[]> = {};
 /** Set of role names currently checked in the role-filter UI; empty = no filter UI shown */
@@ -707,6 +711,12 @@ export function openEmailComposer(options: CRMEmailComposerOptions): void {
 
 async function openFromEndpoint(endpoint: string, title: string): Promise<void> {
   ensureModalExists();
+  // Abort any in-flight fetch from a previous openFromEndpoint call so that
+  // a stale response cannot overwrite the fresher modal state that this call sets.
+  if (fetchController) fetchController.abort();
+  fetchController = new AbortController();
+  const signal = fetchController.signal;
+
   bccMode = false;
   updateBccToggleAppearance();
   includeDefaultTo = true; // reset: each open starts with the default recipient included
@@ -715,7 +725,7 @@ async function openFromEndpoint(endpoint: string, title: string): Promise<void> 
 
   try {
     const url = buildAPIUrl(endpoint);
-    const res = await fetch(url, { credentials: "same-origin" });
+    const res = await fetch(url, { credentials: "same-origin", signal });
     if (!res.ok) {
       const body = (await res.json().catch(() => ({}))) as { message?: string; error?: string };
       const msg = body.message ?? body.error ?? i18next.t("Request failed ({{status}})", { status: res.status });
@@ -741,6 +751,9 @@ async function openFromEndpoint(endpoint: string, title: string): Promise<void> 
     // single window.CRM.comm config, not returned by the email-list API.
     renderRecipients(title, emails, safeByRole, getConfiguredDefaultTo());
   } catch (err) {
+    // AbortError is expected when a newer openFromEndpoint() call aborts this fetch.
+    // Silently discard — the newer call's renderLoading/renderRecipients is already running.
+    if (err instanceof DOMException && err.name === "AbortError") return;
     console.error("[email-composer] fetch failed:", err);
     renderError(title, i18next.t("Failed to load recipients. Please try again."));
   }

--- a/webpack/common/email-composer.ts
+++ b/webpack/common/email-composer.ts
@@ -793,6 +793,9 @@ document.addEventListener("DOMContentLoaded", () => {
   // re-created fresh on the next open (avoids stale DOM references).
   if (modalEl) {
     modalEl.addEventListener("hidden.bs.modal", () => {
+      // Abort any in-flight fetch so it doesn't write to the now-hidden DOM.
+      fetchController?.abort();
+      fetchController = null;
       tooManyHintEl = null;
       recipientListWrapperEl = null;
       recipientSummaryEl = null;

--- a/webpack/common/email-composer.ts
+++ b/webpack/common/email-composer.ts
@@ -63,6 +63,10 @@ let baseRecipients: string[] = [];
 let defaultToAddress = "";
 /** Whether the default "to" address is currently included (user can uncheck to drop it) */
 let includeDefaultTo = true;
+/** Full byRole map stored so role checkboxes can recompute baseRecipients */
+let byRoleMap: Record<string, string[]> = {};
+/** Set of role names currently checked in the role-filter UI; empty = no filter UI shown */
+let activeRoles: Set<string> = new Set();
 /** Pending timer for copy-feedback reset — stored so it can be cancelled on state transitions */
 let copyFeedbackTimer: ReturnType<typeof setTimeout> | null = null;
 /** Whether the BCC toggle is active */
@@ -344,6 +348,23 @@ function renderError(title: string, message: string): void {
   }
 }
 
+/** Recompute baseRecipients from the active roles (or the full set when no role filter is shown). */
+function recomputeBaseRecipients(): void {
+  if (activeRoles.size === 0) return; // no role filter UI — baseRecipients set in renderRecipients
+  const seen = new Set<string>();
+  baseRecipients = [];
+  for (const role of activeRoles) {
+    const roleEmails = byRoleMap[role] ?? [];
+    for (const email of roleEmails) {
+      const key = email.toLowerCase();
+      if (!seen.has(key)) {
+        seen.add(key);
+        baseRecipients.push(email);
+      }
+    }
+  }
+}
+
 /** Recompute currentEmails from the member list plus the optional default recipient. */
 function recomputeCurrentEmails(): void {
   currentEmails =
@@ -384,10 +405,33 @@ function renderRecipients(
 ): void {
   if (!modalTitle || !modalBody) return;
 
-  // Member recipients only. When byRole is present, derive the flat list from it so the
-  // visible grouped list and the action payload stay in sync.
-  const hasRoles = Object.keys(byRole).length > 0;
-  baseRecipients = hasRoles ? Object.values(byRole).flat() : [...emails];
+  // Store byRole for role-filter recomputation and set up the active roles set.
+  byRoleMap = byRole;
+  const roleKeys = Object.keys(byRole);
+  const hasRoles = roleKeys.length > 0;
+  const showRoleFilter = roleKeys.length >= 2;
+  // All roles active by default on each open.
+  activeRoles = showRoleFilter ? new Set(roleKeys) : new Set();
+
+  // When byRole is present, derive baseRecipients from the active roles (dedup across roles).
+  if (hasRoles) {
+    if (showRoleFilter) {
+      recomputeBaseRecipients();
+    } else {
+      // Single role or flat list — no filter UI, just flatten.
+      const seen = new Set<string>();
+      baseRecipients = Object.values(byRole)
+        .flat()
+        .filter((v) => {
+          const key = v.toLowerCase();
+          if (seen.has(key)) return false;
+          seen.add(key);
+          return true;
+        });
+    }
+  } else {
+    baseRecipients = [...emails];
+  }
 
   // Offer the church default "to" address (sToEmailAddress) as a removable recipient only
   // when it is configured, there is at least one member recipient, and it is not already
@@ -411,6 +455,49 @@ function renderRecipients(
   modalTitle.appendChild(countBadge);
 
   modalBody.textContent = "";
+
+  // Role filter checkboxes (shown only when ≥2 roles present)
+  if (showRoleFilter) {
+    const filterSection = document.createElement("div");
+    filterSection.className = "mb-3";
+    const filterLabel = document.createElement("div");
+    filterLabel.className = "text-body-secondary small fw-semibold mb-2";
+    filterLabel.textContent = i18next.t("Roles to include:");
+    filterSection.appendChild(filterLabel);
+    const filterRow = document.createElement("div");
+    filterRow.className = "d-flex flex-wrap gap-2";
+    for (const role of roleKeys) {
+      const roleEmails = byRoleMap[role] ?? [];
+      const check = document.createElement("div");
+      check.className = "form-check form-check-inline mb-0";
+      const cbId = `crm-role-cb-${role.replace(/\s+/g, "-").toLowerCase()}`;
+      const cb = document.createElement("input");
+      cb.type = "checkbox";
+      cb.className = "form-check-input";
+      cb.id = cbId;
+      cb.checked = true;
+      cb.addEventListener("change", () => {
+        if (cb.checked) {
+          activeRoles.add(role);
+        } else {
+          activeRoles.delete(role);
+        }
+        recomputeBaseRecipients();
+        recomputeCurrentEmails();
+        updateCountBadge();
+        updateActionButtons();
+      });
+      const lbl = document.createElement("label");
+      lbl.className = "form-check-label small";
+      lbl.setAttribute("for", cbId);
+      lbl.textContent = `${role} (${roleEmails.length})`;
+      check.appendChild(cb);
+      check.appendChild(lbl);
+      filterRow.appendChild(check);
+    }
+    filterSection.appendChild(filterRow);
+    modalBody.appendChild(filterSection);
+  }
 
   if (baseRecipients.length === 0) {
     const empty = document.createElement("div");
@@ -639,6 +726,8 @@ document.addEventListener("DOMContentLoaded", () => {
   if (modalEl) {
     modalEl.addEventListener("hidden.bs.modal", () => {
       tooManyHintEl = null;
+      byRoleMap = {};
+      activeRoles = new Set();
       if (bccToggle) bccToggle.setAttribute("aria-pressed", "false");
     });
   }

--- a/webpack/common/email-composer.ts
+++ b/webpack/common/email-composer.ts
@@ -53,6 +53,8 @@ let countBadge: HTMLElement | null = null;
 let tooManyHintEl: HTMLElement | null = null;
 /** The scrollable <div> inside the collapsible recipient list — updated by rebuildRecipientList() */
 let recipientListWrapperEl: HTMLElement | null = null;
+/** The <summary> element inside the collapsible recipient list — updated by updateCountBadge() */
+let recipientSummaryEl: HTMLElement | null = null;
 
 /** Current resolved email list (member recipients plus the default "to" when included) */
 let currentEmails: string[] = [];
@@ -377,12 +379,18 @@ function recomputeBaseRecipients(): void {
 /** Recompute currentEmails from the member list plus the optional default recipient. */
 function recomputeCurrentEmails(): void {
   currentEmails =
-    defaultToAddress !== "" && includeDefaultTo ? [...baseRecipients, defaultToAddress] : [...baseRecipients];
+    baseRecipients.length > 0 && defaultToAddress !== "" && includeDefaultTo
+      ? [...baseRecipients, defaultToAddress]
+      : [...baseRecipients];
 }
 
-/** Update the title count badge to match the current recipient total. */
+/** Update the title count badge and the collapsible-list summary text to match the current total. */
 function updateCountBadge(): void {
   if (countBadge) countBadge.textContent = String(currentEmails.length);
+  if (recipientSummaryEl) {
+    const word = currentEmails.length === 1 ? i18next.t("recipient") : i18next.t("recipients");
+    recipientSummaryEl.textContent = `${currentEmails.length} ${word} \u2014 ${i18next.t("click to expand")}`;
+  }
 }
 
 /**
@@ -505,7 +513,7 @@ function renderRecipients(
       const roleEmails = byRoleMap[role] ?? [];
       const check = document.createElement("div");
       check.className = "form-check form-check-inline mb-0";
-      const cbId = `crm-role-cb-${role.replace(/[^a-z0-9]/g, "-").toLowerCase()}`;
+      const cbId = `crm-role-cb-${role.toLowerCase().replace(/[^a-z0-9]/g, "-")}`;
       const cb = document.createElement("input");
       cb.type = "checkbox";
       cb.className = "form-check-input";
@@ -562,6 +570,7 @@ function renderRecipients(
   summary.className = "text-body-secondary small mb-2";
   const recipientWord = baseRecipients.length === 1 ? i18next.t("recipient") : i18next.t("recipients");
   summary.textContent = `${baseRecipients.length} ${recipientWord} — ${i18next.t("click to expand")}`;
+  recipientSummaryEl = summary;
   details.appendChild(summary);
 
   const listWrapper = document.createElement("div");
@@ -771,6 +780,7 @@ document.addEventListener("DOMContentLoaded", () => {
     modalEl.addEventListener("hidden.bs.modal", () => {
       tooManyHintEl = null;
       recipientListWrapperEl = null;
+      recipientSummaryEl = null;
       byRoleMap = {};
       activeRoles = new Set();
       if (bccToggle) bccToggle.setAttribute("aria-pressed", "false");

--- a/webpack/kiosk/kiosk-jsom.ts
+++ b/webpack/kiosk/kiosk-jsom.ts
@@ -20,22 +20,6 @@ import type {
 // Declare moment as global (loaded via CDN in header)
 declare const moment: typeof import("moment");
 
-// Declare i18next as global (loaded via skin-core.js)
-declare const i18next: { t(key: string, options?: Record<string, unknown>): string };
-
-// Declare bootstrap on window (set by skin-core.js via @tabler/core)
-declare global {
-  interface Window {
-    bootstrap: {
-      Modal: {
-        getOrCreateInstance(el: Element): { show(): void; hide(): void };
-        getInstance(el: Element): { show(): void; hide(): void } | null;
-        new (el: Element, options?: Record<string, unknown>): { show(): void; hide(): void };
-      };
-    };
-  }
-}
-
 // Helper to access window.CRM safely
 function getCRM(): CRMNamespace {
   return window.CRM ?? {};

--- a/webpack/types/window.d.ts
+++ b/webpack/types/window.d.ts
@@ -3,6 +3,9 @@
  * No imports/exports — this is a plain ambient script so all interfaces are globally accessible.
  */
 
+// i18next — loaded globally via skin-core.js
+declare const i18next: { t(key: string, options?: Record<string, unknown>): string };
+
 interface CRMGravatarPlugin {
   enabled?: boolean;
   defaultImage?: string;
@@ -19,6 +22,16 @@ interface CRMAPIRequestOptions {
   [key: string]: unknown;
 }
 
+interface CRMEmailComposerOptions {
+  emails: string[];
+  byRole?: Record<string, string[]>;
+  title: string;
+}
+
+interface CRMEmailComposer {
+  open(options: CRMEmailComposerOptions): void;
+}
+
 interface CRMNamespace {
   root?: string;
   timeZone?: string;
@@ -32,9 +45,22 @@ interface CRMNamespace {
   notyf?: unknown;
   escapeHtml?: (s: string) => string;
   escapeAttribute?: (s: string) => string;
+  emailComposer?: CRMEmailComposer;
   [key: string]: unknown;
+}
+
+interface BootstrapModalInstance {
+  show(): void;
+  hide(): void;
 }
 
 interface Window {
   CRM?: CRMNamespace;
+  bootstrap: {
+    Modal: {
+      getOrCreateInstance(el: Element): BootstrapModalInstance;
+      getInstance(el: Element): BootstrapModalInstance | null;
+      new (el: Element, options?: Record<string, unknown>): BootstrapModalInstance;
+    };
+  };
 }

--- a/webpack/types/window.d.ts
+++ b/webpack/types/window.d.ts
@@ -26,6 +26,8 @@ interface CRMEmailComposerOptions {
   emails: string[];
   byRole?: Record<string, string[]>;
   title: string;
+  /** Church default "to" address (sToEmailAddress); offered as a removable default recipient. */
+  defaultTo?: string;
 }
 
 interface CRMEmailComposer {
@@ -46,6 +48,13 @@ interface CRMNamespace {
   escapeHtml?: (s: string) => string;
   escapeAttribute?: (s: string) => string;
   emailComposer?: CRMEmailComposer;
+  comm?: {
+    smtpConfigured?: boolean;
+    vonageEnabled?: boolean;
+    /** Church default "to" address (sToEmailAddress); "" when unset or user lacks email permission. */
+    defaultEmailToAddress?: string;
+    [key: string]: unknown;
+  };
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Replaces all multi-recipient mailto: link patterns with an in-app Bootstrap 5 email composer modal. Closes #8433. Prior art: PR #8909.

**Why this matters:** mailto: URLs are limited to ~2000 chars — a church with 200+ members hits this immediately. The composer handles unlimited lists via clipboard copy, keeps users in-app, and works consistently across all email entry points.

## What changed

**New APIs (consistent `{emails, byRole}` array shape, `EmailRoleAuthMiddleware`):**
- `GET /api/people/emails` — active-family mailing list grouped by classification role
- `GET /api/cart/emails` — cart member list
- `GET /api/groups/{id}/emails` — refactored to use `PersonService::getGroupMailingEmails()`, returns arrays (was CSV strings); adds missing `EmailRoleAuthMiddleware`

**Backend:** `PersonService::getMailingEmails()`, `::getGroupMailingEmails()`, `::buildDoNotEmailSet()` (shared DoNotEmail helper); `Cart::getEmails()` (removed `getEmailLink()` dead code)

**DB migration (7.5.1):** `7.5.1-remove-sMailtoDelimiter.sql` removes `sMailtoDelimiter` from `userconfig_ucfg` and `ui.email.delimiter` from `user_settings`. `upgrade.json` adds `pre-7.5.1` step; `current.versions: []` is intentional placeholder for next release.

**Composer modal (`webpack/common/email-composer.ts`):** loading spinner, recipient count badge + collapsible list (grouped by role), BCC toggle, Copy Addresses (clipboard — unlimited lists), Open in Email Client (enabled ≤50 addresses, disabled+tooltip for larger). All strings via `i18next.t()`. Auto-wires `[data-email-composer]` buttons; exposes `window.CRM.emailComposer.open()` for legacy callers.

**Pages converted:** people dashboard, cart view, group view (GroupView.js email dropdown logic removed).

## API shape note

`GET /api/groups/{id}/emails` response shape changed from `{all: csv_string, roles: {name: csv_string}}` to `{emails: string[], byRole: {name: string[]}}`. Internal caller (GroupView.js) updated in same commit.

## Design decisions

- `/api/people/emails` uses `/people/` prefix intentionally — returns collective mailing lists, not individual person data (distinct from `/api/persons/*`)
- `upgrade.json current.versions: []` — placeholder for future migrations; `pre-7.5.1` block handles the 7.5.0→7.5.1 path
- Phase 2 (SMTP send, email templates, tracking) not implemented

## Testing

- `cypress/e2e/api/private/standard/private.email-endpoints.spec.js` — 200 shape, seeded data, 401, 403 for all 3 endpoints
- `cypress/e2e/ui/people/people.dashboard.email.spec.js` — updated for composer button UI
- `npm run lint` passes (2 pre-existing warnings in unchanged files)
- `npm run build:webpack` compiled successfully

Docs: (create docs issue for the new email composer UX and updated API shape)