### PR TITLE
Fix dropdown clipping on group members table and event types list

### DIFF
--- a/src/event/views/types-list.php
+++ b/src/event/views/types-list.php
@@ -11,7 +11,7 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
 <div class="card">
   <div class="card-body">
     <?php if (count($rows) > 0): ?>
-      <div class="table-responsive">
+      <div style="overflow: visible;">
         <table id="eventTypesTable" class="table table-hover table-vcenter">
           <thead>
             <tr>

--- a/src/groups/views/group-view.php
+++ b/src/groups/views/group-view.php
@@ -207,7 +207,7 @@ if ($bCanManageGroups) {
                 <?php endif; ?>
 
                 <!-- DataTable -->
-                <div class="table-responsive">
+                <div style="overflow: visible;">
                     <table class="table table-hover table-vcenter table-sm" id="membersTable"></table>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Fixes action-menu dropdown clipping on `#membersTable` (`src/groups/views/group-view.php`, dropdown built in `GroupView.js`) and `#eventTypesTable` (`src/event/views/types-list.php`, dropdown hardcoded in PHP).
- Both wrapped their table in `.table-responsive`, which sets `overflow-x: auto` and implicitly forces `overflow-y: auto` too — clipping the absolutely-positioned dropdown despite `data-bs-display="static"` on the trigger button.

## Why
A full-codebase audit (prompted by the same bug on a page in a sibling branch) found these were the only two other real instances of the pattern. The root cause was actually **wrong documentation**: `.agents/skills/churchcrm/table-action-menu.md`'s "Overflow / Dropdown Clipping" section claimed `data-bs-display="static"` alone prevents clipping inside `.table-responsive` — it doesn't. That skill-doc fix landed separately on `master` directly (per this repo's convention that skill edits go straight to master).

## Changes
- `src/groups/views/group-view.php` — `#membersTable` wrapper switched to `style="overflow: visible;"`
- `src/event/views/types-list.php` — `#eventTypesTable` wrapper switched to `style="overflow: visible;"`

## Testing
- `php -l` passed on both files
- Manual review against the corrected `table-action-menu.md` reference examples