### PR TITLE
locale: translate all locales (7.6.0)

### DIFF
--- a/locale/terms/missing/af/af-1.json
+++ b/locale/terms/missing/af/af-1.json
@@ -1,20 +1,20 @@
 {
-  "Items": "",
-  "Data": "",
+  "Items": "Items",
+  "Data": "Data",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} lid gekopieer",
+    "other": "{{count}} lede gekopieer"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Hierdie lys het {{count}} ontvanger — te veel vir 'n mailto:-skakel. Gebruik eerder Kopieer adresse.",
+    "other": "Hierdie lys het {{count}} ontvangers — te veel vir 'n mailto:-skakel. Gebruik eerder Kopieer adresse."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Te veel ontvangers vir e-posprogram ({{count}} > {{max}}). Gebruik eerder Kopieer adresse.",
+    "other": "Te veel ontvangers vir e-posprogram ({{count}} > {{max}}). Gebruik eerder Kopieer adresse."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} min oor",
+    "other": "{{count}} min oor"
   }
 }

--- a/locale/terms/missing/am/am-1.json
+++ b/locale/terms/missing/am/am-1.json
@@ -1,18 +1,18 @@
 {
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} አባል ተቀድቷል",
+    "other": "{{count}} አባላት ተቀድተዋል"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "ይህ ዝርዝር {{count}} ተቀባይ አለው — ለ mailto: ሊንክ በጣም ብዙ ነው። ይልቁንስ አድራሻዎችን ቅዳ ይጠቀሙ።",
+    "other": "ይህ ዝርዝር {{count}} ተቀባዮች አሉት — ለ mailto: ሊንክ በጣም ብዙ ነው። ይልቁንስ አድራሻዎችን ቅዳ ይጠቀሙ።"
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "ለኢሜይል ደንበኛ ብዙ ተቀባዮች ({{count}} > {{max}})። ይልቁንስ አድራሻዎችን ቅዳ ይጠቀሙ።",
+    "other": "ለኢሜይል ደንበኛ ብዙ ተቀባዮች ({{count}} > {{max}})። ይልቁንስ አድራሻዎችን ቅዳ ይጠቀሙ።"
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} ደቂቃ ቀርቷል",
+    "other": "{{count}} ደቂቃዎች ቀርተዋል"
   }
 }

--- a/locale/terms/missing/ar/ar-1.json
+++ b/locale/terms/missing/ar/ar-1.json
@@ -1,18 +1,18 @@
 {
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "تم نسخ {{count}} عضو",
+    "other": "تم نسخ {{count}} أعضاء"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "تحتوي هذه القائمة على {{count}} مستلم — كثير جداً لرابط mailto:. استخدم نسخ العناوين بدلاً من ذلك.",
+    "other": "تحتوي هذه القائمة على {{count}} مستلمين — كثير جداً لرابط mailto:. استخدم نسخ العناوين بدلاً من ذلك."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "عدد المستلمين كبير جداً لعميل البريد الإلكتروني ({{count}} > {{max}}). استخدم نسخ العناوين بدلاً من ذلك.",
+    "other": "عدد المستلمين كبير جداً لعميل البريد الإلكتروني ({{count}} > {{max}}). استخدم نسخ العناوين بدلاً من ذلك."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} دقيقة متبقية",
+    "other": "{{count}} دقائق متبقية"
   }
 }

--- a/locale/terms/missing/cs/cs-1.json
+++ b/locale/terms/missing/cs/cs-1.json
@@ -1,20 +1,20 @@
 {
-  "Fundraising": "",
-  "Data": "",
+  "Fundraising": "Fundraising",
+  "Data": "Data",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Zkopírován {{count}} člen",
+    "other": "Zkopírováno {{count}} členů"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Tento seznam má {{count}} příjemce — příliš mnoho pro odkaz mailto:. Použijte místo toho Kopírovat adresy.",
+    "other": "Tento seznam má {{count}} příjemců — příliš mnoho pro odkaz mailto:. Použijte místo toho Kopírovat adresy."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Příliš mnoho příjemců pro e-mailového klienta ({{count}} > {{max}}). Použijte místo toho Kopírovat adresy.",
+    "other": "Příliš mnoho příjemců pro e-mailového klienta ({{count}} > {{max}}). Použijte místo toho Kopírovat adresy."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} min zbývá",
+    "other": "{{count}} min zbývá"
   }
 }

--- a/locale/terms/missing/de/de-1.json
+++ b/locale/terms/missing/de/de-1.json
@@ -1,19 +1,19 @@
 {
-  "Code": "",
+  "Code": "Code",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} Mitglied kopiert",
+    "other": "{{count}} Mitglieder kopiert"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Diese Liste hat {{count}} Empfänger — zu viele für einen mailto:-Link. Verwenden Sie stattdessen Adressen kopieren.",
+    "other": "Diese Liste hat {{count}} Empfänger — zu viele für einen mailto:-Link. Verwenden Sie stattdessen Adressen kopieren."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Zu viele Empfänger für den E-Mail-Client ({{count}} > {{max}}). Verwenden Sie stattdessen Adressen kopieren.",
+    "other": "Zu viele Empfänger für den E-Mail-Client ({{count}} > {{max}}). Verwenden Sie stattdessen Adressen kopieren."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} Min übrig",
+    "other": "{{count}} Min übrig"
   }
 }

