### PR TITLE
fix: remove MariaDB-only IF NOT EXISTS from ALTER TABLE ADD COLUMN/INDEX

### DIFF
--- a/src/mysql/upgrade/6.7.0.sql
+++ b/src/mysql/upgrade/6.7.0.sql
@@ -1,5 +1,5 @@
--- Add order column to donation funds table for custom sorting (IF NOT EXISTS for idempotency)
-ALTER TABLE donationfund_fun ADD COLUMN IF NOT EXISTS fun_Order INT NOT NULL DEFAULT 0 AFTER fun_Description;
+-- Add order column to donation funds table for custom sorting
+ALTER TABLE donationfund_fun ADD COLUMN fun_Order INT NOT NULL DEFAULT 0 AFTER fun_Description;
 
 -- Initialize order values based on current fund IDs
 SET @row_number = 0;

--- a/src/mysql/upgrade/6.7.0.sql
+++ b/src/mysql/upgrade/6.7.0.sql
@@ -1,4 +1,6 @@
--- Add order column to donation funds table for custom sorting
+-- Add order column to donation funds table for custom sorting.
+-- Plain ALTER TABLE (no IF NOT EXISTS): that clause is MariaDB-only; the version-gated
+-- upgrade runner guarantees this script never runs on a DB that already has this column.
 ALTER TABLE donationfund_fun ADD COLUMN fun_Order INT NOT NULL DEFAULT 0 AFTER fun_Description;
 
 -- Initialize order values based on current fund IDs

--- a/src/mysql/upgrade/7.4.3-manage-fundraisers.sql
+++ b/src/mysql/upgrade/7.4.3-manage-fundraisers.sql
@@ -2,8 +2,8 @@
 -- Grants users the ability to access and manage fundraiser pages.
 -- Admins always retain access regardless of this flag.
 --
--- IF NOT EXISTS is required for idempotency: Install.sql already includes
--- this column, so applying this migration on a fresh install (where the
--- upgrade runner applies all scripts after Install.sql) would otherwise
--- fail with "Duplicate column name 'usr_ManageFundraisers'".
-ALTER TABLE `user_usr` ADD COLUMN IF NOT EXISTS `usr_ManageFundraisers` tinyint(1) unsigned NOT NULL DEFAULT 0 AFTER `usr_Finance`;
+-- Note: plain ALTER TABLE (no IF NOT EXISTS) is safe here because the upgrade
+-- runner is version-gated: fresh installs set the DB version to the current
+-- release via installChurchCRMSchema() and never execute historical migration
+-- scripts. IF NOT EXISTS is a MariaDB-only extension unsupported by MySQL.
+ALTER TABLE `user_usr` ADD COLUMN `usr_ManageFundraisers` tinyint(1) unsigned NOT NULL DEFAULT 0 AFTER `usr_Finance`;

--- a/src/mysql/upgrade/pre-6.0.0-consolidated.sql
+++ b/src/mysql/upgrade/pre-6.0.0-consolidated.sql
@@ -31,8 +31,8 @@
 
 -- ===== from 2.0.0.sql =====
 
-ALTER TABLE version_ver ADD COLUMN IF NOT EXISTS `ver_update_start` datetime DEFAULT NULL;
-ALTER TABLE version_ver ADD COLUMN IF NOT EXISTS `ver_update_end` datetime DEFAULT NULL;
+ALTER TABLE version_ver ADD COLUMN `ver_update_start` datetime DEFAULT NULL;
+ALTER TABLE version_ver ADD COLUMN `ver_update_end` datetime DEFAULT NULL;
 ALTER TABLE version_ver DROP COLUMN IF EXISTS `ver_date`;
 
 DELETE FROM config_cfg WHERE cfg_id IN (2, 4, 15, 17, 24, 32, 35, 999);
@@ -54,7 +54,7 @@ UPDATE user_usr SET usr_Style = 'skin-blue';
 
 -- ===== from 2.1.0.sql =====
 
-ALTER TABLE note_nte ADD COLUMN IF NOT EXISTS nte_Type VARCHAR(45) NOT NULL DEFAULT 'note' AFTER nte_EditedBy;
+ALTER TABLE note_nte ADD COLUMN nte_Type VARCHAR(45) NOT NULL DEFAULT 'note' AFTER nte_EditedBy;
 
 -- Back-fill create/edit timeline notes for existing persons and families.
 INSERT IGNORE INTO note_nte
@@ -125,7 +125,7 @@ ALTER TABLE group_grp MODIFY grp_hasSpecialProps BOOLEAN;
 ALTER TABLE `config_cfg`
 MODIFY `cfg_type` ENUM('text','number','date','boolean','textarea','json','choice') NOT NULL default 'text';
 
