### PR TITLE
Add MySQL latest to upgrade-tests workflow matrix

### DIFF
--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -125,6 +125,7 @@ jobs:
   # Upgrade test: ChurchCRM 6.0.0 → current
   # Restores a 6.0.0 SQL snapshot, lets the bootstrapper auto-migrate, and
   # verifies login + API smoke checks.
+  # Matrix: php-version × database (mariadb, mysql)
   # ---------------------------------------------------------------------------
   test-upgrade-from-6:
     needs: [configure, build]
@@ -133,10 +134,14 @@ jobs:
       contents: read
       checks: write
     runs-on: ubuntu-latest
+    env:
+      # For the mysql leg, append the MySQL override compose file; empty for mariadb.
+      COMPOSE_MYSQL: ${{ matrix.database == 'mysql' && '-f docker/docker-compose.mysql.yaml' || '' }}
     strategy:
       fail-fast: false
       matrix:
         php-version: ${{ fromJSON(needs.configure.outputs.php-versions) }}
+        database: [mariadb, mysql]
     steps:
     - name: Checkout
       uses: actions/checkout@v7
@@ -168,7 +173,7 @@ jobs:
       run: rm -f src/Include/Config.php
 
     - name: Start Docker (upgrade from 6.0.0)
-      run: docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-new-system up -d
+      run: docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml $COMPOSE_MYSQL --profile ci-new-system up -d
 
     - name: Wait for server
       run: |
@@ -177,8 +182,8 @@ jobs:
         until curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8081/ | grep -q "302\|200"; do
           if [ $attempt -eq $max_attempts ]; then
             echo "Server failed to respond after $max_attempts attempts"
-            docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-new-system ps -a
-            docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-new-system logs
+            docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml $COMPOSE_MYSQL --profile ci-new-system ps -a
+            docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml $COMPOSE_MYSQL --profile ci-new-system logs
             exit 1
           fi
           echo "Attempt $attempt/$max_attempts — retrying in 5s..."
@@ -187,10 +192,10 @@ jobs:
         done
         echo "Server ready."
 
-    - name: Run Cypress upgrade test (6.0.0 → current, PHP ${{ matrix.php-version }})
+    - name: Run Cypress upgrade test (6.0.0 → current, PHP ${{ matrix.php-version }}, ${{ matrix.database }})
       uses: cypress-io/github-action@v7
       with:
-        command: npx cypress run --config-file cypress/configs/upgrade.config.ts --headless --browser electron --reporter junit --reporter-options mochaFile=cypress/reports/junit-php${{ matrix.php-version }}-upgrade-6-[hash].xml
+        command: npx cypress run --config-file cypress/configs/upgrade.config.ts --headless --browser electron --reporter junit --reporter-options mochaFile=cypress/reports/junit-php${{ matrix.php-version }}-${{ matrix.database }}-upgrade-6-[hash].xml
       env:
         CYPRESS_UPGRADE_SQL_FILE: cypress/fixtures/upgrade/churchcrm-6.0.0.sql
         CYPRESS_UPGRADE_ADMIN_USER: Admin
@@ -200,15 +205,15 @@ jobs:
       if: failure()
       run: |
         mkdir -p cypress/logs/docker cypress/logs/php
-        docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-new-system logs > cypress/logs/docker/docker-compose-php${{ matrix.php-version }}-upgrade-6.log 2>&1 || true
-        docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-new-system ps -a >> cypress/logs/docker/docker-compose-php${{ matrix.php-version }}-upgrade-6.log 2>&1 || true
+        docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml $COMPOSE_MYSQL --profile ci-new-system logs > cypress/logs/docker/docker-compose-php${{ matrix.php-version }}-${{ matrix.database }}-upgrade-6.log 2>&1 || true
+        docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml $COMPOSE_MYSQL --profile ci-new-system ps -a >> cypress/logs/docker/docker-compose-php${{ matrix.php-version }}-${{ matrix.database }}-upgrade-6.log 2>&1 || true
         [ -d src/logs ] && cp -r src/logs cypress/logs/php/ || true
 
     - name: Upload debug artifacts
       if: always()
       uses: actions/upload-artifact@v7
       with:
-        name: cypress-artifacts-php${{ matrix.php-version }}-upgrade-6-${{ github.run_id }}
+        name: cypress-artifacts-php${{ matrix.php-version }}-${{ matrix.database }}-upgrade-6-${{ github.run_id }}
         path: |
           cypress/logs
           cypress/screenshots
