### PR TITLE
locale: translate all locales (7.6.0)

### DIFF
--- a/locale/terms/missing/af/af-1.json
+++ b/locale/terms/missing/af/af-1.json
@@ -1,15 +1,15 @@
 {
-  "Items": "",
+  "Items": "Items",
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "{{count}} lid gekopieer",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Hierdie lys het {{count}} ontvanger — te veel vir 'n mailto:-skakel. Gebruik Kopieer Adresse in plaas daarvan.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Te veel ontvangers vir e-poskliënt ({{count}} > {{max}}). Gebruik Kopieer Adresse in plaas daarvan.",
+    "{{count}} min left": "{{count}} min oor"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "{{count}} lede gekopieer",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Hierdie lys het {{count}} ontvangers — te veel vir 'n mailto:-skakel. Gebruik Kopieer Adresse in plaas daarvan.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Te veel ontvangers vir e-poskliënt ({{count}} > {{max}}). Gebruik Kopieer Adresse in plaas daarvan.",
+    "{{count}} min left": "{{count}} min oor"
   }
 }

--- a/locale/terms/missing/am/am-1.json
+++ b/locale/terms/missing/am/am-1.json
@@ -1,14 +1,14 @@
 {
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "{{count}} አባል ተቀድቷል",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "ይህ ዝርዝር {{count}} ተቀባይ አለው — ለ mailto: አገናኝ በጣም ብዙ ነው። ይልቁንም አድራሻዎችን ቅዳ ይጠቀሙ።",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "ለኢሜይል ደንበኛ በጣም ብዙ ተቀባዮች ({{count}} > {{max}})። ይልቁንም አድራሻዎችን ቅዳ ይጠቀሙ።",
+    "{{count}} min left": "{{count}} ደቂቃ ቀርቷል"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "{{count}} አባላት ተቀድተዋል",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "ይህ ዝርዝር {{count}} ተቀባዮች አሉት — ለ mailto: አገናኝ በጣም ብዙ ናቸው። ይልቁንም አድራሻዎችን ቅዳ ይጠቀሙ።",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "ለኢሜይል ደንበኛ በጣም ብዙ ተቀባዮች ({{count}} > {{max}})። ይልቁንም አድራሻዎችን ቅዳ ይጠቀሙ።",
+    "{{count}} min left": "{{count}} ደቂቃዎች ቀርተዋል"
   }
 }

--- a/locale/terms/missing/ar/ar-1.json
+++ b/locale/terms/missing/ar/ar-1.json
@@ -1,14 +1,14 @@
 {
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "تم نسخ {{count}} عضو",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "تحتوي هذه القائمة على {{count}} مستلم — عدد كبير جداً لرابط mailto:. استخدم نسخ العناوين بدلاً من ذلك.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "عدد المستلمين كبير جداً لعميل البريد الإلكتروني ({{count}} > {{max}}). استخدم نسخ العناوين بدلاً من ذلك.",
+    "{{count}} min left": "دقيقة {{count}} متبقية"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "تم نسخ {{count}} أعضاء",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "تحتوي هذه القائمة على {{count}} مستلمين — عدد كبير جداً لرابط mailto:. استخدم نسخ العناوين بدلاً من ذلك.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "عدد المستلمين كبير جداً لعميل البريد الإلكتروني ({{count}} > {{max}}). استخدم نسخ العناوين بدلاً من ذلك.",
+    "{{count}} min left": "{{count}} دقائق متبقية"
   }
 }

--- a/locale/terms/missing/cs/cs-1.json
+++ b/locale/terms/missing/cs/cs-1.json
@@ -1,15 +1,15 @@
 {
-  "Fundraising": "",
+  "Fundraising": "Fundraising",
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Zkopírován {{count}} člen",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Tento seznam má {{count}} příjemce – příliš mnoho pro odkaz mailto:. Místo toho použijte Kopírovat adresy.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Příliš mnoho příjemců pro e-mailového klienta ({{count}} > {{max}}). Místo toho použijte Kopírovat adresy.",
+    "{{count}} min left": "Zbývá {{count}} minuta"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Zkopírováno {{count}} členů",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Tento seznam má {{count}} příjemců – příliš mnoho pro odkaz mailto:. Místo toho použijte Kopírovat adresy.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Příliš mnoho příjemců pro e-mailového klienta ({{count}} > {{max}}). Místo toho použijte Kopírovat adresy.",
+    "{{count}} min left": "Zbývá {{count}} minut"
   }
 }

--- a/locale/terms/missing/de/de-1.json
+++ b/locale/terms/missing/de/de-1.json
@@ -1,15 +1,15 @@
 {
-  "Code": "",
+  "Code": "Code",
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "{{count}} Gemeindemitglied kopiert",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Diese Liste hat {{count}} Empfänger – zu viele für einen mailto:-Link. Verwenden Sie stattdessen „Adressen kopieren“.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Zu viele Empfänger für das E-Mail-Programm ({{count}} > {{max}}). Verwenden Sie stattdessen „Adressen kopieren“.",
+    "{{count}} min left": "{{count}} Min. verbleibend"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "{{count}} Gemeindemitglieder kopiert",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Diese Liste hat {{count}} Empfänger – zu viele für einen mailto:-Link. Verwenden Sie stattdessen „Adressen kopieren“.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Zu viele Empfänger für das E-Mail-Programm ({{count}} > {{max}}). Verwenden Sie stattdessen „Adressen kopieren“.",
+    "{{count}} min left": "{{count}} Min. verbleibend"
   }
 }