-ALTER TABLE `config_cfg` ADD COLUMN IF NOT EXISTS `cfg_data` text default NULL;
+ALTER TABLE `config_cfg` ADD COLUMN `cfg_data` text default NULL;
 
 UPDATE `config_cfg` SET `cfg_data` = '{"Choices":["smtp","SendMail"]}',    `cfg_type` = 'choice' WHERE `cfg_id` = 25;
 UPDATE `config_cfg` SET `cfg_data` = '{"Choices":["miles","kilometers"]}',  `cfg_type` = 'choice' WHERE `cfg_id` = 64;
@@ -225,8 +225,8 @@ ALTER TABLE config_cfg DROP COLUMN IF EXISTS `cfg_default`;
 
 -- ===== from 2.7.0.sql =====
 
-ALTER TABLE group_grp ADD COLUMN IF NOT EXISTS grp_active               BOOLEAN DEFAULT 1 NOT NULL AFTER grp_hasSpecialProps;
-ALTER TABLE group_grp ADD COLUMN IF NOT EXISTS grp_include_email_export BOOLEAN DEFAULT 1 NOT NULL AFTER grp_active;
+ALTER TABLE group_grp ADD COLUMN grp_active               BOOLEAN DEFAULT 1 NOT NULL AFTER grp_hasSpecialProps;
+ALTER TABLE group_grp ADD COLUMN grp_include_email_export BOOLEAN DEFAULT 1 NOT NULL AFTER grp_active;
 
 ALTER TABLE queryparameteroptions_qpo MODIFY qpo_Value VARCHAR(255) NOT NULL DEFAULT '';
 
@@ -238,7 +238,7 @@ WHERE qry_ID = 15;
 
 DELETE FROM userconfig_ucfg WHERE ucfg_name IN ('sFromEmailAddress', 'sFromName', 'bSendPHPMail');
 
-ALTER TABLE event_attend ADD COLUMN IF NOT EXISTS attend_id INT PRIMARY KEY AUTO_INCREMENT FIRST;
+ALTER TABLE event_attend ADD COLUMN attend_id INT PRIMARY KEY AUTO_INCREMENT FIRST;
 
 
 -- ===== from 2.8.0.sql =====
@@ -271,7 +271,7 @@ CREATE TABLE `kioskassginment_kasm` (
   UNIQUE KEY `kasm_ID` (`kasm_ID`)
 ) ENGINE=MyISAM CHARACTER SET utf8 COLLATE utf8_unicode_ci;
 
-ALTER TABLE event_types ADD COLUMN IF NOT EXISTS type_grpid mediumint(9) AFTER type_active;
+ALTER TABLE event_types ADD COLUMN type_grpid mediumint(9) AFTER type_active;
 
 ALTER TABLE `tokens` CHANGE COLUMN `type` `type` VARCHAR(50);
 
@@ -297,8 +297,8 @@ UPDATE config_cfg SET cfg_name = 'aDisallowedPasswords'        WHERE cfg_name = 
 
 -- ===== from 2.9.0.sql =====
 
-ALTER TABLE person_per ADD COLUMN IF NOT EXISTS per_Twitter  varchar(50) default NULL AFTER per_Flags;
-ALTER TABLE person_per ADD COLUMN IF NOT EXISTS per_LinkedIn varchar(50) default NULL AFTER per_Twitter;
+ALTER TABLE person_per ADD COLUMN per_Twitter  varchar(50) default NULL AFTER per_Flags;
+ALTER TABLE person_per ADD COLUMN per_LinkedIn varchar(50) default NULL AFTER per_Twitter;
 
 ALTER TABLE person_custom_master ADD PRIMARY KEY (custom_Field);
 
@@ -310,15 +310,15 @@ ALTER TABLE person_custom_master ADD PRIMARY KEY (custom_Field);
 -- ===== from 2.10.0.sql =====
 
 -- AFTER clause omitted: event_grpid is not created in this consolidated script.
-ALTER TABLE events_event ADD COLUMN IF NOT EXISTS event_publicly_visible BOOLEAN DEFAULT FALSE;
+ALTER TABLE events_event ADD COLUMN event_publicly_visible BOOLEAN DEFAULT FALSE;
 
 
 -- ===== from 3.0.0.sql =====
 
