### PR TITLE
feat: add Auto theme mode following OS/browser prefers-color-scheme

### DIFF
--- a/cypress/e2e/ui/user/standard.user.settings.spec.js
+++ b/cypress/e2e/ui/user/standard.user.settings.spec.js
@@ -74,6 +74,7 @@ describe("Standard User Settings Page", () => {
         cy.get('#settingsNav a[href="#tab-appearance"]').click();
         cy.get("#tab-appearance").should("be.visible");
 
+        cy.get("#themeModeAuto").should("exist");
         cy.get("#themeModeLight").should("exist");
         cy.get("#themeModeDark").should("exist");
 

--- a/locale/messages.po
+++ b/locale/messages.po
@@ -1300,6 +1300,12 @@ msgstr ""
 msgid "Authentication is required for API v2 if you've enabled it in OpenLP's Remote plugin settings. The plugin uses HTTP Basic Authentication. Most local network setups don't require authentication, but it's recommended for security."
 msgstr ""
 
+msgid "Auto"
+msgstr ""
+
+msgid "Auto follows your OS or browser setting; Light and Dark override it"
+msgstr ""
+
 msgid "Auto TLS"
 msgstr ""
 

--- a/src/ChurchCRM/model/ChurchCRM/User.php
+++ b/src/ChurchCRM/model/ChurchCRM/User.php
@@ -645,6 +645,30 @@ class User extends BaseUser
         return null;
     }
 
+    /**
+     * Returns the effective theme mode for this user.
+     *
+     * Maps the raw ui.style setting to a canonical value:
+     *   '' (unset) => 'auto'  — users who never chose a theme default to system preference
+     *   'auto'     => 'auto'
+     *   'default'  => 'default' (explicit light)
+     *   'dark'     => 'dark'
+     *
+     * @return string 'auto' | 'default' | 'dark'
+     */
+    public function getThemeMode(): string
+    {
+        $raw = $this->getSettingValue(UserSetting::UI_STYLE);
+        if ($raw === '' || $raw === 'auto') {
+            return 'auto';
+        }
+        if ($raw === 'dark') {
+            return 'dark';
+        }
+
+        return 'default';
+    }
+
     public function getStyle(): string
     {
         $skin = $this->getSetting(UserSetting::UI_STYLE) ?? 'skin-red';

--- a/src/ChurchCRM/model/ChurchCRM/User.php
+++ b/src/ChurchCRM/model/ChurchCRM/User.php
@@ -659,7 +659,7 @@ class User extends BaseUser
     public function getThemeMode(): string
     {
         $raw = $this->getSettingValue(UserSetting::UI_STYLE);
-        if ($raw === '' || $raw === 'auto') {
+        if ($raw === null || $raw === '' || $raw === 'auto') {
             return 'auto';
         }
         if ($raw === 'dark') {

--- a/src/Include/Header.php
+++ b/src/Include/Header.php
@@ -29,9 +29,11 @@ PluginManager::init($pluginsPath);
 
 // Resolve theme attributes from user settings
 $_themeUser = AuthenticationManager::getCurrentUser();
+$_themeMode = $_themeUser->getThemeMode(); // 'auto' | 'default' | 'dark'
 $_themeAttrs = '';
-$_themeStyle = $_themeUser->getSettingValue('ui.style');
-if ($_themeStyle === 'dark') {
+// Explicit dark: stamp data-bs-theme on <html> server-side for FOWT-safe rendering
+// without JS. Auto mode is handled by the inline <head> script below.
+if ($_themeMode === 'dark') {
     $_themeAttrs .= ' data-bs-theme="dark"';
 }
 $_themePrimary = $_themeUser->getSettingValue('ui.theme.primary');
@@ -46,6 +48,55 @@ $MenuFirst = 1;
 <head>
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <!-- Theme controller: must run synchronously before page paint to prevent flash-of-wrong-theme. -->
+  <script nonce="<?= SystemURLs::getCSPNonce() ?>">
+    (function () {
+      // Ensure window.CRM exists; body script will Object.assign more properties later.
+      window.CRM = window.CRM || {};
+
+      var mql = window.matchMedia('(prefers-color-scheme: dark)');
+      var _listening = false;
+
+      function _applyDark() {
+        document.documentElement.setAttribute('data-bs-theme', 'dark');
+      }
+      function _applyLight() {
+        document.documentElement.removeAttribute('data-bs-theme');
+      }
+      function _applySystem() {
+        if (mql.matches) { _applyDark(); } else { _applyLight(); }
+      }
+      function _onChange(e) {
+        if (e.matches) { _applyDark(); } else { _applyLight(); }
+      }
+
+      /**
+       * Apply a theme mode and manage the matchMedia listener lifecycle.
+       * mode: 'auto' | 'default' | 'dark'
+       * Called once on page load (below) and by user.js when the user toggles the setting.
+       */
+      window.CRM.theme = {
+        setMode: function (mode) {
+          if (mode === 'auto') {
+            _applySystem();
+            if (!_listening) {
+              mql.addEventListener('change', _onChange);
+              _listening = true;
+            }
+          } else {
+            if (_listening) {
+              mql.removeEventListener('change', _onChange);
+              _listening = false;
+            }
+            if (mode === 'dark') { _applyDark(); } else { _applyLight(); }
+          }
+        }
+      };
+
+      // Apply the server-resolved theme mode immediately (FOWT prevention).
+      window.CRM.theme.setMode(<?= json_encode($_themeMode) ?>);
+    }());
+  </script>
   <?php require_once __DIR__ . '/Header-HTML-Scripts.php'; ?>
   <?= PluginManager::getPluginHeadContent() ?>
 

--- a/src/Include/Header.php
+++ b/src/Include/Header.php
@@ -54,7 +54,7 @@ $MenuFirst = 1;
       // Ensure window.CRM exists; body script will Object.assign more properties later.
       window.CRM = window.CRM || {};
 
-      var mql = window.matchMedia('(prefers-color-scheme: dark)');
+      var mql = window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)') : null;
       var _listening = false;
 
       function _applyDark() {
@@ -63,11 +63,13 @@ $MenuFirst = 1;
       function _applyLight() {
         document.documentElement.removeAttribute('data-bs-theme');
       }
-      function _applySystem() {
-        if (mql.matches) { _applyDark(); } else { _applyLight(); }
-      }
       function _onChange(e) {
         if (e.matches) { _applyDark(); } else { _applyLight(); }
+      }
+      // Delegate to _onChange so both paths share the same dark/light logic.
+      // Falls back to light when matchMedia is unavailable (mql === null).
+      function _applySystem() {
+        _onChange({ matches: mql ? mql.matches : false });
       }
 
       /**
@@ -79,7 +81,7 @@ $MenuFirst = 1;
         setMode: function (mode) {
           if (mode === 'auto') {
             _applySystem();
-            if (!_listening) {
+            if (mql && !_listening) {
               mql.addEventListener('change', _onChange);
               _listening = true;
             }

--- a/src/skin/js/user.js
+++ b/src/skin/js/user.js
@@ -45,17 +45,13 @@ $("#regenApiKey").on("click", () => {
     .fail(notifyError);
 });
 
-// ── Theme Mode (Light / Dark) ────────────────────────────────────
+// ── Theme Mode (Light / Dark / Auto) ────────────────────────────
 $('input[name="themeMode"]').on("change", function () {
   const value = $(this).val();
   saveUserSetting("ui.style", value)
     .done(() => {
-      if (window.CRM.viewIsOwnProfile) {
-        if (value === "dark") {
-          document.documentElement.setAttribute("data-bs-theme", "dark");
-        } else {
-          document.documentElement.removeAttribute("data-bs-theme");
-        }
+      if (window.CRM.viewIsOwnProfile && window.CRM.theme) {
+        window.CRM.theme.setMode(value);
       }
       notifySuccess();
     })

--- a/src/v2/templates/user/user.php
+++ b/src/v2/templates/user/user.php
@@ -30,7 +30,7 @@ if (AuthenticationManager::getCurrentUser()->isAdmin()) {
 $viewedUserLocaleInfo = new LocaleInfo(SystemConfig::getValue('sLanguage'), $user->getSetting('ui.locale'));
 
 // Read user settings server-side so controls are pre-populated without JS API calls
-$_userStyle = $user->getSettingValue('ui.style');
+$_userThemeMode = $user->getThemeMode(); // 'auto' | 'default' | 'dark'
 $_userPrimary = $user->getSettingValue('ui.theme.primary');
 $_userTableSize = $user->getSettingValue('ui.table.size');
 
@@ -221,19 +221,25 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
               <div class="col-sm-9">
                 <div class="form-selectgroup">
                   <label class="form-selectgroup-item">
-                    <input type="radio" name="themeMode" value="default" class="form-selectgroup-input" id="themeModeLight"<?= $_userStyle !== 'dark' ? ' checked' : '' ?>>
+                    <input type="radio" name="themeMode" value="auto" class="form-selectgroup-input" id="themeModeAuto"<?= $_userThemeMode === 'auto' ? ' checked' : '' ?>>
+                    <span class="form-selectgroup-label">
+                      <i class="ti ti-device-desktop me-1"></i><?= gettext("Auto") ?>
+                    </span>
+                  </label>
+                  <label class="form-selectgroup-item">
+                    <input type="radio" name="themeMode" value="default" class="form-selectgroup-input" id="themeModeLight"<?= $_userThemeMode === 'default' ? ' checked' : '' ?>>
                     <span class="form-selectgroup-label">
                       <i class="ti ti-sun me-1"></i><?= gettext("Light") ?>
                     </span>
                   </label>
                   <label class="form-selectgroup-item">
-                    <input type="radio" name="themeMode" value="dark" class="form-selectgroup-input" id="themeModeDark"<?= $_userStyle === 'dark' ? ' checked' : '' ?>>
+                    <input type="radio" name="themeMode" value="dark" class="form-selectgroup-input" id="themeModeDark"<?= $_userThemeMode === 'dark' ? ' checked' : '' ?>>
                     <span class="form-selectgroup-label">
                       <i class="ti ti-moon me-1"></i><?= gettext("Dark") ?>
                     </span>
                   </label>
                 </div>
-                <small class="form-hint"><?= gettext("Choose between light and dark color scheme") ?></small>
+                <small class="form-hint"><?= gettext("Auto follows your OS or browser setting; Light and Dark override it") ?></small>
               </div>
             </div>
 


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Adds a third **Auto** option to the theme selector (Light / Dark → Auto / Light / Dark). When Auto is chosen, the page reads `window.matchMedia('(prefers-color-scheme: dark)')` and switches live when the OS preference changes — no page reload required.

## What changed

- **`User::getThemeMode()`** (new helper) — maps raw `ui.style` DB value to `'auto' | 'default' | 'dark'`. Users who never set a preference (`ui.style = ''`) now default to Auto (follows system). Users who explicitly chose Light (`'default'`) or Dark (`'dark'`) are unaffected.
- **`Header.php`** — synchronous inline `<head>` script defines `window.CRM.theme.setMode(mode)` controller and calls it immediately to apply the correct theme before first paint (FOWT prevention). Server-side `data-bs-theme="dark"` stamp on `<html>` is preserved for the explicit-dark case (works even with JS disabled).
- **`user.php` (Appearance tab)** — third radio button (Auto, `ti-device-desktop` icon). Pre-selected when mode is unset or explicitly `'auto'`.
- **`user.js`** — change handler delegates to `window.CRM.theme.setMode(value)`, correctly managing listener add/remove as the user switches modes.
- **`locale/messages.po`** — two new strings: `"Auto"` and the updated hint.
- **Cypress** — asserts `#themeModeAuto` exists alongside the existing Light/Dark checks.

## Behavior notes

- **Existing users with no stored preference:** silently migrated from implicit Light to Auto (system preference). This is intentional per the feature requirements — only users who *explicitly* chose Light stored `'default'`; unset (`''`) means they never chose. Site admins upgrading should be aware of this.
- **Deliberate double-write for explicit Dark:** server stamps `data-bs-theme="dark"` on `<html>` server-side (no-JS FOWT guarantee) and the head script also calls `setMode('dark')` (state-machine consistency). Both writes are idempotent and intentional.

## Testing
- PHP syntax: `npm run build:php` — 3 files validated ✅  
- JS lint: `npm run lint` — 0 new warnings ✅  
- Webpack: `npm run build:webpack` — compiled successfully ✅