--- a/locale/terms/missing/el/el-1.json
+++ b/locale/terms/missing/el/el-1.json
@@ -1,15 +1,15 @@
 {
-  "BCC Mode": "",
+  "BCC Mode": "Λειτουργία BCC",
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Αντιγράφηκε {{count}} μέλος",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Αυτή η λίστα έχει {{count}} παραλήπτη — πάρα πολλοί για έναν σύνδεσμο mailto:. Χρησιμοποιήστε αντ’ αυτού την Αντιγραφή Διευθύνσεων.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Πάρα πολλοί παραλήπτες για το πρόγραμμα email ({{count}} > {{max}}). Χρησιμοποιήστε αντ’ αυτού την Αντιγραφή Διευθύνσεων.",
+    "{{count}} min left": "Απομένει {{count}} λεπτό"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Αντιγράφηκαν {{count}} μέλη",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Αυτή η λίστα έχει {{count}} παραλήπτες — πάρα πολλοί για έναν σύνδεσμο mailto:. Χρησιμοποιήστε αντ’ αυτού την Αντιγραφή Διευθύνσεων.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Πάρα πολλοί παραλήπτες για το πρόγραμμα email ({{count}} > {{max}}). Χρησιμοποιήστε αντ’ αυτού την Αντιγραφή Διευθύνσεων.",
+    "{{count}} min left": "Απομένουν {{count}} λεπτά"
   }
 }

--- a/locale/terms/missing/es-AR/es-AR-1.json
+++ b/locale/terms/missing/es-AR/es-AR-1.json
@@ -1,14 +1,14 @@
 {
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Se copió {{count}} miembro",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Esta lista tiene {{count}} destinatario — demasiados para un enlace mailto:. Usá Copiar direcciones.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Usá Copiar direcciones.",
+    "{{count}} min left": "Queda {{count}} min"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Se copiaron {{count}} miembros",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Esta lista tiene {{count}} destinatarios — demasiados para un enlace mailto:. Usá Copiar direcciones.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Usá Copiar direcciones.",
+    "{{count}} min left": "Quedan {{count}} min"
   }
 }

--- a/locale/terms/missing/es-CO/es-CO-1.json
+++ b/locale/terms/missing/es-CO/es-CO-1.json
@@ -1,14 +1,14 @@
 {
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Se copió {{count}} miembro",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Esta lista tiene {{count}} destinatario — demasiados para un enlace mailto:. Use Copiar direcciones en su lugar.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Use Copiar direcciones en su lugar.",
+    "{{count}} min left": "Queda {{count}} min"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Se copiaron {{count}} miembros",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Esta lista tiene {{count}} destinatarios — demasiados para un enlace mailto:. Use Copiar direcciones en su lugar.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Use Copiar direcciones en su lugar.",
+    "{{count}} min left": "Quedan {{count}} min"
   }
 }

--- a/locale/terms/missing/es-MX/es-MX-1.json
+++ b/locale/terms/missing/es-MX/es-MX-1.json
@@ -1,14 +1,14 @@
 {
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Se copió {{count}} miembro",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Esta lista tiene {{count}} destinatario — demasiados para un enlace mailto:. Use Copiar direcciones en su lugar.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Use Copiar direcciones en su lugar.",
+    "{{count}} min left": "Queda {{count}} minuto"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Se copiaron {{count}} miembros",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Esta lista tiene {{count}} destinatarios — demasiados para un enlace mailto:. Use Copiar direcciones en su lugar.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Use Copiar direcciones en su lugar.",
+    "{{count}} min left": "Quedan {{count}} minutos"
   }
 }

--- a/locale/terms/missing/es-SV/es-SV-1.json
+++ b/locale/terms/missing/es-SV/es-SV-1.json
@@ -1,14 +1,14 @@
 {
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Se copió {{count}} miembro",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Esta lista tiene {{count}} destinatario — demasiados para un enlace mailto:. Use Copiar direcciones en su lugar.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Use Copiar direcciones en su lugar.",
+    "{{count}} min left": "Queda {{count}} min"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Se copiaron {{count}} miembros",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Esta lista tiene {{count}} destinatarios — demasiados para un enlace mailto:. Use Copiar direcciones en su lugar.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Use Copiar direcciones en su lugar.",
+    "{{count}} min left": "Quedan {{count}} min"
   }
 }

--- a/locale/terms/missing/es/es-1.json
+++ b/locale/terms/missing/es/es-1.json
@@ -1,14 +1,14 @@
 {
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Se copió {{count}} miembro",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Esta lista tiene {{count}} destinatario — demasiados para un enlace mailto:. Use Copiar direcciones en su lugar.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Use Copiar direcciones en su lugar.",
+    "{{count}} min left": "{{count}} min restante"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Se copiaron {{count}} miembros",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Esta lista tiene {{count}} destinatarios — demasiados para un enlace mailto:. Use Copiar direcciones en su lugar.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Use Copiar direcciones en su lugar.",
+    "{{count}} min left": "{{count}} min restantes"
   }
 }

--- a/locale/terms/missing/et/et-1.json
+++ b/locale/terms/missing/et/et-1.json
@@ -1,14 +1,14 @@
 {
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Kopeeriti {{count}} liige",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Sellel loendil on {{count}} saaja — liiga palju mailto: lingi jaoks. Kasutage selle asemel aadresside kopeerimist.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Liiga palju saajaid meilikliendi jaoks ({{count}} > {{max}}). Kasutage selle asemel aadresside kopeerimist.",
+    "{{count}} min left": "{{count}} min jäänud"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Kopeeriti {{count}} liiget",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Sellel loendil on {{count}} saajat — liiga palju mailto: lingi jaoks. Kasutage selle asemel aadresside kopeerimist.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Liiga palju saajaid meilikliendi jaoks ({{count}} > {{max}}). Kasutage selle asemel aadresside kopeerimist.",
+    "{{count}} min left": "{{count}} min jäänud"
   }
 }