--- a/locale/terms/missing/el/el-1.json
+++ b/locale/terms/missing/el/el-1.json
@@ -1,18 +1,18 @@
 {
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Αντιγράφηκε {{count}} μέλος",
+    "other": "Αντιγράφηκαν {{count}} μέλη"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Αυτή η λίστα έχει {{count}} παραλήπτη — πολύ πολλοί για σύνδεσμο mailto:. Χρησιμοποιήστε την Αντιγραφή Διευθύνσεων.",
+    "other": "Αυτή η λίστα έχει {{count}} παραλήπτες — πολύ πολλοί για σύνδεσμο mailto:. Χρησιμοποιήστε την Αντιγραφή Διευθύνσεων."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Πολλοί παραλήπτες για πρόγραμμα email ({{count}} > {{max}}). Χρησιμοποιήστε την Αντιγραφή Διευθύνσεων.",
+    "other": "Πολλοί παραλήπτες για πρόγραμμα email ({{count}} > {{max}}). Χρησιμοποιήστε την Αντιγραφή Διευθύνσεων."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} λεπτό απομένει",
+    "other": "{{count}} λεπτά απομένουν"
   }
 }

--- a/locale/terms/missing/es-AR/es-AR-1.json
+++ b/locale/terms/missing/es-AR/es-AR-1.json
@@ -1,18 +1,18 @@
 {
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Se copió {{count}} miembro",
+    "other": "Se copiaron {{count}} miembros"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Esta lista tiene {{count}} destinatario — demasiados para un enlace mailto:. Use Copiar Direcciones en su lugar.",
+    "other": "Esta lista tiene {{count}} destinatarios — demasiados para un enlace mailto:. Use Copiar Direcciones en su lugar."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Use Copiar Direcciones en su lugar.",
+    "other": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Use Copiar Direcciones en su lugar."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} min restante",
+    "other": "{{count}} min restantes"
   }
 }

--- a/locale/terms/missing/es-CO/es-CO-1.json
+++ b/locale/terms/missing/es-CO/es-CO-1.json
@@ -1,18 +1,18 @@
 {
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Se copió {{count}} miembro",
+    "other": "Se copiaron {{count}} miembros"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Esta lista tiene {{count}} destinatario — demasiados para un enlace mailto:. Use Copiar Direcciones en su lugar.",
+    "other": "Esta lista tiene {{count}} destinatarios — demasiados para un enlace mailto:. Use Copiar Direcciones en su lugar."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Use Copiar Direcciones en su lugar.",
+    "other": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Use Copiar Direcciones en su lugar."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} min restante",
+    "other": "{{count}} min restantes"
   }
 }

--- a/locale/terms/missing/es-MX/es-MX-1.json
+++ b/locale/terms/missing/es-MX/es-MX-1.json
@@ -1,18 +1,18 @@
 {
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Se copió {{count}} miembro",
+    "other": "Se copiaron {{count}} miembros"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Esta lista tiene {{count}} destinatario — demasiados para un enlace mailto:. Use Copiar Direcciones en su lugar.",
+    "other": "Esta lista tiene {{count}} destinatarios — demasiados para un enlace mailto:. Use Copiar Direcciones en su lugar."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Use Copiar Direcciones en su lugar.",
+    "other": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Use Copiar Direcciones en su lugar."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} min restante",
+    "other": "{{count}} min restantes"
   }
 }

--- a/locale/terms/missing/es-SV/es-SV-1.json
+++ b/locale/terms/missing/es-SV/es-SV-1.json
@@ -1,18 +1,18 @@
 {
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Se copió {{count}} miembro",
+    "other": "Se copiaron {{count}} miembros"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Esta lista tiene {{count}} destinatario — demasiados para un enlace mailto:. Use Copiar Direcciones en su lugar.",
+    "other": "Esta lista tiene {{count}} destinatarios — demasiados para un enlace mailto:. Use Copiar Direcciones en su lugar."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Use Copiar Direcciones en su lugar.",
+    "other": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Use Copiar Direcciones en su lugar."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} min restante",
+    "other": "{{count}} min restantes"
   }
 }

--- a/locale/terms/missing/es/es-1.json
+++ b/locale/terms/missing/es/es-1.json
@@ -1,18 +1,18 @@
 {
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Se copió {{count}} miembro",
+    "other": "Se copiaron {{count}} miembros"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Esta lista tiene {{count}} destinatario — demasiados para un enlace mailto:. Use Copiar Direcciones en su lugar.",
+    "other": "Esta lista tiene {{count}} destinatarios — demasiados para un enlace mailto:. Use Copiar Direcciones en su lugar."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Use Copiar Direcciones en su lugar.",
+    "other": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Use Copiar Direcciones en su lugar."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} min restante",
+    "other": "{{count}} min restantes"
   }
 }

--- a/locale/terms/missing/et/et-1.json
+++ b/locale/terms/missing/et/et-1.json
@@ -1,18 +1,18 @@
 {
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Kopeeritud {{count}} liige",
+    "other": "Kopeeritud {{count}} liiget"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Sellel loendil on {{count}} adressaat — liiga palju mailto: lingi jaoks. Kasutage selle asemel Kopeeri aadressid.",
+    "other": "Sellel loendil on {{count}} adressaati — liiga palju mailto: lingi jaoks. Kasutage selle asemel Kopeeri aadressid."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Liiga palju adressaate meilikliendile ({{count}} > {{max}}). Kasutage selle asemel Kopeeri aadressid.",
+    "other": "Liiga palju adressaate meilikliendile ({{count}} > {{max}}). Kasutage selle asemel Kopeeri aadressid."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} min jäänud",
+    "other": "{{count}} min jäänud"
   }
 }

