### PR TITLE
test: fix case mismatch in church-info geocoding toast assertion

### DIFF
--- a/cypress/e2e/ui/admin/admin.church-info.spec.js
+++ b/cypress/e2e/ui/admin/admin.church-info.spec.js
@@ -430,7 +430,7 @@ describe("Admin - Church Information Page", () => {
             cy.wait("@geocode");
 
             // Notyf success toast
-            cy.contains("Coordinates updated", { timeout: 5000 }).should("be.visible");
+            cy.contains("Coordinates Updated", { timeout: 5000 }).should("be.visible");
 
             // Map container should have d-none removed
             cy.get("#church-location-map").should("not.have.class", "d-none");


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Fixes failing CI run [#31270200356](https://github.com/ChurchCRM/CRM/actions/runs/31270200356).

All four UI test matrix jobs (root/subdir × PHP 8.4/8.5) were failing on the same spec:
`admin/admin.church-info.spec.js` → *Generate Coordinates button and live map preview → should show success notification and reveal map container after geocoding*

**Root cause:** `cy.contains()` is case-sensitive. The application emits the Notyf toast `"Coordinates Updated"` (capital U) via `t("Coordinates Updated")` in `webpack/church-info.js`, matching every locale JSON file. The test assertion incorrectly used `"Coordinates updated"` (lowercase u).

**Fix:** One-character change — lowercase `u` → uppercase `U` in the test assertion.

**Testing:** Lint (Biome) passes with only pre-existing unrelated warnings; no new issues introduced.