--- a/locale/terms/missing/fi/fi-1.json
+++ b/locale/terms/missing/fi/fi-1.json
@@ -1,14 +1,14 @@
 {
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Kopioitu {{count}} jäsen",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Tässä listassa on {{count}} vastaanottaja — liian monta mailto:-linkkiä varten. Käytä sen sijaan Kopioi osoitteet -toimintoa.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Liian monta vastaanottajaa sähköpostiohjelmalle ({{count}} > {{max}}). Käytä sen sijaan Kopioi osoitteet -toimintoa.",
+    "{{count}} min left": "{{count}} min jäljellä"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Kopioitu {{count}} jäsentä",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Tässä listassa on {{count}} vastaanottajaa — liian monta mailto:-linkkiä varten. Käytä sen sijaan Kopioi osoitteet -toimintoa.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Liian monta vastaanottajaa sähköpostiohjelmalle ({{count}} > {{max}}). Käytä sen sijaan Kopioi osoitteet -toimintoa.",
+    "{{count}} min left": "{{count}} min jäljellä"
   }
 }

--- a/locale/terms/missing/fil/fil-1.json
+++ b/locale/terms/missing/fil/fil-1.json
@@ -1,23 +1,23 @@
 {
-  "Access": "",
-  "Self-service": "",
-  "Changelog": "",
-  "Feature": "",
-  "Check-out": "",
-  "Code": "",
-  "Live Preview": "",
-  "Sell-through": "",
-  "BCC Mode": "",
+  "Access": "Access",
+  "Self-service": "Self-service",
+  "Changelog": "Changelog",
+  "Feature": "Feature",
+  "Check-out": "Check-out",
+  "Code": "Code",
+  "Live Preview": "Live Preview",
+  "Sell-through": "Sell-through",
+  "BCC Mode": "BCC Mode",
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Nakopya ang {{count}} miyembro",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Ang listahang ito ay may {{count}} tatanggap — masyadong marami para sa isang mailto: link. Gamitin ang Kopyahin ang mga Address sa halip.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Masyadong maraming tatanggap para sa email client ({{count}} > {{max}}). Gamitin ang Kopyahin ang mga Address sa halip.",
+    "{{count}} min left": "{{count}} minuto na lang"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Nakopya ang {{count}} mga miyembro",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Ang listahang ito ay may {{count}} mga tatanggap — masyadong marami para sa isang mailto: link. Gamitin ang Kopyahin ang mga Address sa halip.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Masyadong maraming tatanggap para sa email client ({{count}} > {{max}}). Gamitin ang Kopyahin ang mga Address sa halip.",
+    "{{count}} min left": "{{count}} minuto na lang"
   }
 }

--- a/locale/terms/missing/fr/fr-1.json
+++ b/locale/terms/missing/fr/fr-1.json
@@ -1,16 +1,16 @@
 {
-  "Code": "",
-  "Signature": "",
+  "Code": "Code",
+  "Signature": "Signature",
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "{{count}} membre copié",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Cette liste contient {{count}} destinataire — trop pour un lien mailto:. Utilisez plutôt Copier les adresses.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Trop de destinataires pour le client de messagerie ({{count}} > {{max}}). Utilisez plutôt Copier les adresses.",
+    "{{count}} min left": "{{count}} min restante"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "{{count}} membres copiés",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Cette liste contient {{count}} destinataires — trop pour un lien mailto:. Utilisez plutôt Copier les adresses.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Trop de destinataires pour le client de messagerie ({{count}} > {{max}}). Utilisez plutôt Copier les adresses.",
+    "{{count}} min left": "{{count}} min restantes"
   }
 }

--- a/locale/terms/missing/he/he-1.json
+++ b/locale/terms/missing/he/he-1.json
@@ -1,14 +1,14 @@
 {
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "הועתק חבר {{count}}",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "לרשימה זו יש {{count}} נמען — יותר מדי עבור קישור mailto:. השתמש ב’העתק כתובות’ במקום.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "יותר מדי נמענים עבור לקוח הדואר האלקטרוני ({{count}} > {{max}}). השתמש ב’העתק כתובות’ במקום.",
+    "{{count}} min left": "נותרה {{count}} דקה"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "הועתקו {{count}} חברים",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "לרשימה זו יש {{count}} נמענים — יותר מדי עבור קישור mailto:. השתמש ב’העתק כתובות’ במקום.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "יותר מדי נמענים עבור לקוח הדואר האלקטרוני ({{count}} > {{max}}). השתמש ב’העתק כתובות’ במקום.",
+    "{{count}} min left": "נותרו {{count}} דקות"
   }
 }

--- a/locale/terms/missing/hi/hi-1.json
+++ b/locale/terms/missing/hi/hi-1.json
@@ -1,14 +1,14 @@
 {
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "{{count}} सदस्य कॉपी किया गया",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "इस सूची में {{count}} प्राप्तकर्ता है — mailto: लिंक के लिए बहुत अधिक। इसके बजाय पते कॉपी करें का उपयोग करें।",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "ईमेल क्लाइंट के लिए बहुत अधिक प्राप्तकर्ता ({{count}} > {{max}})। इसके बजाय पते कॉपी करें का उपयोग करें।",
+    "{{count}} min left": "{{count}} मिनट शेष"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "{{count}} सदस्य कॉपी किए गए",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "इस सूची में {{count}} प्राप्तकर्ता हैं — mailto: लिंक के लिए बहुत अधिक। इसके बजाय पते कॉपी करें का उपयोग करें।",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "ईमेल क्लाइंट के लिए बहुत अधिक प्राप्तकर्ता ({{count}} > {{max}})। इसके बजाय पते कॉपी करें का उपयोग करें।",
+    "{{count}} min left": "{{count}} मिनट शेष"
   }
 }