--- a/locale/terms/missing/fi/fi-1.json
+++ b/locale/terms/missing/fi/fi-1.json
@@ -1,18 +1,18 @@
 {
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} jäsen kopioitu",
+    "other": "{{count}} jäsentä kopioitu"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Tässä listassa on {{count}} vastaanottaja — liian monta mailto:-linkkiä varten. Käytä sen sijaan Kopioi osoitteet -toimintoa.",
+    "other": "Tässä listassa on {{count}} vastaanottajaa — liian monta mailto:-linkkiä varten. Käytä sen sijaan Kopioi osoitteet -toimintoa."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Liian monta vastaanottajaa sähköpostiohjelmalle ({{count}} > {{max}}). Käytä sen sijaan Kopioi osoitteet -toimintoa.",
+    "other": "Liian monta vastaanottajaa sähköpostiohjelmalle ({{count}} > {{max}}). Käytä sen sijaan Kopioi osoitteet -toimintoa."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} min jäljellä",
+    "other": "{{count}} min jäljellä"
   }
 }

--- a/locale/terms/missing/fil/fil-1.json
+++ b/locale/terms/missing/fil/fil-1.json
@@ -1,29 +1,29 @@
 {
-  "Access": "",
-  "Self-service": "",
-  "Changelog": "",
-  "Feature": "",
-  "Check-out": "",
-  "Code": "",
-  "Live Preview": "",
-  "Sell-through": "",
-  "BCC Mode": "",
-  "Data": "",
-  "Deposit Slip": "",
+  "Access": "Access",
+  "Self-service": "Self-service",
+  "Changelog": "Changelog",
+  "Feature": "Feature",
+  "Check-out": "Check-out",
+  "Code": "Code",
+  "Live Preview": "Live Preview",
+  "Sell-through": "Sell-through",
+  "BCC Mode": "BCC Mode",
+  "Data": "Data",
+  "Deposit Slip": "Deposit Slip",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} miyembro ang nakopya",
+    "other": "{{count}} miyembro ang nakopya"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Ang listahang ito ay may {{count}} tatanggap — napakarami para sa isang mailto: link. Gamitin ang Kopyahin ang mga Address sa halip.",
+    "other": "Ang listahang ito ay may {{count}} tatanggap — napakarami para sa isang mailto: link. Gamitin ang Kopyahin ang mga Address sa halip."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Napakaraming tatanggap para sa email client ({{count}} > {{max}}). Gamitin ang Kopyahin ang mga Address sa halip.",
+    "other": "Napakaraming tatanggap para sa email client ({{count}} > {{max}}). Gamitin ang Kopyahin ang mga Address sa halip."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} minuto na lang",
+    "other": "{{count}} minuto na lang"
   }
 }

--- a/locale/terms/missing/fr/fr-1.json
+++ b/locale/terms/missing/fr/fr-1.json
@@ -1,20 +1,20 @@
 {
-  "Code": "",
-  "Signature": "",
+  "Code": "Code",
+  "Signature": "Signature",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} membre copié",
+    "other": "{{count}} membres copiés"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Cette liste a {{count}} destinataire — trop pour un lien mailto:. Utilisez Copier les adresses à la place.",
+    "other": "Cette liste a {{count}} destinataires — trop pour un lien mailto:. Utilisez Copier les adresses à la place."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Trop de destinataires pour le client de messagerie ({{count}} > {{max}}). Utilisez Copier les adresses à la place.",
+    "other": "Trop de destinataires pour le client de messagerie ({{count}} > {{max}}). Utilisez Copier les adresses à la place."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} min restante",
+    "other": "{{count}} min restantes"
   }
 }

--- a/locale/terms/missing/he/he-1.json
+++ b/locale/terms/missing/he/he-1.json
@@ -1,18 +1,18 @@
 {
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "חבר {{count}} הועתק",
+    "other": "{{count}} חברים הועתקו"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "לרשימה זו יש {{count}} נמען — יותר מדי לקישור mailto:. השתמש בהעתקת כתובות.",
+    "other": "לרשימה זו יש {{count}} נמענים — יותר מדי לקישור mailto:. השתמש בהעתקת כתובות."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "יותר מדי נמענים ליישום הדואר ({{count}} > {{max}}). השתמש בהעתקת כתובות.",
+    "other": "יותר מדי נמענים ליישום הדואר ({{count}} > {{max}}). השתמש בהעתקת כתובות."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "נותרה {{count}} דקה",
+    "other": "נותרו {{count}} דקות"
   }
 }

