### PR TITLE
Fix multiple stored/reflected XSS advisories in shared views and headers

### DIFF
--- a/src/Include/Footer.php
+++ b/src/Include/Footer.php
@@ -129,7 +129,7 @@ $isAdmin = AuthenticationManager::getCurrentUser()->isAdmin();
 <?php if (isset($sGlobalMessage) && !empty($sGlobalMessage)) { ?>
     <script nonce="<?= SystemURLs::getCSPNonce() ?>">
         $("document").ready(function () {
-            showGlobalMessage("<?= $sGlobalMessage ?>","<?= $sGlobalMessageClass ?>");
+            showGlobalMessage(<?= json_encode($sGlobalMessage) ?>, <?= json_encode($sGlobalMessageClass) ?>);
         });
     </script>
 <?php } ?>

--- a/src/Include/Header-HTML-Scripts.php
+++ b/src/Include/Header-HTML-Scripts.php
@@ -1,9 +1,10 @@
 <?php
 
 use ChurchCRM\dto\SystemURLs;
+use ChurchCRM\Utils\InputUtils;
 
 ?>
-<title>ChurchCRM: <?= $sPageTitle ?></title>
+<title>ChurchCRM: <?= InputUtils::escapeHTML($sPageTitle) ?></title>
 
 <link rel="icon" href="<?= SystemURLs::getRootPath() ?>/favicon.ico" type="image/x-icon">
 

--- a/src/Include/Header.php
+++ b/src/Include/Header.php
@@ -422,9 +422,9 @@ $MenuFirst = 1;
               </li>
               <?php foreach ($aBreadcrumbs as $crumb) : ?>
                 <?php if (!empty($crumb['active'])) : ?>
-              <li class="breadcrumb-item active" aria-current="page"><?= $crumb['label'] ?></li>
+              <li class="breadcrumb-item active" aria-current="page"><?= InputUtils::escapeHTML($crumb['label']) ?></li>
                 <?php else : ?>
-              <li class="breadcrumb-item"><a href="<?= $crumb['url'] ?>"><?= $crumb['label'] ?></a></li>
+              <li class="breadcrumb-item"><a href="<?= InputUtils::escapeAttribute($crumb['url']) ?>"><?= InputUtils::escapeHTML($crumb['label']) ?></a></li>
                 <?php endif; ?>
               <?php endforeach; ?>
             </ol>
@@ -439,9 +439,9 @@ $MenuFirst = 1;
         <?php endif; ?>
         <div class="row g-2 align-items-center">
           <div class="col">
-            <h2 class="page-title"><?= $sPageTitle ?></h2>
+            <h2 class="page-title"><?= InputUtils::escapeHTML($sPageTitle) ?></h2>
             <?php if (!empty($sPageSubtitle)) : ?>
-            <div class="text-body-secondary mt-1"><?= $sPageSubtitle ?></div>
+            <div class="text-body-secondary mt-1"><?= InputUtils::escapeHTML($sPageSubtitle) ?></div>
             <?php endif; ?>
           </div>
         </div>

--- a/src/Include/HeaderNotLoggedIn.php
+++ b/src/Include/HeaderNotLoggedIn.php
@@ -32,7 +32,7 @@ $localeInfo = Bootstrapper::getCurrentLocale(); // always returns a LocaleInfo o
 
     <script src="<?= SystemURLs::assetVersioned('/skin/external/moment/moment.min.js') ?>"></script>
 
-    <title>ChurchCRM: <?= $sPageTitle ?></title>
+    <title>ChurchCRM: <?= InputUtils::escapeHTML($sPageTitle) ?></title>
 
     <?= PluginManager::getPluginHeadContent() ?>
 