--- a/locale/terms/missing/hr/hr-1.json
+++ b/locale/terms/missing/hr/hr-1.json
@@ -1,14 +1,14 @@
 {
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Kopiran {{count}} član",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Ovaj popis ima {{count}} primatelja — previše za mailto: vezu. Umjesto toga koristite Kopiraj adrese.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Previše primatelja za klijent e-pošte ({{count}} > {{max}}). Umjesto toga koristite Kopiraj adrese.",
+    "{{count}} min left": "Još {{count}} min"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Kopirano {{count}} članova",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Ovaj popis ima {{count}} primatelja — previše za mailto: vezu. Umjesto toga koristite Kopiraj adrese.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Previše primatelja za klijent e-pošte ({{count}} > {{max}}). Umjesto toga koristite Kopiraj adrese.",
+    "{{count}} min left": "Još {{count}} min"
   }
 }

--- a/locale/terms/missing/hu/hu-1.json
+++ b/locale/terms/missing/hu/hu-1.json
@@ -1,14 +1,14 @@
 {
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "{{count}} tag másolva",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Ez a lista {{count}} címzettet tartalmaz – túl sok egy mailto: hivatkozáshoz. Használja inkább a Címek másolása funkciót.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Túl sok címzett az e-mail kliens számára ({{count}} > {{max}}). Használja inkább a Címek másolása funkciót.",
+    "{{count}} min left": "{{count}} perc van hátra"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "{{count}} tag másolva",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Ez a lista {{count}} címzettet tartalmaz – túl sok egy mailto: hivatkozáshoz. Használja inkább a Címek másolása funkciót.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Túl sok címzett az e-mail kliens számára ({{count}} > {{max}}). Használja inkább a Címek másolása funkciót.",
+    "{{count}} min left": "{{count}} perc van hátra"
   }
 }

--- a/locale/terms/missing/id/id-1.json
+++ b/locale/terms/missing/id/id-1.json
@@ -1,14 +1,14 @@
 {
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "{{count}} anggota telah disalin",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Daftar ini memiliki {{count}} penerima — terlalu banyak untuk tautan mailto:. Gunakan Salin Alamat.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Terlalu banyak penerima untuk klien email ({{count}} > {{max}}). Gunakan Salin Alamat.",
+    "{{count}} min left": "{{count}} menit tersisa"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "{{count}} anggota telah disalin",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Daftar ini memiliki {{count}} penerima — terlalu banyak untuk tautan mailto:. Gunakan Salin Alamat.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Terlalu banyak penerima untuk klien email ({{count}} > {{max}}). Gunakan Salin Alamat.",
+    "{{count}} min left": "{{count}} menit tersisa"
   }
 }

--- a/locale/terms/missing/it/it-1.json
+++ b/locale/terms/missing/it/it-1.json
@@ -1,15 +1,15 @@
 {
-  "Check-out": "",
+  "Check-out": "Check-out",
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Copiato {{count}} membro",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Questa lista ha {{count}} destinatario — troppi per un link mailto:. Usa Copia Indirizzi.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Troppi destinatari per il client di posta ({{count}} > {{max}}). Usa Copia Indirizzi.",
+    "{{count}} min left": "{{count}} min rimanente"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Copiati {{count}} membri",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Questa lista ha {{count}} destinatari — troppi per un link mailto:. Usa Copia Indirizzi.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Troppi destinatari per il client di posta ({{count}} > {{max}}). Usa Copia Indirizzi.",
+    "{{count}} min left": "{{count}} min rimanenti"
   }
 }

--- a/locale/terms/missing/ja/ja-1.json
+++ b/locale/terms/missing/ja/ja-1.json
@@ -1,20 +1,20 @@
 {
   "%d archived fundraiser": {
-    "other": ""
+    "other": "%d件のアーカイブ済み募金活動"
   },
   "%d person successfully added to selected family.": {
-    "other": ""
+    "other": "%d人が選択した家族に正常に追加されました。"
   },
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "{{count}}人のメンバーをコピーしました",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "このリストには{{count}}人の受信者がいます — mailto: リンクには多すぎます。代わりにアドレスをコピーを使用してください。",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "メールクライアントには受信者が多すぎます（{{count}} > {{max}}）。代わりにアドレスをコピーを使用してください。",
+    "{{count}} min left": "残り{{count}}分"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "{{count}}人のメンバーをコピーしました",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "このリストには{{count}}人の受信者がいます — mailto: リンクには多すぎます。代わりにアドレスをコピーを使用してください。",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "メールクライアントには受信者が多すぎます（{{count}} > {{max}}）。代わりにアドレスをコピーを使用してください。",
+    "{{count}} min left": "残り{{count}}分"
   }
 }

--- a/locale/terms/missing/ko/ko-1.json
+++ b/locale/terms/missing/ko/ko-1.json
@@ -1,14 +1,14 @@
 {
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "{{count}}명의 교인을 복사했습니다",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "이 목록에는 {{count}}명의 수신자가 있습니다 — mailto: 링크에 사용하기에는 너무 많습니다. 대신 주소 복사를 사용하세요.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "이메일 클라이언트에 수신자가 너무 많습니다 ({{count}} > {{max}}). 대신 주소 복사를 사용하세요.",
+    "{{count}} min left": "{{count}}분 남음"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "{{count}}명의 교인을 복사했습니다",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "이 목록에는 {{count}}명의 수신자가 있습니다 — mailto: 링크에 사용하기에는 너무 많습니다. 대신 주소 복사를 사용하세요.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "이메일 클라이언트에 수신자가 너무 많습니다 ({{count}} > {{max}}). 대신 주소 복사를 사용하세요.",
+    "{{count}} min left": "{{count}}분 남음"
   }
 }

