### PR TITLE
fix: repair broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ A heartfelt thank you to all our contributors, past and present. Your efforts ma
 
 ### Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=churchcrm/crm&type=Date)](https://star-history.com/#churchcrm/crm&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=churchcrm/crm&type=Date)](https://star-history.dera.page/#churchcrm/crm&Date)
 
 ## 🌐 Stay Connected
 


### PR DESCRIPTION
The star history chart in the README no longer renders because the upstream provider is affected by GitHub stargazer API restrictions. This change swaps the chart and its link to a working provider so the chart displays again.

No API token is required, and the chart endpoint and the frontend for exploring the history are served from the same domain.