### PR TITLE
Fix plural forms structure in POEditor scripts

### DIFF
--- a/cypress/e2e/ui/finance/finance.payment-submission.spec.js
+++ b/cypress/e2e/ui/finance/finance.payment-submission.spec.js
@@ -109,6 +109,7 @@ describe("Finance Payment Submission - Issue #7257 Regression Test", () => {
         // Provide a family (required by the new pledge editor form)
         cy.get("#FamilyID").invoke("val", "1");
 
+        cy.get("#Method").select("CHECK");
         cy.get(".fund-select").first().select(1);
         cy.get("#CheckNo").type(checkNumber); // Fill check number first
 
@@ -155,6 +156,7 @@ describe("Finance Payment Submission - Issue #7257 Regression Test", () => {
         // Provide a family (required by the new pledge editor form)
         cy.get("#FamilyID").invoke("val", "1");
 
+        cy.get("#Method").select("CHECK");
         cy.get("#CheckNo").type(checkNumber); // Fill check number first
 
         // Fill payment form with multiple funds

--- a/cypress/e2e/ui/finance/finance.payment-submission.spec.js
+++ b/cypress/e2e/ui/finance/finance.payment-submission.spec.js
@@ -109,7 +109,6 @@ describe("Finance Payment Submission - Issue #7257 Regression Test", () => {
         // Provide a family (required by the new pledge editor form)
         cy.get("#FamilyID").invoke("val", "1");
 
-        cy.get("#Method").select("CHECK");
         cy.get(".fund-select").first().select(1);
         cy.get("#CheckNo").type(checkNumber); // Fill check number first
 
@@ -156,7 +155,6 @@ describe("Finance Payment Submission - Issue #7257 Regression Test", () => {
         // Provide a family (required by the new pledge editor form)
         cy.get("#FamilyID").invoke("val", "1");
 
-        cy.get("#Method").select("CHECK");
         cy.get("#CheckNo").type(checkNumber); // Fill check number first
 
         // Fill payment form with multiple funds

--- a/locale/scripts/poeditor-downloader.js
+++ b/locale/scripts/poeditor-downloader.js
@@ -140,10 +140,38 @@ async function fetchUntranslatedTerms(poEditorLocale) {
 }
 
 /**
+ * Restructure POEditor export from malformed to correct format for upload.
+ * POEditor returns: { "one": { term1: "...", term2: "..." }, "other": { ... } }
+ * We need: { "term1": { "one": "...", "other": "..." }, "term2": { ... } }
+ */
+function restructurePluralForms(data) {
+    if (!data.one && !data.other) return data;
+    if (typeof data.one === 'object' && typeof data.other === 'object') {
+        const restructured = {};
+        for (const [key, value] of Object.entries(data)) {
+            if (key !== 'one' && key !== 'other' && typeof value === 'string') {
+                restructured[key] = value;
+            }
+        }
+        const termKeys = new Set([...Object.keys(data.one || {}), ...Object.keys(data.other || {})]);
+        for (const term of termKeys) {
+            const pluralForms = {};
+            if (data.one && data.one[term]) pluralForms.one = data.one[term];
+            if (data.other && data.other[term]) pluralForms.other = data.other[term];
+            if (Object.keys(pluralForms).length > 0) restructured[term] = pluralForms;
+        }
+        return restructured;
+    }
+    return data;
+}
+
+/**
  * Save missing terms in batched JSON files under MISSING_OUTPUT_DIR/{poEditorCode}/
  * Returns array of written file paths.
  */
 function saveBatchedMissingTerms(poEditorCode, missingTerms) {
+    missingTerms = restructurePluralForms(missingTerms);
+
     const localeOutDir = path.join(MISSING_OUTPUT_DIR, poEditorCode);
 
     if (!fs.existsSync(localeOutDir)) {

--- a/locale/scripts/poeditor-downloader.js
+++ b/locale/scripts/poeditor-downloader.js
@@ -156,8 +156,8 @@ function restructurePluralForms(data) {
         const termKeys = new Set([...Object.keys(data.one || {}), ...Object.keys(data.other || {})]);
         for (const term of termKeys) {
             const pluralForms = {};
-            if (data.one && data.one[term]) pluralForms.one = data.one[term];
-            if (data.other && data.other[term]) pluralForms.other = data.other[term];
+            if (data.one != null && data.one[term] !== undefined && data.one[term] !== null) pluralForms.one = data.one[term];
+            if (data.other != null && data.other[term] !== undefined && data.other[term] !== null) pluralForms.other = data.other[term];
             if (Object.keys(pluralForms).length > 0) restructured[term] = pluralForms;
         }
         return restructured;

--- a/locale/scripts/poeditor-upload-missing.js
+++ b/locale/scripts/poeditor-upload-missing.js
@@ -188,6 +188,33 @@ function loadEnglishOkAllowlist() {
     }
 }
 
+// ── Plural form restructuring ───────────────────────────────────────────────
+
+/**
+ * Defensive restructure for malformed plural forms from POEditor export.
+ * If batch file has top-level "one"/"other", fixes to proper nesting.
+ */
+function restructurePluralForms(data) {
+    if (!data.one && !data.other) return data;
+    if (typeof data.one === 'object' && typeof data.other === 'object') {
+        const restructured = {};
+        for (const [key, value] of Object.entries(data)) {
+            if (key !== 'one' && key !== 'other' && typeof value === 'string') {
+                restructured[key] = value;
+            }
+        }
+        const termKeys = new Set([...Object.keys(data.one || {}), ...Object.keys(data.other || {})]);
+        for (const term of termKeys) {
+            const pluralForms = {};
+            if (data.one && data.one[term]) pluralForms.one = data.one[term];
+            if (data.other && data.other[term]) pluralForms.other = data.other[term];
+            if (Object.keys(pluralForms).length > 0) restructured[term] = pluralForms;
+        }
+        return restructured;
+    }
+    return data;
+}
+
 // ── Term analysis ────────────────────────────────────────────────────────────
 
 /**
@@ -229,7 +256,8 @@ function isNotIdenticalToKey(termKey, value) {
  * @param {Set<string>} [englishOkSet] - optional set of terms safe to upload as-is
  */
 function analyzeFile(filePath, englishOkSet = new Set()) {
-    const raw = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    let raw = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    raw = restructurePluralForms(raw); // Defensive: fix malformed plural structure if present
     const localizedTerms = {};
     const suspectTerms = {};
     const emptyTerms = {};

--- a/locale/scripts/poeditor-upload-missing.js
+++ b/locale/scripts/poeditor-upload-missing.js
@@ -206,8 +206,8 @@ function restructurePluralForms(data) {
         const termKeys = new Set([...Object.keys(data.one || {}), ...Object.keys(data.other || {})]);
         for (const term of termKeys) {
             const pluralForms = {};
-            if (data.one && data.one[term]) pluralForms.one = data.one[term];
-            if (data.other && data.other[term]) pluralForms.other = data.other[term];
+            if (data.one != null && data.one[term] !== undefined && data.one[term] !== null) pluralForms.one = data.one[term];
+            if (data.other != null && data.other[term] !== undefined && data.other[term] !== null) pluralForms.other = data.other[term];
             if (Object.keys(pluralForms).length > 0) restructured[term] = pluralForms;
         }
         return restructured;


### PR DESCRIPTION
## Summary
Fixes malformed plural forms structure returned by POEditor's API, ensuring batch files are properly formatted for upload and translation workflow.

## Changes
- **poeditor-downloader.js**: Added `restructurePluralForms()` to convert POEditor's export format immediately after download
  - Converts `{ "one": {...}, "other": {...} }` to proper nesting `{ "term": { "one": "...", "other": "..." } }`
  - Prevents malformed files from being saved to disk
  
- **poeditor-upload-missing.js**: Added defensive `restructurePluralForms()` in `analyzeFile()`
  - Safety check: fixes malformed files during analysis if they exist
  - Ensures upload works even with incorrectly structured batch files

## Why
POEditor's API returns plural forms with "one"/"other" at the top level when exporting untranslated terms. This doesn't match the nested structure expected by the upload API, causing:
- Incorrect term counting during validation
- Upload failures or incomplete uploads
- Batch files cleared by refresh mechanism due to mismatched structure

## Testing
- Both scripts now properly handle plural form restructuring
- Batch files will be created with correct structure going forward
- Upload script can handle legacy malformed files defensively

## Related Issues
Fixes upload issues when running `npm run locale:upload:missing`