--- a/locale/terms/missing/ml/ml-1.json
+++ b/locale/terms/missing/ml/ml-1.json
@@ -1,14 +1,14 @@
 {
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "{{count}} അംഗത്തെ പകർത്തി",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "ഈ പട്ടികയിൽ {{count}} സ്വീകർത്താവ് ഉണ്ട് — mailto: ലിങ്കിന് അധികം. പകരം വിലാസങ്ങൾ പകർത്തുക ഉപയോഗിക്കുക.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "ഇമെയിൽ ക്ലയൻ്റിന് അധികം സ്വീകർത്താക്കൾ ({{count}} > {{max}}). പകരം വിലാസങ്ങൾ പകർത്തുക ഉപയോഗിക്കുക.",
+    "{{count}} min left": "{{count}} മിനിറ്റ് ശേഷിക്കുന്നു"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "{{count}} അംഗങ്ങളെ പകർത്തി",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "ഈ പട്ടികയിൽ {{count}} സ്വീകർത്താക്കൾ ഉണ്ട് — mailto: ലിങ്കിന് അധികം. പകരം വിലാസങ്ങൾ പകർത്തുക ഉപയോഗിക്കുക.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "ഇമെയിൽ ക്ലയൻ്റിന് അധികം സ്വീകർത്താക്കൾ ({{count}} > {{max}}). പകരം വിലാസങ്ങൾ പകർത്തുക ഉപയോഗിക്കുക.",
+    "{{count}} min left": "{{count}} മിനിറ്റുകൾ ശേഷിക്കുന്നു"
   }
 }

--- a/locale/terms/missing/nb/nb-1.json
+++ b/locale/terms/missing/nb/nb-1.json
@@ -1,14 +1,14 @@
 {
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Kopierte {{count}} medlem",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Denne listen har {{count}} mottaker — for mange for en mailto:-lenke. Bruk Kopier adresser i stedet.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "For mange mottakere for e-postklienten ({{count}} > {{max}}). Bruk Kopier adresser i stedet.",
+    "{{count}} min left": "{{count}} min igjen"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Kopierte {{count}} medlemmer",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Denne listen har {{count}} mottakere — for mange for en mailto:-lenke. Bruk Kopier adresser i stedet.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "For mange mottakere for e-postklienten ({{count}} > {{max}}). Bruk Kopier adresser i stedet.",
+    "{{count}} min left": "{{count}} min igjen"
   }
 }

--- a/locale/terms/missing/nl/nl-1.json
+++ b/locale/terms/missing/nl/nl-1.json
@@ -1,17 +1,17 @@
 {
-  "Code": "",
-  "Items": "",
-  "Planning": "",
+  "Code": "Code",
+  "Items": "Items",
+  "Planning": "Planning",
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "{{count}} lid gekopieerd",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Deze lijst heeft {{count}} ontvanger — te veel voor een mailto:-link. Gebruik in plaats daarvan Adressen kopiëren.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Te veel ontvangers voor e-mailclient ({{count}} > {{max}}). Gebruik in plaats daarvan Adressen kopiëren.",
+    "{{count}} min left": "{{count}} min over"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "{{count}} leden gekopieerd",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Deze lijst heeft {{count}} ontvangers — te veel voor een mailto:-link. Gebruik in plaats daarvan Adressen kopiëren.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Te veel ontvangers voor e-mailclient ({{count}} > {{max}}). Gebruik in plaats daarvan Adressen kopiëren.",
+    "{{count}} min left": "{{count}} min over"
   }
 }

--- a/locale/terms/missing/pl/pl-1.json
+++ b/locale/terms/missing/pl/pl-1.json
@@ -1,14 +1,14 @@
 {
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Skopiowano {{count}} parafianina",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Ta lista ma {{count}} odbiorcę — zbyt wielu dla łącza mailto:. Zamiast tego użyj opcji Kopiuj adresy.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Zbyt wielu odbiorców dla klienta poczty e-mail ({{count}} > {{max}}). Zamiast tego użyj opcji Kopiuj adresy.",
+    "{{count}} min left": "Pozostała {{count}} minuta"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Skopiowano {{count}} parafian",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Ta lista ma {{count}} odbiorców — zbyt wielu dla łącza mailto:. Zamiast tego użyj opcji Kopiuj adresy.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Zbyt wielu odbiorców dla klienta poczty e-mail ({{count}} > {{max}}). Zamiast tego użyj opcji Kopiuj adresy.",
+    "{{count}} min left": "Pozostało {{count}} minut"
   }
 }

--- a/locale/terms/missing/pt-br/pt-br-1.json
+++ b/locale/terms/missing/pt-br/pt-br-1.json
@@ -1,14 +1,14 @@
 {
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "{{count}} membro copiado",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Esta lista tem {{count}} destinatário — muitos para um link mailto:. Use Copiar Endereços.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Destinatários demais para o cliente de e-mail ({{count}} > {{max}}). Use Copiar Endereços.",
+    "{{count}} min left": "{{count}} min restante"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "{{count}} membros copiados",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Esta lista tem {{count}} destinatários — muitos para um link mailto:. Use Copiar Endereços.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Destinatários demais para o cliente de e-mail ({{count}} > {{max}}). Use Copiar Endereços.",
+    "{{count}} min left": "{{count}} min restantes"
   }
 }

