### PR TITLE
fix: gate all fundraiser access on bEnabledFundraiser setting

### DIFF
--- a/cypress/e2e/ui/security/finance-page-guards.spec.js
+++ b/cypress/e2e/ui/security/finance-page-guards.spec.js
@@ -128,6 +128,7 @@ describe("bEnabledFundraiser feature flag — fundraiser module disabled", () =>
             url: "/admin/api/system/config/bEnabledFundraiser",
             body: { value: "1" },
             headers: { "Content-Type": "application/json" },
+            failOnStatusCode: false,
         });
     });
 

--- a/cypress/e2e/ui/security/finance-page-guards.spec.js
+++ b/cypress/e2e/ui/security/finance-page-guards.spec.js
@@ -111,6 +111,80 @@ describe("ManageFundraisers permission guard on fundraiser pages", () => {
     });
 });
 
+/**
+ * Tests that the bEnabledFundraiser feature flag gates /fundraiser/ for ALL
+ * users — including admins — when set to false.
+ *
+ * The flag is toggled via the admin config API, then restored in an after()
+ * hook so subsequent specs start with the default (enabled) state.
+ */
+describe("bEnabledFundraiser feature flag — fundraiser module disabled", () => {
+    after(() => {
+        // Always restore the flag regardless of test outcome so other specs
+        // that visit fundraiser pages are not broken.
+        cy.setupAdminSession();
+        cy.request({
+            method: "POST",
+            url: "/admin/api/system/config/bEnabledFundraiser",
+            body: { value: "1" },
+            headers: { "Content-Type": "application/json" },
+        });
+    });
+
+    it("blocks admin access to /fundraiser/ and redirects to home when disabled", () => {
+        cy.setupAdminSession();
+
+        // Disable the feature flag.
+        cy.request({
+            method: "POST",
+            url: "/admin/api/system/config/bEnabledFundraiser",
+            body: { value: "0" },
+            headers: { "Content-Type": "application/json" },
+        });
+
+        // Admin should be redirected away — NOT see the fundraiser page or
+        // the generic role access-denied page, and should land on the home
+        // dashboard (SystemURLs::getRootPath() + '/' resolves to /v2/dashboard).
+        cy.visit("/fundraiser/", { failOnStatusCode: false });
+        cy.url().should("not.include", "/fundraiser/");
+        cy.url().should("not.include", ACCESS_DENIED);
+        cy.url().should("include", "/v2/dashboard");
+    });
+
+    it("blocks API access to /api/fundraisers when disabled (returns 403)", () => {
+        cy.setupAdminSession();
+
+        // Disable the feature flag.
+        cy.request({
+            method: "POST",
+            url: "/admin/api/system/config/bEnabledFundraiser",
+            body: { value: "0" },
+            headers: { "Content-Type": "application/json" },
+        });
+
+        cy.request({
+            method: "GET",
+            url: "/api/fundraisers",
+            failOnStatusCode: false,
+        }).its("status").should("eq", 403);
+    });
+
+    it("hides Fundraisers button on Finance dashboard when disabled", () => {
+        cy.setupAdminSession();
+
+        // Disable the feature flag.
+        cy.request({
+            method: "POST",
+            url: "/admin/api/system/config/bEnabledFundraiser",
+            body: { value: "0" },
+            headers: { "Content-Type": "application/json" },
+        });
+
+        cy.visit("/finance/", { failOnStatusCode: false });
+        cy.contains("a", "Fundraisers").should("not.exist");
+    });
+});
+
 describe("Finance permission guard on pledge pages", () => {
     describe("User WITHOUT Finance (judith.matthews: AddRecords+EditRecords, Finance=0)", () => {
         beforeEach(() => {

--- a/src/ChurchCRM/Slim/Middleware/Request/Setting/FundraiserEnabledMiddleware.php
+++ b/src/ChurchCRM/Slim/Middleware/Request/Setting/FundraiserEnabledMiddleware.php
@@ -31,7 +31,8 @@ class FundraiserEnabledMiddleware implements MiddlewareInterface
             }
 
             $response = new Response();
-            $body     = json_encode(['error' => gettext('Fundraiser is disabled'), 'code' => 403]);
+            $body     = json_encode(['error' => gettext('Fundraiser is disabled'), 'code' => 403])
+                ?: '{"error":"Fundraiser is disabled","code":403}';
             $response->getBody()->write($body);
             return $response->withStatus(403)->withHeader('Content-Type', 'application/json');
         }

--- a/src/ChurchCRM/Slim/Middleware/Request/Setting/FundraiserEnabledMiddleware.php
+++ b/src/ChurchCRM/Slim/Middleware/Request/Setting/FundraiserEnabledMiddleware.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace ChurchCRM\Slim\Middleware\Request\Setting;
+
+use ChurchCRM\dto\SystemConfig;
+use ChurchCRM\dto\SystemURLs;
+use ChurchCRM\Slim\Middleware\BrowserRequestTrait;
+use ChurchCRM\Utils\LoggerUtils;
+use Laminas\Diactoros\Response;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class FundraiserEnabledMiddleware implements MiddlewareInterface
+{
+    use BrowserRequestTrait;
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        if (!SystemConfig::getBooleanValue('bEnabledFundraiser')) {
+            LoggerUtils::getAppLogger()->info('Fundraiser access blocked: feature is disabled', [
+                'path' => $request->getUri()->getPath(),
+            ]);
+
+            if ($this->isBrowserRequest($request)) {
+                $response = new Response();
+                return $response
+                    ->withStatus(302)
+                    ->withHeader('Location', SystemURLs::getRootPath() . '/');
+            }
+
+            $response = new Response();
+            $body     = json_encode(['error' => gettext('Fundraiser is disabled'), 'code' => 403]);
+            $response->getBody()->write($body);
+            return $response->withStatus(403)->withHeader('Content-Type', 'application/json');
+        }
+
+        return $handler->handle($request);
+    }
+}

--- a/src/ChurchCRM/SystemCalendars/FundraisersCalendar.php
+++ b/src/ChurchCRM/SystemCalendars/FundraisersCalendar.php
@@ -2,6 +2,7 @@
 
 namespace ChurchCRM\SystemCalendars;
 
+use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\dto\SystemURLs;
 use ChurchCRM\model\ChurchCRM\Event;
 use ChurchCRM\model\ChurchCRM\FundRaiserQuery;
@@ -11,7 +12,7 @@ class FundraisersCalendar implements SystemCalendar
 {
     public static function isAvailable(): bool
     {
-        return true;
+        return SystemConfig::getBooleanValue('bEnabledFundraiser');
     }
 
     public function getAccessToken(): bool

--- a/src/api/routes/finance/finance-fundraisers.php
+++ b/src/api/routes/finance/finance-fundraisers.php
@@ -9,6 +9,7 @@ use ChurchCRM\Utils\CurrencyFormatter;
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\Slim\Middleware\InputSanitizationMiddleware;
 use ChurchCRM\Slim\Middleware\Request\Auth\ManageFundraisersRoleAuthMiddleware;
+use ChurchCRM\Slim\Middleware\Request\Setting\FundraiserEnabledMiddleware;
 use ChurchCRM\Slim\SlimUtils;
 use ChurchCRM\Utils\DateTimeUtils;
 use Psr\Http\Message\ResponseInterface as Response;
@@ -272,4 +273,4 @@ $app->group('/fundraisers', function (RouteCollectorProxy $group): void {
             return SlimUtils::renderErrorJSON($response, gettext('Failed to delete fundraiser'), [], 500, $e, $request);
         }
     });
-})->add(ManageFundraisersRoleAuthMiddleware::class);
+})->add(new FundraiserEnabledMiddleware())->add(ManageFundraisersRoleAuthMiddleware::class);