--- a/locale/terms/missing/hi/hi-1.json
+++ b/locale/terms/missing/hi/hi-1.json
@@ -1,18 +1,18 @@
 {
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} सदस्य कॉपी किया गया",
+    "other": "{{count}} सदस्य कॉपी किए गए"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "इस सूची में {{count}} प्राप्तकर्ता है — mailto: लिंक के लिए बहुत अधिक। इसके बजाय पतों की प्रतिलिपि बनाएँ का उपयोग करें।",
+    "other": "इस सूची में {{count}} प्राप्तकर्ता हैं — mailto: लिंक के लिए बहुत अधिक। इसके बजाय पतों की प्रतिलिपि बनाएँ का उपयोग करें।"
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "ईमेल क्लाइंट के लिए बहुत अधिक प्राप्तकर्ता ({{count}} > {{max}})। इसके बजाय पतों की प्रतिलिपि बनाएँ का उपयोग करें।",
+    "other": "ईमेल क्लाइंट के लिए बहुत अधिक प्राप्तकर्ता ({{count}} > {{max}})। इसके बजाय पतों की प्रतिलिपि बनाएँ का उपयोग करें।"
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} मिनट शेष",
+    "other": "{{count}} मिनट शेष"
   }
 }

--- a/locale/terms/missing/hr/hr-1.json
+++ b/locale/terms/missing/hr/hr-1.json
@@ -1,18 +1,18 @@
 {
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Kopiran {{count}} član",
+    "other": "Kopirano {{count}} članova"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Ovaj popis ima {{count}} primatelja — previše za mailto: vezu. Umjesto toga koristite Kopiraj adrese.",
+    "other": "Ovaj popis ima {{count}} primatelja — previše za mailto: vezu. Umjesto toga koristite Kopiraj adrese."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Previše primatelja za e-mail klijent ({{count}} > {{max}}). Umjesto toga koristite Kopiraj adrese.",
+    "other": "Previše primatelja za e-mail klijent ({{count}} > {{max}}). Umjesto toga koristite Kopiraj adrese."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} min preostalo",
+    "other": "{{count}} min preostalo"
   }
 }

--- a/locale/terms/missing/hu/hu-1.json
+++ b/locale/terms/missing/hu/hu-1.json
@@ -1,18 +1,18 @@
 {
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} tag másolva",
+    "other": "{{count}} tag másolva"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Ez a lista {{count}} címzettet tartalmaz — túl sok egy mailto: hivatkozáshoz. Ehelyett használja a Címek másolása funkciót.",
+    "other": "Ez a lista {{count}} címzettet tartalmaz — túl sok egy mailto: hivatkozáshoz. Ehelyett használja a Címek másolása funkciót."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Túl sok címzett a levelezőprogramhoz ({{count}} > {{max}}). Ehelyett használja a Címek másolása funkciót.",
+    "other": "Túl sok címzett a levelezőprogramhoz ({{count}} > {{max}}). Ehelyett használja a Címek másolása funkciót."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} perc maradt",
+    "other": "{{count}} perc maradt"
   }
 }

--- a/locale/terms/missing/id/id-1.json
+++ b/locale/terms/missing/id/id-1.json
@@ -1,19 +1,19 @@
 {
-  "Data": "",
+  "Data": "Data",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} anggota disalin",
+    "other": "{{count}} anggota disalin"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Daftar ini memiliki {{count}} penerima — terlalu banyak untuk tautan mailto:. Gunakan Salin Alamat sebagai gantinya.",
+    "other": "Daftar ini memiliki {{count}} penerima — terlalu banyak untuk tautan mailto:. Gunakan Salin Alamat sebagai gantinya."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Terlalu banyak penerima untuk klien email ({{count}} > {{max}}). Gunakan Salin Alamat sebagai gantinya.",
+    "other": "Terlalu banyak penerima untuk klien email ({{count}} > {{max}}). Gunakan Salin Alamat sebagai gantinya."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} menit tersisa",
+    "other": "{{count}} menit tersisa"
   }
 }

--- a/locale/terms/missing/it/it-1.json
+++ b/locale/terms/missing/it/it-1.json
@@ -1,19 +1,19 @@
 {
-  "Check-out": "",
+  "Check-out": "Check-out",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} membro copiato",
+    "other": "{{count}} membri copiati"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Questa lista ha {{count}} destinatario — troppi per un link mailto:. Usa Copia indirizzi invece.",
+    "other": "Questa lista ha {{count}} destinatari — troppi per un link mailto:. Usa Copia indirizzi invece."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Troppi destinatari per il client di posta ({{count}} > {{max}}). Usa Copia indirizzi invece.",
+    "other": "Troppi destinatari per il client di posta ({{count}} > {{max}}). Usa Copia indirizzi invece."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} min rimasto",
+    "other": "{{count}} min rimanenti"
   }
 }

--- a/locale/terms/missing/ja/ja-1.json
+++ b/locale/terms/missing/ja/ja-1.json
@@ -1,18 +1,18 @@
 {
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}}人のメンバーをコピーしました",
+    "other": "{{count}}人のメンバーをコピーしました"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "このリストには{{count}}人の受信者がいます — mailto: リンクには多すぎます。代わりにアドレスをコピーを使用してください。",
+    "other": "このリストには{{count}}人の受信者がいます — mailto: リンクには多すぎます。代わりにアドレスをコピーを使用してください。"
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "メールクライアントの受信者が多すぎます ({{count}} > {{max}})。代わりにアドレスをコピーを使用してください。",
+    "other": "メールクライアントの受信者が多すぎます ({{count}} > {{max}})。代わりにアドレスをコピーを使用してください。"
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "残り{{count}}分",
+    "other": "残り{{count}}分"
   }
 }

