### PR TITLE
fix: allow /external/calendars route to be embedded in cross-origin iframes (#9248)

### DIFF
--- a/cypress/e2e/api/public/public.calendar.spec.js
+++ b/cypress/e2e/api/public/public.calendar.spec.js
@@ -211,6 +211,27 @@ describe("Public Calendar - Event Visibility (regression: PR #8981)", () => {
 
             // FullCalendar's timeZone option must be wired up
             expect(resp.body).to.include("timeZone:");
+
+            // --- Framing headers: calendar.php (happy path) ---
+            // The page must be embeddable in a cross-origin <iframe>.
+            // Verify X-Frame-Options is absent and CSP frame-ancestors is open.
+            expect(
+                resp.headers["x-frame-options"],
+                "x-frame-options must be absent on the external calendar route",
+            ).to.be.undefined;
+
+            const cspHeader =
+                resp.headers["content-security-policy"] ??
+                resp.headers["content-security-policy-report-only"];
+            expect(cspHeader, "a CSP header must be present").to.be.a("string");
+            expect(cspHeader).to.match(
+                /frame-ancestors \*/,
+                'frame-ancestors must be "*" on the external calendar page',
+            );
+            expect(cspHeader).not.to.match(
+                /frame-ancestors 'self'/,
+                "frame-ancestors must not restrict to 'self' on the external calendar page",
+            );
         });
     });
 });

--- a/cypress/e2e/ui/events/external.calendar.spec.js
+++ b/cypress/e2e/ui/events/external.calendar.spec.js
@@ -30,6 +30,40 @@ function setExternalCalendarApi(enabled) {
     });
 }
 
+/**
+ * Helper: assert that a response from the external-calendar route has the
+ * correct framing headers — no X-Frame-Options restriction and a CSP
+ * frame-ancestors directive that permits embedding from any origin.
+ *
+ * We check whichever CSP flavour the server sends
+ * (Content-Security-Policy or Content-Security-Policy-Report-Only —
+ *  determined by the bEnforceCSP system config, defaulting to report-only).
+ */
+function assertFramingHeadersOpen(response) {
+    // Must NOT send X-Frame-Options — its absence means no legacy restriction.
+    expect(
+        response.headers['x-frame-options'],
+        'x-frame-options should be absent on the external calendar route',
+    ).to.be.undefined;
+
+    // Exactly one CSP flavour should be present; pick whichever is set.
+    const cspHeader =
+        response.headers['content-security-policy'] ??
+        response.headers['content-security-policy-report-only'];
+    expect(cspHeader, 'a CSP header must be present').to.be.a('string');
+
+    // frame-ancestors must be open to all origins…
+    expect(cspHeader).to.match(
+        /frame-ancestors \*/,
+        'frame-ancestors should be "*" on the external calendar route',
+    );
+    // …and must NOT carry the same-origin restriction.
+    expect(cspHeader).not.to.match(
+        /frame-ancestors 'self'/,
+        "frame-ancestors must not be 'self' on the external calendar route",
+    );
+}
+
 describe("External calendar — HTML surface", () => {
     after(() => {
         // Leave the setting disabled so other specs aren't surprised. The
@@ -55,6 +89,26 @@ describe("External calendar — HTML surface", () => {
         cy.visit("/external/calendars/notarealtoken12345", { failOnStatusCode: false });
         cy.contains("Calendar not found").should("be.visible");
         cy.contains("Go to home").should("be.visible");
+    });
+
+    it("omits X-Frame-Options and sets frame-ancestors * when the API is disabled (error page)", () => {
+        // Framing headers are emitted before content is rendered, so even
+        // the 403 error page (API disabled) must carry the open headers.
+        setExternalCalendarApi(false);
+
+        cy.request({
+            url: "/external/calendars/anytoken",
+            failOnStatusCode: false,
+        }).then(assertFramingHeadersOpen);
+    });
+
+    it("omits X-Frame-Options and sets frame-ancestors * for a 404 (bad token)", () => {
+        setExternalCalendarApi(true);
+
+        cy.request({
+            url: "/external/calendars/notarealtoken12345",
+            failOnStatusCode: false,
+        }).then(assertFramingHeadersOpen);
     });
 });
 
@@ -100,6 +154,25 @@ describe("External calendar — JSON surface", () => {
         }).then((response) => {
             expect(response.status).to.eq(403);
             expect(response.headers["content-type"]).to.match(/application\/json/);
+        });
+    });
+});
+
+describe("Framing-header regression — non-external routes still protected", () => {
+    // Verifies that the $allowFraming opt-in in the external calendar
+    // templates does NOT affect any other route.
+    it("sends X-Frame-Options: SAMEORIGIN on the public login page", () => {
+        // The setup / login page is always accessible without credentials
+        // and goes through HeaderNotLoggedIn.php without $allowFraming set.
+        cy.request({
+            url: "/",
+            followRedirect: true,
+            failOnStatusCode: false,
+        }).then((response) => {
+            expect(
+                (response.headers['x-frame-options'] ?? '').toLowerCase(),
+                'non-external pages must still block cross-origin framing',
+            ).to.eq('sameorigin');
         });
     });
 });