--- a/src/finance/views/dashboard.php
+++ b/src/finance/views/dashboard.php
@@ -149,9 +149,11 @@ $sRootPath = SystemURLs::getRootPath();
                 <a href="<?= $sRootPath ?>/finance/pledge/dashboard" class="btn btn-outline-secondary">
                     <i class="fa-solid fa-handshake me-1"></i><?= gettext('Pledges') ?>
                 </a>
+                <?php if (SystemConfig::getBooleanValue('bEnabledFundraiser')): ?>
                 <a href="<?= $sRootPath ?>/fundraiser/" class="btn btn-outline-secondary">
                     <i class="fa-solid fa-gavel me-1"></i><?= gettext('Fundraisers') ?>
                 </a>
+                <?php endif; ?>
                 <?php if ($isAdmin): ?>
                 <a href="<?= $sRootPath ?>/DonationFundEditor.php" class="btn btn-outline-secondary">
                     <i class="fa-solid fa-piggy-bank me-1"></i><?= gettext('Manage Funds') ?>

--- a/src/fundraiser/index.php
+++ b/src/fundraiser/index.php
@@ -5,6 +5,7 @@ require_once __DIR__ . '/../Include/LoadConfigs.php';
 use ChurchCRM\Slim\MvcAppFactory;
 use ChurchCRM\Slim\Middleware\CSRFMiddleware;
 use ChurchCRM\Slim\Middleware\Request\Auth\ManageFundraisersRoleAuthMiddleware;
