### PR TITLE
Fix: Tabler icons not loading due to unquoted CSS URLs

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,8 +28,11 @@ class FixCssUrlQuotesPlugin {
                 const fullPath = path.join(outputPath, cleanPath);
                 try {
                   fs.accessSync(fullPath, fs.constants.F_OK);
-                } catch {
-                  missingFiles.push({ file: asset.name, url: urlPath, fullPath });
+                } catch (accessErr) {
+                  if (accessErr.code === 'ENOENT') {
+                    missingFiles.push({ file: asset.name, url: urlPath, fullPath });
+                  }
+                  // else: EPERM / EINVAL — file may exist but be unreadable; skip silently
                 }
               }
             }
@@ -38,7 +41,7 @@ class FixCssUrlQuotesPlugin {
             // Note: the regex [^'")\ s] already excludes quote chars, so every captured
             // url is unquoted — no dead-code guard needed.
             content = content.replace(
-              /url\(([^'")\s][^)]*)\)/g,
+              /url\(([^'")\s]+)\)/g,
               (_match, url) => `url("${url}")`
             );
             fs.writeFileSync(filePath, content, 'utf-8');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,7 +23,9 @@ class FixCssUrlQuotesPlugin {
               const urlPath = match[1];
               // Only check relative URLs (not data:, external, or absolute paths)
               if (!urlPath.startsWith('data:') && !urlPath.startsWith('http') && !urlPath.startsWith('//') && !urlPath.startsWith('/')) {
-                const fullPath = path.join(outputPath, urlPath);
+                // Strip query-string and fragment before testing for file existence
+                const cleanPath = urlPath.split('?')[0].split('#')[0];
+                const fullPath = path.join(outputPath, cleanPath);
                 try {
                   fs.accessSync(fullPath, fs.constants.F_OK);
                 } catch {
@@ -33,14 +35,11 @@ class FixCssUrlQuotesPlugin {
             }
 
             // Add quotes around unquoted URLs
+            // Note: the regex [^'")\ s] already excludes quote chars, so every captured
+            // url is unquoted — no dead-code guard needed.
             content = content.replace(
               /url\(([^'")\s][^)]*)\)/g,
-              (match, url) => {
-                if (url.startsWith('"') || url.startsWith("'")) {
-                  return match;
-                }
-                return `url("${url}")`;
-              }
+              (_match, url) => `url("${url}")`
             );
             fs.writeFileSync(filePath, content, 'utf-8');
           } catch (err) {
@@ -56,7 +55,7 @@ class FixCssUrlQuotesPlugin {
           .map((f) => `  ❌ ${f.file}: url("${f.url}") → ${f.fullPath}`)
           .join('\n');
         console.error('\n⚠️  Missing font/asset files referenced in CSS:\n' + errorMsg + '\n');
-        throw new Error(`${missingFiles.length} missing asset file(s) referenced in CSS`);
+        compilation.errors.push(new Error(`${missingFiles.length} missing asset file(s) referenced in CSS`));
       }
     });
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,7 @@ class FixCssUrlQuotesPlugin {
       compilation.getAssets().forEach((asset) => {
         if (asset.name.endsWith('.css')) {
           const filePath = path.join(outputPath, asset.name);
-          if (fs.existsSync(filePath)) {
+          try {
             let content = fs.readFileSync(filePath, 'utf-8');
 
             // Check for missing font/asset files referenced in url() declarations
@@ -24,7 +24,9 @@ class FixCssUrlQuotesPlugin {
               // Only check relative URLs (not data:, external, or absolute paths)
               if (!urlPath.startsWith('data:') && !urlPath.startsWith('http') && !urlPath.startsWith('//') && !urlPath.startsWith('/')) {
                 const fullPath = path.join(outputPath, urlPath);
-                if (!fs.existsSync(fullPath)) {
+                try {
+                  fs.accessSync(fullPath, fs.constants.F_OK);
+                } catch {
                   missingFiles.push({ file: asset.name, url: urlPath, fullPath });
                 }
               }
@@ -41,6 +43,9 @@ class FixCssUrlQuotesPlugin {
               }
             );
             fs.writeFileSync(filePath, content, 'utf-8');
+          } catch (err) {
+            // Skip if file cannot be read (might have been deleted between emit and this hook)
+            console.warn(`Warning: Could not process CSS file ${asset.name}: ${err.message}`);
           }
         }
       });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,61 @@
 const path = require('path');
+const fs = require('fs');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 const isProduction = process.env.NODE_ENV === 'production';
+
+// Plugin to fix unquoted URLs in CSS (especially fonts)
+class FixCssUrlQuotesPlugin {
+  apply(compiler) {
+    compiler.hooks.afterEmit.tap('FixCssUrlQuotesPlugin', (compilation) => {
+      const outputPath = compiler.outputPath;
+      const missingFiles = [];
+
+      compilation.getAssets().forEach((asset) => {
+        if (asset.name.endsWith('.css')) {
+          const filePath = path.join(outputPath, asset.name);
+          if (fs.existsSync(filePath)) {
+            let content = fs.readFileSync(filePath, 'utf-8');
+
+            // Check for missing font/asset files referenced in url() declarations
+            const urlMatches = content.matchAll(/url\(["']?([^"')\s]+)["']?\)/g);
+            for (const match of urlMatches) {
+              const urlPath = match[1];
+              // Only check relative URLs (not data:, external, or absolute paths)
+              if (!urlPath.startsWith('data:') && !urlPath.startsWith('http') && !urlPath.startsWith('//') && !urlPath.startsWith('/')) {
+                const fullPath = path.join(outputPath, urlPath);
+                if (!fs.existsSync(fullPath)) {
+                  missingFiles.push({ file: asset.name, url: urlPath, fullPath });
+                }
+              }
+            }
+
+            // Add quotes around unquoted URLs
+            content = content.replace(
+              /url\(([^'")\s][^)]*)\)/g,
+              (match, url) => {
+                if (url.startsWith('"') || url.startsWith("'")) {
+                  return match;
+                }
+                return `url("${url}")`;
+              }
+            );
+            fs.writeFileSync(filePath, content, 'utf-8');
+          }
+        }
+      });
+
+      // Report missing files as errors
+      if (missingFiles.length > 0) {
+        const errorMsg = missingFiles
+          .map((f) => `  ❌ ${f.file}: url("${f.url}") → ${f.fullPath}`)
+          .join('\n');
+        console.error('\n⚠️  Missing font/asset files referenced in CSS:\n' + errorMsg + '\n');
+        throw new Error(`${missingFiles.length} missing asset file(s) referenced in CSS`);
+      }
+    });
+  }
+}
 
 module.exports = {
   mode: isProduction ? 'production' : 'development',
@@ -109,5 +163,6 @@ module.exports = {
       filename: '[name].min.css',
       ignoreOrder: false,
     }),
+    new FixCssUrlQuotesPlugin(),
   ],
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,14 +37,17 @@ class FixCssUrlQuotesPlugin {
               }
             }
 
-            // Add quotes around unquoted URLs
+            // Add quotes around unquoted URLs; only write when something changed
+            // to avoid unnecessary I/O and mtime churn on unchanged CSS files.
             // Note: the regex [^'")\ s] already excludes quote chars, so every captured
             // url is unquoted — no dead-code guard needed.
-            content = content.replace(
+            const fixed = content.replace(
               /url\(([^'")\s]+)\)/g,
               (_match, url) => `url("${url}")`
             );
-            fs.writeFileSync(filePath, content, 'utf-8');
+            if (fixed !== content) {
+              fs.writeFileSync(filePath, fixed, 'utf-8');
+            }
           } catch (err) {
             // Skip if file cannot be read (might have been deleted between emit and this hook)
             console.warn(`Warning: Could not process CSS file ${asset.name}: ${err.message}`);


### PR DESCRIPTION
## Summary
Fixed Tabler icons failing to load on all pages. webpack's css-loader was stripping quotes from font URLs during rewriting, causing browsers to reject the @font-face rule entirely.

## Changes
- Added `FixCssUrlQuotesPlugin` webpack plugin that:
  - Re-adds quotes around unquoted URLs in CSS (browsers require quotes for special characters)
  - Validates that all referenced font/asset files exist at build time
  - Fails the build with clear error messages if assets are missing
  - Uses `fs.accessSync()` with try-catch to avoid TOCTOU race conditions
- Icons now load correctly and missing assets are caught during build

## Why
Webpack's css-loader rewrites relative paths like `url("./fonts/tabler-icons.woff2")` to absolute paths with content hashes like `url(assets/tabler-icons.38235162f4c9496bfc92.woff2)`, but it strips the quotes in the process. Browsers cannot parse unquoted URLs with special characters (dots, slashes), so they reject the entire @font-face rule. Result: icons existed on disk but were never requested by the browser.

## Security
Fixed CodeQL alert js/file-system-race by using `fs.accessSync()` with try-catch instead of separate `fs.existsSync()` checks.

## Testing
- ✅ Build passes
- ✅ Biome lint passes
- ✅ Tabler icons now load in browser
- ✅ Missing asset files are caught at build time
- ✅ TOCTOU race condition fixed

🤖 Generated with Claude Code