-ALTER TABLE events_event ADD COLUMN IF NOT EXISTS location_id                 INT DEFAULT NULL AFTER `event_typename`;
-ALTER TABLE events_event ADD COLUMN IF NOT EXISTS primary_contact_person_id   INT DEFAULT NULL AFTER `location_id`;
-ALTER TABLE events_event ADD COLUMN IF NOT EXISTS secondary_contact_person_id INT DEFAULT NULL AFTER `primary_contact_person_id`;
-ALTER TABLE events_event ADD COLUMN IF NOT EXISTS event_url                   text DEFAULT NULL AFTER `secondary_contact_person_id`;
+ALTER TABLE events_event ADD COLUMN location_id                 INT DEFAULT NULL AFTER `event_typename`;
+ALTER TABLE events_event ADD COLUMN primary_contact_person_id   INT DEFAULT NULL AFTER `location_id`;
+ALTER TABLE events_event ADD COLUMN secondary_contact_person_id INT DEFAULT NULL AFTER `primary_contact_person_id`;
+ALTER TABLE events_event ADD COLUMN event_url                   text DEFAULT NULL AFTER `secondary_contact_person_id`;
 
 DROP TABLE IF EXISTS `event_audience`;
 CREATE TABLE `event_audience` (
@@ -366,8 +366,8 @@ CREATE TABLE IF NOT EXISTS `locations` (
 DROP TABLE IF EXISTS `church_location`;
 
 -- Split the original combined ALTER (ADD COLUMN + ADD UNIQUE INDEX) into two statements.
-ALTER TABLE user_usr ADD COLUMN IF NOT EXISTS usr_apiKey VARCHAR(255) AFTER usr_UserName;
-ALTER TABLE user_usr ADD UNIQUE INDEX IF NOT EXISTS `usr_apiKey_unique` (`usr_apiKey` ASC);
+ALTER TABLE user_usr ADD COLUMN usr_apiKey VARCHAR(255) AFTER usr_UserName;
+ALTER TABLE user_usr ADD UNIQUE INDEX `usr_apiKey_unique` (`usr_apiKey` ASC);
 
 DROP TABLE IF EXISTS menuconfig_mcf;
 
@@ -446,9 +446,9 @@ DEALLOCATE PREPARE _pre6_stmt;
 
 -- ===== from 4.0.0-TwoFactorAuth.sql =====
 
-ALTER TABLE user_usr ADD COLUMN IF NOT EXISTS usr_TwoFactorAuthSecret          VARCHAR(255) NULL AFTER `usr_Canvasser`;
-ALTER TABLE user_usr ADD COLUMN IF NOT EXISTS usr_TwoFactorAuthLastKeyTimestamp INT NULL AFTER `usr_TwoFactorAuthSecret`;
-ALTER TABLE user_usr ADD COLUMN IF NOT EXISTS usr_TwoFactorAuthRecoveryCodes    TEXT NULL AFTER `usr_TwoFactorAuthLastKeyTimestamp`;
+ALTER TABLE user_usr ADD COLUMN usr_TwoFactorAuthSecret          VARCHAR(255) NULL AFTER `usr_Canvasser`;
+ALTER TABLE user_usr ADD COLUMN usr_TwoFactorAuthLastKeyTimestamp INT NULL AFTER `usr_TwoFactorAuthSecret`;
+ALTER TABLE user_usr ADD COLUMN usr_TwoFactorAuthRecoveryCodes    TEXT NULL AFTER `usr_TwoFactorAuthLastKeyTimestamp`;
 
 
 -- ===== from 4.1.0-cleanup.sql =====
@@ -515,7 +515,7 @@ INSERT IGNORE INTO user_settings SELECT usr_per_ID, 'finance.FY',               
 
 -- ===== from 4.4.0-FB.sql =====
 
-ALTER TABLE person_per ADD COLUMN IF NOT EXISTS per_Facebook VARCHAR(50) NULL;
+ALTER TABLE person_per ADD COLUMN per_Facebook VARCHAR(50) NULL;
 
 
 -- ===== from 5.1.0.sql =====


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

## What changed and why

`ALTER TABLE … ADD COLUMN IF NOT EXISTS` and `ALTER TABLE … ADD UNIQUE INDEX IF NOT EXISTS` are **MariaDB-only extensions** (added in MariaDB 10.0.2). MySQL — which the setup page explicitly supports ("MySQL 5.7+ or MariaDB 10.2+") — rejects them with `ERROR 1064`, breaking upgrades on MySQL installs.

Removes the clause from all **20 affected statements** across three migration files:

| File | Statements fixed |
|---|---|
| `src/mysql/upgrade/pre-6.0.0-consolidated.sql` | 19× ADD COLUMN + 1× ADD UNIQUE INDEX |
| `src/mysql/upgrade/6.7.0.sql` | 1× ADD COLUMN |
| `src/mysql/upgrade/7.4.3-manage-fundraisers.sql` | 1× ADD COLUMN |

All other `IF NOT EXISTS` / `IF EXISTS` clauses (`DROP TABLE`, `DROP COLUMN`, `CREATE TABLE`, `DROP VIEW`) are MySQL-compatible and are **untouched**.

## Why the guard is safe to drop

The upgrade runner (`UpgradeService`) is **version-gated**: each entry in `upgrade.json` fires only when `getDBVersion()` matches the entry's `versions` array. Fresh installs call `installChurchCRMSchema()`, which writes the current release version to `version_ver` before any upgrade logic runs — so `isDBCurrent()` returns `true` immediately and no historical migration scripts ever execute on a newly installed database.

## Testing

- `grep -rn "ADD COLUMN IF NOT EXISTS\|ADD UNIQUE INDEX IF NOT EXISTS" src/mysql/upgrade/` — empty (verified)
- All MySQL-compatible `IF EXISTS` / `IF NOT EXISTS` clauses preserved (verified)
- `npm run lint` — passes (2 pre-existing warnings in unrelated JS files, 0 errors)