### PR TITLE
test: E2E tests for external family verify form submission (issue #9096)

### DIFF
--- a/cypress/e2e/ui/family/family.verify.spec.js
+++ b/cypress/e2e/ui/family/family.verify.spec.js
@@ -80,9 +80,13 @@ describe("Family verification — self-verify token link (no account)", () => {
         cy.get("#confirmVerifyBtn").click();
         cy.get("#confirm-Verify").should("be.visible");
 
-        // Select "changes needed" and provide our unique traceable message
+        // Select "changes needed" and set the textarea value directly.
+        // Using invoke("val") instead of .type() avoids a Bootstrap 5 modal
+        // focus-trap issue where the keyboard delivery gets cut off mid-string;
+        // the submit handler reads textarea.value at click-time, so a direct
+        // DOM-property write produces the same result as typing.
         cy.get("#UpdateNeeded").click();
-        cy.get("#confirm-info-data").should("be.visible").click().type(uniqueMessage);
+        cy.get("#confirm-info-data").should("be.visible").invoke("val", uniqueMessage);
         cy.get("#onlineVerifyBtn").click();
 
         // Wait for the fetch POST to complete successfully
@@ -98,8 +102,10 @@ describe("Family verification — self-verify token link (no account)", () => {
         // the exact value set by the external POST handler in src/external/routes/verify.php.
         cy.makePrivateAdminAPICall("GET", "/api/families/self-verify", null, 200).then((resp) => {
             const notes = resp.body.families;
+            // Number() coercion guards against PHP/PDO returning integer
+            // columns as strings in some MariaDB/PDO configurations.
             const found = notes.find(
-                (n) => n.FamId === familyId && n.Text === uniqueMessage
+                (n) => Number(n.FamId) === familyId && n.Text === uniqueMessage
             );
             expect(found, "self-verify note for the family should exist with the submitted message").to.exist;
         });

--- a/cypress/e2e/ui/family/family.verify.spec.js
+++ b/cypress/e2e/ui/family/family.verify.spec.js
@@ -66,4 +66,69 @@ describe("Family verification — self-verify token link (no account)", () => {
         // verification page. The visitor verifies everything *except* notes.
         cy.get("body").should("not.contain", "Notes");
     });
+
+    // ── Happy-path: submit the form and assert the note is recorded in the DB ──
+
+    it("Should submit verification and create a self-verify note in the database", function() {
+        const uniqueMessage = `Cypress self-verify ${Date.now()}`;
+
+        // Register intercept before page load so the fetch POST is captured.
+        // Glob prefix ('**') required for subdirectory CI mode.
+        cy.intercept("POST", "**/external/verify/*").as("verifySubmit");
+
+        cy.visit(this.verifyUrl);
+        cy.get("#confirmVerifyBtn").click();
+        cy.get("#confirm-Verify").should("be.visible");
+
+        // Select "changes needed" and provide our unique traceable message
+        cy.get("#UpdateNeeded").click();
+        cy.get("#confirm-info-data").should("be.visible").click().type(uniqueMessage);
+        cy.get("#onlineVerifyBtn").click();
+
+        // Wait for the fetch POST to complete successfully
+        cy.wait("@verifySubmit").its("response.statusCode").should("eq", 200);
+
+        // UI transitions: done panel shown, submit hidden, church-website shown
+        cy.get("#confirm-modal-done").should("not.have.class", "d-none");
+        cy.get("#onlineVerifyBtn").should("have.class", "d-none");
+        cy.get("#onlineVerifySiteBtn").should("not.have.class", "d-none");
+
+        // DB assertion: a self-verify note with our message must exist.
+        // GET /api/families/self-verify returns notes with EnteredBy = SELF_VERIFY (-2),
+        // the exact value set by the external POST handler in src/external/routes/verify.php.
+        cy.makePrivateAdminAPICall("GET", "/api/families/self-verify", null, 200).then((resp) => {
+            const notes = resp.body.families;
+            const found = notes.find(
+                (n) => n.FamId === familyId && n.Text === uniqueMessage
+            );
+            expect(found, "self-verify note for the family should exist with the submitted message").to.exist;
+        });
+
+        // Sanity: the family record itself is still accessible and unchanged
+        cy.makePrivateAdminAPICall("GET", `/api/family/${familyId}`, null, 200).then((resp) => {
+            expect(resp.body.Id).to.equal(familyId);
+        });
+    });
+
+    // ── Token consumption: token uses drain to 0 and are eventually rejected ──
+
+    it("Should reject the verify URL once all token uses are exhausted", function() {
+        // Token.build('verifyFamily') sets RemainingUses = 5.
+        // Each GET to the verify URL calls token.consume(), decrementing by one.
+        // When RemainingUses reaches 0, isValid() returns false and the handler
+        // renders the error template instead of the family-verification form.
+        //
+        // We exhaust the 5 uses via cy.request (fast HTTP-only GETs, no browser
+        // rendering), then assert the 6th request shows the error page.
+        Cypress._.times(5, () => {
+            // Each valid response contains the "Confirm Family Info" button
+            cy.request(this.verifyUrl).its("body").should("include", "confirmVerifyBtn");
+        });
+
+        // Token now exhausted (RemainingUses = 0): next request renders error page
+        cy.request(this.verifyUrl)
+            .its("body")
+            .should("not.include", "confirmVerifyBtn")
+            .and("include", "Unable to load verification info");
+    });
 });


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Extends `cypress/e2e/ui/family/family.verify.spec.js` with the two coverage gaps from #9096:

**What changed**
- **Happy-path submit**: visit verify URL → open modal → select UpdateNeeded → type unique message → click `#onlineVerifyBtn`; intercept the fetch POST, assert done-modal transitions (submit hidden, site-btn revealed), confirm a `SELF_VERIFY` note with the exact message text persists in the DB via `GET /api/families/self-verify`; sanity-check family record via `GET /api/family/1`.
- **Token exhaustion**: drain all 5 `RemainingUses` via `cy.request` GETs, then assert the 6th request renders the error page (`Unable to load verification info`) instead of the family form. (The verifyFamily token has 5 uses, not 1 — documented in comments.)

**Notes**
- The `#NoChanges` radio path is not DB-asserted (noted by reviewer as low-severity gap; can be a follow-up).
- Token isolation guaranteed: `beforeEach` always calls `GET /api/family/{id}/verify/url` which deletes prior tokens and mints a fresh 5-use token.

Closes #9096