--- a/src/ChurchCRM/dto/SystemConfig.php
+++ b/src/ChurchCRM/dto/SystemConfig.php
@@ -220,6 +220,7 @@ class   SystemConfig
             'sChurchWebSite'                       => new ConfigItem('sChurchWebSite', 'text', '', ''),
             'sChurchLogoURL'                       => new ConfigItem('sChurchLogoURL', 'text', '', gettext('Absolute http(s) URL of the church logo shown in email templates (and re-used elsewhere in the future). For best rendering across email clients, use a wide banner image at roughly a 3.5:1 aspect ratio (for example 350×100 px), PNG or JPG, served over HTTPS. Leave blank or enter an invalid value to fall back to the default ChurchCRM logo.')),
             'bEnableExternalCalendarAPI'           => new ConfigItem('bEnableExternalCalendarAPI', 'boolean', '0', gettext('Allow unauthenticated reads of events from the external calendar API')),
+            'sCalendarEmbedOrigins'                => new ConfigItem('sCalendarEmbedOrigins', 'text', '*', gettext('Space-separated list of origins allowed to embed the public external calendar page in an <iframe> (CSP frame-ancestors). Default "*" allows any origin. Restrict to specific origins for tighter security, e.g. "https://mysite.org https://embed.example.com".')),
             
             'sNewPersonNotificationRecipientIDs'   => new ConfigItem('sNewPersonNotificationRecipientIDs', 'text', '', gettext('Comma Separated list of PersonIDs of people to notify when a new family or person is added')),
             'bSearchIncludePersons'                => new ConfigItem('bSearchIncludePersons', 'boolean', '1', gettext('Search People')),

--- a/src/Include/Header-Security.php
+++ b/src/Include/Header-Security.php
@@ -17,7 +17,8 @@
  * Opt-in for embeddable public pages (e.g. the external calendar route):
  * Set  $allowFraming = true;  in the template BEFORE requiring
  * HeaderNotLoggedIn.php (which in turn requires this file). When set,
- * X-Frame-Options is omitted and frame-ancestors is widened to "*" so
+ * X-Frame-Options is omitted and frame-ancestors is set to the value of
+ * the sCalendarEmbedOrigins system setting (default "*", any origin) so
  * the page can be embedded in a third-party <iframe>. All other
  * clickjacking protections remain in force for every other route.
  */
@@ -49,11 +50,15 @@ if (empty($allowFraming)) {
     $csp[] = "frame-ancestors 'self'";
     header('X-Frame-Options: SAMEORIGIN');
 } else {
-    // Embeddable route: allow framing from any origin.
-    $csp[] = 'frame-ancestors *';
-    // X-Frame-Options is intentionally omitted; browsers honour
-    // CSP frame-ancestors when present, and absence of the legacy
-    // header imposes no framing restriction.
+    // Embeddable route: allow framing from the configured origins.
+    // sCalendarEmbedOrigins defaults to "*" (any origin); admins can restrict
+    // it to a space-separated list of specific origins (e.g. "https://mysite.org").
+    $origins = SystemConfig::getValue('sCalendarEmbedOrigins') ?: '*';
+    $csp[] = 'frame-ancestors ' . $origins;
+    // X-Frame-Options is intentionally omitted — its absence is what
+    // actually permits cross-origin framing in the default (report-only)
+    // CSP mode. When bEnforceCSP is enabled, the enforcing CSP header's
+    // frame-ancestors directive takes over that role.
 }
 
 $csp[] = 'report-uri ' . SystemURLs::getRootPath() . '/api/public/csp-report';