--- a/locale/terms/missing/ko/ko-1.json
+++ b/locale/terms/missing/ko/ko-1.json
@@ -1,18 +1,18 @@
 {
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}}명의 회원이 복사되었습니다",
+    "other": "{{count}}명의 회원이 복사되었습니다"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "이 목록에는 {{count}}명의 수신자가 있습니다 — mailto: 링크에 사용하기에는 너무 많습니다. 대신 주소 복사를 사용하세요.",
+    "other": "이 목록에는 {{count}}명의 수신자가 있습니다 — mailto: 링크에 사용하기에는 너무 많습니다. 대신 주소 복사를 사용하세요."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "이메일 클라이언트에 수신자가 너무 많습니다 ({{count}} > {{max}}). 대신 주소 복사를 사용하세요.",
+    "other": "이메일 클라이언트에 수신자가 너무 많습니다 ({{count}} > {{max}}). 대신 주소 복사를 사용하세요."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}}분 남았습니다",
+    "other": "{{count}}분 남았습니다"
   }
 }

--- a/locale/terms/missing/ml/ml-1.json
+++ b/locale/terms/missing/ml/ml-1.json
@@ -1,18 +1,18 @@
 {
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} അംഗം പകർത്തി",
+    "other": "{{count}} അംഗങ്ങൾ പകർത്തി"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "ഈ ലിസ്റ്റിൽ {{count}} സ്വീകർത്താവ് ഉണ്ട് — mailto: ലിങ്കിന് വളരെ കൂടുതൽ. പകരം വിലാസങ്ങൾ പകർത്തുക ഉപയോഗിക്കുക.",
+    "other": "ഈ ലിസ്റ്റിൽ {{count}} സ്വീകർത്താക്കൾ ഉണ്ട് — mailto: ലിങ്കിന് വളരെ കൂടുതൽ. പകരം വിലാസങ്ങൾ പകർത്തുക ഉപയോഗിക്കുക."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "ഇമെയിൽ ക്ലയന്റിന് സ്വീകർത്താക്കൾ വളരെ കൂടുതൽ ({{count}} > {{max}}). പകരം വിലാസങ്ങൾ പകർത്തുക ഉപയോഗിക്കുക.",
+    "other": "ഇമെയിൽ ക്ലയന്റിന് സ്വീകർത്താക്കൾ വളരെ കൂടുതൽ ({{count}} > {{max}}). പകരം വിലാസങ്ങൾ പകർത്തുക ഉപയോഗിക്കുക."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} മിനിറ്റ് ശേഷിക്കുന്നു",
+    "other": "{{count}} മിനിറ്റ് ശേഷിക്കുന്നു"
   }
 }

--- a/locale/terms/missing/nb/nb-1.json
+++ b/locale/terms/missing/nb/nb-1.json
@@ -1,19 +1,19 @@
 {
-  "Data": "",
+  "Data": "Data",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} medlem kopiert",
+    "other": "{{count}} medlemmer kopiert"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Denne listen har {{count}} mottaker — for mange for en mailto:-lenke. Bruk Kopier adresser i stedet.",
+    "other": "Denne listen har {{count}} mottakere — for mange for en mailto:-lenke. Bruk Kopier adresser i stedet."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "For mange mottakere for e-postklienten ({{count}} > {{max}}). Bruk Kopier adresser i stedet.",
+    "other": "For mange mottakere for e-postklienten ({{count}} > {{max}}). Bruk Kopier adresser i stedet."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} min igjen",
+    "other": "{{count}} min igjen"
   }
 }

--- a/locale/terms/missing/nl/nl-1.json
+++ b/locale/terms/missing/nl/nl-1.json
@@ -1,21 +1,21 @@
 {
-  "Code": "",
-  "Items": "",
-  "Planning": "",
+  "Code": "Code",
+  "Items": "Items",
+  "Planning": "Planning",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} lid gekopieerd",
+    "other": "{{count}} leden gekopieerd"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Deze lijst heeft {{count}} ontvanger — te veel voor een mailto:-link. Gebruik in plaats daarvan Adressen kopiëren.",
+    "other": "Deze lijst heeft {{count}} ontvangers — te veel voor een mailto:-link. Gebruik in plaats daarvan Adressen kopiëren."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Te veel ontvangers voor e-mailclient ({{count}} > {{max}}). Gebruik in plaats daarvan Adressen kopiëren.",
+    "other": "Te veel ontvangers voor e-mailclient ({{count}} > {{max}}). Gebruik in plaats daarvan Adressen kopiëren."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} min over",
+    "other": "{{count}} min over"
   }
 }

--- a/locale/terms/missing/pl/pl-1.json
+++ b/locale/terms/missing/pl/pl-1.json
@@ -1,18 +1,18 @@
 {
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Skopiowano {{count}} członka",
+    "other": "Skopiowano {{count}} członków"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Ta lista ma {{count}} odbiorcę — za dużo dla łącza mailto:. Użyj opcji Kopiuj adresy.",
+    "other": "Ta lista ma {{count}} odbiorców — za dużo dla łącza mailto:. Użyj opcji Kopiuj adresy."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Za dużo odbiorców dla klienta poczty ({{count}} > {{max}}). Użyj opcji Kopiuj adresy.",
+    "other": "Za dużo odbiorców dla klienta poczty ({{count}} > {{max}}). Użyj opcji Kopiuj adresy."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} min pozostała",
+    "other": "{{count}} min pozostało"
   }
 }