--- a/src/PledgeDetails.php
+++ b/src/PledgeDetails.php
@@ -49,7 +49,7 @@ if ($resArr) {
 
 <div class="card">
   <div class="card-body">
-    <form method="post" action="PledgeDetails.php?<?= 'PledgeID=' . $iPledgeID . '&linkBack=' . $linkBack ?>" name="PledgeDelete">
+    <form method="post" action="PledgeDetails.php?<?= 'PledgeID=' . $iPledgeID . '&linkBack=' . InputUtils::escapeAttribute($linkBack) ?>" name="PledgeDelete">
       <input type="submit" class="btn btn-secondary" value="<?= gettext('Back') ?>" name="Back">
     </form>
   </div>

--- a/src/SelectDelete.php
+++ b/src/SelectDelete.php
@@ -75,7 +75,7 @@ require_once __DIR__ . '/Include/Header.php';
             echo '<p class="lead">' . gettext('WARNING: This family has records of donations and may NOT be deleted until these donations are associated with another family.') . '</p>';
             echo '<form name=SelectFamily method=get action=SelectDelete.php>';
             echo '<div class="card-body">';
-            echo '<div class="card-header"><strong>' . gettext('Family Name') . ':' ." $fam_Name</strong></div>";
+            echo '<div class="card-header"><strong>' . gettext('Family Name') . ':' . ' ' . InputUtils::escapeHTML($fam_Name) . '</strong></div>';
             echo '<p>' . gettext('Please select another family with whom to associate these donations') . ':';
             echo '<br><b>' . gettext('WARNING: This action can not be undone and may have legal implications!') . '</b></p>';
             echo"<input name=FamilyID value=$iFamilyID type=hidden>";

--- a/src/WhyCameEditor.php
+++ b/src/WhyCameEditor.php
@@ -86,7 +86,7 @@ require_once __DIR__ . '/Include/Header.php';
     </h5>
   </div>
   <div class="card-body">
-    <form method="post" action="WhyCameEditor.php?<?= 'PersonID=' . $iPerson . '&WhyCameID=' . $iWhyCameID . '&linkBack=' . $linkBack ?>" name="WhyCameEditor">
+    <form method="post" action="WhyCameEditor.php?<?= 'PersonID=' . $iPerson . '&WhyCameID=' . $iWhyCameID . '&linkBack=' . InputUtils::escapeAttribute($linkBack) ?>" name="WhyCameEditor">
       <div class="mb-3">
         <label class="form-label"><?= gettext('Why did you come to the church?') ?></label>
         <textarea name="Join" class="form-control" rows="3"><?= InputUtils::escapeHTML($tJoin) ?></textarea>

--- a/src/people/views/family-view.php
+++ b/src/people/views/family-view.php
@@ -426,7 +426,7 @@ $canEditRecords = AuthenticationManager::getCurrentUser()->isEditRecordsEnabled(
             </div>
             <div class="card-body">
                 <a href="https://maps.google.com/?q=<?= urlencode($familyAddress) ?>"
-                   target="_blank" rel="noopener noreferrer"><?= $familyAddress ?></a>
+                   target="_blank" rel="noopener noreferrer"><?= InputUtils::escapeHTML($familyAddress) ?></a>
                 <?php
                 $directionsUrl = $family->getDirectionsUrl();
                 $appleDirectionsUrl = $family->getAppleMapsDirectionsUrl();
@@ -435,7 +435,7 @@ $canEditRecords = AuthenticationManager::getCurrentUser()->isEditRecordsEnabled(
                     <?php if (!empty($directionsUrl) || !empty($appleDirectionsUrl)) : ?>
                     <div class="btn-group directions-btn-group">
                         <?php if (!empty($directionsUrl)) : ?>
-                        <a href="<?= $directionsUrl ?>" target="_blank" rel="noopener noreferrer"
+                        <a href="<?= InputUtils::escapeAttribute($directionsUrl) ?>" target="_blank" rel="noopener noreferrer"
                            class="btn btn-sm btn-outline-primary">
                             <i class="fa-solid fa-diamond-turn-right me-1"></i><?= gettext('Get Directions') ?>
                         </a>
@@ -448,11 +448,11 @@ $canEditRecords = AuthenticationManager::getCurrentUser()->isEditRecordsEnabled(
                         </button>
                         <div class="dropdown-menu directions-provider-menu d-none">
                             <?php if (!empty($directionsUrl)) : ?>
-                            <a class="dropdown-item" href="<?= $directionsUrl ?>" target="_blank" rel="noopener noreferrer">
+                            <a class="dropdown-item" href="<?= InputUtils::escapeAttribute($directionsUrl) ?>" target="_blank" rel="noopener noreferrer">
                                 <i class="fa-brands fa-google me-2"></i><?= gettext('Open in Google Maps') ?>
                             </a>
                             <?php endif; ?>
-                            <a class="dropdown-item apple-maps-option" href="<?= $appleDirectionsUrl ?>" target="_blank" rel="noopener noreferrer">
+                            <a class="dropdown-item apple-maps-option" href="<?= InputUtils::escapeAttribute($appleDirectionsUrl) ?>" target="_blank" rel="noopener noreferrer">
                                 <i class="fa-brands fa-apple me-2"></i><?= gettext('Open in Apple Maps') ?>
                             </a>
                         </div>

--- a/src/people/views/person-view.php
+++ b/src/people/views/person-view.php
@@ -119,7 +119,7 @@ $fam_Longitude      = (float) ($personData['fam_Longitude'] ?? 0);
                         <?php if ($sCellPhone) : ?>
                         <li class="mb-2">
                             <i class="fa-solid fa-mobile-screen me-2 text-body-secondary"></i>
-                            <a href="tel:<?= InputUtils::escapeAttribute($sCellPhoneUnformatted) ?>"><?= $sCellPhone ?></a>
+                            <a href="tel:<?= InputUtils::escapeAttribute($sCellPhoneUnformatted) ?>"><?= InputUtils::escapeHTML($sCellPhone) ?></a>
                             <a href="sms:<?= InputUtils::escapeAttribute(preg_replace('/[^\d+]/', '', $sCellPhoneUnformatted)) ?>"
                                class="ms-1 text-body-secondary" title="<?= gettext('Send text message') ?>">
                                 <i class="fa-solid fa-comment-sms"></i>
@@ -135,7 +135,7 @@ $fam_Longitude      = (float) ($personData['fam_Longitude'] ?? 0);
                         <?php if ($sHomePhone) : ?>
                         <li class="mb-2">
                             <i class="fa-solid fa-house me-2 text-body-secondary"></i>
-                            <a href="tel:<?= InputUtils::escapeAttribute($sHomePhoneUnformatted) ?>"><?= $sHomePhone ?></a>
+                            <a href="tel:<?= InputUtils::escapeAttribute($sHomePhoneUnformatted) ?>"><?= InputUtils::escapeHTML($sHomePhone) ?></a>
                             <button class="btn btn-sm btn-ghost-secondary ms-1 copy-phone-btn" type="button"
                                     data-phone="<?= InputUtils::escapeAttribute($sHomePhone) ?>"
                                     title="<?= gettext('Copy to clipboard') ?>">
@@ -147,7 +147,7 @@ $fam_Longitude      = (float) ($personData['fam_Longitude'] ?? 0);
                         <?php if ($sWorkPhone) : ?>
                         <li class="mb-2">
                             <i class="fa-solid fa-briefcase me-2 text-body-secondary"></i>
-                            <a href="tel:<?= InputUtils::escapeAttribute($sWorkPhoneUnformatted) ?>"><?= $sWorkPhone ?></a>
+                            <a href="tel:<?= InputUtils::escapeAttribute($sWorkPhoneUnformatted) ?>"><?= InputUtils::escapeHTML($sWorkPhone) ?></a>
                             <button class="btn btn-sm btn-ghost-secondary ms-1 copy-phone-btn" type="button"
                                     data-phone="<?= InputUtils::escapeAttribute($sWorkPhone) ?>"
                                     title="<?= gettext('Copy to clipboard') ?>">
@@ -168,7 +168,7 @@ $fam_Longitude      = (float) ($personData['fam_Longitude'] ?? 0);
                         <?php if (!empty($sEmail)) : ?>
                         <li class="mb-2">
                             <i class="fa-solid fa-at me-2 text-body-secondary"></i>
-                            <a href="mailto:<?= InputUtils::escapeAttribute($sUnformattedEmail) ?>" target="_blank" rel="noopener noreferrer"><?= $sEmail ?></a>
+                            <a href="mailto:<?= InputUtils::escapeAttribute($sUnformattedEmail) ?>" target="_blank" rel="noopener noreferrer"><?= InputUtils::escapeHTML($sEmail) ?></a>
                             <button class="btn btn-sm btn-ghost-secondary ms-1 copy-email-btn" type="button"
                                     data-email="<?= InputUtils::escapeAttribute($sUnformattedEmail) ?>"
                                     title="<?= gettext('Copy to clipboard') ?>">


### PR DESCRIPTION
## Summary
Bundles fixes for six related XSS advisories, all following the same output-escaping-at-sink pattern:

- **GHSA-864x-m2jj-h957** — Stored XSS via unescaped page title/subtitle/breadcrumb in `Header.php` (and sibling header templates)
- **GHSA-f8vm-66mm-9f4c** — Stored XSS via unescaped family name in `SelectDelete.php`
- **GHSA-6m8p-xqqp-v872** — Stored XSS via unescaped family address/directions links in `family-view.php`
- **GHSA-wppr-wvw2-hxw6** — Stored XSS via unescaped phone/email anchor text in `person-view.php`
- **GHSA-9gpc-c4mc-w24j** — Reflected XSS via unescaped `linkBack` GET param in form `action` attribute (`WhyCameEditor.php`, `PledgeDetails.php`)
- **GHSA-82rp-5vf3-pc5r** — Reflected XSS via unescaped `AllPDFsEmailed` GET param injected into a JS string literal (`Footer.php`)

Each advisory reports the same root cause class: a value flows from the database or request into HTML/JS output without encoding at the sink. No caller changes were required for any of the six — all fixes are one-line encoding wraps at the existing output points.

## Changes
- `src/Include/Header.php` — escape breadcrumb label/url, page title, page subtitle
- `src/Include/HeaderNotLoggedIn.php`, `src/Include/Header-HTML-Scripts.php` — escape page title in `<title>` tag
- `src/SelectDelete.php` — escape family name in card header
- `src/people/views/family-view.php` — escape family address (body) and directions URLs (href, both Google/Apple variants)
- `src/people/views/person-view.php` — escape cell/home/work phone and email anchor text
- `src/WhyCameEditor.php`, `src/PledgeDetails.php` — escape `linkBack` in form `action` attribute
- `src/Include/Footer.php` — replace raw string interpolation with `json_encode()` for values passed into the inline `showGlobalMessage()` script call

## Why
All six are confirmed-valid CWE-79 stored/reflected XSS findings from GitHub security advisory triage. The fix follows the established project pattern: encode at the output sink (`InputUtils::escapeHTML()` for HTML body, `InputUtils::escapeAttribute()` for attributes, `json_encode()` for values embedded in `<script>` blocks) rather than relying on write-time sanitization, since these values can originate from multiple write paths (UI forms, CSV import, API writes) that don't uniformly sanitize.

## Files Changed
- `src/Include/Header.php`
- `src/Include/HeaderNotLoggedIn.php`
- `src/Include/Header-HTML-Scripts.php`
- `src/SelectDelete.php`
- `src/people/views/family-view.php`
- `src/people/views/person-view.php`
- `src/WhyCameEditor.php`
- `src/PledgeDetails.php`
- `src/Include/Footer.php`

## Testing
- `php -l` — no syntax errors on all changed files
- `npm run build:php` — all changed files pass syntax validation
- `npm run lint` — 0 errors (2 pre-existing unrelated warnings in `webpack/event-form.js` and `webpack/localization.js`)

## Related Issues
Fixes GHSA-864x-m2jj-h957, GHSA-f8vm-66mm-9f4c, GHSA-6m8p-xqqp-v872, GHSA-wppr-wvw2-hxw6, GHSA-9gpc-c4mc-w24j, GHSA-82rp-5vf3-pc5r