--- a/src/Include/Header-Security.php
+++ b/src/Include/Header-Security.php
@@ -53,7 +53,10 @@ if (empty($allowFraming)) {
     // Embeddable route: allow framing from the configured origins.
     // sCalendarEmbedOrigins defaults to "*" (any origin); admins can restrict
     // it to a space-separated list of specific origins (e.g. "https://mysite.org").
-    $origins = SystemConfig::getValue('sCalendarEmbedOrigins') ?: '*';
+    // Strip CSP structural characters (;) and HTTP header newlines (\r\n) before
+    // injecting into the header — defense-in-depth against directive injection
+    // and response splitting even when input comes from an authenticated admin.
+    $origins = preg_replace('/[;\r\n]/', '', SystemConfig::getValue('sCalendarEmbedOrigins') ?: '*');
     $csp[] = 'frame-ancestors ' . $origins;
     // X-Frame-Options is intentionally omitted — its absence is what
     // actually permits cross-origin framing in the default (report-only)

--- a/src/Include/Header-Security.php
+++ b/src/Include/Header-Security.php
@@ -13,6 +13,13 @@
  * - X-Frame-Options: Prevents clickjacking attacks
  * - X-Content-Type-Options: Prevents MIME-sniffing attacks
  * - Referrer-Policy: Controls how much referrer information is sent
+ *
+ * Opt-in for embeddable public pages (e.g. the external calendar route):
+ * Set  $allowFraming = true;  in the template BEFORE requiring
+ * HeaderNotLoggedIn.php (which in turn requires this file). When set,
+ * X-Frame-Options is omitted and frame-ancestors is widened to "*" so
+ * the page can be embedded in a third-party <iframe>. All other
+ * clickjacking protections remain in force for every other route.
  */
 
 use ChurchCRM\dto\SystemConfig;
@@ -30,11 +37,27 @@ $csp = [
     "connect-src 'self' https://www.google-analytics.com",
     "base-uri 'self'",
     "form-action 'self'",
-    "frame-ancestors 'self'",
-    'report-uri ' . SystemURLs::getRootPath() . '/api/public/csp-report',
 ];
 
-header('X-Frame-Options: SAMEORIGIN');
+// Framing / clickjacking protection.
+// Public embeddable routes (e.g. /external/calendars/{token}) opt in to
+// cross-origin embedding by setting $allowFraming = true in the template
+// before requiring this file. All other pages keep the default clickjacking
+// protection.
+if (empty($allowFraming)) {
+    // Default: prevent framing from other origins.
+    $csp[] = "frame-ancestors 'self'";
+    header('X-Frame-Options: SAMEORIGIN');
+} else {
+    // Embeddable route: allow framing from any origin.
+    $csp[] = 'frame-ancestors *';
+    // X-Frame-Options is intentionally omitted; browsers honour
+    // CSP frame-ancestors when present, and absence of the legacy
+    // header imposes no framing restriction.
+}
+
+$csp[] = 'report-uri ' . SystemURLs::getRootPath() . '/api/public/csp-report';
+
 header('X-Content-Type-Options: nosniff');
 header('Referrer-Policy: strict-origin-when-cross-origin');
 // CSP can be in report-only mode (violations logged but not blocked) or enforcing mode (violations blocked)

--- a/src/event/views/calendar.php
+++ b/src/event/views/calendar.php
@@ -102,6 +102,12 @@ $calendarSettingsPanelConfig = [
             'label'   => gettext('Enable External Calendar API'),
             'tooltip' => gettext('Allow unauthenticated access to calendar events via public HTML, ICS, and JSON URLs. Required for sharing calendars with external apps.'),
         ],
+        [
+            'name'    => 'sCalendarEmbedOrigins',
+            'type'    => 'text',
+            'label'   => gettext('Calendar Embed Origins'),
+            'tooltip' => gettext('Space-separated origins allowed to embed the public calendar page in an <iframe> (CSP frame-ancestors). Default "*" allows any site. Restrict for tighter security, e.g. "https://mysite.org".'),
+        ],
     ],
 ];
 ?>

--- a/src/external/templates/calendar/calendar.php
+++ b/src/external/templates/calendar/calendar.php
@@ -7,6 +7,10 @@ use ChurchCRM\Utils\InputUtils;
 $sPageTitle = $calendarName;
 $churchTz   = ChurchMetaData::getChurchTimeZone();
 
+// Allow this page to be embedded in a third-party <iframe>.
+// See src/Include/Header-Security.php for the opt-in mechanism.
+$allowFraming = true;
+
 require SystemURLs::getDocumentRoot() ."/Include/HeaderNotLoggedIn.php";
 ?>
 <script src="<?= SystemURLs::assetVersioned('/skin/external/fullcalendar/index.global.min.js') ?>"></script>

--- a/src/external/templates/calendar/error.php
+++ b/src/external/templates/calendar/error.php
@@ -15,6 +15,10 @@ $rootPath = SystemURLs::getRootPath();
 $churchName = ChurchMetaData::getChurchName();
 $logoURL = ChurchMetaData::getChurchLogoURL();
 
+// Allow external-calendar error pages to be embedded in a third-party <iframe>.
+// See src/Include/Header-Security.php for the opt-in mechanism.
+$allowFraming = true;
+
 require SystemURLs::getDocumentRoot() . '/Include/HeaderNotLoggedIn.php';
 ?>
 


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Fixes #9248.

The public calendar page (`/external/calendars/{token}`) was blocked from embedding in a third-party `<iframe>` because the server globally emitted `X-Frame-Options: SAMEORIGIN` and `CSP: frame-ancestors 'self'`.

## Changes

- **`src/Include/Header-Security.php`** — adds an opt-in `$allowFraming` flag. Default (flag absent or falsy): unchanged clickjacking protection. When truthy: omits `X-Frame-Options` entirely and sets `frame-ancestors *`.
- **`src/external/templates/calendar/calendar.php`** and **`error.php`** — set `$allowFraming = true;` before the `require HeaderNotLoggedIn.php` chain; PHP `require` shares the caller's scope so the flag reaches the header file.
- **Cypress tests** — assert framing headers are open on the external-calendar route (error paths + happy path with real token) and that normal pages still send `SAMEORIGIN`.

## Testing

Validated via PHP 8.3 `php -l` (all changed PHP files) and Biome lint (no new issues). Cypress tests require the Docker dev environment with a seeded DB.

## Docs

A sibling issue should be filed to document on [docs.churchcrm.io](https://docs.churchcrm.io) that the external calendar page can now be embedded in an `<iframe>`.