### PR TITLE
Fix localization junk, near-duplicate terms, dangling colons, and split-sentence fragments

### DIFF
--- a/.agents/skills/churchcrm/code-standards.md
+++ b/.agents/skills/churchcrm/code-standards.md
@@ -349,19 +349,16 @@ echo gettext('File Name') . ':';
 
 **Apply to:** All UI labels, field names, and sentence-ending colons (introducing lists).
 
-**Also update messages.po:** When moving a colon out of a gettext call, update the `msgid` in `locale/terms/messages.po`:
+**Do not hand-edit `locale/messages.po` for this change** <!-- learned: 2026-07-24 -->
+Extraction is automated (see `git-workflow.md` → "Mandatory Pre-Push Biome Check" area and
+`i18n-localization.md` → "Never rebuild the locale catalog"). Moving the colon out of the
+`gettext()`/`i18next.t()` call in source is the whole fix — do not touch `messages.po` yourself.
 
-```gettext
-# BEFORE
-msgid "Birth Date:"
-msgstr ""
-
-# AFTER
-msgid "Birth Date"
-msgstr ""
-```
-
-The `msgid` key must exactly match the string passed to gettext() in PHP code.
+**A batch audit (2026-07-24) found and fixed ~54 colon-suffixed `gettext()`/`i18next.t()` calls**
+across the codebase, several of which duplicated an existing colon-less msgid for the same term
+(`Warning`, `Family Members`, `Database`, `Version`, `Orphaned Files`, `Tip`) — see
+`i18n-localization.md` → "Punctuation & Colon Placement" for the detection grep and full list of
+real-world fixes.
 
 ## Unified Page Header Standard (MANDATORY) <!-- learned: 2026-03-25 -->
 

--- a/.agents/skills/churchcrm/i18n-localization.md
+++ b/.agents/skills/churchcrm/i18n-localization.md
@@ -573,6 +573,23 @@ echo gettext('Please select from the following:');
 echo gettext('Please select from the following') . ':';
 ```
 
+**Detection — grep for a trailing colon inside the quotes:**
+```bash
+grep -rnoE "gettext\('[^']*:'\)" src/
+grep -rnoE 'gettext\("[^"]*:"\)' src/
+grep -rnoE "i18next\.t\('[^']*:'" webpack/ src/
+grep -rnoE 'i18next\.t\("[^"]*:"' webpack/ src/
+```
+
+**Before fixing, check whether the colon-less form already exists** — a term wrapped with and
+without a trailing colon in different files is two msgids for one word (e.g. `gettext('Warning')`
+in one place, `gettext('Warning:')` in another). Search for the bare term first and reuse it:
+```bash
+grep -rn "gettext('Warning')" src/   # does the colon-less form already exist?
+```
+If it does, fix the colon-suffixed call sites to use the existing bare term plus a literal `:`
+outside the call, rather than leaving two separate msgids for the same word. <!-- learned: 2026-07-24 -->
+
 **In HTML attributes or templates:**
 ```php
 // ✅ CORRECT - Inline concatenation
@@ -587,18 +604,12 @@ echo '<label>'
     . ':</label>';
 ```
 
-**Update messages.po when making this change:**
-```gettext
-# BEFORE
-msgid "Birth Date:"
-msgstr ""
-
-# AFTER
-msgid "Birth Date"
-msgstr ""
-```
-
-The msgid key must match what's passed to gettext() in PHP code.
+**Do not hand-edit `locale/messages.po` for this change.** <!-- learned: 2026-07-24 -->
+Moving the colon out of the `gettext()`/`i18next.t()` call is enough — the old `"Label:"` msgid
+simply stops being extracted on the next automated run, and a new `"Label"` msgid appears in its
+place. This supersedes older guidance in this section that said to update `messages.po` by hand;
+see ["Never rebuild the locale catalog"](#never-rebuild-the-locale-catalog----learned-2026-07-11-)
+below — the automation, not the developer, owns that file.
 
 ### Do Not Wrap Brand / Technical Literals <!-- learned: 2026-04-22 -->
 
@@ -735,11 +746,13 @@ $("#upgradePathSummary").html(
 );
 // Produces msgids: "You are" and "releases behind. Here's what you'll gain:"
 
-// ✅ CORRECT — single parameterised msgid; HTML emphasis kept inside the template key
+// ✅ CORRECT — single parameterised msgid; HTML emphasis kept inside the template key.
+// Trailing colon is UI punctuation (see "Punctuation & Colon Placement" above) — kept
+// outside the t() call even in JS.
 $("#upgradePathSummary").html(
-  i18next.t("You are <strong>{{releaseCount}}</strong> releases behind. Here's what you'll gain:", {
+  `${i18next.t("You are <strong>{{releaseCount}}</strong> releases behind. Here's what you'll gain", {
     releaseCount: count,
-  }),
+  })}:`,
 );
 ```
 

--- a/.agents/skills/churchcrm/i18n-localization.md
+++ b/.agents/skills/churchcrm/i18n-localization.md
@@ -112,6 +112,25 @@ for v in g.values():
 "
 ```
 
+> [!WARNING] The case-dupe grep has a high false-positive rate — verify each hit's call sites before merging <!-- learned: 2026-07-24 -->
+> A 2026-07-24 audit ran this script and got **72 case-duplicate groups** (`Active`/`active`,
+> `People`/`people`, `Loading`/`loading`, `By`/`by`, `Family`/`family`, `Records`/`records`, …).
+> Grepping the actual call sites for a sample showed almost all of them are **already correct**
+> per the Title-Case-vs-sentence-case rule above — e.g. `gettext('people')` in
+> `webpack/people/importDemoData.js` renders `"5 people"` (a count, correctly sentence case) while
+> `gettext('People')` in nav breadcrumbs is UI chrome (correctly Title Case). Same story for
+> `gettext('active')` → `"3 active"` badge count vs. `gettext('Active')` → status badge label, and
+> `gettext('by')` → `"by John Smith"` attribution vs. a Title-Case heading elsewhere.
+> Some flagged msgids (e.g. `Loading`/`loading`) had **no live call site at all** for one side —
+> `locale/messages.po` accumulates entries that the automation hasn't pruned yet, so a msgid
+> existing in the `.po` file doesn't guarantee a matching `gettext()`/`i18next.t()` call still
+> exists in source.
+> **Rule: never merge a case-dupe pair from the `.po` grep alone.** For each pair, `grep -rn` both
+> forms across `src/` and `webpack/`, read the surrounding context, and only touch call sites
+> where the same UI role (both chrome, or both body text) is using two different casings of the
+> same string. `Id`/`ID` (below) is the pattern of a genuine hit: same role (table column header)
+> in every call site, just an unnormalized acronym.
+
 **Acronym exceptions** (always uppercase regardless of case form): `URL`, `ID`, `IP`, `SMTP`, `CSV`, `PDF`, `2FA`, `API`, `HTML`, `TLS`, `SSL`. Never write `Id`, `Url`, `Sms`, etc. — pick the acronym form once and use it everywhere.
 
 ```php
@@ -123,6 +142,8 @@ gettext('SMTP Host')
 gettext('User Id')
 gettext('Smtp Host')
 ```
+
+**Real-world instance (2026-07-24):** `person-list.php` (2 call sites, both DataTables column-header maps) and `self-register.php` used `gettext('Id')` / `i18next.t('Id')` for a table column header, while `finance/views/dashboard.php` used `gettext('ID')` for the same kind of column header — two msgids for one concept. Fixed by normalizing all three to `gettext('ID')` / `i18next.t('ID')`. The internal array key/DataTables `data:` field (`'Id'`) was left untouched — that's an identifier, not display text, and renaming it would require a matching change on the API response shape.
 
 **Dialog title special case:** `i18next.t('ERROR')` was historically used as a bootbox title and created an `ERROR`/`Error` msgid pair. Always use `i18next.t('Error')` (Title Case) for dialog titles. Reserve all-caps strings for log levels / data attribute values, NOT translation keys (e.g. `data-level="ERROR"` is fine, but the visible label uses `gettext('Error')`).
 
@@ -593,6 +614,7 @@ The msgid key must match what's passed to gettext() in PHP code.
 | Protocol / tech acronyms | `TLS`, `Auto-TLS`, `SSL`, `SMTP`, `IMAP`, `DNS`, `CSP`, `CORS`, `SHA1 Hash` |
 | Brand names | `ChurchCRM`, `Vonage`, `MailChimp`, `GitHub`, `OpenLP`, `Nextcloud`, `Gravatar`, `WebDAV`, `POEditor`, `ownCloud`, `Stripe`, `PayPal` |
 | Placeholder examples | `name@example.com`, `+1-555-123-4567`, `https://example.com` |
+| Punctuation-only placeholders | `—` (em dash "no data" marker), `-`, `...`, `•` |
 
 **Pattern:**
 