--- a/locale/terms/missing/pt-br/pt-br-1.json
+++ b/locale/terms/missing/pt-br/pt-br-1.json
@@ -1,18 +1,18 @@
 {
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} membro copiado",
+    "other": "{{count}} membros copiados"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Esta lista tem {{count}} destinatário — muitos para um link mailto:. Use Copiar Endereços em vez disso.",
+    "other": "Esta lista tem {{count}} destinatários — muitos para um link mailto:. Use Copiar Endereços em vez disso."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Destinatários demais para o cliente de e-mail ({{count}} > {{max}}). Use Copiar Endereços em vez disso.",
+    "other": "Destinatários demais para o cliente de e-mail ({{count}} > {{max}}). Use Copiar Endereços em vez disso."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} min restante",
+    "other": "{{count}} min restantes"
   }
 }

--- a/locale/terms/missing/pt/pt-1.json
+++ b/locale/terms/missing/pt/pt-1.json
@@ -1,18 +1,18 @@
 {
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} membro copiado",
+    "other": "{{count}} membros copiados"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Esta lista tem {{count}} destinatário — demasiados para um link mailto:. Use Copiar Endereços em vez disso.",
+    "other": "Esta lista tem {{count}} destinatários — demasiados para um link mailto:. Use Copiar Endereços em vez disso."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Destinatários a mais para o cliente de e-mail ({{count}} > {{max}}). Use Copiar Endereços em vez disso.",
+    "other": "Destinatários a mais para o cliente de e-mail ({{count}} > {{max}}). Use Copiar Endereços em vez disso."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} min restante",
+    "other": "{{count}} min restantes"
   }
 }

--- a/locale/terms/missing/ro/ro-1.json
+++ b/locale/terms/missing/ro/ro-1.json
@@ -1,21 +1,21 @@
 {
-  "Important": "",
-  "Major": "",
-  "Catalog": "",
+  "Important": "Important",
+  "Major": "Major",
+  "Catalog": "Catalog",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} membru copiat",
+    "other": "{{count}} membri copiați"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Această listă are {{count}} destinatar — prea mulți pentru un link mailto:. Folosiți Copiați adresele în schimb.",
+    "other": "Această listă are {{count}} destinatari — prea mulți pentru un link mailto:. Folosiți Copiați adresele în schimb."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Prea mulți destinatari pentru clientul de e-mail ({{count}} > {{max}}). Folosiți Copiați adresele în schimb.",
+    "other": "Prea mulți destinatari pentru clientul de e-mail ({{count}} > {{max}}). Folosiți Copiați adresele în schimb."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} min rămas",
+    "other": "{{count}} min rămase"
   }
 }

--- a/locale/terms/missing/ru/ru-1.json
+++ b/locale/terms/missing/ru/ru-1.json
@@ -1,18 +1,18 @@
 {
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Скопирован {{count}} участник",
+    "other": "Скопировано {{count}} участников"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Этот список содержит {{count}} получателя — слишком много для ссылки mailto:. Используйте «Копировать адреса».",
+    "other": "Этот список содержит {{count}} получателей — слишком много для ссылки mailto:. Используйте «Копировать адреса»."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Слишком много получателей для почтового клиента ({{count}} > {{max}}). Используйте «Копировать адреса».",
+    "other": "Слишком много получателей для почтового клиента ({{count}} > {{max}}). Используйте «Копировать адреса»."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "Осталась {{count}} мин",
+    "other": "Осталось {{count}} мин"
   }
 }

--- a/locale/terms/missing/sk/sk-1.json
+++ b/locale/terms/missing/sk/sk-1.json
@@ -1,18 +1,18 @@
 {
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Skopírovaný {{count}} člen",
+    "other": "Skopírovaných {{count}} členov"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Tento zoznam má {{count}} príjemcu — priveľa pre odkaz mailto:. Použite namiesto toho Kopírovať adresy.",
+    "other": "Tento zoznam má {{count}} príjemcov — priveľa pre odkaz mailto:. Použite namiesto toho Kopírovať adresy."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Priveľa príjemcov pre e-mailového klienta ({{count}} > {{max}}). Použite namiesto toho Kopírovať adresy.",
+    "other": "Priveľa príjemcov pre e-mailového klienta ({{count}} > {{max}}). Použite namiesto toho Kopírovať adresy."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "Zostáva {{count}} min",
+    "other": "Zostáva {{count}} min"
   }
 }

--- a/locale/terms/missing/sq/sq-1.json
+++ b/locale/terms/missing/sq/sq-1.json
@@ -1,18 +1,18 @@
 {
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} anëtar u kopjua",
+    "other": "{{count}} anëtarë u kopjuan"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Kjo listë ka {{count}} marrës — shumë për një lidhje mailto:. Përdorni Kopjo Adresat.",
+    "other": "Kjo listë ka {{count}} marrës — shumë për një lidhje mailto:. Përdorni Kopjo Adresat."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Shumë marrës për klientin e emailit ({{count}} > {{max}}). Përdorni Kopjo Adresat.",
+    "other": "Shumë marrës për klientin e emailit ({{count}} > {{max}}). Përdorni Kopjo Adresat."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} min mbetur",
+    "other": "{{count}} min mbetur"
   }
 }