--- a/locale/terms/missing/pt/pt-1.json
+++ b/locale/terms/missing/pt/pt-1.json
@@ -1,14 +1,14 @@
 {
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "{{count}} membro copiado",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Esta lista tem {{count}} destinatário — demasiados para um link mailto:. Use Copiar Endereços.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Destinatários a mais para o cliente de email ({{count}} > {{max}}). Use Copiar Endereços.",
+    "{{count}} min left": "{{count}} min restante"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "{{count}} membros copiados",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Esta lista tem {{count}} destinatários — demasiados para um link mailto:. Use Copiar Endereços.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Destinatários a mais para o cliente de email ({{count}} > {{max}}). Use Copiar Endereços.",
+    "{{count}} min left": "{{count}} min restantes"
   }
 }

--- a/locale/terms/missing/ro/ro-1.json
+++ b/locale/terms/missing/ro/ro-1.json
@@ -1,17 +1,17 @@
 {
-  "Important": "",
-  "Major": "",
-  "Catalog": "",
+  "Important": "Important",
+  "Major": "Major",
+  "Catalog": "Catalog",
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "A fost copiat {{count}} membru",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Această listă are {{count}} destinatar — prea mulți pentru un link mailto:. Folosiți în schimb Copiați adresele.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Prea mulți destinatari pentru clientul de e-mail ({{count}} > {{max}}). Folosiți în schimb Copiați adresele.",
+    "{{count}} min left": "A mai rămas {{count}} minut"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Au fost copiați {{count}} membri",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Această listă are {{count}} destinatari — prea mulți pentru un link mailto:. Folosiți în schimb Copiați adresele.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Prea mulți destinatari pentru clientul de e-mail ({{count}} > {{max}}). Folosiți în schimb Copiați adresele.",
+    "{{count}} min left": "Au mai rămas {{count}} minute"
   }
 }

--- a/locale/terms/missing/ru/ru-1.json
+++ b/locale/terms/missing/ru/ru-1.json
@@ -1,14 +1,14 @@
 {
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Скопирован {{count}} участник",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "В этом списке {{count}} получатель — слишком много для ссылки mailto:. Используйте «Копировать адреса».",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Слишком много получателей для почтового клиента ({{count}} > {{max}}). Используйте «Копировать адреса».",
+    "{{count}} min left": "Осталась {{count}} минута"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Скопировано {{count}} участников",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "В этом списке {{count}} получателей — слишком много для ссылки mailto:. Используйте «Копировать адреса».",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Слишком много получателей для почтового клиента ({{count}} > {{max}}). Используйте «Копировать адреса».",
+    "{{count}} min left": "Осталось {{count}} минут"
   }
 }

--- a/locale/terms/missing/sk/sk-1.json
+++ b/locale/terms/missing/sk/sk-1.json
@@ -1,14 +1,14 @@
 {
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Skopírovaný {{count}} člen",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Tento zoznam má {{count}} príjemcu — príliš veľa pre odkaz mailto:. Namiesto toho použite Kopírovať adresy.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Príliš veľa príjemcov pre e-mailového klienta ({{count}} > {{max}}). Namiesto toho použite Kopírovať adresy.",
+    "{{count}} min left": "{{count}} min zostáva"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Skopírovaných {{count}} členov",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Tento zoznam má {{count}} príjemcov — príliš veľa pre odkaz mailto:. Namiesto toho použite Kopírovať adresy.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Príliš veľa príjemcov pre e-mailového klienta ({{count}} > {{max}}). Namiesto toho použite Kopírovať adresy.",
+    "{{count}} min left": "{{count}} min zostáva"
   }
 }

--- a/locale/terms/missing/sq/sq-1.json
+++ b/locale/terms/missing/sq/sq-1.json
@@ -1,14 +1,14 @@
 {
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "U kopjua {{count}} anëtar",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Kjo listë ka {{count}} marrës — shumë për një lidhje mailto:. Përdorni Kopjo Adresat.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Shumë marrës për klientin e email-it ({{count}} > {{max}}). Përdorni Kopjo Adresat.",
+    "{{count}} min left": "{{count}} minutë e mbetur"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "U kopjuan {{count}} anëtarë",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Kjo listë ka {{count}} marrës — shumë për një lidhje mailto:. Përdorni Kopjo Adresat.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Shumë marrës për klientin e email-it ({{count}} > {{max}}). Përdorni Kopjo Adresat.",
+    "{{count}} min left": "{{count}} minuta të mbetura"
   }
 }

--- a/locale/terms/missing/sv/sv-1.json
+++ b/locale/terms/missing/sv/sv-1.json
@@ -1,14 +1,14 @@
 {
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Kopierade {{count}} medlem",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Den här listan har {{count}} mottagare — för många för en mailto:-länk. Använd Kopiera adresser istället.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "För många mottagare för e-postklienten ({{count}} > {{max}}). Använd Kopiera adresser istället.",
+    "{{count}} min left": "{{count}} min kvar"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Kopierade {{count}} medlemmar",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Den här listan har {{count}} mottagare — för många för en mailto:-länk. Använd Kopiera adresser istället.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "För många mottagare för e-postklienten ({{count}} > {{max}}). Använd Kopiera adresser istället.",
+    "{{count}} min left": "{{count}} min kvar"
   }
 }

--- a/locale/terms/missing/sw/sw-1.json
+++ b/locale/terms/missing/sw/sw-1.json
@@ -1,14 +1,14 @@
 {
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Amenakiliwa mwanachama {{count}}",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Orodha hii ina mpokeaji {{count}} — wengi sana kwa kiungo cha mailto:. Tumia Nakili Anwani badala yake.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Wapokeaji wengi sana kwa programu ya barua pepe ({{count}} > {{max}}). Tumia Nakili Anwani badala yake.",
+    "{{count}} min left": "Dakika {{count}} imebaki"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Wamenakiliwa wanachama {{count}}",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Orodha hii ina wapokeaji {{count}} — wengi sana kwa kiungo cha mailto:. Tumia Nakili Anwani badala yake.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Wapokeaji wengi sana kwa programu ya barua pepe ({{count}} > {{max}}). Tumia Nakili Anwani badala yake.",
+    "{{count}} min left": "Dakika {{count}} zimebaki"
   }
 }

