### PR TITLE
fix: remove stale DataTables v1 CSS selectors (.dataTables_wrapper etc)

### DIFF
--- a/src/DepositSlipEditor.php
+++ b/src/DepositSlipEditor.php
@@ -316,12 +316,12 @@ require_once __DIR__ . '/Include/Header.php';
 #paymentsTable {
     margin-bottom: 0;
 }
-#paymentsTable_wrapper .dataTables_length,
-#paymentsTable_wrapper .dataTables_filter {
+.dt-length,
+.dt-search {
     padding: 1rem 0.75rem;
 }
-#paymentsTable_wrapper .dataTables_info,
-#paymentsTable_wrapper .dataTables_paginate {
+.dt-info,
+.dt-paging {
     padding: 1rem 0.75rem;
 }
 .dt-buttons {

--- a/src/skin/scss/_tabler-bridge.scss
+++ b/src/skin/scss/_tabler-bridge.scss
@@ -25,9 +25,9 @@
 }
 
 // --- DataTables — Tabler skin ----------------------------------------
-.dataTables_wrapper {
-  .dataTables_filter input,
-  .dataTables_length select {
+.dt-container {
+  .dt-search input,
+  .dt-length select {
     border: 1px solid var(--tblr-border-color);
     border-radius: var(--tblr-border-radius);
     padding: 0.375rem 0.75rem;
@@ -217,7 +217,7 @@ select {
   }
 
   // DataTables: compact layout on mobile
-  .dataTables_wrapper {
+  .dt-container {
     .dt-layout-row {
       flex-direction: column;
       gap: 0.5rem;

--- a/src/skin/scss/_utility-classes.scss
+++ b/src/skin/scss/_utility-classes.scss
@@ -80,8 +80,8 @@
   textarea,
   .form-control,
   .form-select,
-  .dataTables_filter,
-  .dataTables_length,
+  .dt-search,
+  .dt-length,
   .ts-wrapper {
     display: none !important;
   }


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

These selectors stopped matching when DataTables v2 renamed `.dataTables_wrapper` → `.dt-container` etc. Surfaced by the DataTables v3 upgrade review in #9362.

## Changes

**`src/skin/scss/_tabler-bridge.scss`**
- Tabler skin block: `.dataTables_wrapper` → `.dt-container`; `.dataTables_filter input` → `.dt-search input`; `.dataTables_length select` → `.dt-length select` — these rules were dead since v2, so the Tabler skin overrides were silently not applying
- Mobile compact layout block (`@media max-width: 767px`): outer `.dataTables_wrapper` → `.dt-container` (inner `.dt-layout-row` and `.dt-search input` were already v2-correct)

**`src/skin/scss/_utility-classes.scss`**
- `@media print` hide-when-printing rule: `.dataTables_filter` → `.dt-search`; `.dataTables_length` → `.dt-length` — search/length controls were leaking into print output

**`src/DepositSlipEditor.php`**
- Inline `<style>` block: migrated `#paymentsTable_wrapper .dataTables_length/filter/info/paginate` → `.dt-length/.dt-search/.dt-info/.dt-paging`

## Validation

- [x] `npm run lint` passes (exit 0)
- [x] `npm run build:webpack` passes — SCSS compiles cleanly
- [x] No stale `dataTables_*` selectors remain anywhere in `src/`

## Note on DepositSlipEditor.php scope

The original selectors were scoped to `#paymentsTable_wrapper`; the new ones are not. The `_wrapper` ID is still generated by DataTables at runtime, so scoped selectors would also work. The unscoped approach was chosen for consistency with the adjacent `.dt-buttons` rule in the same `<style>` block (already unscoped pre-existing). Only one DataTable exists on this page so the unscoped rules are functionally equivalent.