--- a/locale/terms/missing/sv/sv-1.json
+++ b/locale/terms/missing/sv/sv-1.json
@@ -1,20 +1,20 @@
 {
-  "Check #": "",
-  "Data": "",
+  "Check #": "Check nr",
+  "Data": "Data",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} medlem kopierad",
+    "other": "{{count}} medlemmar kopierade"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Den här listan har {{count}} mottagare — för många för en mailto:-länk. Använd Kopiera adresser istället.",
+    "other": "Den här listan har {{count}} mottagare — för många för en mailto:-länk. Använd Kopiera adresser istället."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "För många mottagare för e-postklienten ({{count}} > {{max}}). Använd Kopiera adresser istället.",
+    "other": "För många mottagare för e-postklienten ({{count}} > {{max}}). Använd Kopiera adresser istället."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} min kvar",
+    "other": "{{count}} min kvar"
   }
 }

--- a/locale/terms/missing/sw/sw-1.json
+++ b/locale/terms/missing/sw/sw-1.json
@@ -1,19 +1,19 @@
 {
-  "Data": "",
+  "Data": "Data",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Wanachama {{count}} amenakiliwa",
+    "other": "Wanachama {{count}} wamenakiliwa"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Orodha hii ina wapokeaji {{count}} — wengi sana kwa kiungo cha mailto:. Tumia Nakili Anwani badala yake.",
+    "other": "Orodha hii ina wapokeaji {{count}} — wengi sana kwa kiungo cha mailto:. Tumia Nakili Anwani badala yake."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Wapokeaji wengi sana kwa programu ya barua pepe ({{count}} > {{max}}). Tumia Nakili Anwani badala yake.",
+    "other": "Wapokeaji wengi sana kwa programu ya barua pepe ({{count}} > {{max}}). Tumia Nakili Anwani badala yake."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "Dakika {{count}} zimebaki",
+    "other": "Dakika {{count}} zimebaki"
   }
 }

--- a/locale/terms/missing/te/te-1.json
+++ b/locale/terms/missing/te/te-1.json
@@ -1,18 +1,18 @@
 {
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} సభ్యుడు కాపీ చేయబడ్డారు",
+    "other": "{{count}} సభ్యులు కాపీ చేయబడ్డారు"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "ఈ జాబితాలో {{count}} గ్రహీత ఉన్నారు — mailto: లింక్ కోసం చాలా ఎక్కువ. బదులుగా చిరునామాలు కాపీ చేయండి ఉపయోగించండి.",
+    "other": "ఈ జాబితాలో {{count}} గ్రహీతలు ఉన్నారు — mailto: లింక్ కోసం చాలా ఎక్కువ. బదులుగా చిరునామాలు కాపీ చేయండి ఉపయోగించండి."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "ఇమెయిల్ క్లయింట్ కోసం చాలా ఎక్కువ గ్రహీతలు ({{count}} > {{max}}). బదులుగా చిరునామాలు కాపీ చేయండి ఉపయోగించండి.",
+    "other": "ఇమెయిల్ క్లయింట్ కోసం చాలా ఎక్కువ గ్రహీతలు ({{count}} > {{max}}). బదులుగా చిరునామాలు కాపీ చేయండి ఉపయోగించండి."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} నిమిషం మిగిలింది",
+    "other": "{{count}} నిమిషాలు మిగిలాయి"
   }
 }

--- a/locale/terms/missing/th/th-1.json
+++ b/locale/terms/missing/th/th-1.json
@@ -1,18 +1,18 @@
 {
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "คัดลอก {{count}} สมาชิกแล้ว",
+    "other": "คัดลอก {{count}} สมาชิกแล้ว"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "รายการนี้มีผู้รับ {{count}} ราย — มากเกินไปสำหรับลิงก์ mailto: ใช้คัดลอกที่อยู่แทน",
+    "other": "รายการนี้มีผู้รับ {{count}} ราย — มากเกินไปสำหรับลิงก์ mailto: ใช้คัดลอกที่อยู่แทน"
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "ผู้รับมากเกินไปสำหรับโปรแกรมอีเมล ({{count}} > {{max}}) ใช้คัดลอกที่อยู่แทน",
+    "other": "ผู้รับมากเกินไปสำหรับโปรแกรมอีเมล ({{count}} > {{max}}) ใช้คัดลอกที่อยู่แทน"
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "เหลือ {{count}} นาที",
+    "other": "เหลือ {{count}} นาที"
   }
 }

--- a/locale/terms/missing/tr/tr-1.json
+++ b/locale/terms/missing/tr/tr-1.json
@@ -1,18 +1,18 @@
 {
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} üye kopyalandı",
+    "other": "{{count}} üye kopyalandı"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Bu listede {{count}} alıcı var — mailto: bağlantısı için çok fazla. Bunun yerine Adresleri Kopyala seçeneğini kullanın.",
+    "other": "Bu listede {{count}} alıcı var — mailto: bağlantısı için çok fazla. Bunun yerine Adresleri Kopyala seçeneğini kullanın."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "E-posta istemcisi için çok fazla alıcı ({{count}} > {{max}}). Bunun yerine Adresleri Kopyala seçeneğini kullanın.",
+    "other": "E-posta istemcisi için çok fazla alıcı ({{count}} > {{max}}). Bunun yerine Adresleri Kopyala seçeneğini kullanın."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} dakika kaldı",
+    "other": "{{count}} dakika kaldı"
   }
 }

