### PR TITLE
chore(ci): bump actions/setup-dotnet from v5 to v6

### DIFF
--- a/.github/workflows/security-analysis.yml
+++ b/.github/workflows/security-analysis.yml
@@ -110,7 +110,7 @@ jobs:
             devskim-rules-${{ runner.os }}-
 
       - name: Setup .NET 6.0
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '6.0.x'
 


### PR DESCRIPTION
## Summary
Bumps the `actions/setup-dotnet` action from v5 to v6 to match Dependabot's recommendation in the actions group update.

## Changes
- Updated `.github/workflows/security-analysis.yml` to use `actions/setup-dotnet@v6`
- Kept .NET runtime version at `6.0.x` (no change to SDK version)

## Why
This is a maintenance bump to use the latest stable version of the setup-dotnet action, which includes dependency updates and performance improvements. The .NET 6.0.x runtime remains unchanged, maintaining backward compatibility.

## Testing
- DevSkim security scanning continues to work with .NET 6.0 SDK
- Pre-commit and pre-push checks passed
- No workflow logic changes, only action version bump

Ref: PR #9336 (partial - action version bump only, SDK version unchanged)