### PR TITLE
Fix issue #9330: add admin menu before plugin menu items are merged

### DIFF
--- a/src/ChurchCRM/Config/Menu/Menu.php
+++ b/src/ChurchCRM/Config/Menu/Menu.php
@@ -53,7 +53,13 @@ class Menu
             $menus['Email'] = $menus['Communication'];
         }
 
-        // Add plugin menu items to their parent menus
+        // Admin menu is always last (at bottom of nav)
+        if ($isAdmin) {
+            $menus['Admin'] = self::getAdminMenu($isAdmin);
+        }
+
+        // Add plugin menu items to their parent menus (must run after Admin menu is set,
+        // so plugins can attach submenu items to the Admin menu)
         self::addPluginMenuItems($menus);
 
         // Remove the backward-compat alias so it doesn't appear as a duplicate menu
@@ -61,11 +67,6 @@ class Menu
         
         // Allow plugins to add top-level menus via the MENU_BUILDING hook
         $menus = HookManager::applyFilters(Hooks::MENU_BUILDING, $menus);
-        
-        // Admin menu is always last (at bottom of nav)
-        if ($isAdmin) {
-            $menus['Admin'] = self::getAdminMenu($isAdmin);
-        }
         
         return $menus;
 


### PR DESCRIPTION
## Summary
Fix plugin menu items with `parent: 'admin'` being silently dropped from the sidebar. The Admin menu is now added to the menu tree *before* plugin menu items are merged, so plugins can attach submenu items to it.

## Changes
- Reordered `Menu::buildMenuItems()` so `$menus['Admin']` is set before `addPluginMenuItems()` runs

## Why
- `addPluginMenuItems()` ran before the `Admin` menu existed, so any plugin item declaring `parent: 'admin'` was silently discarded
- Fixes issue #9330

## Files Changed
- `src/ChurchCRM/Config/Menu/Menu.php` - 7 insertions, 6 deletions

## Testing
- ✅ PHP syntax validated (`php -l`, PHP 8.3)
- ✅ Biome lint passes
- ✅ Manual test with a custom plugin

## Related Issues
Fixes #9330