--- a/locale/terms/missing/ta/ta-1.json
+++ b/locale/terms/missing/ta/ta-1.json
@@ -1,14 +1,14 @@
 {
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "{{count}} உறுப்பினர் நகலெடுக்கப்பட்டார்",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "இந்தப் பட்டியலில் {{count}} பெறுநர் உள்ளார் — mailto: இணைப்பிற்கு மிகவும் அதிகம். பதிலாக முகவரிகளை நகலெடு பயன்படுத்தவும்.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "மின்னஞ்சல் கிளையண்டிற்கு மிகவும் அதிகமான பெறுநர்கள் ({{count}} > {{max}}). பதிலாக முகவரிகளை நகலெடு பயன்படுத்தவும்.",
+    "{{count}} min left": "{{count}} நிமிடம் மீதம்"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "{{count}} உறுப்பினர்கள் நகலெடுக்கப்பட்டனர்",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "இந்தப் பட்டியலில் {{count}} பெறுநர்கள் உள்ளனர் — mailto: இணைப்பிற்கு மிகவும் அதிகம். பதிலாக முகவரிகளை நகலெடு பயன்படுத்தவும்.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "மின்னஞ்சல் கிளையண்டிற்கு மிகவும் அதிகமான பெறுநர்கள் ({{count}} > {{max}}). பதிலாக முகவரிகளை நகலெடு பயன்படுத்தவும்.",
+    "{{count}} min left": "{{count}} நிமிடங்கள் மீதம்"
   }
 }

--- a/locale/terms/missing/te/te-1.json
+++ b/locale/terms/missing/te/te-1.json
@@ -1,14 +1,14 @@
 {
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "{{count}} సభ్యుడిని కాపీ చేయబడింది",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "ఈ జాబితాలో {{count}} గ్రహీత ఉన్నారు — mailto: లింక్ కోసం చాలా ఎక్కువ. బదులుగా చిరునామాలను కాపీ చేయి ఉపయోగించండి.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "ఇమెయిల్ క్లయింట్ కోసం చాలా ఎక్కువ మంది గ్రహీతలు ({{count}} > {{max}}). బదులుగా చిరునామాలను కాపీ చేయి ఉపయోగించండి.",
+    "{{count}} min left": "{{count}} నిమిషం మిగిలింది"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "{{count}} సభ్యులను కాపీ చేయబడింది",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "ఈ జాబితాలో {{count}} గ్రహీతలు ఉన్నారు — mailto: లింక్ కోసం చాలా ఎక్కువ. బదులుగా చిరునామాలను కాపీ చేయి ఉపయోగించండి.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "ఇమెయిల్ క్లయింట్ కోసం చాలా ఎక్కువ మంది గ్రహీతలు ({{count}} > {{max}}). బదులుగా చిరునామాలను కాపీ చేయి ఉపయోగించండి.",
+    "{{count}} min left": "{{count}} నిమిషాలు మిగిలాయి"
   }
 }

--- a/locale/terms/missing/th/th-1.json
+++ b/locale/terms/missing/th/th-1.json
@@ -1,20 +1,20 @@
 {
   "%d archived fundraiser": {
-    "other": ""
+    "other": "%d แคมเปญระดมทุนที่เก็บถาวร"
   },
   "%d person successfully added to selected family.": {
-    "other": ""
+    "other": "เพิ่ม %d คนเข้าครอบครัวที่เลือกสำเร็จแล้ว"
   },
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "คัดลอก {{count}} สมาชิกแล้ว",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "รายการนี้มีผู้รับ {{count}} คน — มากเกินไปสำหรับลิงก์ mailto: ใช้ \"คัดลอกที่อยู่\" แทน",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "ผู้รับมากเกินไปสำหรับโปรแกรมอีเมล ({{count}} > {{max}}) ใช้ \"คัดลอกที่อยู่\" แทน",
+    "{{count}} min left": "เหลืออีก {{count}} นาที"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "คัดลอก {{count}} สมาชิกแล้ว",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "รายการนี้มีผู้รับ {{count}} คน — มากเกินไปสำหรับลิงก์ mailto: ใช้ \"คัดลอกที่อยู่\" แทน",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "ผู้รับมากเกินไปสำหรับโปรแกรมอีเมล ({{count}} > {{max}}) ใช้ \"คัดลอกที่อยู่\" แทน",
+    "{{count}} min left": "เหลืออีก {{count}} นาที"
   }
 }

--- a/locale/terms/missing/tr/tr-1.json
+++ b/locale/terms/missing/tr/tr-1.json
@@ -1,14 +1,14 @@
 {
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "{{count}} üye kopyalandı",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Bu listede {{count}} alıcı var — mailto: bağlantısı için çok fazla. Bunun yerine Adresleri Kopyala'yı kullanın.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "E-posta istemcisi için çok fazla alıcı ({{count}} > {{max}}). Bunun yerine Adresleri Kopyala'yı kullanın.",
+    "{{count}} min left": "{{count}} dakika kaldı"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "{{count}} üye kopyalandı",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Bu listede {{count}} alıcı var — mailto: bağlantısı için çok fazla. Bunun yerine Adresleri Kopyala'yı kullanın.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "E-posta istemcisi için çok fazla alıcı ({{count}} > {{max}}). Bunun yerine Adresleri Kopyala'yı kullanın.",
+    "{{count}} min left": "{{count}} dakika kaldı"
   }
 }