@@ -220,8 +225,8 @@ jobs:
       uses: dorny/test-reporter@v3
       if: always()
       with:
-        name: 'PHP ${{ matrix.php-version }}: Upgrade from 6.0.0'
-        path: cypress/reports/junit-php${{ matrix.php-version }}-upgrade-6-*.xml
+        name: 'PHP ${{ matrix.php-version }} / ${{ matrix.database }}: Upgrade from 6.0.0'
+        path: cypress/reports/junit-php${{ matrix.php-version }}-${{ matrix.database }}-upgrade-6-*.xml
         reporter: java-junit
         fail-on-error: true
         fail-on-empty: false
@@ -239,6 +244,7 @@ jobs:
   # Restores a ChurchInfo 1.3.1 SQL snapshot (MD5 password hashes), lets the
   # bootstrapper auto-migrate, and verifies login (MD5→bcrypt migration) +
   # API smoke checks. Requires User::isPasswordValid() MD5 support (this PR).
+  # Matrix: php-version × database (mariadb, mysql)
   # ---------------------------------------------------------------------------
   test-upgrade-from-churchinfo:
     needs: [configure, build]
@@ -247,10 +253,14 @@ jobs:
       contents: read
       checks: write
     runs-on: ubuntu-latest
+    env:
+      # For the mysql leg, append the MySQL override compose file; empty for mariadb.
+      COMPOSE_MYSQL: ${{ matrix.database == 'mysql' && '-f docker/docker-compose.mysql.yaml' || '' }}
     strategy:
       fail-fast: false
       matrix:
         php-version: ${{ fromJSON(needs.configure.outputs.php-versions) }}
+        database: [mariadb, mysql]
     steps:
     - name: Checkout
       uses: actions/checkout@v7
@@ -282,7 +292,7 @@ jobs:
       run: rm -f src/Include/Config.php
 
     - name: Start Docker (upgrade from ChurchInfo)
-      run: docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-new-system up -d
+      run: docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml $COMPOSE_MYSQL --profile ci-new-system up -d
 
     - name: Wait for server
       run: |
@@ -291,8 +301,8 @@ jobs:
         until curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8081/ | grep -q "302\|200"; do
           if [ $attempt -eq $max_attempts ]; then
             echo "Server failed to respond after $max_attempts attempts"
-            docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-new-system ps -a
-            docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-new-system logs
+            docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml $COMPOSE_MYSQL --profile ci-new-system ps -a
+            docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml $COMPOSE_MYSQL --profile ci-new-system logs
             exit 1
           fi
           echo "Attempt $attempt/$max_attempts — retrying in 5s..."
@@ -301,10 +311,10 @@ jobs:
         done
         echo "Server ready."
 
-    - name: Run Cypress upgrade test (ChurchInfo 1.3.1 → current, PHP ${{ matrix.php-version }})
+    - name: Run Cypress upgrade test (ChurchInfo 1.3.1 → current, PHP ${{ matrix.php-version }}, ${{ matrix.database }})
       uses: cypress-io/github-action@v7
       with:
-        command: npx cypress run --config-file cypress/configs/upgrade.config.ts --headless --browser electron --reporter junit --reporter-options mochaFile=cypress/reports/junit-php${{ matrix.php-version }}-upgrade-churchinfo-[hash].xml
+        command: npx cypress run --config-file cypress/configs/upgrade.config.ts --headless --browser electron --reporter junit --reporter-options mochaFile=cypress/reports/junit-php${{ matrix.php-version }}-${{ matrix.database }}-upgrade-churchinfo-[hash].xml
       env:
         CYPRESS_UPGRADE_SQL_FILE: cypress/fixtures/upgrade/churchinfo-1.3.1.sql
         CYPRESS_UPGRADE_ADMIN_USER: Admin
@@ -315,15 +325,15 @@ jobs:
       if: failure()
       run: |
         mkdir -p cypress/logs/docker cypress/logs/php