+use ChurchCRM\Slim\Middleware\Request\Setting\FundraiserEnabledMiddleware;
 use Slim\Routing\RouteCollectorProxy;
 
 // Global gate: every /fundraiser/* request requires login (AuthMiddleware) AND
@@ -16,12 +17,12 @@ $app = MvcAppFactory::create('/fundraiser', [
     'roleMiddleware' => ManageFundraisersRoleAuthMiddleware::class,
 ]);
 
-// Register routes inside a group guarded by CSRFMiddleware. Group middleware
-// runs inside the routing/body-parsing layer, so the parsed body (and its
-// csrf_token) is available for validation — an app-level middleware would run
-// before body parsing and never see it. This validates every state-changing
-// request (POST/PUT/DELETE/PATCH) automatically, replacing the per-route
-// inline CSRFUtils::verifyRequest() checks. The route files reference $app, so
+// Register routes inside a group guarded by CSRFMiddleware and
+// FundraiserEnabledMiddleware (LIFO: FundraiserEnabled runs first, then CSRF).
+// FundraiserEnabledMiddleware ensures ALL access — including by admins who
+// would otherwise pass the app-level ManageFundraisersRoleAuthMiddleware —
+// is blocked when bEnabledFundraiser is false (redirects browser to home;
+// returns 403 JSON for API clients). The route files reference $app, so
 // alias the group proxy to $app for them.
 $app->group('', function (RouteCollectorProxy $group): void {
     $app = $group;
@@ -31,6 +32,6 @@ $app->group('', function (RouteCollectorProxy $group): void {
     require __DIR__ . '/routes/donors.php';
     require __DIR__ . '/routes/batch-winner.php';
     require __DIR__ . '/routes/reports.php';
-})->add(new CSRFMiddleware());
+})->add(new CSRFMiddleware())->add(new FundraiserEnabledMiddleware());
 
 $app->run();


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

When \`bEnabledFundraiser\` was set to \`false\`, non-admin users were correctly denied (\`isManageFundraisersEnabled()\` gates on the flag). However, \`ManageFundraisersRoleAuthMiddleware::hasRole()\` used an \`isAdmin() || ...\` short-circuit that bypassed the flag entirely, leaving \`/fundraiser/\` and \`/api/fundraisers\` accessible to admin users.

## What changed

- **New \`FundraiserEnabledMiddleware\`** (mirrors \`SundaySchoolEnabledMiddleware\`): checks \`bEnabledFundraiser\`; browser → 302 redirect to home, API → 403 JSON.
- **\`src/fundraiser/index.php\`**: middleware wired as the outermost group-level guard — runs after app-level auth/role checks, so admins are blocked when the flag is off.
- **\`src/api/routes/finance/finance-fundraisers.php\`**: middleware added to the \`/fundraisers\` group (role check runs first per Slim LIFO, then feature-flag guard).
- **\`FundraisersCalendar::isAvailable()\`**: now returns \`bEnabledFundraiser\` — fundraiser calendar events are hidden when the feature is off.
- **Finance dashboard**: \`Fundraisers\` quick-action button wrapped in a \`bEnabledFundraiser\` guard.

## Testing

Cypress tests added to \`finance-page-guards.spec.js\`:
- Admin with flag off → redirected to \`/v2/dashboard\` (not \`/v2/access-denied\`).
- \`GET /api/fundraisers\` with flag off → 403.
- Finance dashboard hides the Fundraisers button when flag is off.