--- a/locale/terms/missing/uk/uk-1.json
+++ b/locale/terms/missing/uk/uk-1.json
@@ -1,18 +1,18 @@
 {
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Скопійовано {{count}} учасника",
+    "other": "Скопійовано {{count}} учасників"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Цей список містить {{count}} одержувача — занадто багато для посилання mailto:. Використовуйте «Копіювати адреси».",
+    "other": "Цей список містить {{count}} одержувачів — занадто багато для посилання mailto:. Використовуйте «Копіювати адреси»."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Забагато одержувачів для поштового клієнта ({{count}} > {{max}}). Використовуйте «Копіювати адреси».",
+    "other": "Забагато одержувачів для поштового клієнта ({{count}} > {{max}}). Використовуйте «Копіювати адреси»."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "Залишилась {{count}} хв",
+    "other": "Залишилось {{count}} хв"
   }
 }

--- a/locale/terms/missing/vi/vi-1.json
+++ b/locale/terms/missing/vi/vi-1.json
@@ -1,18 +1,18 @@
 {
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Đã sao chép {{count}} thành viên",
+    "other": "Đã sao chép {{count}} thành viên"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Danh sách này có {{count}} người nhận — quá nhiều cho liên kết mailto:. Hãy dùng Sao chép địa chỉ thay thế.",
+    "other": "Danh sách này có {{count}} người nhận — quá nhiều cho liên kết mailto:. Hãy dùng Sao chép địa chỉ thay thế."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Quá nhiều người nhận cho ứng dụng email ({{count}} > {{max}}). Hãy dùng Sao chép địa chỉ thay thế.",
+    "other": "Quá nhiều người nhận cho ứng dụng email ({{count}} > {{max}}). Hãy dùng Sao chép địa chỉ thay thế."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "Còn {{count}} phút",
+    "other": "Còn {{count}} phút"
   }
 }

--- a/locale/terms/missing/zh-CN/zh-CN-1.json
+++ b/locale/terms/missing/zh-CN/zh-CN-1.json
@@ -1,18 +1,18 @@
 {
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "已复制 {{count}} 位成员",
+    "other": "已复制 {{count}} 位成员"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "此列表有 {{count}} 位收件人 — 对于 mailto: 链接来说太多了。请改用复制地址。",
+    "other": "此列表有 {{count}} 位收件人 — 对于 mailto: 链接来说太多了。请改用复制地址。"
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "邮件客户端的收件人太多 ({{count}} > {{max}})。请改用复制地址。",
+    "other": "邮件客户端的收件人太多 ({{count}} > {{max}})。请改用复制地址。"
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "剩余 {{count}} 分钟",
+    "other": "剩余 {{count}} 分钟"
   }
 }

--- a/locale/terms/missing/zh-TW/zh-TW-1.json
+++ b/locale/terms/missing/zh-TW/zh-TW-1.json
@@ -1,18 +1,18 @@
 {
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "已複製 {{count}} 位成員",
+    "other": "已複製 {{count}} 位成員"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "此清單有 {{count}} 位收件人 — 對於 mailto: 連結來說太多了。請改用複製地址。",
+    "other": "此清單有 {{count}} 位收件人 — 對於 mailto: 連結來說太多了。請改用複製地址。"
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "郵件用戶端的收件人太多 ({{count}} > {{max}})。請改用複製地址。",
+    "other": "郵件用戶端的收件人太多 ({{count}} > {{max}})。請改用複製地址。"
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "剩餘 {{count}} 分鐘",
+    "other": "剩餘 {{count}} 分鐘"
   }
 }


### PR DESCRIPTION
Automated locale translation for ChurchCRM 7.6.0.

## Translation Summary

| Group | Locales | Status |
|-------|---------|--------|
| A – Latin America & Iberia | es, es-MX, pt-br, pt, es-AR | ✅ |
| B – Romance & Europe | es-CO, es-SV, fr, it, ro | ✅ |
| C – Eastern Europe | ru, uk, pl, cs, hu | ✅ |
| D – Northern Europe | de, nl, sv, nb, fi, et | ✅ |
| E – Asia Pacific | fil, ko, id, vi, zh-CN | ✅ |
| F – More Asia | zh-TW, hi, ja, te | ✅ |
| G – Africa & Other | sw, am, af, sq, ml | ✅ |
| H – Completion | ar, el, he, th, sk, tr, hr | ✅ |

**Total: 42 locales, 198 terms translated**

## New Terms Translated
- `Copied {{count}} members` — plural form in all locales
- `This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.` — plural form in all locales
- `Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.` — plural form in all locales
- `{{count}} min left` — plural form in all locales
- Plus locale-specific terms: Code, Signature, Check-out, Important, Major, Catalog, Fundraising, Data, Check #, Items, Planning, Access, Self-service, Changelog, Feature, Live Preview, Sell-through, BCC Mode, Deposit Slip

## Next Steps
1. Review translations and merge
2. Run: `npm run locale:upload:missing -- --yes` (POEditor upload — requires POEDITOR_TOKEN)