-        docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-new-system logs > cypress/logs/docker/docker-compose-php${{ matrix.php-version }}-upgrade-churchinfo.log 2>&1 || true
-        docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-new-system ps -a >> cypress/logs/docker/docker-compose-php${{ matrix.php-version }}-upgrade-churchinfo.log 2>&1 || true
+        docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml $COMPOSE_MYSQL --profile ci-new-system logs > cypress/logs/docker/docker-compose-php${{ matrix.php-version }}-${{ matrix.database }}-upgrade-churchinfo.log 2>&1 || true
+        docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml $COMPOSE_MYSQL --profile ci-new-system ps -a >> cypress/logs/docker/docker-compose-php${{ matrix.php-version }}-${{ matrix.database }}-upgrade-churchinfo.log 2>&1 || true
         [ -d src/logs ] && cp -r src/logs cypress/logs/php/ || true
 
     - name: Upload debug artifacts
       if: always()
       uses: actions/upload-artifact@v7
       with:
-        name: cypress-artifacts-php${{ matrix.php-version }}-upgrade-churchinfo-${{ github.run_id }}
+        name: cypress-artifacts-php${{ matrix.php-version }}-${{ matrix.database }}-upgrade-churchinfo-${{ github.run_id }}
         path: |
           cypress/logs
           cypress/screenshots
@@ -335,8 +345,8 @@ jobs:
       uses: dorny/test-reporter@v3
       if: always()
       with:
-        name: 'PHP ${{ matrix.php-version }}: Upgrade from ChurchInfo 1.3.1'
-        path: cypress/reports/junit-php${{ matrix.php-version }}-upgrade-churchinfo-*.xml
+        name: 'PHP ${{ matrix.php-version }} / ${{ matrix.database }}: Upgrade from ChurchInfo 1.3.1'
+        path: cypress/reports/junit-php${{ matrix.php-version }}-${{ matrix.database }}-upgrade-churchinfo-*.xml
         reporter: java-junit
         fail-on-error: true
         fail-on-empty: false

--- a/docker/docker-compose.mysql.yaml
+++ b/docker/docker-compose.mysql.yaml
@@ -1,0 +1,28 @@
+# MySQL override for upgrade-test CI jobs.
+# Layer this on top of docker-compose.yaml + docker-compose.parallel.yaml to replace
+# the MariaDB image in the ci-new-system profile with the latest MySQL image.
+# Only the image and healthcheck differ from the base definition; every other
+# property (profile, ports, MYSQL_* env, depends_on, hostname) is inherited.
+#
+# Usage (Upgrade Tests workflow):
+#   docker compose -f docker/docker-compose.yaml \
+#                  -f docker/docker-compose.parallel.yaml \
+#                  -f docker/docker-compose.mysql.yaml \
+#                  --profile ci-new-system up -d
+
+services:
+  database-new-system:
+    image: mysql:latest
+    # Use TCP (-h 127.0.0.1) so the healthcheck only passes after the full
+    # server is up with networking — MySQL's mid-init temp server runs with
+    # --skip-networking, which prevents premature "healthy" signals.
+    # mysqladmin ping exits 0 whenever the server responds (even access-denied),
+    # so no credentials are required for the liveness check.
+    # No --mysql-native-password flag: PHP 8.4 pdo_mysql supports the default
+    # caching_sha2_password plugin over plain TCP without native-password mode.
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Both upgrade-test CI jobs (ChurchCRM 6.0.0→current and ChurchInfo 1.3.1→current) now run against **both MariaDB 10.11 and MySQL latest** via a second `database: [mariadb, mysql]` matrix dimension.

## Changes
- New `docker/docker-compose.mysql.yaml`: compose override swapping `database-new-system` to `mysql:latest` with a MySQL-compatible healthcheck (`mysqladmin ping -h 127.0.0.1`). Uses TCP to avoid false-positives during MySQL's mid-init `--skip-networking` phase.
- No `--mysql-native-password` flag — it crashes MySQL 8.4+/9.x and is unnecessary since PHP 8.4 pdo_mysql supports `caching_sha2_password` natively over plain TCP.
- `COMPOSE_MYSQL` job-level env threads the override into all inline `docker compose` invocations for the mysql leg; empty string for mariadb (preserves original behaviour exactly).
- Artifact names, junit paths, log filenames, and Test Report names now include `${{ matrix.database }}` to prevent cross-leg collisions.

## Testing
CI-only change. Verified compose merge locally: `docker compose ... config` shows `database-new-system` resolves to `image: mysql:latest` with the new healthcheck. Lint: 2 pre-existing warnings in unrelated JS files, no errors.