### PR TITLE
test: fix empty-cart assertion in cart-to-group spec

### DIFF
--- a/cypress/e2e/ui/groups/standard.cart-to-group.spec.js
+++ b/cypress/e2e/ui/groups/standard.cart-to-group.spec.js
@@ -77,7 +77,7 @@ describe("Standard Groups - Cart to Group", () => {
 
         cy.visit("/groups/cart-to-group");
 
-        cy.contains("Your cart is empty!").should("be.visible");
+        cy.contains("Your cart is empty").should("be.visible");
         cy.contains("Add people to your cart first").should("be.visible");
     });
 });


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

The `shows empty-cart state when cart has no members` test was failing because it asserted:
`cy.contains("Your cart is empty!")`

But the view (`src/groups/views/cart-to-group.php`) renders `gettext('Your cart is empty')` — no exclamation mark. This string is canonical across 40+ locale translation files.

**Fix**: remove the spurious `!` from the test assertion so it matches the actual rendered heading.

**Root cause**: typo in the test; no source code change required.

**Validation**:
- Biome lint: 2 pre-existing warnings in unrelated webpack files, no errors
- Webpack build: passes cleanly
- PHP build: not runnable (PHP not installed in sandbox — pre-existing environment constraint)
- Reviewer: approved