### PR TITLE
Fix security/code-scanning/499: remove magic-path dispatch, add path-traversal guard

### DIFF
--- a/cypress/e2e/api/private/private.index-php-routing.spec.js
+++ b/cypress/e2e/api/private/private.index-php-routing.spec.js
@@ -47,7 +47,16 @@ describe("API Private - index.php Routing", () => {
                 expect(redirectResponse.status).to.equal(302);
                 expect(redirectResponse.headers.location).to.include("/errors/not-found.php");
 
-                cy.request({ url: redirectResponse.headers.location, failOnStatusCode: false })
+                // Use new URL() to resolve the Location header against baseUrl — Cypress
+                // cy.request concatenates baseUrl + url for paths starting with '/', which
+                // in a subdir install doubles the prefix (e.g. /churchcrm/ + /churchcrm/errors/…
+                // → /churchcrm/churchcrm/errors/…). Constructing an absolute URL first
+                // prevents Cypress from prepending baseUrl again.
+                const resolvedUrl = new URL(
+                    redirectResponse.headers.location,
+                    Cypress.config('baseUrl')
+                ).href;
+                cy.request({ url: resolvedUrl, failOnStatusCode: false })
                     .then((finalResponse) => {
                         expect(finalResponse.status).to.equal(404);
                         expect(finalResponse.body).to.include("Page Not Found");

--- a/cypress/e2e/api/private/private.index-php-routing.spec.js
+++ b/cypress/e2e/api/private/private.index-php-routing.spec.js
@@ -1,0 +1,66 @@
+/// <reference types="cypress" />
+
+/**
+ * index.php front-controller — HTTP status/redirect contract
+ *
+ * Covers the dispatch logic in src/index.php: the removed legacy filename
+ * shims (UserEditor.php / SettingsUser.php, migrated to Admin MVC in #9173),
+ * the /index.php -> /v2/dashboard redirect, and the 404 flow for paths that
+ * don't resolve to a real .php file under the doc root (bare 404 for
+ * js/css-looking paths, the standalone errors/not-found.php page for
+ * everything else).
+ */
+describe("API Private - index.php Routing", () => {
+    beforeEach(() => {
+        cy.setupStandardSession();
+    });
+
+    it("redirects /index.php to the v2 dashboard", () => {
+        cy.request({ url: "/index.php", followRedirect: false, failOnStatusCode: false })
+            .then((response) => {
+                expect(response.status).to.equal(302);
+                expect(response.headers.location).to.include("/v2/dashboard");
+            });
+    });
+
+    it("no longer special-cases the deleted UserEditor.php shim", () => {
+        cy.request({ url: "/UserEditor.php?PersonID=1", followRedirect: false, failOnStatusCode: false })
+            .then((response) => {
+                expect(response.status).to.equal(302);
+                expect(response.headers.location).to.include("/errors/not-found.php");
+                expect(response.headers.location).to.not.include("/admin/system/users");
+            });
+    });
+
+    it("no longer special-cases the deleted SettingsUser.php shim", () => {
+        cy.request({ url: "/SettingsUser.php", followRedirect: false, failOnStatusCode: false })
+            .then((response) => {
+                expect(response.status).to.equal(302);
+                expect(response.headers.location).to.include("/errors/not-found.php");
+                expect(response.headers.location).to.not.include("/admin/system/users");
+            });
+    });
+
+    it("redirects an unresolved page path to the standalone 404 page", () => {
+        cy.request({ url: "/this-page-was-never-real.php", followRedirect: false, failOnStatusCode: false })
+            .then((redirectResponse) => {
+                expect(redirectResponse.status).to.equal(302);
+                expect(redirectResponse.headers.location).to.include("/errors/not-found.php");
+
+                cy.request({ url: redirectResponse.headers.location, failOnStatusCode: false })
+                    .then((finalResponse) => {
+                        expect(finalResponse.status).to.equal(404);
+                        expect(finalResponse.body).to.include("Page Not Found");
+                        expect(finalResponse.body).to.include("this-page-was-never-real.php");
+                    });
+            });
+    });
+
+    it("returns a bare 404 for a missing static asset instead of the HTML error page", () => {
+        cy.request({ url: "/skin/v2/this-chunk-does-not-exist.js", failOnStatusCode: false })
+            .then((response) => {
+                expect(response.status).to.equal(404);
+                expect(response.body).to.not.include("Page Not Found");
+            });
+    });
+});

--- a/src/ChurchCRM/utils/PathUtils.php
+++ b/src/ChurchCRM/utils/PathUtils.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace ChurchCRM\Utils;
+
+use ChurchCRM\dto\SystemURLs;
+
+class PathUtils
+{
+    /**
+     * Resolve $path and verify it is a real file located strictly inside
+     * $containingDir — not merely string-prefixed by it, which would wrongly
+     * accept a sibling directory (e.g. "/var/logs-secret" prefix-matches
+     * "/var/logs"). Returns the resolved real path, or null if $path escapes
+     * $containingDir (e.g. via "../" traversal), doesn't exist, or isn't a
+     * regular file.
+     */
+    public static function resolveRealPathWithin(string $path, string $containingDir): ?string
+    {
+        $containingDirReal = realpath($containingDir);
+        if ($containingDirReal === false) {
+            return null;
+        }
+
+        $pathReal = realpath($path);
+        if ($pathReal === false || !is_file($pathReal)) {
+            return null;
+        }
+
+        if (!str_starts_with($pathReal, $containingDirReal . DIRECTORY_SEPARATOR)) {
+            return null;
+        }
+
+        return $pathReal;
+    }
+
+    /**
+     * Resolve $candidate against the app's document root and return the real,
+     * on-disk path only if it exists as a regular .php file *inside* it. Returns
+     * null for anything that escapes the document root (e.g. "../" traversal),
+     * isn't a .php file, or doesn't resolve to a real file — so non-PHP files
+     * (config, .env, images) can never be dumped raw via require().
+     */
+    public static function resolveSafeRequirePath(string $candidate): ?string
+    {
+        if (strtolower(pathinfo($candidate, PATHINFO_EXTENSION)) !== 'php') {
+            return null;
+        }
+
+        $docRoot = SystemURLs::getDocumentRoot();
+
+        return self::resolveRealPathWithin($docRoot . '/' . $candidate, $docRoot);
+    }
+}

--- a/src/admin/routes/api/system/system-logs.php
+++ b/src/admin/routes/api/system/system-logs.php
@@ -3,6 +3,7 @@
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\dto\SystemURLs;
 use ChurchCRM\Utils\LoggerUtils;
+use ChurchCRM\Utils\PathUtils;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Routing\RouteCollectorProxy;
@@ -100,15 +101,14 @@ $app->group('/api/system/logs', function (RouteCollectorProxy $group): void {
         }
 
         // Security: Verify the file is inside the logs directory (prevent directory traversal)
-        $resolvedPath = realpath($logPath);
-        $resolvedDir = realpath($logsDir);
-        if (!$resolvedPath || !$resolvedDir || strpos($resolvedPath, $resolvedDir) !== 0) {
+        $resolvedPath = PathUtils::resolveRealPathWithin($logPath, $logsDir);
+        if ($resolvedPath === null) {
             $response->getBody()->write('Invalid file path');
             return $response->withStatus(400);
         }
 
         $content = file_get_contents($resolvedPath);
-        
+
         // Parse log lines and return as JSON array
         // Split by newline and filter empty lines, then reindex array for proper JSON output
         $allLines = explode("\n", $content);
@@ -151,9 +151,8 @@ $app->group('/api/system/logs', function (RouteCollectorProxy $group): void {
         }
 
         // Security: Verify the file is inside the logs directory (prevent directory traversal)
-        $resolvedPath = realpath($logPath);
-        $resolvedDir = realpath($logsDir);
-        if (!$resolvedPath || !$resolvedDir || strpos($resolvedPath, $resolvedDir) !== 0) {
+        $resolvedPath = PathUtils::resolveRealPathWithin($logPath, $logsDir);
+        if ($resolvedPath === null) {
             return $response->withStatus(400);
         }
 
@@ -200,9 +199,8 @@ $app->group('/api/system/logs', function (RouteCollectorProxy $group): void {
         }
 
         // Security: Verify the file is inside the logs directory (prevent directory traversal)
-        $resolvedPath = realpath($logPath);
-        $resolvedDir = realpath($logsDir);
-        if (!$resolvedPath || !$resolvedDir || strpos($resolvedPath, $resolvedDir) !== 0) {
+        $resolvedPath = PathUtils::resolveRealPathWithin($logPath, $logsDir);
+        if ($resolvedPath === null) {
             $response->getBody()->write('Invalid file path');
             return $response->withStatus(400);
         }

--- a/src/admin/routes/api/upgrade.php
+++ b/src/admin/routes/api/upgrade.php
@@ -3,6 +3,7 @@
 use ChurchCRM\Service\UpgradeAPIService;
 use ChurchCRM\Slim\SlimUtils;
 use ChurchCRM\Utils\LoggerUtils;
+use ChurchCRM\Utils\PathUtils;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Routing\RouteCollectorProxy;
@@ -111,9 +112,8 @@ $app->group('/api/upgrade', function (RouteCollectorProxy $group): void {
                 return SlimUtils::renderErrorJSON($response, gettext('Missing required fields: fullPath and sha1'), [], 400, null, $request);
             }
             // Prevent path traversal: ensure the file is inside the system temp directory
-            $realPath = realpath($fullPath);
-            $tempDir = realpath(sys_get_temp_dir());
-            if ($realPath === false || $tempDir === false || !str_starts_with($realPath, $tempDir . DIRECTORY_SEPARATOR)) {
+            $realPath = PathUtils::resolveRealPathWithin($fullPath, sys_get_temp_dir());
+            if ($realPath === null) {
                 return SlimUtils::renderErrorJSON($response, gettext('Invalid file path'), [], 400, null, $request);
             }
             // Guard against stray PHP output (warnings/notices from the legacy

--- a/src/errors/config-error.php
+++ b/src/errors/config-error.php
@@ -8,7 +8,7 @@ $errorMessage = $_GET['error'] ?? 'Configuration error';
 
 // Build custom sections for this error
 $customSections = "### Configuration Error Details\n\n";
-$customSections .= "```\n" . htmlspecialchars($errorMessage) . "\n```";
+$customSections .= "```\n" . str_replace('`', "'", $errorMessage) . "\n```";
 
 $issueBody = buildGitHubIssueBody('Configuration Error', $customSections);
 

--- a/src/errors/config-error.php
+++ b/src/errors/config-error.php
@@ -8,7 +8,7 @@ $errorMessage = $_GET['error'] ?? 'Configuration error';
 
 // Build custom sections for this error
 $customSections = "### Configuration Error Details\n\n";
-$customSections .= "```\n" . str_replace('`', "'", $errorMessage) . "\n```";
+$customSections .= "```\n" . str_replace(["\r", "\n", '`'], [' ', ' ', "'"], $errorMessage) . "\n```";
 
 $issueBody = buildGitHubIssueBody('Configuration Error', $customSections);
 

--- a/src/errors/not-found.php
+++ b/src/errors/not-found.php
@@ -5,6 +5,9 @@ http_response_code(404);
 require_once __DIR__ . '/template.php';
 
 $requestedPath = $_GET['path'] ?? ($_SERVER['REQUEST_URI'] ?? 'unknown');
+if (!is_string($requestedPath)) {
+    $requestedPath = 'unknown';
+}
 
 $customSections = "### Requested Path\n\n";
 $customSections .= "```\n" . htmlspecialchars($requestedPath) . "\n```";

--- a/src/errors/not-found.php
+++ b/src/errors/not-found.php
@@ -1,0 +1,19 @@
+<?php
+// The requested page does not exist, or was moved/removed in a later version.
+http_response_code(404);
+
+require_once __DIR__ . '/template.php';
+
+$requestedPath = $_GET['path'] ?? ($_SERVER['REQUEST_URI'] ?? 'unknown');
+
+$customSections = "### Requested Path\n\n";
+$customSections .= "```\n" . htmlspecialchars($requestedPath) . "\n```";
+
+$issueBody = buildGitHubIssueBody('Page Not Found (404)', $customSections);
+
+$content = '<p class="text-muted mb-2">The page you requested could not be found. It may have been moved, renamed, or no longer exists.</p>'
+    . '<div class="alert alert-secondary border-2 mt-3">'
+    . '<strong>Requested:</strong> <code class="small text-break">' . htmlspecialchars($requestedPath) . '</code>'
+    . '</div>';
+
+renderErrorPage('Page Not Found', '🔍', 'secondary', $content, $issueBody);

--- a/src/errors/not-found.php
+++ b/src/errors/not-found.php
@@ -4,13 +4,22 @@ http_response_code(404);
 
 require_once __DIR__ . '/template.php';
 
-$requestedPath = $_GET['path'] ?? ($_SERVER['REQUEST_URI'] ?? 'unknown');
-if (!is_string($requestedPath)) {
-    $requestedPath = 'unknown';
+// $_GET['path'] is set by index.php's redirect: errors/not-found.php?path=<shortName>.
+// Fall back to REQUEST_URI only when this page is visited directly (no ?path= query param);
+// in that case show a sanitised path (leading slash + no query string) so it is readable.
+$_rawPath = $_GET['path'] ?? null;
+if (!is_string($_rawPath) || $_rawPath === '') {
+    $_uri = $_SERVER['REQUEST_URI'] ?? '';
+    $_rawPath = '/' . ltrim(strtok($_uri, '?'), '/');
+    if ($_rawPath === '/') {
+        $_rawPath = 'unknown';
+    }
 }
+$requestedPath = $_rawPath;
+unset($_rawPath, $_uri);
 
 $customSections = "### Requested Path\n\n";
-$customSections .= "```\n" . htmlspecialchars($requestedPath) . "\n```";
+$customSections .= "```\n" . $requestedPath . "\n```";
 
 $issueBody = buildGitHubIssueBody('Page Not Found (404)', $customSections);
 

--- a/src/errors/not-found.php
+++ b/src/errors/not-found.php
@@ -19,7 +19,7 @@ $requestedPath = $_rawPath;
 unset($_rawPath, $_uri);
 
 $customSections = "### Requested Path\n\n";
-$customSections .= "```\n" . $requestedPath . "\n```";
+$customSections .= "```\n" . str_replace('`', "'", $requestedPath) . "\n```";
 
 $issueBody = buildGitHubIssueBody('Page Not Found (404)', $customSections);
 

--- a/src/errors/not-found.php
+++ b/src/errors/not-found.php
@@ -19,7 +19,7 @@ $requestedPath = $_rawPath;
 unset($_rawPath, $_uri);
 
 $customSections = "### Requested Path\n\n";
-$customSections .= "```\n" . str_replace('`', "'", $requestedPath) . "\n```";
+$customSections .= "```\n" . str_replace(["\r", "\n", '`'], [' ', ' ', "'"], $requestedPath) . "\n```";
 
 $issueBody = buildGitHubIssueBody('Page Not Found (404)', $customSections);
 

--- a/src/index.php
+++ b/src/index.php
@@ -91,8 +91,7 @@ if (empty(SystemConfig::getValue('sChurchName'))) {
 // Legacy URL shims — redirect removed pages to their MVC replacements.
 // $shortName is already the path-only portion, so bookmarks like
 // /UserEditor.php?PersonID=5 resolve correctly.
-$_legacyBase = $shortName;
-if ($_legacyBase === 'UserEditor.php') {
+if ($shortName === 'UserEditor.php') {
     if (!empty($_GET['PersonID'])) {
         RedirectUtils::redirect('admin/system/users/' . (int) $_GET['PersonID'] . '/edit');
     } elseif (!empty($_GET['NewPersonID'])) {
@@ -100,17 +99,13 @@ if ($_legacyBase === 'UserEditor.php') {
     } else {
         RedirectUtils::redirect('admin/system/users/new');
     }
-} elseif ($_legacyBase === 'SettingsUser.php') {
+} elseif ($shortName === 'SettingsUser.php') {
     RedirectUtils::redirect('admin/system/users');
 }
-unset($_legacyBase);
-
-$_idx_docRoot = SystemURLs::getDocumentRoot();
-$_idx_safeShortPath = _idx_resolveSafeRequirePath($shortName, $_idx_docRoot);
 
 if (strtolower($shortName) === 'index.php') {
     RedirectUtils::redirect('v2/dashboard');
-} elseif ($_idx_safeShortPath !== null) {
+} elseif (($_idx_safeShortPath = _idx_resolveSafeRequirePath($shortName, SystemURLs::getDocumentRoot())) !== null) {
     require $_idx_safeShortPath;
 } elseif (strpos($_SERVER['REQUEST_URI'], 'js') || strpos($_SERVER['REQUEST_URI'], 'css')) {
     header($_SERVER['SERVER_PROTOCOL'] . ' 404 Not Found', true, 404);

--- a/src/index.php
+++ b/src/index.php
@@ -51,12 +51,15 @@ $shortName = str_replace(SystemURLs::getRootPath() . '/', '', $_idx_requestPath)
 AuthenticationManager::ensureAuthentication();
 
 // On a fresh install (sChurchName empty), redirect admin users to complete setup.
-// getCurrentUser() is safe to call unguarded here: ensureAuthentication() above
-// already guarantees an authenticated session, or it would have redirected/exited.
 if (empty(SystemConfig::getValue('sChurchName'))) {
-    $currentUser = AuthenticationManager::getCurrentUser();
-    if ($currentUser->isAdmin()) {
-        RedirectUtils::redirect('admin/system/church-info');
+    try {
+        $currentUser = AuthenticationManager::getCurrentUser();
+        if ($currentUser->isAdmin()) {
+            RedirectUtils::redirect('admin/system/church-info');
+        }
+    } catch (\Throwable) {
+        // ensureAuthentication() above should have handled any auth failure;
+        // swallow here to avoid a 500 on edge-case provider errors.
     }
 }
 

--- a/src/index.php
+++ b/src/index.php
@@ -48,10 +48,16 @@ if (file_exists(__DIR__ . '/Include/Config.php')) {
 mb_internal_encoding('UTF-8');
 
 // Resolve $candidate against $docRoot and return the real, on-disk path only if
-// it exists as a regular file *inside* $docRoot. Returns null for anything that
-// escapes $docRoot (e.g. "../" traversal) or doesn't resolve to a real file.
+// it exists as a regular .php file *inside* $docRoot. Returns null for anything
+// that escapes $docRoot (e.g. "../" traversal), isn't a .php file, or doesn't
+// resolve to a real file — so non-PHP files (config, .env, images) can never be
+// dumped raw via require().
 function _idx_resolveSafeRequirePath(string $candidate, string $docRoot): ?string
 {
+    if (strtolower(pathinfo($candidate, PATHINFO_EXTENSION)) !== 'php') {
+        return null;
+    }
+
     $docRootReal = realpath($docRoot);
     if ($docRootReal === false) {
         return null;
@@ -107,7 +113,7 @@ if (strtolower($shortName) === 'index.php') {
     RedirectUtils::redirect('v2/dashboard');
 } elseif (($_idx_safeShortPath = _idx_resolveSafeRequirePath($shortName, SystemURLs::getDocumentRoot())) !== null) {
     require $_idx_safeShortPath;
-} elseif (strpos($_SERVER['REQUEST_URI'], 'js') || strpos($_SERVER['REQUEST_URI'], 'css')) {
+} elseif (str_contains($_SERVER['REQUEST_URI'], 'js') || str_contains($_SERVER['REQUEST_URI'], 'css')) {
     header($_SERVER['SERVER_PROTOCOL'] . ' 404 Not Found', true, 404);
     exit;
 } else {

--- a/src/index.php
+++ b/src/index.php
@@ -6,7 +6,6 @@ require_once __DIR__ . '/vendor/autoload.php';
 use ChurchCRM\Authentication\AuthenticationManager;
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\dto\SystemURLs;
-use ChurchCRM\Utils\MiscUtils;
 use ChurchCRM\Utils\RedirectUtils;
 use ChurchCRM\Utils\VersionUtils;
 
@@ -48,10 +47,31 @@ if (file_exists(__DIR__ . '/Include/Config.php')) {
 
 mb_internal_encoding('UTF-8');
 
-// Get the current request path and convert it into a magic filename
-// e.g. /list-events => /ListEvents.php
-$shortName = str_replace(SystemURLs::getRootPath() . '/', '', $_SERVER['REQUEST_URI']);
-$fileName = MiscUtils::dashesToCamelCase($shortName, true) . '.php';
+// Resolve $candidate against $docRoot and return the real, on-disk path only if
+// it exists as a regular file *inside* $docRoot. Returns null for anything that
+// escapes $docRoot (e.g. "../" traversal) or doesn't resolve to a real file.
+function _idx_resolveSafeRequirePath(string $candidate, string $docRoot): ?string
+{
+    $docRootReal = realpath($docRoot);
+    if ($docRootReal === false) {
+        return null;
+    }
+
+    $candidateReal = realpath($docRoot . '/' . $candidate);
+    if ($candidateReal === false || !is_file($candidateReal)) {
+        return null;
+    }
+
+    if (!str_starts_with($candidateReal, $docRootReal . DIRECTORY_SEPARATOR)) {
+        return null;
+    }
+
+    return $candidateReal;
+}
+
+// Get the current request path with query string stripped.
+$_idx_requestPath = strtok($_SERVER['REQUEST_URI'], '?');
+$shortName = str_replace(SystemURLs::getRootPath() . '/', '', $_idx_requestPath);
 
 // First, ensure that the user is authenticated.
 AuthenticationManager::ensureAuthentication();
@@ -69,9 +89,9 @@ if (empty(SystemConfig::getValue('sChurchName'))) {
 }
 
 // Legacy URL shims — redirect removed pages to their MVC replacements.
-// Must match the path-only portion (strtok strips query string) so that
-// bookmarks like /UserEditor.php?PersonID=5 resolve correctly.
-$_legacyBase = strtok($shortName, '?');
+// $shortName is already the path-only portion, so bookmarks like
+// /UserEditor.php?PersonID=5 resolve correctly.
+$_legacyBase = $shortName;
 if ($_legacyBase === 'UserEditor.php') {
     if (!empty($_GET['PersonID'])) {
         RedirectUtils::redirect('admin/system/users/' . (int) $_GET['PersonID'] . '/edit');
@@ -85,16 +105,14 @@ if ($_legacyBase === 'UserEditor.php') {
 }
 unset($_legacyBase);
 
-if (strtolower($shortName) === 'index.php' || strtolower($fileName) === 'index.php') {
-    // Index.php -> v2/dashboard
+$_idx_docRoot = SystemURLs::getDocumentRoot();
+$_idx_safeShortPath = _idx_resolveSafeRequirePath($shortName, $_idx_docRoot);
+
+if (strtolower($shortName) === 'index.php') {
     RedirectUtils::redirect('v2/dashboard');
-} elseif (is_file($shortName)) {
-    // Try actual path
-    require $shortName;
-} elseif (file_exists($fileName)) {
-    // Try magic filename
-    require $fileName;
-} elseif (strpos($_SERVER['REQUEST_URI'], 'js') || strpos($_SERVER['REQUEST_URI'], 'css')) { // if this is a CSS or JS file that we can't find, return 404
+} elseif ($_idx_safeShortPath !== null) {
+    require $_idx_safeShortPath;
+} elseif (strpos($_SERVER['REQUEST_URI'], 'js') || strpos($_SERVER['REQUEST_URI'], 'css')) {
     header($_SERVER['SERVER_PROTOCOL'] . ' 404 Not Found', true, 404);
     exit;
 } else {

--- a/src/index.php
+++ b/src/index.php
@@ -6,30 +6,28 @@ require_once __DIR__ . '/vendor/autoload.php';
 use ChurchCRM\Authentication\AuthenticationManager;
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\dto\SystemURLs;
+use ChurchCRM\Utils\PathUtils;
 use ChurchCRM\Utils\RedirectUtils;
 use ChurchCRM\Utils\VersionUtils;
 
-// Get required PHP version from composer.json (single source of truth)
-// Throws RuntimeException if system state cannot be determined
-try {
-    $requiredPhp = VersionUtils::getRequiredPhpVersion();
-} catch (\RuntimeException $e) {
-    // System cannot determine PHP requirements - fail loudly with clear error
-    http_response_code(500);
-    header('Content-Type: text/plain; charset=utf-8');
-    echo"Critical System Error:" . $e->getMessage() ."\n\n";
-    echo"Please contact your system administrator or check your ChurchCRM installation.";
-    exit(1);
-}
-
 // Derive install prefix from SCRIPT_NAME — works for root and nested subdir installs.
-// Computed before any redirect so both the PHP-version and setup redirects resolve correctly.
+// Computed before any redirect so the config-error, PHP-version, and setup
+// redirects below all resolve correctly.
 //   /churchcrm/index.php  →  dirname → /churchcrm
 //   /index.php            →  dirname → /  → ''
 $_idx_script = str_replace('\\', '/', $_SERVER['SCRIPT_NAME'] ?? '/index.php');
 $_idx_root   = dirname($_idx_script);
 if ($_idx_root === '/' || $_idx_root === '.') {
     $_idx_root = '';
+}
+
+// Get required PHP version from composer.json (single source of truth)
+// Throws RuntimeException if system state cannot be determined
+try {
+    $requiredPhp = VersionUtils::getRequiredPhpVersion();
+} catch (\RuntimeException $e) {
+    header("Location: {$_idx_root}/errors/config-error.php?error=" . rawurlencode($e->getMessage()));
+    exit;
 }
 
 $phpVersion = phpversion();
@@ -45,36 +43,6 @@ if (file_exists(__DIR__ . '/Include/Config.php')) {
     exit;
 }
 
-mb_internal_encoding('UTF-8');
-
-// Resolve $candidate against $docRoot and return the real, on-disk path only if
-// it exists as a regular .php file *inside* $docRoot. Returns null for anything
-// that escapes $docRoot (e.g. "../" traversal), isn't a .php file, or doesn't
-// resolve to a real file — so non-PHP files (config, .env, images) can never be
-// dumped raw via require().
-function _idx_resolveSafeRequirePath(string $candidate, string $docRoot): ?string
-{
-    if (strtolower(pathinfo($candidate, PATHINFO_EXTENSION)) !== 'php') {
-        return null;
-    }
-
-    $docRootReal = realpath($docRoot);
-    if ($docRootReal === false) {
-        return null;
-    }
-
-    $candidateReal = realpath($docRoot . '/' . $candidate);
-    if ($candidateReal === false || !is_file($candidateReal)) {
-        return null;
-    }
-
-    if (!str_starts_with($candidateReal, $docRootReal . DIRECTORY_SEPARATOR)) {
-        return null;
-    }
-
-    return $candidateReal;
-}
-
 // Get the current request path with query string stripped.
 $_idx_requestPath = strtok($_SERVER['REQUEST_URI'], '?');
 $shortName = str_replace(SystemURLs::getRootPath() . '/', '', $_idx_requestPath);
@@ -83,39 +51,26 @@ $shortName = str_replace(SystemURLs::getRootPath() . '/', '', $_idx_requestPath)
 AuthenticationManager::ensureAuthentication();
 
 // On a fresh install (sChurchName empty), redirect admin users to complete setup.
+// getCurrentUser() is safe to call unguarded here: ensureAuthentication() above
+// already guarantees an authenticated session, or it would have redirected/exited.
 if (empty(SystemConfig::getValue('sChurchName'))) {
-    try {
-        $currentUser = AuthenticationManager::getCurrentUser();
-        if ($currentUser->isAdmin()) {
-            RedirectUtils::redirect('admin/system/church-info');
-        }
-    } catch (\Throwable) {
-        // Not logged in or session error — ensureAuthentication() above handles it
+    $currentUser = AuthenticationManager::getCurrentUser();
+    if ($currentUser->isAdmin()) {
+        RedirectUtils::redirect('admin/system/church-info');
     }
-}
-
-// Legacy URL shims — redirect removed pages to their MVC replacements.
-// $shortName is already the path-only portion, so bookmarks like
-// /UserEditor.php?PersonID=5 resolve correctly.
-if ($shortName === 'UserEditor.php') {
-    if (!empty($_GET['PersonID'])) {
-        RedirectUtils::redirect('admin/system/users/' . (int) $_GET['PersonID'] . '/edit');
-    } elseif (!empty($_GET['NewPersonID'])) {
-        RedirectUtils::redirect('admin/system/users/new?personId=' . (int) $_GET['NewPersonID']);
-    } else {
-        RedirectUtils::redirect('admin/system/users/new');
-    }
-} elseif ($shortName === 'SettingsUser.php') {
-    RedirectUtils::redirect('admin/system/users');
 }
 
 if (strtolower($shortName) === 'index.php') {
     RedirectUtils::redirect('v2/dashboard');
-} elseif (($_idx_safeShortPath = _idx_resolveSafeRequirePath($shortName, SystemURLs::getDocumentRoot())) !== null) {
+} elseif (($_idx_safeShortPath = PathUtils::resolveSafeRequirePath($shortName)) !== null) {
     require $_idx_safeShortPath;
-} elseif (str_contains($_SERVER['REQUEST_URI'], 'js') || str_contains($_SERVER['REQUEST_URI'], 'css')) {
-    header($_SERVER['SERVER_PROTOCOL'] . ' 404 Not Found', true, 404);
+} elseif (in_array(strtolower(pathinfo($shortName, PATHINFO_EXTENSION)), ['js', 'css'], true)) {
+    // Missing static asset (e.g. a stale webpack chunk hash after a deploy) —
+    // bare 404, no need for a full error page.
+    http_response_code(404);
     exit;
 } else {
-    RedirectUtils::redirect('index.php');
+    // Self-contained error page (see src/errors/.htaccess) — no Header/Footer
+    // or session/DB state required, same pattern as php-error.php and setup.
+    RedirectUtils::redirect('errors/not-found.php?path=' . rawurlencode($shortName));
 }

--- a/src/index.php
+++ b/src/index.php
@@ -60,7 +60,7 @@ if (empty(SystemConfig::getValue('sChurchName'))) {
     }
 }
 
-if (strtolower($shortName) === 'index.php') {
+if ($shortName === '' || strtolower($shortName) === 'index.php') {
     RedirectUtils::redirect('v2/dashboard');
 } elseif (($_idx_safeShortPath = PathUtils::resolveSafeRequirePath($shortName)) !== null) {
     require $_idx_safeShortPath;


### PR DESCRIPTION
## Summary

Addresses [code scanning alert #499](https://github.com/ChurchCRM/CRM/security/code-scanning/499). The `index.php` dispatcher used `MiscUtils::dashesToCamelCase()` to convert request paths into filenames (e.g. `/list-events` → `ListEvents.php`) and then served those files via `file_exists()` with no containment check, creating a path traversal vector. The PR grew during review to also clean up index.php's error/404 handling and fix a related path-containment bug found elsewhere in the codebase.

## Changes

- **Remove** the magic dash-to-camelCase filename feature entirely — an audit confirmed zero callers use it; every link and redirect in the codebase already includes an explicit `.php` extension.
- **Add** `ChurchCRM\Utils\PathUtils::resolveSafeRequirePath()`: resolves the candidate path with `realpath()`, requires a `.php` extension, and verifies the result is a regular file strictly inside the document root before allowing `require`. Any `../` traversal, symlink escape, or non-`.php` file returns `null`. Extracted out of `index.php` into a proper class (was a bare global function) so it's independently testable.
- **Strip query string** from `REQUEST_URI` with `strtok()` before file resolution so parameters like `?foo=bar` are never included in the candidate path.
- **Replace the dashboard-bounce fallback** for unresolved paths with a real 404 page: new `src/errors/not-found.php`, self-contained like the existing `php-error.php`/`config-error.php` pages (no `Header.php`/`Footer.php` or session/DB dependency — matches the `src/errors/.htaccess` contract that these pages are served directly, never routed back through `index.php`).
- **Fix the missing-static-asset check** to match on the actual file extension of the request path instead of a `strpos()` substring match against the raw `REQUEST_URI` (which could false-positive on a query string containing "js"/"css").
- **Route the PHP-version-detection failure** (composer.json missing/corrupt) through the existing `errors/config-error.php` page instead of an inline plain-text 500 response.
- **Remove** the now-dead `UserEditor.php`/`SettingsUser.php` redirect shims — those files were deleted in #9173 with no other code referencing them; unresolved legacy URLs now fall through to the standard 404 page instead of being special-cased.
- **Remove** the no-op `mb_internal_encoding('UTF-8')` call (PHP 8.4+, the project's minimum, already defaults to UTF-8; the `mbstring.internal_encoding` ini directive was removed in PHP 8.0) and a `try/catch` around `getCurrentUser()` that could never actually throw at that point, since `AuthenticationManager::ensureAuthentication()` already guarantees an authenticated session before that line runs.
- **Fix a related bug**: `src/admin/routes/api/system/system-logs.php` (3 call sites) and `src/admin/routes/api/upgrade.php` verified path containment with `strpos($resolvedPath, $resolvedDir) !== 0`, which wrongly accepts a sibling directory as "inside" the target (e.g. `/var/logs-secret` prefix-matches `/var/logs`). All 4 call sites now use the new `PathUtils::resolveRealPathWithin()`, which requires a trailing `DIRECTORY_SEPARATOR` before the boundary comparison.
- **Add Cypress coverage** (`cypress/e2e/api/private/private.index-php-routing.spec.js`) for the `/index.php` → dashboard redirect, the removed legacy shims falling through to the 404 flow, the standalone 404 page, and the bare 404 for missing js/css assets.

## Why

The previous `file_exists($fileName)` branch could be reached with a crafted URL and bypassed by an attacker to include arbitrary files relative to the document root. Removing the feature eliminates the attack surface; the `realpath()` containment guard in the remaining branch closes the same class of vulnerability on the direct `.php` path. The extension whitelist added during review closes a secondary information-disclosure gap: without it, any non-`.php` file under the document root (e.g. a stray `.env` or config file) could be `require`'d and dumped raw. The `system-logs.php`/`upgrade.php` fix addresses a real, independently-discovered sibling-directory bypass in the same class of containment check.

## Files Changed

- `src/index.php` — reworked dispatch/error flow
- `src/ChurchCRM/utils/PathUtils.php` — **new**, path-safety helpers
- `src/errors/not-found.php` — **new**, standalone 404 page
- `src/admin/routes/api/system/system-logs.php` — containment-check fix
- `src/admin/routes/api/upgrade.php` — containment-check fix
- `cypress/e2e/api/private/private.index-php-routing.spec.js` — **new**, regression coverage

## Testing

- PHP syntax validation: ✅ passed (`npm run build:php`)
- Biome lint: ✅ passed (`npm run lint`)
- Manual verification of `PathUtils::resolveSafeRequirePath()`/`resolveRealPathWithin()` against traversal payloads, non-`.php` files, and the sibling-directory bypass case (confirmed the old `strpos()` check accepted it, the new check rejects it).
- New Cypress spec covers the routing/404 behavioral contract.

## Related

Fixes https://github.com/ChurchCRM/CRM/security/code-scanning/499

🤖 Generated with [Claude Code](https://claude.com/claude-code)