@@ -617,6 +639,25 @@ $phpIni = [
 <td>Auto-TLS</td>
 <input placeholder="name@example.com">
 ```
+
+**Punctuation-only placeholder example** — an em-dash "no data" marker was found wrapped in `gettext()` even though the identical raw `—` character appears unwrapped elsewhere on the same page:
+
+```php
+// ❌ WRONG — punctuation, not copy; there is nothing for a translator to translate
+'noStreak' => gettext('—'),
+
+// ✅ CORRECT — bare literal, matches the raw '—' used elsewhere on the page
+'noStreak' => '—',
+```
+
+A `gettext()`/`i18next.t()` call whose argument is entirely punctuation/whitespace (`-`, `—`, `...`, `•`, a bare space) is always a leak — grep for it directly:
+
+```bash
+grep -rnE "gettext\(['\"][^a-zA-Z0-9]{1,4}['\"]\)" src/
+grep -rnE "i18next\.t\(['\"][^a-zA-Z0-9]{1,4}['\"]\)" src/ webpack/
+```
+(Short *alphanumeric* results like `gettext('To')`, `gettext('OK')`, `gettext('N')` from the same grep are legitimate translatable words/abbreviations — only punctuation-only matches are leaks.) <!-- learned: 2026-07-24 -->
+
 
 **How to detect leaks:** a term that a) appears in `locale/terms/missing/{code}/{code}-N.json` across many locales with an empty string, and b) is a brand / technical / config literal, is almost certainly wrongly wrapped. Quick aggregation:
 
@@ -671,6 +712,15 @@ echo sprintf(gettext('%d record(s) returned'), mysqli_num_rows($rs));
 ```
 
 **Detection:** fragment msgids are identifiable in `locale/messages.po` by a leading or trailing space in the msgid string — e.g. `msgid " characters long"`. Open issue [#8772](https://github.com/ChurchCRM/CRM/issues/8772) tracks the known fragments still in the codebase.
+
+**Real-world instance (2026-07-24):** `ChurchCRM\Service\PersonService::search()` built a family-role string as `$roleText . gettext(' of the') . ' <a>...</a> ' . gettext('family') . ' )'` — an orphaned `' of the'` fragment (leading space) plus a bare `'family'` msgid that duplicates the unrelated `gettext('family')` used elsewhere in `PersonList.php`'s "records" sentence. Fixed by building the dynamic HTML link first, then wrapping the whole phrase in one `sprintf(gettext('%1$s of the %2$s family'), $roleText, $familyLink)` call:
+```php
+// ❌ WRONG — orphaned ' of the' fragment, msgid leading space
+$familyRole .= gettext(' of the') . ' ' . $familyLinkHtml . ' ' . gettext('family') . ' )';
+
+// ✅ CORRECT — one msgid, HTML link passed as a %2$s value
+$familyRole .= sprintf(gettext('%1$s of the %2$s family'), $roleText, $familyLinkHtml) . ' )';
+```
 
 **Checklist addition:** Add `- [ ] No gettext() fragments — full sentence per call, sprintf for values` to your pre-commit review.
 
@@ -1266,4 +1316,4 @@ These rules must be stated explicitly in every agent prompt:
 
 ---
 
-Last updated: April 9, 2026
+Last updated: July 24, 2026

--- a/.agents/skills/churchcrm/i18n-localization.md
+++ b/.agents/skills/churchcrm/i18n-localization.md
@@ -722,7 +722,15 @@ echo mysqli_num_rows($rs) . gettext(' record(s) returned');
 echo sprintf(gettext('%d record(s) returned'), mysqli_num_rows($rs));
 ```
 
-**Detection:** fragment msgids are identifiable in `locale/messages.po` by a leading or trailing space in the msgid string — e.g. `msgid " characters long"`. Open issue [#8772](https://github.com/ChurchCRM/CRM/issues/8772) tracks the known fragments still in the codebase.
+**Detection:** fragment msgids are identifiable in `locale/messages.po` by a leading or trailing space in the msgid string — e.g. `msgid " characters long"`. Open issue [#8772](https://github.com/ChurchCRM/CRM/issues/8772) tracks the known fragments still in the codebase. Grep source directly rather than relying on the `.po` file (which lags the automation):
+```bash
+grep -rnoE "gettext\('[^']* '\)" src/    # trailing space
+grep -rnoE "gettext\('[^']*'\)" src/ | grep -E "\('\s"  # leading space
+```
+
+**Real-world instances fixed (2026-07-24):** the two `❌ WRONG` examples above (`QueryView.php` alpha/numeric validation messages, `PledgeEditor.php` deposit page title) were not hypothetical — they were live bugs in this codebase, along with ~15 more of the same shape in `Reports/TaxReport.php`, `Reports/ReminderReport.php`, `Reports/FamilyPledgeSummary.php`, `WhyCameEditor.php`, `admin/routes/api/import.php`, `ChurchCRM/Authentication/AuthenticationProviders/APITokenAuthentication.php`, and `fundraiser/routes/reports.php` (PDF cell-write calls). All were fixed the same way: pull the fragment into one `sprintf()`-parameterised string. Where a value only fills in a leading/trailing connector word rather than a full sentence (e.g. building `" for fund "` before appending a loop of fund names), the minimal fix is to move the space to a plain string concatenation outside `gettext()` rather than restructure the surrounding loop — e.g. `gettext(' for fund ')` → `' ' . gettext('for fund') . ' '`.
+
+**Related but distinct: pure-formatting content should not be wrapped at all.** A decorative PDF divider line (`gettext('----...----')`, all dashes, no words) was found wrapped in `fundraiser/routes/reports.php` — unwrapped to a bare literal, same as the punctuation-only-placeholder case in ["Do Not Wrap Brand / Technical Literals"](#do-not-wrap-brand--technical-literals----learned-2026-04-22---) above. A related case in the same file padded a real word (`'Signature'`) with 40 leading spaces and 68 trailing underscores for fixed-width PDF layout — the word was pulled into its own `gettext('Signature')` call with the padding built via `str_repeat()` outside it, rather than baking layout whitespace into the msgid.
 
 **Real-world instance (2026-07-24):** `ChurchCRM\Service\PersonService::search()` built a family-role string as `$roleText . gettext(' of the') . ' <a>...</a> ' . gettext('family') . ' )'` — an orphaned `' of the'` fragment (leading space) plus a bare `'family'` msgid that duplicates the unrelated `gettext('family')` used elsewhere in `PersonList.php`'s "records" sentence. Fixed by building the dynamic HTML link first, then wrapping the whole phrase in one `sprintf(gettext('%1$s of the %2$s family'), $roleText, $familyLink)` call:
 ```php

--- a/src/CSVExport.php
+++ b/src/CSVExport.php
@@ -334,7 +334,7 @@ require_once __DIR__ . '/Include/Header.php';
     <div class="col-lg-12">
       <div class="card">
         <div class="card-header d-flex align-items-center">
-          <h3 class="card-title"><?= gettext('Output Method:') ?></h3>
+          <h3 class="card-title"><?= gettext('Output Method') ?>:</h3>
         </div>
         <div class="card-body">
           <div class="mb-3">

--- a/src/ChurchCRM/Authentication/AuthenticationProviders/APITokenAuthentication.php
+++ b/src/ChurchCRM/Authentication/AuthenticationProviders/APITokenAuthentication.php
@@ -44,7 +44,7 @@ class APITokenAuthentication implements IAuthenticationProvider
         $this->currentUser = UserQuery::create()->findOneByApiKey($AuthenticationRequest->APIToken);
 
         if (!empty($this->currentUser)) {
-            LoggerUtils::getAuthLogger()->debug(gettext('User authenticated via API Key: ') . $this->currentUser->getName());
+            LoggerUtils::getAuthLogger()->debug(sprintf(gettext('User authenticated via API Key: %s'), $this->currentUser->getName()));
             $authenticationResult->isAuthenticated = true;
         } else {
             LoggerUtils::getAuthLogger()->warning(gettext('Unsuccessful API Key authentication attempt'));

--- a/src/ChurchCRM/Service/PersonService.php
+++ b/src/ChurchCRM/Service/PersonService.php
@@ -39,12 +39,9 @@ class PersonService
             if ($includeFamilyRole) {
                 $familyRole = '(';
                 if ($values['familyID']) {
-                    if ($person->getFamilyRole()) {
-                        $familyRole .= $person->getFamilyRoleName();
-                    } else {
-                        $familyRole .= gettext('Part');
-                    }
-                    $familyRole .= gettext(' of the') . ' <a href="people/family/' . $values['familyID'] . '">' . $person->getFamily()->getName() . '</a> ' . gettext('family') . ' )';
+                    $roleText = $person->getFamilyRole() ? $person->getFamilyRoleName() : gettext('Part');
+                    $familyLink = '<a href="people/family/' . $values['familyID'] . '">' . $person->getFamily()->getName() . '</a>';
+                    $familyRole .= sprintf(gettext('%1$s of the %2$s family'), $roleText, $familyLink) . ' )';
                 } else {
                     $familyRole = gettext('(No assigned family)');
                 }

--- a/src/DonationFundEditor.php
+++ b/src/DonationFundEditor.php
@@ -127,7 +127,7 @@ require_once __DIR__ . '/Include/Header.php'; ?>
     <script nonce="<?= SystemURLs::getCSPNonce() ?>">
         function confirmDeleteFund(fundName, fundId) {
             var msg = <?= json_encode(gettext('Are you sure you want to delete')) ?> + '"' + fundName + '"?';
-            msg += '<br><br><strong>' + <?= json_encode(gettext('Warning:')) ?> + '</strong> ';
+            msg += '<br><br><strong>' + <?= json_encode(gettext('Warning')) ?> + ':</strong> ';
             msg += <?= json_encode(gettext('By deleting this fund, you may affect historical donation records!')) ?>;
             bootbox.confirm({
                 title: <?= json_encode(gettext('Delete Confirmation')) ?>,

--- a/src/FamilyCustomFieldsEditor.php
+++ b/src/FamilyCustomFieldsEditor.php
@@ -269,7 +269,7 @@ function GetSecurityList($aSecGrp, $fld_name, $currOpt = 'bAll')
 <script nonce="<?= SystemURLs::getCSPNonce() ?>">
     function confirmDeleteField(fieldName, fieldId) {
         var msg = <?= json_encode(gettext('Are you sure you want to delete')) ?> + '"' + fieldName + '"?';
-        msg += '<br><br><strong>' + <?= json_encode(gettext('Warning:')) ?> + '</strong> ';
+        msg += '<br><br><strong>' + <?= json_encode(gettext('Warning')) ?> + ':</strong> ';
         msg += <?= json_encode(gettext('By deleting this field, you will irrevocably lose all family data assigned for this field!')) ?>;
         bootbox.confirm({
             title: <?= json_encode(gettext('Delete Confirmation')) ?>,

--- a/src/FinancialReports.php
+++ b/src/FinancialReports.php
@@ -271,7 +271,7 @@ if ($sReportType === '') {
 
     <?php if ($sReportType === 'Giving Report') : ?>
       <div class="mb-3">
-        <label class="form-label" for="minimum"><?= gettext('Minimum Total Amount:') ?></label>
+        <label class="form-label" for="minimum"><?= gettext('Minimum Total Amount') ?>:</label>
         <small class="text-secondary d-block mb-1"><?= gettext('0 - No Minimum') ?></small>
         <input class="form-control" style="width:120px" name="minimum" id="minimum" type="text" value="0">
       </div>
@@ -310,7 +310,7 @@ if ($sReportType === '') {
 
     <?php if (in_array($sReportType, ['Giving Report', 'Zero Givers'])) : ?>
       <div class="mb-3">
-        <label class="form-label"><?= gettext('Report Heading:') ?></label>
+        <label class="form-label"><?= gettext('Report Heading') ?>:</label>
         <div class="d-flex gap-3">
           <?php foreach (['graphic' => gettext('Graphic'), 'address' => gettext('Church Address'), 'none' => gettext('Blank')] as $val => $label) : ?>
             <div class="form-check">
@@ -321,7 +321,7 @@ if ($sReportType === '') {
         </div>
       </div>
       <div class="mb-3">
-        <label class="form-label"><?= gettext('Remittance Slip:') ?></label>
+        <label class="form-label"><?= gettext('Remittance Slip') ?>:</label>
         <div class="d-flex gap-3">
           <div class="form-check">
             <input class="form-check-input" type="radio" name="remittance" value="yes" id="remittanceYes">
@@ -337,7 +337,7 @@ if ($sReportType === '') {
 
     <?php if ($sReportType === 'Advanced Deposit Report') : ?>
       <div class="mb-3">
-        <label class="form-label"><?= gettext('Sort Data by:') ?></label>
+        <label class="form-label"><?= gettext('Sort Data by') ?>:</label>
         <div class="d-flex gap-3">
           <?php foreach (['deposit' => gettext('Deposit'), 'fund' => gettext('Fund'), 'family' => gettext('Family')] as $val => $label) : ?>
             <div class="form-check">
@@ -369,7 +369,7 @@ if ($sReportType === '') {
 
     <?php if (in_array($sReportType, ['Pledge Summary', 'Giving Report', 'Individual Deposit Report', 'Advanced Deposit Report', 'Zero Givers'])) : ?>
       <div class="mb-3">
-        <label class="form-label"><?= gettext('Output Method:') ?></label>
+        <label class="form-label"><?= gettext('Output Method') ?>:</label>
         <div class="d-flex gap-3">
           <div class="form-check">
             <input class="form-check-input" type="radio" name="output" value="pdf" id="outputPdf" checked>

--- a/src/GroupEditor.php
+++ b/src/GroupEditor.php
@@ -101,7 +101,7 @@ require_once __DIR__ . '/Include/Header.php';
             if ($thisGroup->isSundaySchool()) {
                 ?>
                 <b><?= gettext("Sunday School") ?></b>
-                <p><?= gettext("Sunday School group can't be modified, only in this two cases :")?></p>
+                <p><?= gettext("Sunday School group can't be modified, only in this two cases") ?>:</p>
                 <ul>
                                 <li>
                                     <?= gettext("You can create/delete sunday school group.")?>

--- a/src/GroupPropsFormEditor.php
+++ b/src/GroupPropsFormEditor.php
@@ -66,7 +66,7 @@ require_once __DIR__ . '/Include/Header.php'; ?>
 
         function confirmDeleteField(fieldName, propId, fieldId) {
             var msg = <?= json_encode(gettext('Are you sure you want to delete')) ?> + '"' + window.CRM.escapeHtml(fieldName) + '"?';
-            msg += '<br><br><strong>' + <?= json_encode(gettext('Warning:')) ?> + '</strong> ';
+            msg += '<br><br><strong>' + <?= json_encode(gettext('Warning')) ?> + ':</strong> ';
             msg += <?= json_encode(gettext('By deleting this field, you will irrevocably lose all group member data assigned for this field!')) ?>;
             bootbox.confirm({
                 title: <?= json_encode(gettext('Delete Confirmation')) ?>,

--- a/src/ManageEnvelopes.php
+++ b/src/ManageEnvelopes.php
@@ -144,7 +144,7 @@ if (isset($_POST['PrintReport'])) {
 <thead>
 <tr>
     <th>
-    <b><?= gettext('Family Select')?></b> <?= gettext('with at least one:') ?>
+    <b><?= gettext('Family Select')?></b> <?= gettext('with at least one') ?>:
         <select name="Classification">
         <option value="0"><?= gettext('All') ?></option>
         <?php

--- a/src/PersonCustomFieldsEditor.php
+++ b/src/PersonCustomFieldsEditor.php
@@ -263,7 +263,7 @@ require_once __DIR__ . '/Include/Header.php'; ?>
     <script nonce="<?= SystemURLs::getCSPNonce() ?>">
         function confirmDeleteField(fieldName, fieldId) {
             var msg = <?= json_encode(gettext('Are you sure you want to delete')) ?> + '"' + fieldName + '"?';
-            msg += '<br><br><strong>' + <?= json_encode(gettext('Warning:')) ?> + '</strong> ';
+            msg += '<br><br><strong>' + <?= json_encode(gettext('Warning')) ?> + ':</strong> ';
             msg += <?= json_encode(gettext('By deleting this field, you will irrevocably lose all person data assigned for this field!')) ?>;
             bootbox.confirm({
                 title: <?= json_encode(gettext('Delete Confirmation')) ?>,

--- a/src/PledgeEditor.php
+++ b/src/PledgeEditor.php
@@ -462,7 +462,7 @@ if ($PledgeOrPayment === 'Pledge') {
     $formTypeLabel = gettext('Pledge');
 } elseif ($iCurrentDeposit) {
     $dep_DateFormatted = ($dep_Date instanceof \DateTime) ? $dep_Date->format('Y-m-d') : $dep_Date;
-    $sPageTitle = gettext('New Payment') . " - $dep_Type" . gettext(' Deposit #') . " $iCurrentDeposit ($dep_DateFormatted)";
+    $sPageTitle = sprintf(gettext('New Payment - %1$s Deposit # %2$s (%3$s)'), $dep_Type, $iCurrentDeposit, $dep_DateFormatted);
     $cardHeaderClass = 'bg-primary';
     $cardHeaderTextClass = 'text-white';
     $formTypeLabel = gettext('Payment');
@@ -485,7 +485,7 @@ if ($PledgeOrPayment === 'Pledge') {
     if ($roomForDeposits <= 0) {
         $sPageTitle .= '<span class="text-danger">';
     }
-    $sPageTitle .= ' (' . $roomForDeposits . gettext(' more entries will fit.') . ')';
+    $sPageTitle .= ' (' . sprintf(gettext('%d more entries will fit.'), $roomForDeposits) . ')';
     if ($roomForDeposits <= 0) {
         $sPageTitle .= '</span>';
     }

--- a/src/PropertyList.php
+++ b/src/PropertyList.php
@@ -196,7 +196,7 @@ $(document).ready(function () {
             var propertyName = btn.data('property-name');
             bootbox.confirm({
                 title: '<?= gettext("Confirm Property Deletion") ?>',
-                message: '<p class="text-warning"><strong><?= gettext("Warning:") ?></strong> ' +
+                message: '<p class="text-warning"><strong><?= gettext("Warning") ?>:</strong> ' +
                     '<?= gettext("Deleting this property will also remove all its assignments from any People, Family, or Group records.") ?>' +
                     '</p><p><?= gettext("Delete") ?>: <strong>' + window.CRM.escapeHtml(propertyName) + '</strong></p>',
                 buttons: {

--- a/src/QueryView.php
+++ b/src/QueryView.php
@@ -99,11 +99,11 @@ function ValidateInput()
                         // Is it more than the minimum?
                         if ($_POST[$qrp_Alias] < $qrp_NumericMin) {
                             $bError = true;
-                            $aErrorText[$qrp_Alias] = gettext('This value must be at least ') . $qrp_NumericMin;
+                            $aErrorText[$qrp_Alias] = sprintf(gettext('This value must be at least %s'), $qrp_NumericMin);
                         } elseif ($_POST[$qrp_Alias] > $qrp_NumericMax) {
                             // Is it less than the maximum?
                             $bError = true;
-                            $aErrorText[$qrp_Alias] = gettext('This value cannot be more than ') . $qrp_NumericMax;
+                            $aErrorText[$qrp_Alias] = sprintf(gettext('This value cannot be more than %s'), $qrp_NumericMax);
                         }
                     }
 
@@ -115,11 +115,11 @@ function ValidateInput()
                     // Is the length less than the maximum?
                     if (strlen($_POST[$qrp_Alias]) > $qrp_AlphaMaxLength) {
                         $bError = true;
-                        $aErrorText[$qrp_Alias] = gettext('This value cannot be more than ') . $qrp_AlphaMaxLength . gettext(' characters long');
+                        $aErrorText[$qrp_Alias] = sprintf(gettext('This value cannot be more than %d characters long'), $qrp_AlphaMaxLength);
                     } elseif (strlen($_POST[$qrp_Alias]) < $qrp_AlphaMinLength) {
                         // Is the length more than the minimum?
                         $bError = true;
-                        $aErrorText[$qrp_Alias] = gettext('This value cannot be less than ') . $qrp_AlphaMinLength . gettext(' characters long');
+                        $aErrorText[$qrp_Alias] = sprintf(gettext('This value cannot be less than %d characters long'), $qrp_AlphaMinLength);
                     }
 
                     $vPOST[$qrp_Alias] = InputUtils::legacyFilterInput($_POST[$qrp_Alias]);
@@ -190,7 +190,7 @@ function DisplayRecordCount()
     if ($qry_Count === 1) {
         //Display the count of the recordset
         echo '<p class="text-center">';
-        echo mysqli_num_rows($rsQueryResults) . gettext(' record(s) returned');
+        echo sprintf(gettext('%d record(s) returned'), mysqli_num_rows($rsQueryResults));
         echo '</p>';
     }
 }
@@ -212,7 +212,7 @@ function DoQuery()
 
     <div class="card-body">
         <p class="text-end">
-            <?= $qry_Count ? mysqli_num_rows($rsQueryResults) . gettext(' record(s) returned') : ''; ?>
+            <?= $qry_Count ? sprintf(gettext('%d record(s) returned'), mysqli_num_rows($rsQueryResults)) : ''; ?>
         </p>
 
         <div class="table-responsive">

--- a/src/Reports/FamilyPledgeSummary.php
+++ b/src/Reports/FamilyPledgeSummary.php
@@ -129,12 +129,12 @@ if (!empty($_POST['funds'])) {
 if ($fundCount > 0) {
     if ($fundCount === 1) {
         if ($fund[0] == gettext('All Funds')) {
-            $fundOnlyString = gettext(' for all funds');
+            $fundOnlyString = ' ' . gettext('for all funds');
         } else {
-            $fundOnlyString = gettext(' for fund ');
+            $fundOnlyString = ' ' . gettext('for fund') . ' ';
         }
     } else {
-        $fundOnlyString = gettext('for funds ');
+        $fundOnlyString = gettext('for funds') . ' ';
     }
     for ($i = 0; $i < $fundCount; $i++) {
         $sSQL = 'SELECT fun_Name FROM donationfund_fun WHERE fun_ID=' . $fund[$i];

--- a/src/Reports/ReminderReport.php
+++ b/src/Reports/ReminderReport.php
@@ -142,12 +142,12 @@ if (!empty($_POST['funds'])) {
 if ($fundCount > 0) {
     if ($fundCount === 1) {
         if ($fund[0] === gettext('All Funds')) {
-            $fundOnlyString = gettext(' for all funds');
+            $fundOnlyString = ' ' . gettext('for all funds');
         } else {
-            $fundOnlyString = gettext(' for fund ');
+            $fundOnlyString = ' ' . gettext('for fund') . ' ';
         }
     } else {
-        $fundOnlyString = gettext('for funds ');
+        $fundOnlyString = gettext('for funds') . ' ';
     }
     for ($i = 0; $i < $fundCount; $i++) {
         $sSQL = 'SELECT fun_Name FROM donationfund_fun WHERE fun_ID=' . $fund[$i];

--- a/src/Reports/TaxReport.php
+++ b/src/Reports/TaxReport.php
@@ -189,7 +189,7 @@ if ($output === 'pdf') {
                 $curX = 60;
                 $this->writeAt($curX, $curY, gettext('Please detach this slip and mail with your next gift.'));
                 $curY += (1.5 * SystemConfig::getValue('incrementY'));
-                $church_mailing = gettext('Please mail you next gift to ') . SystemConfig::getValue('sChurchName') . ', '
+                $church_mailing = sprintf(gettext('Please mail you next gift to %s'), SystemConfig::getValue('sChurchName')) . ', '
                     . SystemConfig::getValue('sChurchAddress') . ', ' . SystemConfig::getValue('sChurchCity') . ', ' . SystemConfig::getValue('sChurchState') . '  '
                     . SystemConfig::getValue('sChurchZip') . ', ' . gettext('Phone') . ': ' . SystemConfig::getValue('sChurchPhone');
                 $this->SetFont('Times', 'I', 10);

--- a/src/SelectDelete.php
+++ b/src/SelectDelete.php
@@ -76,7 +76,7 @@ require_once __DIR__ . '/Include/Header.php';
             echo '<form name=SelectFamily method=get action=SelectDelete.php>';
             echo '<div class="card-body">';
             echo '<div class="card-header"><strong>' . gettext('Family Name') . ':' ." $fam_Name</strong></div>";
-            echo '<p>' . gettext('Please select another family with whom to associate these donations:');
+            echo '<p>' . gettext('Please select another family with whom to associate these donations') . ':';
             echo '<br><b>' . gettext('WARNING: This action can not be undone and may have legal implications!') . '</b></p>';
             echo"<input name=FamilyID value=$iFamilyID type=hidden>";
             echo '<select name=DonationFamilyID><option value=0 selected>' . gettext('Unassigned') . '</option>';
@@ -209,14 +209,14 @@ require_once __DIR__ . '/Include/Header.php';
             } else {
                 // No Donations from family.  Normal delete confirmation
                 echo $DonationMessage;
-                echo"<div class='alert alert-warning'><b>" . gettext('Please confirm deletion of this family record:') . '</b><br/>';
+                echo"<div class='alert alert-warning'><b>" . gettext('Please confirm deletion of this family record') . ':</b><br/>';
                 echo gettext('Note: This will also delete all Notes associated with this Family record.');
                 echo gettext('(this action cannot be undone)') . '</div>';
                 echo '<div>';
                 echo '<strong>' . gettext('Family Name') . ':</strong>';
                 echo '&nbsp;' . InputUtils::escapeHTML($fam_Name);
                 echo '</div><br/>';
-                echo '<div><strong>' . gettext('Family Members:') . '</strong><ul>';
+                echo '<div><strong>' . gettext('Family Members') . ':</strong><ul>';
                 //List Family Members
                 $familyMembers = PersonQuery::create()->filterByFamId((int) $iFamilyID)->find();
                 foreach ($familyMembers as $person) {

--- a/src/VolunteerOpportunityEditor.php
+++ b/src/VolunteerOpportunityEditor.php
@@ -106,7 +106,7 @@ if ($sAction === 'delete' && $iOpp > 0) {
                                 ->orderByLastName()
                                 ->orderByFirstName()
                                 ->find();
-                            echo "<div class='alert alert-warning mt-3' role='alert'><i class='fa-solid fa-circle-exclamation'></i> <strong>" . gettext('Warning') . "!</strong>" . gettext('There are people assigned to this Volunteer Opportunity. Deletion will unassign:') . "</div>";
+                            echo "<div class='alert alert-warning mt-3' role='alert'><i class='fa-solid fa-circle-exclamation'></i> <strong>" . gettext('Warning') . "!</strong>" . gettext('There are people assigned to this Volunteer Opportunity. Deletion will unassign') . ':' . "</div>";
                             echo "<div class='ms-3 mb-3'>";
                             foreach ($assignedPeople as $person) {
                                 echo "<div><i class='fa-solid fa-person'></i>" . InputUtils::escapeHTML($person->getFirstName()) . " " . InputUtils::escapeHTML($person->getLastName()) . "</div>";

--- a/src/WhyCameEditor.php
+++ b/src/WhyCameEditor.php
@@ -25,7 +25,7 @@ $person = PersonQuery::create()->findOneById($iPerson);
 $per_FirstName = $person->getFirstName();
 $per_LastName = $person->getLastName();
 
-$sPageTitle = gettext('"Why Came" notes for ') . $per_FirstName . ' ' . $per_LastName;
+$sPageTitle = sprintf(gettext('"Why Came" notes for %1$s %2$s'), $per_FirstName, $per_LastName);
 $sPageSubtitle = gettext('Record why attendees visited your church');
 
 // Is this the second pass?

--- a/src/admin/routes/api/import.php
+++ b/src/admin/routes/api/import.php
@@ -815,7 +815,7 @@ $app->group('/api/import', function (RouteCollectorProxy $group): void {
             $con->commit();
         } catch (\Throwable $e) {
             $con->rollBack();
-            return SlimUtils::renderErrorJSON($response, gettext('Import failed: ') . $e->getMessage(), [], 500, $e, $request);
+            return SlimUtils::renderErrorJSON($response, sprintf(gettext('Import failed: %s'), $e->getMessage()), [], 500, $e, $request);
         } finally {
             @unlink($tmpPath);
         }

--- a/src/admin/views/dashboard.php
+++ b/src/admin/views/dashboard.php
@@ -52,7 +52,7 @@ $healthStatus = $integrityPassed && !$hasOrphanedFiles && !$adminService->hasCri
                 </div>
 
                 <div class="mb-3">
-                    <h6 class="mb-2"><?= gettext('Current $URL[0] value:') ?></h6>
+                    <h6 class="mb-2"><?= gettext('Current $URL[0] value') ?>:</h6>
                     <div class="p-3 bg-dark rounded" style="font-family: 'Courier New', monospace; word-break: break-all;">
                         <code class="text-warning" style="font-size: 1.1em;"><?= InputUtils::escapeHTML($urlError['url']) ?></code>
                     </div>
@@ -60,12 +60,12 @@ $healthStatus = $integrityPassed && !$hasOrphanedFiles && !$adminService->hasCri
 
                 <div class="card border-0 mb-3">
                     <div class="card-body bg-white">
-                        <h6 class="text-dark mb-3"><strong><?= gettext('How to Fix:') ?></strong></h6>
+                        <h6 class="text-dark mb-3"><strong><?= gettext('How to Fix') ?>:</strong></h6>
                         <ol class="mb-2 ps-3 text-dark">
                             <li class="mb-2"><?= gettext('Connect to your server via SSH, FTP, or your hosting control panel') ?></li>
                         <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-                            <li class="mb-2"><?= gettext('Find the line:') ?> <code>$URL[0] = '...';</code></li>
-                            <li class="mb-2"><?= gettext('Update it to a valid URL that:') ?>
+                            <li class="mb-2"><?= gettext('Find the line') ?>: <code>$URL[0] = '...';</code></li>
+                            <li class="mb-2"><?= gettext('Update it to a valid URL that') ?>:
                                 <ul class="mt-1">
                                     <li><?= gettext('Starts with <strong>http://</strong> or <strong>https://</strong>') ?></li>
                                     <li><?= gettext('Ends with a <strong>trailing slash</strong> (/)') ?></li>
@@ -79,18 +79,18 @@ $healthStatus = $integrityPassed && !$hasOrphanedFiles && !$adminService->hasCri
                 <div class="card border-success mb-0">
                     <div class="card-status-top bg-success"></div>
                     <div class="card-header">
-                        <h6 class="mb-0"><i class="fa-solid fa-circle-check me-2"></i><?= gettext('Valid Examples:') ?></h6>
+                        <h6 class="mb-0"><i class="fa-solid fa-circle-check me-2"></i><?= gettext('Valid Examples') ?>:</h6>
                     </div>
                     <div class="card-body bg-white">
                         <div class="mb-2">
-                            <small class="text-body-secondary"><?= gettext('Local development:') ?></small><br>
+                            <small class="text-body-secondary"><?= gettext('Local development') ?>:</small><br>
                             <code class="text-success" style="font-size: 1em;">$URL[0] = 'http://localhost/';</code>
                         </div>
                         <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
                             <code class="text-success" style="font-size: 1em;">$URL[0] = 'https://www.yourdomain.com/churchcrm/';</code>
                         </div>
                         <div>
-                            <small class="text-body-secondary"><?= gettext('Custom port:') ?></small><br>
+                            <small class="text-body-secondary"><?= gettext('Custom port') ?>:</small><br>
                             <code class="text-success" style="font-size: 1em;">$URL[0] = 'https://www.yourdomain.com:8080/app/';</code>
                         </div>
                     </div>
@@ -108,7 +108,7 @@ $healthStatus = $integrityPassed && !$hasOrphanedFiles && !$adminService->hasCri
                 <i class="fa-solid fa-triangle-exclamation fa-2x"></i>
             </div>
             <div class="flex-grow-1">
-                <strong><?= gettext('System Configuration:') ?></strong>
+                <strong><?= gettext('System Configuration') ?>:</strong>
                 <?php 
                 $warningLinks = [];
                 foreach ($systemWarnings as $warning) {
@@ -185,7 +185,7 @@ $healthStatus = $integrityPassed && !$hasOrphanedFiles && !$adminService->hasCri
                     </h5>
                 </div>
                 <div class="card-body">
-                    <p class="text-body-secondary mb-3"><?= gettext('Jump to any setup step:') ?></p>
+                    <p class="text-body-secondary mb-3"><?= gettext('Jump to any setup step') ?>:</p>
 
                     <div class="row">
                         <!-- 1. Church Information -->
@@ -268,7 +268,7 @@ $healthStatus = $integrityPassed && !$hasOrphanedFiles && !$adminService->hasCri
                     </div>
 
                     <div class="alert alert-light border mb-0 py-2">
-                        <small><i class="fa-solid fa-lightbulb text-warning"></i> <strong><?= gettext('Tip:') ?></strong> <?= gettext('Complete these in any order to get ChurchCRM ready for your congregation.') ?></small>
+                        <small><i class="fa-solid fa-lightbulb text-warning"></i> <strong><?= gettext('Tip') ?>:</strong> <?= gettext('Complete these in any order to get ChurchCRM ready for your congregation.') ?></small>
                     </div>
                 </div>
             </div>
@@ -351,11 +351,11 @@ $healthStatus = $integrityPassed && !$hasOrphanedFiles && !$adminService->hasCri
                 </div>
                 <div class="card-body">
                     <div class="d-flex justify-content-between mb-2">
-                        <span class="text-body-secondary"><?= gettext('Version:') ?></span>
+                        <span class="text-body-secondary"><?= gettext('Version') ?>:</span>
                         <code><?= VersionUtils::getInstalledVersion() ?></code>
                     </div>
                     <div class="d-flex justify-content-between mb-3">
-                        <span class="text-body-secondary"><?= gettext('Database:') ?></span>
+                        <span class="text-body-secondary"><?= gettext('Database') ?>:</span>
                         <code><?= VersionUtils::getDBVersion() ?></code>
                     </div>
                     <div class="btn-group d-flex mb-2" role="group">
@@ -380,7 +380,7 @@ $healthStatus = $integrityPassed && !$hasOrphanedFiles && !$adminService->hasCri
                 </div>
                 <div class="card-body">
                     <div class="d-flex justify-content-between align-items-center mb-2">
-                        <span><?= gettext('File Integrity:') ?></span>
+                        <span><?= gettext('File Integrity') ?>:</span>
                         <?php if ($integrityPassed): ?>
                             <span class="badge bg-success-lt text-success"><i class="fa-solid fa-check"></i> <?= gettext('OK') ?></span>
                         <?php else: ?>
@@ -388,7 +388,7 @@ $healthStatus = $integrityPassed && !$hasOrphanedFiles && !$adminService->hasCri
                         <?php endif; ?>
                     </div>
                     <div class="d-flex justify-content-between align-items-center mb-2">
-                        <span><?= gettext('Orphaned Files:') ?></span>
+                        <span><?= gettext('Orphaned Files') ?>:</span>
                         <?php if ($hasOrphanedFiles): ?>
                             <span class="badge bg-warning-lt text-warning"><?= count($orphanedFiles) ?> <?= gettext('found') ?></span>
                         <?php else: ?>
@@ -396,7 +396,7 @@ $healthStatus = $integrityPassed && !$hasOrphanedFiles && !$adminService->hasCri
                         <?php endif; ?>
                     </div>
                     <div class="d-flex justify-content-between align-items-center mb-3">
-                        <span><?= gettext('Configuration:') ?></span>
+                        <span><?= gettext('Configuration') ?>:</span>
                         <?php if ($hasWarnings): ?>
                             <span class="badge bg-warning-lt text-warning"><?= count($systemWarnings) ?> <?= gettext('issues') ?></span>
                         <?php else: ?>

--- a/src/admin/views/logs.php
+++ b/src/admin/views/logs.php
@@ -179,7 +179,7 @@ $currentLevelLabel = $logLevelMap[$currentLogLevel] ?? 'INFO';
             </div>
             <div class="modal-body">
                 <div class="mb-3">
-                    <label><?= gettext('Filter by log level:') ?></label>
+                    <label><?= gettext('Filter by log level') ?>:</label>
                     <div class="btn-group btn-group-sm" role="group">
                         <button type="button" class="btn btn-outline-secondary log-filter active" data-level="all"><?= gettext('All') ?></button>
                         <button type="button" class="btn btn-outline-danger log-filter" data-level="ERROR"><?= gettext('Error') ?></button>
@@ -189,7 +189,7 @@ $currentLevelLabel = $logLevelMap[$currentLogLevel] ?? 'INFO';
                     </div>
                 </div>
                 <div class="mb-3">
-                    <label><?= gettext('Number of lines to display:') ?></label>
+                    <label><?= gettext('Number of lines to display') ?>:</label>
                     <select class="form-select form-select-sm" id="logLinesLimit" style="width: auto; display: inline-block;">
                         <option value="50">50</option>
                         <option value="100" selected>100</option>

--- a/src/admin/views/restore.php
+++ b/src/admin/views/restore.php
@@ -66,7 +66,7 @@ $isOnboarding = $isOnboarding ?? false;
                     <i class="ti ti-cloud-upload mb-3" style="font-size: 2.5rem;"></i>
                     <p class="mb-1"><?= gettext('Drag and drop your backup file here') ?></p>
                     <p class="text-secondary mb-0"><?= gettext('or click to browse') ?></p>
-                    <small class="text-secondary"><?= gettext('Supported formats:') ?> .sql, .sql.gz, .tar.gz</small>
+                    <small class="text-secondary"><?= gettext('Supported formats') ?>: .sql, .sql.gz, .tar.gz</small>
                 </div>
                 <div id="fileInfo" class="card card-sm mt-2 d-none">
                     <div class="card-body py-2 px-3">

--- a/src/admin/views/system-reset.php
+++ b/src/admin/views/system-reset.php
@@ -115,7 +115,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
                 <h3 class="card-title text-danger"><i class="ti ti-alert-triangle me-2"></i><?= gettext('Step 2: Reset Database') ?></h3>
             </div>
             <div class="card-body">
-                <p class="text-secondary"><?= gettext('Resetting will permanently delete:') ?></p>
+                <p class="text-secondary"><?= gettext('Resetting will permanently delete') ?>:</p>
                 <ul class="list-unstyled">
                     <li class="mb-1"><i class="ti ti-x text-danger me-1"></i><?= gettext('All people and family records') ?></li>
                     <li class="mb-1"><i class="ti ti-x text-danger me-1"></i><?= gettext('All groups, roles, and memberships') ?></li>

--- a/src/admin/views/user-editor.php
+++ b/src/admin/views/user-editor.php
@@ -157,7 +157,7 @@ $accessMode = $perms['admin'] ? 'admin' : ($perms['editSelf'] ? 'self' : 'custom
 
         <div id="customPermissions"<?= $accessMode === 'custom' ? '' : ' style="display:none;"' ?>>
             <hr>
-            <p class="text-body-secondary small mb-3"><?= gettext('Grant individual permissions:') ?></p>
+            <p class="text-body-secondary small mb-3"><?= gettext('Grant individual permissions') ?>:</p>
             <?php
             $permissions = [
                 ['name' => 'MenuOptions',  'label' => gettext('Manage Properties and Classifications'), 'checked' => $perms['menuOptions']],

--- a/src/external/templates/verify/verify-family-info.php
+++ b/src/external/templates/verify/verify-family-info.php
@@ -237,7 +237,7 @@ $doShowMap = !(empty($family->getLatitude()) && empty($family->getLongitude()));
             <div class="modal-body" id="confirm-modal-collect">
                 <form id="verifyForm">
                     <div class="mb-3 mb-3">
-                        <label class="form-label"><?= gettext("Please confirm your family information:") ?></label>
+                        <label class="form-label"><?= gettext("Please confirm your family information") ?>:</label>
                         <div class="form-check mb-3">
                             <input class="form-check-input" type="radio" name="verifyType" id="NoChanges" value="no-change" checked>
                             <label class="form-check-label" for="NoChanges">

--- a/src/finance/views/dashboard.php
+++ b/src/finance/views/dashboard.php
@@ -398,15 +398,15 @@ $sRootPath = SystemURLs::getRootPath();
                 </div>
                 <div class="card-body">
                     <div class="d-flex justify-content-between mb-2">
-                        <span><?= gettext('Total Deposits:') ?></span>
+                        <span><?= gettext('Total Deposits') ?>:</span>
                         <strong><?= $totalDeposits ?></strong>
                     </div>
                     <div class="d-flex justify-content-between mb-2">
-                        <span><?= gettext('Open Deposits:') ?></span>
+                        <span><?= gettext('Open Deposits') ?>:</span>
                         <span class="badge bg-warning text-dark"><?= $openDeposits ?></span>
                     </div>
                     <div class="d-flex justify-content-between mb-3">
-                        <span><?= gettext('Closed Deposits:') ?></span>
+                        <span><?= gettext('Closed Deposits') ?>:</span>
                         <span class="badge bg-green-lt text-green"><?= $closedDeposits ?></span>
                     </div>
 

--- a/src/fundraiser/routes/paddle-num.php
+++ b/src/fundraiser/routes/paddle-num.php
@@ -59,7 +59,7 @@ $app->get('/{fundraiserId}/paddle-numbers', function (Request $request, Response
 
     return $renderer->render($response, 'paddle-num-list.php', [
         'sRootPath'     => SystemURLs::getRootPath(),
-        'sPageTitle'    => gettext('Buyers for this fundraiser:'),
+        'sPageTitle'    => gettext('Buyers for this fundraiser'),
         'sPageSubtitle' => gettext('View buyer numbers and paddle assignments'),
         'aBreadcrumbs'  => PageHeader::breadcrumbs([
             [gettext('Fundraiser'), '/fundraiser/'],

--- a/src/fundraiser/routes/reports.php
+++ b/src/fundraiser/routes/reports.php
@@ -181,10 +181,10 @@ $app->get('/{fundraiserId}/reports/bid-sheets', function (Request $request, Resp
         $pdf->SetFont('Times', '', 16);
         $pdf->Write(8, stripslashes($di_description) . "\n");
         if ($di_estprice > 0) {
-            $pdf->Write(8, gettext('Estimated value ') . '$' . $di_estprice . '.  ');
+            $pdf->Write(8, sprintf(gettext('Estimated value $%s.'), $di_estprice) . '  ');
         }
         if ($per_LastName !== '') {
-            $pdf->Write(8, gettext('Donated by ') . $per_FirstName . ' ' . $per_LastName . ".\n");
+            $pdf->Write(8, sprintf(gettext('Donated by %1$s %2$s.'), $per_FirstName, $per_LastName) . "\n");
         }
         $pdf->Write(8, "\n");
 
@@ -269,10 +269,10 @@ $app->get('/{fundraiserId}/reports/certificates', function (Request $request, Re
         $pdf->SetFont('Times', '', 16);
         $pdf->Write(8, stripslashes($di_description) . "\n");
         if ($di_estprice > 0) {
-            $pdf->Write(8, gettext('Estimated value ') . '$' . $di_estprice . '.  ');
+            $pdf->Write(8, sprintf(gettext('Estimated value $%s.'), $di_estprice) . '  ');
         }
         if ($per_LastName !== '') {
-            $pdf->Write(8, gettext('Donated by ') . $per_FirstName . ' ' . $per_LastName . ".\n\n");
+            $pdf->Write(8, sprintf(gettext('Donated by %1$s %2$s.'), $per_FirstName, $per_LastName) . "\n\n");
         }
     }
 
@@ -355,13 +355,13 @@ $app->get('/{fundraiserId}/reports/catalog', function (Request $request, Respons
         $pdf->SetFont('Times', '', 12);
         $pdf->Write(6, stripslashes($di_description) . "\n");
         if ($di_minimum > 0) {
-            $pdf->Write(6, gettext('Minimum bid ') . '$' . $di_minimum . '.  ');
+            $pdf->Write(6, sprintf(gettext('Minimum bid $%s.'), $di_minimum) . '  ');
         }
         if ($di_estprice > 0) {
-            $pdf->Write(6, gettext('Estimated value ') . '$' . $di_estprice . '.  ');
+            $pdf->Write(6, sprintf(gettext('Estimated value $%s.'), $di_estprice) . '  ');
         }
         if ($per_LastName !== '') {
-            $pdf->Write(6, gettext('Donated by ') . $per_FirstName . ' ' . $per_LastName . ".\n");
+            $pdf->Write(6, sprintf(gettext('Donated by %1$s %2$s.'), $per_FirstName, $per_LastName) . "\n");
         }
         $pdf->Write(6, "\n");
     }
@@ -594,13 +594,13 @@ $app->map(['GET', 'POST'], '/{fundraiserId}/reports/statement', function (Reques
             $curY += 2 * SystemConfig::getValue('incrementY');
 
             $curY = 240;
-            $pdf->writeAt(SystemConfig::getValue('leftX'), $curY, gettext('-----------------------------------------------------------------------------------------------------------------------------------------------'));
+            $pdf->writeAt(SystemConfig::getValue('leftX'), $curY, '-----------------------------------------------------------------------------------------------------------------------------------------------');
             $curY += 2 * SystemConfig::getValue('incrementY');
-            $pdf->writeAt(SystemConfig::getValue('leftX'), $curY, gettext('Buyer # ') . $pn_Num . ' : ' . $paddleFirstName . ' ' . $paddleLastName . ' : ' . gettext('Total purchases: $') . $totalAmount . ' : ' . gettext('Amount paid: ________________'));
+            $pdf->writeAt(SystemConfig::getValue('leftX'), $curY, gettext('Buyer #') . ' ' . $pn_Num . ' : ' . $paddleFirstName . ' ' . $paddleLastName . ' : ' . gettext('Total purchases: $') . $totalAmount . ' : ' . gettext('Amount paid: ________________'));
             $curY += 2 * SystemConfig::getValue('incrementY');
             $pdf->writeAt(SystemConfig::getValue('leftX'), $curY, gettext('Paid by (  ) Cash    (  ) Check    (  ) Credit card __ __ __ __    __ __ __ __    __ __ __ __    __ __ __ __  Exp __ / __'));
             $curY += 2 * SystemConfig::getValue('incrementY');
-            $pdf->writeAt(SystemConfig::getValue('leftX'), $curY, gettext('                                        Signature ________________________________________________________________'));
+            $pdf->writeAt(SystemConfig::getValue('leftX'), $curY, str_repeat(' ', 40) . gettext('Signature') . ' ' . str_repeat('_', 68));
 
             $pdf->finishPage($curY);
         }

--- a/src/groups/views/sundayschool/dashboard.php
+++ b/src/groups/views/sundayschool/dashboard.php
@@ -169,7 +169,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
             <hr class="my-3">
             <div class="alert alert-info mb-0">
                 <i class="ti ti-rocket me-1"></i>
-                <strong><?= gettext('Fastest workflow:') ?></strong>
+                <strong><?= gettext('Fastest workflow') ?>:</strong>
                 <?= gettext("Open a class → click \"Create Today's Event\" — the event is created and linked to the class in one shot, then you land on the check-in page ready for a kiosk or walk-in attendance.") ?>
             </div>
         </div>

--- a/src/kiosk/views/manager.php
+++ b/src/kiosk/views/manager.php
@@ -62,7 +62,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
       </div>
       <div class="col">
         <strong><?= gettext('Register New Device') ?></strong>
-        <span class="text-body-secondary ms-1"><?= gettext('Opens a 2-minute window for devices to register at:') ?></span>
+        <span class="text-body-secondary ms-1"><?= gettext('Opens a 2-minute window for devices to register at') ?>:</span>
         <code class="ms-1"><?= InputUtils::escapeHTML(SystemURLs::getURL()) ?>/kiosk</code>
       </div>
       <div class="col-auto">

--- a/src/members/self-register.php
+++ b/src/members/self-register.php
@@ -106,7 +106,7 @@ use ChurchCRM\dto\SystemURLs;
             columns: [
                 {
                     width: '12%',
-                    title: i18next.t('Id'),
+                    title: i18next.t('ID'),
                     data: 'Id',
                     searchable: false,
                     render: function (data, type, full, meta) {

--- a/src/people/views/cart/to-family.php
+++ b/src/people/views/cart/to-family.php
@@ -89,7 +89,7 @@ $rootPath       = SystemURLs::getRootPath();
                 <h3 class="card-title mb-0"><?= gettext('People to assign') ?></h3>
                 <div class="d-flex align-items-center gap-2">
                     <label for="assignRoleToAll" class="form-label mb-0 text-secondary small">
-                        <?= gettext('Assign role to all:') ?>
+                        <?= gettext('Assign role to all') ?>:
                     </label>
                     <select id="assignRoleToAll" class="form-select form-select-sm" style="width:auto">
                         <option value=""><?= gettext('— pick —') ?></option>

--- a/src/people/views/partials/attendance-tab.php
+++ b/src/people/views/partials/attendance-tab.php
@@ -32,7 +32,7 @@ $i18n = [
     'currentStreak'    => gettext('Streak'),
     'streakEvents'     => gettext('events'),
     'never'            => gettext('Never'),
-    'noStreak'         => gettext('—'),
+    'noStreak'         => '—',
 ];
 ?>
 

--- a/src/people/views/person-list.php
+++ b/src/people/views/person-list.php
@@ -222,7 +222,7 @@ $hasDataQualityIssues = $genderDataCheckCount > 0 || $roleDataCheckCount > 0 ||
                     <?php 
                     // Map of column names to localized display titles
                     $htmlColumnTitleMap = [
-                        'Id' => gettext('Id'),
+                        'Id' => gettext('ID'),
                         'Name' => gettext('Name'),
                         'Family Name' => gettext('Family Name'),
                         'Family Status' => gettext('Family Status'),
@@ -515,7 +515,7 @@ $hasDataQualityIssues = $genderDataCheckCount > 0 || $roleDataCheckCount > 0 ||
                 $columns = $personListColumns;
                 // Map of column names to localized display titles
                 $columnTitleMap = [
-                    'Id' => gettext('Id'),
+                    'Id' => gettext('ID'),
                     'Name' => gettext('Name'),
                     'Family Name' => gettext('Family Name'),
                     'Family Status' => gettext('Family Status'),

--- a/src/people/views/person-list.php
+++ b/src/people/views/person-list.php
@@ -129,7 +129,7 @@ $hasDataQualityIssues = $genderDataCheckCount > 0 || $roleDataCheckCount > 0 ||
             <i class="fa-solid fa-clipboard-check fa-2x"></i>
         </div>
         <div>
-            <strong><?= gettext('Data Quality:') ?></strong>
+            <strong><?= gettext('Data Quality') ?>:</strong>
             <?php
             $issues = [];
             if ($genderDataCheckCount > 0) {

--- a/src/people/views/timeline-events.php
+++ b/src/people/views/timeline-events.php
@@ -24,7 +24,7 @@ if (empty($timeline)) { ?>
     }
     ?>
     <div class="timeline-filters d-flex flex-wrap align-items-center gap-2 mt-3 mb-1" role="group" aria-label="<?= gettext('Timeline filters') ?>">
-        <span class="text-muted small me-1"><i class="fa-solid fa-filter me-1"></i><?= gettext('Show:') ?></span>
+        <span class="text-muted small me-1"><i class="fa-solid fa-filter me-1"></i><?= gettext('Show') ?>:</span>
         <button type="button" class="btn btn-sm btn-primary timeline-filter-chip active" data-filter="notes">
             <i class="fa-solid fa-note-sticky me-1"></i><?= gettext('Notes') ?>
             <span class="badge bg-white text-primary ms-1"><?= $timelineCounts['notes'] ?></span>

--- a/src/plugins/views/management.php
+++ b/src/plugins/views/management.php
@@ -170,7 +170,7 @@ function renderPluginCard(array $plugin, string $rootPath, string $nonce): void 
             <?php endif; ?>
             <?php if ($isCommunity && $isVerified && $riskSummary !== null): ?>
                 <div class="alert alert-info mb-3" role="alert">
-                    <strong><?= gettext('What this plugin does:') ?></strong>
+                    <strong><?= gettext('What this plugin does') ?>:</strong>
                     <?= htmlspecialchars((string) $riskSummary) ?>
                     <?php if (!empty($permissions) && is_array($permissions)): ?>
                         <div class="mt-2">

--- a/src/v2/templates/email/dashboard.php
+++ b/src/v2/templates/email/dashboard.php
@@ -15,7 +15,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
         <h3 class="card-title text-warning"><i class="fa-solid fa-triangle-exclamation me-2"></i><?= gettext('Email is Disabled') ?></h3>
     </div>
     <div class="card-body">
-        <p class="mb-2"><?= gettext('Email functionality is currently disabled. The following features will not work until email is enabled:') ?></p>
+        <p class="mb-2"><?= gettext('Email functionality is currently disabled. The following features will not work until email is enabled') ?>:</p>
         <ul class="mb-2">
             <li><?= gettext('Password reset emails — users cannot recover their accounts') ?></li>
             <li><?= gettext('New member notification emails') ?></li>

--- a/src/v2/templates/email/debug.php
+++ b/src/v2/templates/email/debug.php
@@ -33,7 +33,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
                 <div class="flex-grow-1">
                     <h4 class="mb-1"><i class="fa fa-circle-check text-success me-2"></i><?= gettext('Test email accepted by SMTP server') ?></h4>
                     <p class="text-body-secondary mb-2">
-                        <?= gettext('Now check the recipient inbox to confirm delivery. Look for the subject:') ?>
+                        <?= gettext('Now check the recipient inbox to confirm delivery. Look for the subject') ?>:
                         <br>
                         <strong>&ldquo;<?= gettext('ChurchCRM Test Email') ?>&rdquo;</strong>
                     </p>
@@ -140,7 +140,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
                             <td>
                                 <?= InputUtils::escapeHTML($smtpSettings['auth']) ?>
                                 <?php if (!empty($smtpSettings['username'])): ?>
-                                    <span class="text-body-secondary ms-2">(<?= gettext('user:') ?> <code><?= InputUtils::escapeHTML((string) $smtpSettings['username']) ?></code>)</span>
+                                    <span class="text-body-secondary ms-2">(<?= gettext('user') ?>: <code><?= InputUtils::escapeHTML((string) $smtpSettings['username']) ?></code>)</span>
                                 <?php endif; ?>
                             </td>
                         </tr>

--- a/src/v2/templates/user/user.php
+++ b/src/v2/templates/user/user.php
@@ -328,7 +328,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
                 <div><i class="ti ti-info-circle me-2 mt-1"></i></div>
                 <div>
                   <h4 class="alert-title"><?= gettext("Missing or incorrect translations?") ?></h4>
-                  <p class="mb-2"><?= gettext("ChurchCRM translations are managed by the community on POEditor. You can help by:") ?></p>
+                  <p class="mb-2"><?= gettext("ChurchCRM translations are managed by the community on POEditor. You can help by") ?>:</p>
                   <ul class="mb-2">
                     <li><?= gettext("Fixing incorrect or awkward translations in your language") ?></li>
                     <li><?= gettext("Translating missing strings to improve coverage") ?></li>
@@ -373,7 +373,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
             <hr>
 
             <h4 class="mb-3"><?= gettext("Usage") ?></h4>
-            <p class="text-body-secondary"><?= gettext("Include your API key in requests using the x-api-key header:") ?></p>
+            <p class="text-body-secondary"><?= gettext("Include your API key in requests using the x-api-key header") ?>:</p>
             <pre class="p-3 bg-light rounded"><code>curl -H "x-api-key: <?= InputUtils::escapeHTML(substr($user->getApiKey(), 0, 8)) ?>..." \
      <?= SystemURLs::getURL() ?>/api/person/1</code></pre>
           </div>

--- a/webpack/upgrade-wizard-app.js
+++ b/webpack/upgrade-wizard-app.js
@@ -380,9 +380,9 @@ function renderWhatsNew(data) {
   if (releasesAhead >= 2 && upgradePath && upgradePath.length >= 2) {
     const count = upgradePath.length;
     $("#upgradePathSummary").html(
-      i18next.t("You are <strong>{{releaseCount}}</strong> releases behind. Here's what you'll gain:", {
+      `${i18next.t("You are <strong>{{releaseCount}}</strong> releases behind. Here's what you'll gain", {
         releaseCount: count,
-      }),
+      })}:`,
     );
     renderUpgradePath(upgradePath);
     $("#upgradePathPanel").removeClass("d-none");


### PR DESCRIPTION
## What Changed
Reviewed all `gettext()`/`i18next.t()` calls in the codebase for several classes of problems and fixed what was found:

1. **Junk wrapping** — a punctuation-only placeholder (`gettext('—')`) was wrapped for translation even though the identical raw `—` character is already used unwrapped elsewhere on the same page. A decorative all-dash PDF divider (`gettext('----...----')`, no words) had the same problem — unwrapped to a bare literal.
2. **Near-duplicate terms** — `gettext('Id')` / `i18next.t('Id')` (3 call sites) duplicated the existing `gettext('ID')` term used for the same kind of table column header elsewhere; normalized to `ID` per the project's documented acronym convention.
3. **Dangling colons** — ~54 call sites across 30 files wrapped a trailing colon inside the translatable string (e.g. `gettext('Warning:')`), which the project's own convention says to keep outside the call since colons are UI punctuation, not translatable content. Several duplicated an existing colon-less msgid for the same word (`Warning`, `Family Members`, `Database`, `Version`, `Orphaned Files`, `Tip`) and now reuse those terms.
4. **Split-sentence fragments (leading/trailing spaces)** — ~16 call sites wrapped only part of a sentence, leaving a fragment with a leading or trailing space baked into the msgid (e.g. `gettext(' characters long')`, `gettext('Donated by ')`). These were consolidated into single `sprintf()`-parameterised strings across `QueryView.php`, `PledgeEditor.php`, `Reports/TaxReport.php`, `Reports/ReminderReport.php`, `Reports/FamilyPledgeSummary.php`, `WhyCameEditor.php`, `admin/routes/api/import.php`, `APITokenAuthentication.php`, `PersonService.php`, and `fundraiser/routes/reports.php`. Where a term is just a connector word appended in a loop rather than a full sentence, the space was moved to plain string concatenation outside `gettext()` instead of restructuring the surrounding loop.
5. **Layout whitespace baked into a msgid** — a PDF signature-line string padded the real word `'Signature'` with 40 leading spaces and 68 trailing underscores for fixed-width layout. Pulled the word into its own `gettext('Signature')` call with the padding built via `str_repeat()` outside it.

Also fixed a couple of adjacent issues found along the way:
- A stray space-before-colon typo in `GroupEditor.php` (`"...cases :"`).
- A trailing colon on a page title (`paddle-num.php`'s `sPageTitle`) that didn't belong on a heading — dropped rather than moved.
- Stale skill guidance that said to hand-edit `locale/messages.po` when moving a colon — corrected to match the project's actual (automated) locale workflow.

I deliberately did **not** attempt to merge the ~72 case-only duplicate msgid groups (`Active`/`active`, `People`/`people`, etc.) that a broader `messages.po` audit surfaced. Spot-checking several of them showed they're mostly legitimate — Title Case for UI chrome vs. sentence case for inline counts/attribution, exactly per the existing convention — or stale `.po` entries with no live call site. Mass-editing on a shallow case-mismatch heuristic would have produced false fixes, so this is documented as a caveat in the skill file instead of acted on.

## Type
- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
- `npm run lint` — passes (2 pre-existing, unrelated warnings in `event-form.js`/`localization.js`)
- `npm run build:php` — all 580 PHP files pass syntax validation
- `npm run build:webpack` — compiles successfully
- Verified each `sprintf()` consolidation produces byte-identical output to the original for the same inputs
- Re-ran detection greps after each pass — zero remaining colon-suffixed, leading/trailing-space, or pure-formatting `gettext()`/`i18next.t()` calls

## Screenshots
N/A — no visual changes; strings render identically, just with cleaner msgid boundaries for translators.

## Pre-Merge
- [x] Tested locally
- [x] No new warnings
- [x] Build passes
- [x] Backward compatible (or migration documented) — pure string-wrapping cleanup, no behavior change
