### PR TITLE
Scope npm run build:php to changed files, keep full scan in CI

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
 #
-# ChurchCRM pre-commit hook — checks translatable strings staged in this
-# commit against the i18n rules in .agents/skills/churchcrm/i18n-localization.md
-# (no trailing colon, no HTML/markup, no decorative wrapper punctuation baked
-# into gettext()/i18next.t() calls).
+# ChurchCRM pre-commit hook — runs two fast, scoped checks on what's actually
+# staged in this commit (not the whole repo):
+#   1. Translatable-string rules in .agents/skills/churchcrm/i18n-localization.md
+#      (no trailing colon, no HTML/markup, no decorative wrapper punctuation
+#      baked into gettext()/i18next.t() calls).
+#   2. PHP syntax (`php -l`) on changed .php files only. The full 700+ file
+#      scan (`npm run build:php:validate:all`) still runs in CI — this is
+#      just a fast local guard so a typo isn't caught 10 minutes later in CI.
 #
 # Enabled automatically by `npm install` (the `prepare` script in
 # package.json points core.hooksPath at this directory). To bypass for
@@ -33,4 +37,16 @@ if ! node scripts/locale-check.js --staged; then
 fi
 
 echo "✓ pre-commit: locale-check passed."
+
+echo "→ pre-commit: validating changed PHP files (npm run build:php:validate)…"
+
+if ! npm run --silent build:php:validate; then
+    echo ""
+    echo "✘ pre-commit: PHP syntax error in a changed file."
+    echo "  Fix the error above and re-stage, or bypass in an emergency with:"
+    echo "  git commit --no-verify (justify in PR)."
+    exit 1
+fi
+
+echo "✓ pre-commit: PHP syntax check passed."
 exit 0

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -157,7 +157,7 @@ jobs:
       run: npm run package
 
     - name: Validate PHP syntax
-      run: npm run build:php:validate
+      run: npm run build:php:validate:all
 
     - name: Build Docker images
       run: |

--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -95,7 +95,7 @@ jobs:
       run: npm run package
 
     - name: Validate PHP syntax
-      run: npm run build:php:validate
+      run: npm run build:php:validate:all
 
     - name: Build Docker images
       env:

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
         "deploy:clean": "run-s preinstall build",
         "build:signatures": "node scripts/generate-signatures-node.js",
         "build:php:validate": "node scripts/validate-php-syntax.js",
+        "build:php:validate:all": "node scripts/validate-php-syntax.js --all",
         "format:web": "biome format --write .",
         "locale:audit": "node locale/scripts/locale-audit.js",
         "locale:build": "node locale/scripts/locale-build.js",

--- a/scripts/validate-php-syntax.js
+++ b/scripts/validate-php-syntax.js
@@ -4,6 +4,8 @@ const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
 
+const fullScan = process.argv.includes('--all');
+
 console.log('🔍 PHP Syntax Validation');
 console.log('========================\n');
 
@@ -35,14 +37,59 @@ if (!signatures.files || !Array.isArray(signatures.files)) {
 
 console.log(`📋 Found ${signatures.files.length} files in signatures\n`);
 
-const phpFiles = signatures.files
+let phpFiles = signatures.files
     .map((f) => (typeof f === 'string' ? f : f.filename))
     .filter((f) => f.endsWith('.php') && !f.includes('/vendor/') && !f.startsWith('vendor/'))
     .map((f) => path.join(srcDir, f.replace(/\//g, path.sep)));
 
+// By default, only validate files that actually changed (staged, unstaged, or
+// committed-but-unmerged vs the base branch). Full-repo scans belong in CI
+// (`npm run build:php:validate:all`) — running php -l on 700+ files on every
+// local build/commit is overkill for a diff touching a handful of files.
+if (!fullScan) {
+    const repoRoot = path.join(__dirname, '..');
+    const runGit = (args) => {
+        try {
+            return execSync(`git ${args}`, { cwd: repoRoot, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] })
+                .split('\n')
+                .map((l) => l.trim())
+                .filter(Boolean);
+        } catch {
+            return null;
+        }
+    };
+
+    const mergeBase =
+        runGit('merge-base HEAD origin/master')?.[0] || runGit('merge-base HEAD master')?.[0] || null;
+
+    const changedLists = [
+        mergeBase ? runGit(`diff --name-only ${mergeBase} HEAD`) : null,
+        runGit('diff --name-only HEAD'),
+        runGit('ls-files --others --exclude-standard'),
+    ];
+
+    if (changedLists.every((l) => l === null)) {
+        console.log('⚠️  Not a git repo (or git unavailable) — falling back to full scan.\n');
+    } else {
+        const changedSet = new Set(
+            changedLists
+                .filter(Boolean)
+                .flat()
+                .map((f) => path.join(repoRoot, f))
+        );
+        phpFiles = phpFiles.filter((f) => changedSet.has(f));
+        console.log(`🔎 Scoped run: checking ${phpFiles.length} changed PHP file(s) (use --all for a full scan)\n`);
+    }
+}
+
 let errors = 0;
 let validated = 0;
 let notFound = 0;
+
+if (phpFiles.length === 0) {
+    console.log('✨ No changed PHP files to validate.');
+    process.exit(0);
+}
 
 for (const filePath of phpFiles) {
     if (!fs.existsSync(filePath)) {


### PR DESCRIPTION
## Summary
- `npm run build:php` ran `php -l` on all 700+ tracked PHP files on every local build/commit — overkill for a diff touching a handful of files.
- Default `build:php:validate` now checks only files changed vs the merge-base with `origin/master`, plus uncommitted/untracked changes.
- Adds `build:php:validate:all` (and updates both CI workflows to call it) so CI keeps validating the entire repo as the real safety net — nothing removed from CI coverage.
- Wires the scoped check into `.githooks/pre-commit` so a syntax typo is caught locally before it ever reaches CI, without waiting ~1-2 minutes for a full scan on every commit.

## Why
Local build/commit feedback loop was slower than necessary. The full-repo scan is still exactly as thorough — it just now runs in CI (`build:php:validate:all`) instead of on every local invocation.

## Changes
- `scripts/validate-php-syntax.js` — accepts `--all` for full scan; default scopes to changed files via git diff
- `package.json` — new `build:php:validate:all` script
- `.github/workflows/build-test-package.yml`, `.github/workflows/upgrade-tests.yml` — call `build:php:validate:all` to preserve full CI coverage
- `.githooks/pre-commit` — runs the scoped check alongside the existing locale-check

## Testing
- Ran the scoped validator locally — correctly reports 0 changed files on a clean branch, and only the touched files on a dirty one
- `npm run lint` passes