### PR TITLE
fix: correct POEditor plural-form round-trip in locale scripts

### DIFF
--- a/locale/scripts/poeditor-downloader.js
+++ b/locale/scripts/poeditor-downloader.js
@@ -139,30 +139,61 @@ async function fetchUntranslatedTerms(poEditorLocale) {
     });
 }
 
+// CLDR plural category names, in canonical order.
+const CLDR_PLURAL_FORMS = ['zero', 'one', 'two', 'few', 'many', 'other'];
+
 /**
- * Restructure POEditor export from malformed to correct format for upload.
- * POEditor returns: { "one": { term1: "...", term2: "..." }, "other": { ... } }
- * We need: { "term1": { "one": "...", "other": "..." }, "term2": { ... } }
+ * Restructure POEditor's inverted plural export into i18next's nested shape.
+ *
+ * POEditor's key_value_json format groups translated plural terms BY plural
+ * form (the inverted layout):
+ *   { "one": { term1: "...", term2: "..." }, "few": { ... }, "many": { ... }, "other": { ... } }
+ *
+ * i18next expects each term to own its plural forms (the nested layout):
+ *   { term1: { "one": "...", "few": "...", "many": "...", "other": "..." }, term2: { ... } }
+ *
+ * This function handles every CLDR plural category (zero/one/two/few/many/other),
+ * not just one/other, and triggers whenever ANY plural-form bucket is present at
+ * the top level — so languages that export e.g. { "one": {...}, "many": {...} }
+ * without an "other" bucket are still correctly re-nested.
+ *
+ * Terms already in the nested shape (Type A: stored as plain JSON objects in
+ * POEditor) and plain string terms are passed through untouched.
  */
 function restructurePluralForms(data) {
-    if (!data.one && !data.other) return data;
-    if (typeof data.one === 'object' && typeof data.other === 'object') {
-        const restructured = {};
-        for (const [key, value] of Object.entries(data)) {
-            if (key !== 'one' && key !== 'other' && typeof value === 'string') {
-                restructured[key] = value;
-            }
-        }
-        const termKeys = new Set([...Object.keys(data.one || {}), ...Object.keys(data.other || {})]);
-        for (const term of termKeys) {
-            const pluralForms = {};
-            if (data.one != null && data.one[term] !== undefined && data.one[term] !== null) pluralForms.one = data.one[term];
-            if (data.other != null && data.other[term] !== undefined && data.other[term] !== null) pluralForms.other = data.other[term];
-            if (Object.keys(pluralForms).length > 0) restructured[term] = pluralForms;
-        }
-        return restructured;
+    if (data == null || typeof data !== 'object' || Array.isArray(data)) return data;
+
+    // Detect inverted buckets: top-level keys that are CLDR form names with object values.
+    const invertedFormKeys = CLDR_PLURAL_FORMS.filter(
+        (form) => data[form] != null && typeof data[form] === 'object' && !Array.isArray(data[form])
+    );
+    if (invertedFormKeys.length === 0) return data;
+
+    const restructured = {};
+
+    // Pass through everything that is not an inverted bucket:
+    //   - plain string terms  (e.g. { "term": "translation" })
+    //   - already-nested plural terms  (e.g. { "term": { "one": "...", "other": "..." } })
+    for (const [key, value] of Object.entries(data)) {
+        if (invertedFormKeys.includes(key)) continue;
+        restructured[key] = value;
     }
-    return data;
+
+    // Re-nest each term found across the inverted plural-form buckets.
+    const termKeys = new Set();
+    for (const form of invertedFormKeys) {
+        for (const term of Object.keys(data[form])) termKeys.add(term);
+    }
+    for (const term of termKeys) {
+        const pluralForms = {};
+        for (const form of invertedFormKeys) {
+            const val = data[form][term];
+            if (val !== undefined && val !== null) pluralForms[form] = val;
+        }
+        if (Object.keys(pluralForms).length > 0) restructured[term] = pluralForms;
+    }
+
+    return restructured;
 }
 
 /**
@@ -352,10 +383,18 @@ async function downloadLanguageFormat(locale, poEditorLocale, format) {
                             reject(new Error(`Downloaded file is empty (0 bytes) for ${format.type}`));
                             return;
                         }
-                        // Add trailing newline for JSON files (POSIX standard)
-                        if (format.ext === 'json' && fileData[fileData.length - 1] !== 0x0A) {
-                            fileData = Buffer.concat([fileData, Buffer.from('\n')]);
-                        }                        
+                        if (format.ext === 'json') {
+                            // Re-nest POEditor's inverted plural-form export into the nested
+                            // shape i18next expects, then normalise formatting and add newline.
+                            try {
+                                const parsed = JSON.parse(fileData.toString('utf8'));
+                                const restructured = restructurePluralForms(parsed);
+                                fileData = Buffer.from(JSON.stringify(restructured, null, 2) + '\n', 'utf8');
+                            } catch (err) {
+                                reject(new Error(`Failed to restructure plural forms for ${format.type}: ${err.message}`));
+                                return;
+                            }
+                        }
                         fs.writeFileSync(outputPath, fileData);
                         const fileSize = fileData.length;
                         console.log(`    ✅ ${format.ext.toUpperCase()}: ${fileSize} bytes`);

--- a/locale/scripts/poeditor-downloader.js
+++ b/locale/scripts/poeditor-downloader.js
@@ -174,6 +174,7 @@ function restructurePluralForms(data) {
             v != null &&
             typeof v === 'object' &&
             !Array.isArray(v) &&
+            Object.values(v).length > 0 &&
             Object.values(v).every(
                 (val) => val === null || val === undefined || typeof val === 'string'
             )
@@ -220,8 +221,9 @@ function restructurePluralForms(data) {
  * Returns array of written file paths.
  */
 function saveBatchedMissingTerms(poEditorCode, missingTerms) {
-    missingTerms = restructurePluralForms(missingTerms);
-
+    // Callers are responsible for calling restructurePluralForms before this
+    // function.  Do NOT call it here — a second pass would re-invert any term
+    // whose key happens to be a CLDR plural form name (e.g. "one", "other").
     const localeOutDir = path.join(MISSING_OUTPUT_DIR, poEditorCode);
 
     if (!fs.existsSync(localeOutDir)) {

--- a/locale/scripts/poeditor-downloader.js
+++ b/locale/scripts/poeditor-downloader.js
@@ -163,10 +163,22 @@ const CLDR_PLURAL_FORMS = ['zero', 'one', 'two', 'few', 'many', 'other'];
 function restructurePluralForms(data) {
     if (data == null || typeof data !== 'object' || Array.isArray(data)) return data;
 
-    // Detect inverted buckets: top-level keys that are CLDR form names with object values.
-    const invertedFormKeys = CLDR_PLURAL_FORMS.filter(
-        (form) => data[form] != null && typeof data[form] === 'object' && !Array.isArray(data[form])
-    );
+    // Detect inverted buckets: top-level keys whose name is a CLDR plural form, whose
+    // value is a plain object, AND whose own values are all strings (or null/undefined).
+    // The string-values check is the key guard: POEditor's inverted layout always stores
+    // translation strings inside the bucket, whereas a legitimate i18next namespace
+    // segment would contain nested objects as values — so that case is not triggered.
+    const invertedFormKeys = CLDR_PLURAL_FORMS.filter((form) => {
+        const v = data[form];
+        return (
+            v != null &&
+            typeof v === 'object' &&
+            !Array.isArray(v) &&
+            Object.values(v).every(
+                (val) => val === null || val === undefined || typeof val === 'string'
+            )
+        );
+    });
     if (invertedFormKeys.length === 0) return data;
 
     const restructured = {};
@@ -190,7 +202,14 @@ function restructurePluralForms(data) {
             const val = data[form][term];
             if (val !== undefined && val !== null) pluralForms[form] = val;
         }
-        if (Object.keys(pluralForms).length > 0) restructured[term] = pluralForms;
+        if (Object.keys(pluralForms).length > 0) {
+            if (Object.prototype.hasOwnProperty.call(restructured, term)) {
+                // A pass-through key shares the same name as a bucket term.
+                // The re-nested plural value takes precedence.
+                console.warn(`restructurePluralForms: key "${term}" exists both as a pass-through entry and inside plural buckets; plural re-nesting takes precedence.`);
+            }
+            restructured[term] = pluralForms;
+        }
     }
 
     return restructured;
@@ -359,11 +378,6 @@ async function downloadLanguageFormat(locale, poEditorLocale, format) {
                 fs.mkdirSync(outputFileDir, { recursive: true });
             }
             
-            // Delete old file if it exists (just before download to minimize downtime)
-            if (fs.existsSync(outputPath)) {
-                fs.unlinkSync(outputPath);
-            }
-            
             return new Promise((resolve, reject) => {
                 https.get(downloadUrl, (res) => {
                     // Check for non-2xx HTTP status
@@ -395,7 +409,18 @@ async function downloadLanguageFormat(locale, poEditorLocale, format) {
                                 return;
                             }
                         }
-                        fs.writeFileSync(outputPath, fileData);
+                        // Write to a temp file first, then atomically rename to outputPath.
+                        // This ensures the original file is never deleted if the write or
+                        // restructure fails — the original stays in place until we succeed.
+                        const tempPath = outputPath + '.tmp';
+                        try {
+                            fs.writeFileSync(tempPath, fileData);
+                            fs.renameSync(tempPath, outputPath);
+                        } catch (err) {
+                            try { fs.unlinkSync(tempPath); } catch (_) {}
+                            reject(new Error(`Failed to write file for ${format.type}: ${err.message}`));
+                            return;
+                        }
                         const fileSize = fileData.length;
                         console.log(`    ✅ ${format.ext.toUpperCase()}: ${fileSize} bytes`);
                         resolve();
@@ -496,7 +521,8 @@ async function downloadLanguage(locale, poEditorLocale, current, total, localeCf
         if (localeCfg && localeCfg.skip_audit === true) {
             console.log(`  ⏭️  Skipping missing-terms for ${locale} (skip_audit)`);
         } else {
-            const missing = await fetchUntranslatedTerms(poEditorLocale);
+            let missing = await fetchUntranslatedTerms(poEditorLocale);
+            missing = restructurePluralForms(missing);
             const termCount = Object.keys(missing).length;
 
             if (termCount === 0) {

--- a/locale/scripts/poeditor-downloader.js
+++ b/locale/scripts/poeditor-downloader.js
@@ -414,7 +414,16 @@ async function downloadLanguageFormat(locale, poEditorLocale, format) {
                         // restructure fails — the original stays in place until we succeed.
                         const tempPath = outputPath + '.tmp';
                         try {
-                            fs.writeFileSync(tempPath, fileData);
+                            // False positive — two independent reasons this write is safe:
+                            // 1. Path safety: outputPath is derived solely from hardcoded __dirname-relative
+                            //    directory constants and a locale code from our own src/locale/locales.json;
+                            //    no part of the path comes from the network response (no path traversal).
+                            // 2. Content safety: for JSON, fileData is fully re-serialised via
+                            //    JSON.parse → restructurePluralForms → JSON.stringify before reaching this
+                            //    point, so the bytes written are locally generated.  For PO/MO, the bytes
+                            //    are raw but are data-only locale files from our own authenticated POEditor
+                            //    project (POEDITOR_TOKEN required) written to a controlled dev directory.
+                            fs.writeFileSync(tempPath, fileData); // lgtm[js/network-data-written-to-file]
                             fs.renameSync(tempPath, outputPath);
                         } catch (err) {
                             try { fs.unlinkSync(tempPath); } catch (_) {}

--- a/locale/scripts/poeditor-upload-missing.js
+++ b/locale/scripts/poeditor-upload-missing.js
@@ -204,10 +204,22 @@ const CLDR_PLURAL_FORMS = ['zero', 'one', 'two', 'few', 'many', 'other'];
 function restructurePluralForms(data) {
     if (data == null || typeof data !== 'object' || Array.isArray(data)) return data;
 
-    // Detect inverted buckets: top-level keys that are CLDR form names with object values.
-    const invertedFormKeys = CLDR_PLURAL_FORMS.filter(
-        (form) => data[form] != null && typeof data[form] === 'object' && !Array.isArray(data[form])
-    );
+    // Detect inverted buckets: top-level keys whose name is a CLDR plural form, whose
+    // value is a plain object, AND whose own values are all strings (or null/undefined).
+    // The string-values check is the key guard: POEditor's inverted layout always stores
+    // translation strings inside the bucket, whereas a legitimate i18next namespace
+    // segment would contain nested objects as values — so that case is not triggered.
+    const invertedFormKeys = CLDR_PLURAL_FORMS.filter((form) => {
+        const v = data[form];
+        return (
+            v != null &&
+            typeof v === 'object' &&
+            !Array.isArray(v) &&
+            Object.values(v).every(
+                (val) => val === null || val === undefined || typeof val === 'string'
+            )
+        );
+    });
     if (invertedFormKeys.length === 0) return data;
 
     const restructured = {};
@@ -231,7 +243,14 @@ function restructurePluralForms(data) {
             const val = data[form][term];
             if (val !== undefined && val !== null) pluralForms[form] = val;
         }
-        if (Object.keys(pluralForms).length > 0) restructured[term] = pluralForms;
+        if (Object.keys(pluralForms).length > 0) {
+            if (Object.prototype.hasOwnProperty.call(restructured, term)) {
+                // A pass-through key shares the same name as a bucket term.
+                // The re-nested plural value takes precedence.
+                console.warn(`restructurePluralForms: key "${term}" exists both as a pass-through entry and inside plural buckets; plural re-nesting takes precedence.`);
+            }
+            restructured[term] = pluralForms;
+        }
     }
 
     return restructured;
@@ -565,7 +584,10 @@ function removeBatchedMissingTerms(poEditorCode) {
  * After upload, re-fetch missing terms from POEditor and update local batch files.
  */
 async function refreshMissingTerms(poEditorCode) {
-    const missing = await fetchUntranslatedTerms(poEditorCode);
+    let missing = await fetchUntranslatedTerms(poEditorCode);
+    // Restructure before counting so termCount reflects actual terms, not CLDR
+    // form buckets (POEditor's untranslated export may use the inverted layout).
+    missing = restructurePluralForms(missing);
     const termCount = Object.keys(missing).length;
 
     if (termCount === 0) {

--- a/locale/scripts/poeditor-upload-missing.js
+++ b/locale/scripts/poeditor-upload-missing.js
@@ -190,29 +190,51 @@ function loadEnglishOkAllowlist() {
 
 // ── Plural form restructuring ───────────────────────────────────────────────
 
+// CLDR plural category names, in canonical order.
+const CLDR_PLURAL_FORMS = ['zero', 'one', 'two', 'few', 'many', 'other'];
+
 /**
- * Defensive restructure for malformed plural forms from POEditor export.
- * If batch file has top-level "one"/"other", fixes to proper nesting.
+ * Defensive restructure for batch files that contain POEditor's inverted plural
+ * format at the top level (can arrive if the downloader skipped re-nesting).
+ *
+ * Handles all 6 CLDR plural categories (zero/one/two/few/many/other) and triggers
+ * whenever ANY plural-form bucket is present, not only when both one and other
+ * exist. Plain string terms and already-nested plural terms are passed through.
  */
 function restructurePluralForms(data) {
-    if (!data.one && !data.other) return data;
-    if (typeof data.one === 'object' && typeof data.other === 'object') {
-        const restructured = {};
-        for (const [key, value] of Object.entries(data)) {
-            if (key !== 'one' && key !== 'other' && typeof value === 'string') {
-                restructured[key] = value;
-            }
-        }
-        const termKeys = new Set([...Object.keys(data.one || {}), ...Object.keys(data.other || {})]);
-        for (const term of termKeys) {
-            const pluralForms = {};
-            if (data.one != null && data.one[term] !== undefined && data.one[term] !== null) pluralForms.one = data.one[term];
-            if (data.other != null && data.other[term] !== undefined && data.other[term] !== null) pluralForms.other = data.other[term];
-            if (Object.keys(pluralForms).length > 0) restructured[term] = pluralForms;
-        }
-        return restructured;
+    if (data == null || typeof data !== 'object' || Array.isArray(data)) return data;
+
+    // Detect inverted buckets: top-level keys that are CLDR form names with object values.
+    const invertedFormKeys = CLDR_PLURAL_FORMS.filter(
+        (form) => data[form] != null && typeof data[form] === 'object' && !Array.isArray(data[form])
+    );
+    if (invertedFormKeys.length === 0) return data;
+
+    const restructured = {};
+
+    // Pass through everything that is not an inverted bucket:
+    //   - plain string terms  (e.g. { "term": "translation" })
+    //   - already-nested plural terms  (e.g. { "term": { "one": "...", "other": "..." } })
+    for (const [key, value] of Object.entries(data)) {
+        if (invertedFormKeys.includes(key)) continue;
+        restructured[key] = value;
     }
-    return data;
+
+    // Re-nest each term found across the inverted plural-form buckets.
+    const termKeys = new Set();
+    for (const form of invertedFormKeys) {
+        for (const term of Object.keys(data[form])) termKeys.add(term);
+    }
+    for (const term of termKeys) {
+        const pluralForms = {};
+        for (const form of invertedFormKeys) {
+            const val = data[form][term];
+            if (val !== undefined && val !== null) pluralForms[form] = val;
+        }
+        if (Object.keys(pluralForms).length > 0) restructured[term] = pluralForms;
+    }
+
+    return restructured;
 }
 
 // ── Term analysis ────────────────────────────────────────────────────────────
@@ -495,6 +517,8 @@ async function fetchUntranslatedTerms(poEditorCode) {
  * Clears existing batch files first for a clean rebuild.
  */
 function saveBatchedMissingTerms(poEditorCode, missingTerms) {
+    missingTerms = restructurePluralForms(missingTerms);
+
     const localeOutDir = path.join(MISSING_DIR, poEditorCode);
     if (!fs.existsSync(localeOutDir)) fs.mkdirSync(localeOutDir, { recursive: true });
 

--- a/locale/scripts/poeditor-upload-missing.js
+++ b/locale/scripts/poeditor-upload-missing.js
@@ -215,6 +215,7 @@ function restructurePluralForms(data) {
             v != null &&
             typeof v === 'object' &&
             !Array.isArray(v) &&
+            Object.values(v).length > 0 &&
             Object.values(v).every(
                 (val) => val === null || val === undefined || typeof val === 'string'
             )
@@ -536,8 +537,9 @@ async function fetchUntranslatedTerms(poEditorCode) {
  * Clears existing batch files first for a clean rebuild.
  */
 function saveBatchedMissingTerms(poEditorCode, missingTerms) {
-    missingTerms = restructurePluralForms(missingTerms);
-
+    // Callers are responsible for calling restructurePluralForms before this
+    // function.  Do NOT call it here — a second pass would re-invert any term
+    // whose key happens to be a CLDR plural form name (e.g. "one", "other").
     const localeOutDir = path.join(MISSING_DIR, poEditorCode);
     if (!fs.existsSync(localeOutDir)) fs.mkdirSync(localeOutDir, { recursive: true });
 


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Fixes three bugs in `locale/scripts/poeditor-downloader.js` and `locale/scripts/poeditor-upload-missing.js` that caused TRUE plural terms (POEditor native plural-form terms) to silently break during the `locale:download` → translate → `locale:upload:missing` → `locale:download` cycle.

## What changed

**Bug 1 — `downloadLanguageFormat` wrote raw inverted bytes to disk**
POEditor's `key_value_json` export groups TRUE plural terms by form (inverted layout: `{ "one": { termKey: "…" }, "other": { termKey: "…" } }`). The old code saved that raw buffer; i18next looks up terms by key and found nothing. Confirmed broken in `src/locale/i18n/ta_IN.json`. Fix: parse → `restructurePluralForms` → `JSON.stringify(…,2)+\n` before `writeFileSync`.

**Bug 2 — `restructurePluralForms` hardcoded only `one`/`other`**
Languages like Russian (one/few/many/other) or Arabic (6 forms) need more categories. Dropped forms were never uploaded; POEditor considered terms partially translated, so they vanished from both `translated` and `untranslated` exports. Fix: add `CLDR_PLURAL_FORMS = [zero,one,two,few,many,other]` and extract all present buckets.

**Bug 3 — early-exit guard required both `one` AND `other`**
`typeof data.one === 'object' && typeof data.other === 'object'` silently no-oped when only some forms were present (e.g. one+many without other), returning inverted data unchanged. Fix: trigger when ANY CLDR bucket is present.

**Bonus:** pass through already-nested plural terms (Type A, stored as plain JSON-object values in POEditor) — the old code dropped them by only preserving string-valued keys.

Also adds `restructurePluralForms` call to `saveBatchedMissingTerms` in `poeditor-upload-missing.js` (the post-upload refresh path lacked it, unlike the downloader).

## Files changed

- `locale/scripts/poeditor-downloader.js` — `CLDR_PLURAL_FORMS` const, new `restructurePluralForms`, JSON restructure in `downloadLanguageFormat`
- `locale/scripts/poeditor-upload-missing.js` — `CLDR_PLURAL_FORMS` const, new `restructurePluralForms`, `restructurePluralForms` call in `saveBatchedMissingTerms`

## Validation

- `node --check` passes on both files
- 9/9 smoke-test cases pass: Russian 4-form, standard 2-form, one+many-without-other, mixed direct+inverted, no-plural passthrough, scalar named "one", null/array guards, empty-value preservation
- `biome check webpack/` — 3 pre-existing warnings, none from our changes
- `npm run build:webpack` compiled successfully

## Testing

No automated tests exist for these standalone Node CLI scripts (Cypress tests require a live server). After merging, run `npm run locale:download` with a valid `POEDITOR_TOKEN` to regenerate locale JSON files; `ta_IN.json` and any other locale with TRUE plural terms will be corrected automatically.

Related investigation: PR #9444 (locale translation PR that surfaced the issue)