--- a/locale/terms/missing/uk/uk-1.json
+++ b/locale/terms/missing/uk/uk-1.json
@@ -1,14 +1,14 @@
 {
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Скопійовано {{count}} члена",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Цей список має {{count}} отримувача — забагато для посилання mailto:. Скористайтеся функцією «Копіювати адреси».",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Забагато отримувачів для поштового клієнта ({{count}} > {{max}}). Скористайтеся функцією «Копіювати адреси».",
+    "{{count}} min left": "{{count}} хвилина залишилась"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Скопійовано {{count}} членів",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Цей список має {{count}} отримувачів — забагато для посилання mailto:. Скористайтеся функцією «Копіювати адреси».",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Забагато отримувачів для поштового клієнта ({{count}} > {{max}}). Скористайтеся функцією «Копіювати адреси».",
+    "{{count}} min left": "{{count}} хвилин залишилось"
   }
 }

--- a/locale/terms/missing/vi/vi-1.json
+++ b/locale/terms/missing/vi/vi-1.json
@@ -1,14 +1,14 @@
 {
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Đã sao chép {{count}} thành viên",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Danh sách này có {{count}} người nhận — quá nhiều cho liên kết mailto:. Vui lòng dùng Sao Chép Địa Chỉ thay thế.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Quá nhiều người nhận cho ứng dụng email ({{count}} > {{max}}). Vui lòng dùng Sao Chép Địa Chỉ thay thế.",
+    "{{count}} min left": "Còn {{count}} phút"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "Đã sao chép {{count}} thành viên",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "Danh sách này có {{count}} người nhận — quá nhiều cho liên kết mailto:. Vui lòng dùng Sao Chép Địa Chỉ thay thế.",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "Quá nhiều người nhận cho ứng dụng email ({{count}} > {{max}}). Vui lòng dùng Sao Chép Địa Chỉ thay thế.",
+    "{{count}} min left": "Còn {{count}} phút"
   }
 }

--- a/locale/terms/missing/zh-CN/zh-CN-1.json
+++ b/locale/terms/missing/zh-CN/zh-CN-1.json
@@ -1,20 +1,20 @@
 {
   "%d archived fundraiser": {
-    "other": ""
+    "other": "%d 个已归档的募款活动"
   },
   "%d person successfully added to selected family.": {
-    "other": ""
+    "other": "%d 人已成功添加到所选家庭。"
   },
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "已复制 {{count}} 位成员",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "此列表有 {{count}} 位收件人——对于 mailto: 链接来说过多。请改用“复制地址”。",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "邮件客户端收件人过多（{{count}} > {{max}}）。请改用“复制地址”。",
+    "{{count}} min left": "剩余 {{count}} 分钟"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "已复制 {{count}} 位成员",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "此列表有 {{count}} 位收件人——对于 mailto: 链接来说过多。请改用“复制地址”。",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "邮件客户端收件人过多（{{count}} > {{max}}）。请改用“复制地址”。",
+    "{{count}} min left": "剩余 {{count}} 分钟"
   }
 }

--- a/locale/terms/missing/zh-TW/zh-TW-1.json
+++ b/locale/terms/missing/zh-TW/zh-TW-1.json
@@ -1,20 +1,20 @@
 {
   "%d archived fundraiser": {
-    "other": ""
+    "other": "%d 個已封存的募款活動"
   },
   "%d person successfully added to selected family.": {
-    "other": ""
+    "other": "%d 位成員已成功加入所選家庭。"
   },
   "one": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "已複製 {{count}} 位成員",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "此清單有 {{count}} 位收件人——對 mailto: 連結而言數量過多，請改用「複製地址」。",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "收件人數量對電子郵件用戶端而言過多（{{count}} > {{max}}），請改用「複製地址」。",
+    "{{count}} min left": "剩餘 {{count}} 分鐘"
   },
   "other": {
-    "Copied {{count}} members": "",
-    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "",
-    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "",
-    "{{count}} min left": ""
+    "Copied {{count}} members": "已複製 {{count}} 位成員",
+    "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": "此清單有 {{count}} 位收件人——對 mailto: 連結而言數量過多，請改用「複製地址」。",
+    "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": "收件人數量對電子郵件用戶端而言過多（{{count}} > {{max}}），請改用「複製地址」。",
+    "{{count}} min left": "剩餘 {{count}} 分鐘"
   }
 }


### PR DESCRIPTION
Automated locale translation for ChurchCRM 7.6.0.

## Translation Summary

| Group | Locales | Status |
|-------|---------|--------|
| A – Latin America & Iberia | es, es-MX, pt-br, pt, es-AR | ✅ |
| B – Romance & Europe | es-CO, es-SV, fr, it, ro | ✅ |
| C – Eastern Europe | ru, uk, pl, cs, hu | ✅ |
| D – Northern Europe | de, nl, sv, nb, fi, et | ✅ |
| E – Asia Pacific | fil, ko, id, vi, zh-CN | ✅ |
| F – More Asia | zh-TW, hi, ja, ta, te | ✅ |
| G – Africa & Other | sw, am, af, sq, ml | ✅ |
| H – Completion | ar, el, he, th, sk, tr, hr | ✅ |

**Total: 44 locales, ~120 terms**

## New terms translated
- Plural forms for `Copied {{count}} members`
- Plural forms for `This list has {{count}} recipients — too many for a mailto: link`
- Plural forms for `Too many recipients for email client`
- Plural forms for `{{count}} min left`
- Additional standalone terms per locale (Code, Signature, BCC Mode, Check-out, Fundraising, Items, Planning, Catalog, Important, Major, Access, Self-service, Changelog, Feature, Live Preview, Sell-through, `%d archived fundraiser`, `%d person successfully added to selected family.`)

## Next Steps
1. Review and merge this PR
2. Run: `npm run locale:upload:missing -- --yes` (requires POEDITOR_TOKEN)