### PR TITLE
security: fix GHSA-qc2c-qmw4-52fp — remove orphaned query parameters

### DIFF
--- a/src/mysql/install/Install.sql
+++ b/src/mysql/install/Install.sql
@@ -636,15 +636,6 @@ CREATE TABLE `queryparameteroptions_qpo` (
 --
 
 INSERT INTO `queryparameteroptions_qpo` (`qpo_qrp_ID`, `qpo_Display`, `qpo_Value`) VALUES
-  (4, 'Male', '1'),
-  (4, 'Female', '2'),
-  (6, 'Male', '1'),
-  (6, 'Female', '2'),
-  (15, 'Name', 'CONCAT(COALESCE(`per_FirstName`,''''),COALESCE(`per_MiddleName`,''''),COALESCE(`per_LastName`,''''))'),
-  (15, 'Zip Code', 'fam_Zip'),
-  (15, 'State', 'fam_State'),
-  (15, 'City', 'fam_City'),
-  (15, 'Home Phone', 'per_HomePhone'),
   (27, '2012/2013', '17'),
   (27, '2013/2014', '18'),
   (27, '2014/2015', '19'),
@@ -689,8 +680,6 @@ INSERT INTO `queryparameteroptions_qpo` (`qpo_qrp_ID`, `qpo_Display`, `qpo_Value
   (31, '2020/2021', '25'),
   (31, '2021/2022', '26'),
   (31, '2022/2023', '27'),
-  (15, 'Email', 'per_Email'),
-  (15, 'WorkEmail', 'per_WorkEmail'),
   (33, 'Member', '1'),
   (33, 'Regular Attender', '2'),
   (33, 'Guest', '3'),
@@ -728,21 +717,8 @@ CREATE TABLE `queryparameters_qrp` (
 --
 
 INSERT INTO `queryparameters_qrp` (`qrp_ID`, `qrp_qry_ID`, `qrp_Type`, `qrp_OptionSQL`, `qrp_Name`, `qrp_Description`, `qrp_Alias`, `qrp_Default`, `qrp_Required`, `qrp_InputBoxSize`, `qrp_Validation`, `qrp_NumericMax`, `qrp_NumericMin`, `qrp_AlphaMinLength`, `qrp_AlphaMaxLength`) VALUES
-  (1, 4, 0, NULL, 'Minimum Age', 'The minimum age for which you want records returned.', 'min', '0', 0, 5, 'n', 120, 0, NULL, NULL),
-  (2, 4, 0, NULL, 'Maximum Age', 'The maximum age for which you want records returned.', 'max', '120', 1, 5, 'n', 120, 0, NULL, NULL),
-  (4, 6, 1, '', 'Gender', 'The desired gender to search the database for.', 'gender', '1', 1, 0, '', 0, 0, 0, 0),
-  (5, 7, 2, 'SELECT lst_OptionID as Value, lst_OptionName as Display FROM list_lst WHERE lst_ID=2 ORDER BY lst_OptionSequence', 'Family Role', 'Select the desired family role.', 'role', '1', 0, 0, '', 0, 0, 0, 0),
-  (6, 7, 1, '', 'Gender', 'The gender for which you would like records returned.', 'gender', '1', 1, 0, '', 0, 0, 0, 0),
   (8, 9, 2, 'SELECT pro_ID AS Value, pro_Name as Display \r\nFROM property_pro\r\nWHERE pro_Class= ''p'' \r\nORDER BY pro_Name ', 'Property', 'The property for which you would like person records returned.', 'PropertyID', '0', 1, 0, '', 0, 0, 0, 0),
-  (9, 10, 2, 'SELECT distinct don_date as Value, don_date as Display FROM donations_don ORDER BY don_date ASC', 'Beginning Date', 'Please select the beginning date to calculate total contributions for each member (i.e. YYYY-MM-DD). NOTE: You can only choose dates that contain donations.', 'startdate', '1', 1, 0, '0', 0, 0, 0, 0),
-  (10, 10, 2, 'SELECT distinct don_date as Value, don_date as Display FROM donations_don\r\nORDER BY don_date DESC', 'Ending Date', 'Please enter the last date to calculate total contributions for each member (i.e. YYYY-MM-DD).', 'enddate', '1', 1, 0, '', 0, 0, 0, 0),
-  (14, 15, 0, '', 'Search', 'Enter any part of the following: Name, City, State, Zip, Home Phone, Email, or Work Email.', 'searchstring', '', 1, 0, '', 0, 0, 0, 0),
-  (15, 15, 1, '', 'Field', 'Select field to search for.', 'searchwhat', '1', 1, 0, '', 0, 0, 0, 0),
-  (16, 11, 2, 'SELECT distinct don_date as Value, don_date as Display FROM donations_don ORDER BY don_date ASC', 'Beginning Date', 'Please select the beginning date to calculate total contributions for each member (i.e. YYYY-MM-DD). NOTE: You can only choose dates that contain donations.', 'startdate', '1', 1, 0, '0', 0, 0, 0, 0),
-  (17, 11, 2, 'SELECT distinct don_date as Value, don_date as Display FROM donations_don\r\nORDER BY don_date DESC', 'Ending Date', 'Please enter the last date to calculate total contributions for each member (i.e. YYYY-MM-DD).', 'enddate', '1', 1, 0, '', 0, 0, 0, 0),
   (18, 18, 0, '', 'Month', 'The birthday month for which you would like records returned.', 'birthmonth', '1', 1, 0, '', 12, 1, 1, 2),
-  (19, 19, 2, 'SELECT grp_ID AS Value, grp_Name AS Display FROM group_grp ORDER BY grp_Type', 'Class', 'The sunday school class for which you would like records returned.', 'group', '1', 1, 0, '', 12, 1, 1, 2),
-  (20, 20, 2, 'SELECT grp_ID AS Value, grp_Name AS Display FROM group_grp ORDER BY grp_Type', 'Class', 'The sunday school class for which you would like records returned.', 'group', '1', 1, 0, '', 12, 1, 1, 2),
   (22, 22, 0, '', 'Month', 'The membership anniversary month for which you would like records returned.', 'membermonth', '1', 1, 0, '', 12, 1, 1, 2),
   (25, 25, 2, 'SELECT vol_ID AS Value, vol_Name AS Display FROM volunteeropportunity_vol ORDER BY vol_Name', 'Volunteer opportunities', 'Choose a volunteer opportunity', 'volopp', '1', 1, 0, '', 12, 1, 1, 2),
   (26, 26, 0, '', 'Months', 'Number of months since becoming a friend', 'friendmonths', '1', 1, 0, '', 24, 1, 1, 2),

--- a/src/mysql/upgrade.json
+++ b/src/mysql/upgrade.json
@@ -83,7 +83,7 @@
   },
   "current": {
     "versions": ["7.5.1"],
-    "scripts": [],
+    "scripts": ["/mysql/upgrade/7.6.0-remove-orphaned-query-parameters.sql"],
     "dbVersion": "7.6.0"
   }
 }

--- a/src/mysql/upgrade/7.6.0-remove-orphaned-query-parameters.sql
+++ b/src/mysql/upgrade/7.6.0-remove-orphaned-query-parameters.sql
@@ -1,0 +1,35 @@
+-- ChurchCRM 7.6.0 Security Migration — GHSA-qc2c-qmw4-52fp (CWE-89)
+-- Remove orphaned predefined-query parameters and parameter options.
+--
+-- Background:
+--   The 6.6.0 and 6.7.0 upgrades retired a number of predefined queries by
+--   deleting rows from query_qry, but never deleted the child rows in
+--   queryparameters_qrp / queryparameteroptions_qpo. Those orphans survive on
+--   every upgraded install.
+--
+--   The orphans left behind by the retired "Advanced Search" query (qry_ID 15)
+--   are the subject of GHSA-qc2c-qmw4-52fp: its 'searchwhat' parameter is
+--   substituted into the WHERE clause as a bare column name, and its
+--   queryparameteroptions_qpo rows store raw SQL column expressions as option
+--   values. Deleting the rows removes the injection surface outright rather
+--   than escaping around it.
+--
+--   Matching rows were also removed from Install.sql, so new installations
+--   never carry them.
+--
+-- Order matters: options are identified through their parent parameter row, so
+-- they must be deleted before the parameters themselves.
+--
+-- Idempotent: safe to re-run; a second run matches nothing.
+
+DELETE qpo
+FROM queryparameteroptions_qpo qpo
+	LEFT JOIN queryparameters_qrp qrp ON qpo.qpo_qrp_ID = qrp.qrp_ID
+	LEFT JOIN query_qry qry ON qrp.qrp_qry_ID = qry.qry_ID
+WHERE qrp.qrp_ID IS NULL
+	OR qry.qry_ID IS NULL;
+
+DELETE qrp
+FROM queryparameters_qrp qrp
+	LEFT JOIN query_qry qry ON qrp.qrp_qry_ID = qry.qry_ID
+WHERE qry.qry_ID IS NULL;


### PR DESCRIPTION
## Summary
Closes GHSA-qc2c-qmw4-52fp — SQL injection via column-name parameter in QueryView.

**Approach:** Instead of validating/escaping around the vulnerable `searchwhat` parameter, this removes it (and other pre-existing orphaned rows) entirely. The Advanced Search query (`qry_ID` 15) was retired in a prior upgrade (6.6.0/6.7.0), which deleted its `query_qry` row but left the child `queryparameters_qrp` / `queryparameteroptions_qpo` rows behind. Since `QueryView.php` substitutes `~searchwhat~` directly into the SQL `WHERE` clause as a bare column name using attacker-controlled `qpo_Value` data, these orphaned rows were the injection surface. Deleting them removes the surface outright rather than adding validation logic around it.

## Changes
- `src/mysql/install/Install.sql` — remove orphaned `queryparameters_qrp` / `queryparameteroptions_qpo` rows for retired queries (`qry_ID` 4, 6, 7, 10, 11, 15, 19, 20) so new installs never carry them
- `src/mysql/upgrade/7.6.0-remove-orphaned-query-parameters.sql` — new idempotent migration that deletes the same orphaned rows from existing installs (options before parameters, to respect the FK relationship)
- `src/mysql/upgrade.json` — register the new migration script under the `7.6.0` upgrade step

## Why
- Fixes GHSA-qc2c-qmw4-52fp (CWE-89, SQL injection via `searchwhat` parameter)
- The orphaned rows served no functional purpose (their parent query was already retired) — removing them is safer and simpler than adding validation for dead code paths
- Verified via `Install.sql`: every removed `qrp` row's `qrp_qry_ID` has no matching `query_qry` row

## Testing
- ✅ `npm run lint` — no new errors (2 pre-existing warnings in unrelated files)
- ✅ `npm run build:php` — no changed PHP files, syntax check passed
- ✅ Manually verified all removed `qrp_ID` rows reference orphaned `qry_ID` values (4, 6, 7, 10, 11, 15, 19, 20) not present in `query_qry`

## Migration scope
The database migration removes *all* orphaned `queryparameters_qrp` and `queryparameteroptions_qpo` rows (i.e. rows with no corresponding system query), not just specific IDs. This broad-scope cleanup is intentional — it is safer and more maintainable than maintaining a hardcoded list of IDs to remove, and ensures any similar orphaned rows accumulated over time are also cleaned up.

## Related
Supersedes #9346, which took a validate-in-place approach (identifier backticking / whitelist) for the same advisory. This PR removes the vulnerable feature's dead data instead.