### PR TITLE
feat: add *_formatted currency siblings to all money API payloads (Phase 4)

### DIFF
--- a/cypress/e2e/api/private/finance/finance-deposits.spec.js
+++ b/cypress/e2e/api/private/finance/finance-deposits.spec.js
@@ -320,6 +320,9 @@ describe("API Private Deposit Operations", () => {
                         const pledge = resp.body[0];
                         expect(pledge).to.have.property("GroupKey");
                         expect(pledge).to.have.property("sumAmount");
+                        // Phase 4: *_formatted siblings must be present
+                        expect(pledge).to.have.property("sumAmount_formatted");
+                        expect(pledge.sumAmount_formatted).to.be.a("string");
                     }
                 }
             });

--- a/cypress/e2e/api/private/finance/finance-payments.spec.js
+++ b/cypress/e2e/api/private/finance/finance-payments.spec.js
@@ -89,6 +89,13 @@ describe("API Finance Payments - Type Mismatch Fix", () => {
                 expect(parsed.total).to.be.closeTo(100.00, 0.01);
                 expect(parsed).to.have.property("total_formatted");
                 expect(parsed.total_formatted).to.be.a("string").and.to.have.length.greaterThan(0);
+                // Phase 4: fund-level *_formatted siblings (from getPledgeorPayment)
+                expect(parsed.funds).to.be.an("array").with.length.greaterThan(0);
+                const fund = parsed.funds[0];
+                expect(fund).to.have.property("amount_formatted");
+                expect(fund.amount_formatted).to.be.a("string").and.to.have.length.greaterThan(0);
+                expect(fund).to.have.property("nonDeductible_formatted");
+                expect(fund.nonDeductible_formatted).to.be.a("string");
             });
         });
 
@@ -117,6 +124,12 @@ describe("API Finance Payments - Type Mismatch Fix", () => {
                 expect(parsed.total).to.be.closeTo(100.00, 0.01);
                 expect(parsed).to.have.property("total_formatted");
                 expect(parsed.total_formatted).to.be.a("string").and.to.have.length.greaterThan(0);
+                // Phase 4: fund-level *_formatted siblings on each fund entry
+                const firstFund = parsed.funds[0];
+                expect(firstFund).to.have.property("amount_formatted");
+                expect(firstFund.amount_formatted).to.be.a("string").and.to.have.length.greaterThan(0);
+                expect(firstFund).to.have.property("nonDeductible_formatted");
+                expect(firstFund.nonDeductible_formatted).to.be.a("string");
             });
         });
     });

--- a/cypress/e2e/api/private/finance/finance-payments.spec.js
+++ b/cypress/e2e/api/private/finance/finance-payments.spec.js
@@ -87,6 +87,8 @@ describe("API Finance Payments - Type Mismatch Fix", () => {
                 expect(parsed.GroupKey).to.be.a("string").and.to.have.length.greaterThan(0);
                 expect(parsed).to.have.property("total");
                 expect(parsed.total).to.be.closeTo(100.00, 0.01);
+                expect(parsed).to.have.property("total_formatted");
+                expect(parsed.total_formatted).to.be.a("string").and.to.have.length.greaterThan(0);
             });
         });
 
@@ -113,6 +115,8 @@ describe("API Finance Payments - Type Mismatch Fix", () => {
                 expect(parsed.funds).to.be.an("array").with.length(2);
                 // Total reflects both allocations
                 expect(parsed.total).to.be.closeTo(100.00, 0.01);
+                expect(parsed).to.have.property("total_formatted");
+                expect(parsed.total_formatted).to.be.a("string").and.to.have.length.greaterThan(0);
             });
         });
     });
@@ -138,6 +142,14 @@ describe("API Finance Payments - Type Mismatch Fix", () => {
                     expect(getResp.body.pledgeOrPayment).to.equal("Payment");
                     expect(getResp.body.funds).to.be.an("array").with.length(1);
                     expect(getResp.body.total).to.be.closeTo(100.00, 0.01);
+                    // Phase 4: *_formatted siblings must be present
+                    expect(getResp.body).to.have.property("total_formatted");
+                    expect(getResp.body.total_formatted).to.be.a("string").and.to.have.length.greaterThan(0);
+                    const fund = getResp.body.funds[0];
+                    expect(fund).to.have.property("amount_formatted");
+                    expect(fund.amount_formatted).to.be.a("string").and.to.have.length.greaterThan(0);
+                    expect(fund).to.have.property("nonDeductible_formatted");
+                    expect(fund.nonDeductible_formatted).to.be.a("string");
                 });
             });
         });
@@ -247,6 +259,11 @@ describe("API Finance Payments - Type Mismatch Fix", () => {
                     expect(payment).to.have.property("Fund");
                     expect(payment).to.have.property("Date");
                     expect(payment).to.have.property("Amount");
+                    // Phase 4: *_formatted siblings must be present
+                    expect(payment).to.have.property("Amount_formatted");
+                    expect(payment.Amount_formatted).to.be.a("string").and.to.have.length.greaterThan(0);
+                    expect(payment).to.have.property("Nondeductible_formatted");
+                    expect(payment.Nondeductible_formatted).to.be.a("string");
                     expect(payment).to.have.property("PledgeOrPayment");
                 }
             });

--- a/src/ChurchCRM/Service/DepositService.php
+++ b/src/ChurchCRM/Service/DepositService.php
@@ -13,6 +13,7 @@ use ChurchCRM\model\ChurchCRM\PledgeQuery;
 use ChurchCRM\Service\AuthService;
 use ChurchCRM\Service\FinancialService;
 use ChurchCRM\Utils\CsvExporter;
+use ChurchCRM\Utils\CurrencyFormatter;
 use ChurchCRM\Utils\FunctionsUtils;
 use ChurchCRM\Utils\InputUtils;
 use Propel\Runtime\ActiveQuery\Criteria;
@@ -162,8 +163,13 @@ class DepositService {
             ->find();
 
         // Propel's ObjectCollection::toArray() doesn't call individual model's toArray(),
-        // so we iterate to ensure each Pledge's custom toArray() executes (which populates FamilyString)
-        return array_map(fn($pledge) => $pledge->toArray(), iterator_to_array($items));
+        // so we iterate to ensure each Pledge's custom toArray() executes (which populates FamilyString).
+        // sumAmount_formatted is added here so the API contract (raw + formatted sibling) is met.
+        return array_map(function ($pledge) {
+            $row = $pledge->toArray();
+            $row['sumAmount_formatted'] = CurrencyFormatter::format($row['sumAmount'] ?? null);
+            return $row;
+        }, iterator_to_array($items));
     }
 
     public function createDeposit(string $depositType, string $depositComment, string $depositDate): Deposit

--- a/src/ChurchCRM/Service/FinancialService.php
+++ b/src/ChurchCRM/Service/FinancialService.php
@@ -17,6 +17,7 @@ use ChurchCRM\model\ChurchCRM\PledgeQuery;
 use ChurchCRM\Plugin\Hook\HookManager;
 use ChurchCRM\Plugin\Hooks;
 use ChurchCRM\Utils\FunctionsUtils;
+use ChurchCRM\Utils\CurrencyFormatter;
 use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Service\AuthService;
 use ChurchCRM\Service\DonationFundService;
@@ -65,6 +66,7 @@ class FinancialService
             $newRow['FormattedFY'] = $row->getFormattedFY();
             $newRow['GroupKey'] = $row->getGroupKey();
             $newRow['Amount'] = $row->getAmount();
+            $newRow['Amount_formatted'] = CurrencyFormatter::format($row->getAmount());
             $newRow['Nondeductible'] = $row->getNondeductible();
             $newRow['Schedule'] = $row->getSchedule();
             $newRow['Method'] = $row->getMethod();
@@ -226,15 +228,17 @@ class FinancialService
             $total += $amount;
 
             $funds[] = [
-                'fundId'       => (int) $pledge->getFundId(),
-                'fundName'     => $fund ? $fund->getName() : '',
-                'amount'       => $amount,
-                'nonDeductible' => (float) $pledge->getNondeductible(),
-                'comment'      => $pledge->getComment() ?? '',
+                'fundId'          => (int) $pledge->getFundId(),
+                'fundName'        => $fund ? $fund->getName() : '',
+                'amount'          => $amount,
+                'amount_formatted' => CurrencyFormatter::format($amount),
+                'nonDeductible'   => (float) $pledge->getNondeductible(),
+                'comment'         => $pledge->getComment() ?? '',
             ];
         }
 
         $header['total'] = $total;
+        $header['total_formatted'] = CurrencyFormatter::format($total);
         $header['funds'] = $funds;
 
         return $header;
@@ -538,6 +542,7 @@ class FinancialService
             $fund = [];
             $fund['FundID'] = $row->getFundId();
             $fund['Amount'] = $row->getAmount();
+            $fund['Amount_formatted'] = CurrencyFormatter::format($row->getAmount());
             $fund['NonDeductible'] = $row->getNondeductible();
             $fund['Comment'] = $row->getComment();
             $payment->funds[] = $fund;
@@ -549,6 +554,7 @@ class FinancialService
         }
         $payment->GroupKey = $GroupKey;
         $payment->total = $total;
+        $payment->total_formatted = CurrencyFormatter::format($total);
 
         return json_encode($payment, JSON_THROW_ON_ERROR);
     }

--- a/src/ChurchCRM/Service/FinancialService.php
+++ b/src/ChurchCRM/Service/FinancialService.php
@@ -544,9 +544,9 @@ class FinancialService
             $fund = [];
             $fund['FundID'] = $row->getFundId();
             $fund['Amount'] = $row->getAmount();
-            $fund['Amount_formatted'] = CurrencyFormatter::format($row->getAmount());
+            $fund['amount_formatted'] = CurrencyFormatter::format($row->getAmount());
             $fund['NonDeductible'] = $row->getNondeductible();
-            $fund['NonDeductible_formatted'] = CurrencyFormatter::format($row->getNondeductible());
+            $fund['nonDeductible_formatted'] = CurrencyFormatter::format($row->getNondeductible());
             $fund['Comment'] = $row->getComment();
             $payment->funds[] = $fund;
             $total += $row->getAmount();

--- a/src/ChurchCRM/Service/FinancialService.php
+++ b/src/ChurchCRM/Service/FinancialService.php
@@ -16,8 +16,8 @@ use ChurchCRM\model\ChurchCRM\Pledge;
 use ChurchCRM\model\ChurchCRM\PledgeQuery;
 use ChurchCRM\Plugin\Hook\HookManager;
 use ChurchCRM\Plugin\Hooks;
-use ChurchCRM\Utils\FunctionsUtils;
 use ChurchCRM\Utils\CurrencyFormatter;
+use ChurchCRM\Utils\FunctionsUtils;
 use ChurchCRM\Utils\InputUtils;
 use ChurchCRM\Service\AuthService;
 use ChurchCRM\Service\DonationFundService;
@@ -68,6 +68,7 @@ class FinancialService
             $newRow['Amount'] = $row->getAmount();
             $newRow['Amount_formatted'] = CurrencyFormatter::format($row->getAmount());
             $newRow['Nondeductible'] = $row->getNondeductible();
+            $newRow['Nondeductible_formatted'] = CurrencyFormatter::format($row->getNondeductible());
             $newRow['Schedule'] = $row->getSchedule();
             $newRow['Method'] = $row->getMethod();
             $newRow['Comment'] = InputUtils::sanitizeAndEscapeText($row->getComment() ?? '');
@@ -228,12 +229,13 @@ class FinancialService
             $total += $amount;
 
             $funds[] = [
-                'fundId'          => (int) $pledge->getFundId(),
-                'fundName'        => $fund ? $fund->getName() : '',
-                'amount'          => $amount,
-                'amount_formatted' => CurrencyFormatter::format($amount),
-                'nonDeductible'   => (float) $pledge->getNondeductible(),
-                'comment'         => $pledge->getComment() ?? '',
+                'fundId'               => (int) $pledge->getFundId(),
+                'fundName'             => $fund ? $fund->getName() : '',
+                'amount'               => $amount,
+                'amount_formatted'     => CurrencyFormatter::format($amount),
+                'nonDeductible'        => (float) $pledge->getNondeductible(),
+                'nonDeductible_formatted' => CurrencyFormatter::format($pledge->getNondeductible()),
+                'comment'              => $pledge->getComment() ?? '',
             ];
         }
 
@@ -544,6 +546,7 @@ class FinancialService
             $fund['Amount'] = $row->getAmount();
             $fund['Amount_formatted'] = CurrencyFormatter::format($row->getAmount());
             $fund['NonDeductible'] = $row->getNondeductible();
+            $fund['NonDeductible_formatted'] = CurrencyFormatter::format($row->getNondeductible());
             $fund['Comment'] = $row->getComment();
             $payment->funds[] = $fund;
             $total += $row->getAmount();

--- a/src/api/routes/finance/finance-payments.php
+++ b/src/api/routes/finance/finance-payments.php
@@ -4,6 +4,7 @@ use ChurchCRM\Authentication\AuthenticationManager;
 use ChurchCRM\model\ChurchCRM\PledgeQuery;
 use ChurchCRM\Slim\Middleware\Request\Auth\FinanceRoleAuthMiddleware;
 use ChurchCRM\Slim\SlimUtils;
+use ChurchCRM\Utils\CurrencyFormatter;
 use ChurchCRM\Utils\InputUtils;
 use Propel\Runtime\ActiveQuery\Criteria;
 use Psr\Http\Message\ResponseInterface as Response;
@@ -101,6 +102,7 @@ $app->group('/payments', function (RouteCollectorProxy $group): void {
             $newRow['FormattedFY'] = $row->getFormattedFY();
             $newRow['GroupKey'] = $row->getGroupKey();
             $newRow['Amount'] = $row->getAmount();
+            $newRow['Amount_formatted'] = CurrencyFormatter::format($row->getAmount());
             $newRow['Nondeductible'] = $row->getNondeductible();
             $newRow['Schedule'] = $row->getSchedule();
             $newRow['Method'] = $row->getMethod();

--- a/src/api/routes/finance/finance-payments.php
+++ b/src/api/routes/finance/finance-payments.php
@@ -2,6 +2,7 @@
 
 use ChurchCRM\Authentication\AuthenticationManager;
 use ChurchCRM\model\ChurchCRM\PledgeQuery;
+use ChurchCRM\Service\FinancialService;
 use ChurchCRM\Slim\Middleware\Request\Auth\FinanceRoleAuthMiddleware;
 use ChurchCRM\Slim\SlimUtils;
 use ChurchCRM\Utils\CurrencyFormatter;
@@ -10,7 +11,6 @@ use Propel\Runtime\ActiveQuery\Criteria;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Routing\RouteCollectorProxy;
-use ChurchCRM\Service\FinancialService;
 
 $app->group('/payments', function (RouteCollectorProxy $group): void {
     /**
@@ -73,6 +73,9 @@ $app->group('/payments', function (RouteCollectorProxy $group): void {
      *         @OA\JsonContent(@OA\Property(property="data", type="array", @OA\Items(
      *             @OA\Property(property="FormattedFY", type="string"),
      *             @OA\Property(property="Amount", type="number"),
+     *             @OA\Property(property="Amount_formatted", type="string"),
+     *             @OA\Property(property="Nondeductible", type="number"),
+     *             @OA\Property(property="Nondeductible_formatted", type="string"),
      *             @OA\Property(property="PledgeOrPayment", type="string"),
      *             @OA\Property(property="Date", type="string", format="date"),
      *             @OA\Property(property="Fund", type="string")
@@ -104,6 +107,7 @@ $app->group('/payments', function (RouteCollectorProxy $group): void {
             $newRow['Amount'] = $row->getAmount();
             $newRow['Amount_formatted'] = CurrencyFormatter::format($row->getAmount());
             $newRow['Nondeductible'] = $row->getNondeductible();
+            $newRow['Nondeductible_formatted'] = CurrencyFormatter::format($row->getNondeductible());
             $newRow['Schedule'] = $row->getSchedule();
             $newRow['Method'] = $row->getMethod();
             $newRow['Comment'] = InputUtils::escapeHTML($row->getComment() ?? '');
@@ -147,11 +151,14 @@ $app->group('/payments', function (RouteCollectorProxy $group): void {
      *             @OA\Property(property="pledgeOrPayment", type="string", enum={"Pledge","Payment"}, example="Payment"),
      *             @OA\Property(property="schedule", type="string", nullable=true, example="Monthly"),
      *             @OA\Property(property="total", type="number", format="float", example=250.00),
+     *             @OA\Property(property="total_formatted", type="string", example="$250.00"),
      *             @OA\Property(property="funds", type="array", @OA\Items(
      *                 @OA\Property(property="fundId", type="integer", example=1),
      *                 @OA\Property(property="fundName", type="string", example="General Fund"),
      *                 @OA\Property(property="amount", type="number", format="float", example=200.00),
+     *                 @OA\Property(property="amount_formatted", type="string", example="$200.00"),
      *                 @OA\Property(property="nonDeductible", type="number", format="float", example=0.00),
+     *                 @OA\Property(property="nonDeductible_formatted", type="string", example="$0.00"),
      *                 @OA\Property(property="comment", type="string", example="Annual pledge")
      *             ))
      *         )


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Fixes #8718, partial #8459 (Phase 4 — API contract)

Every money field in the affected JSON payloads now returns a raw number **and** a `*_formatted` sibling produced by `CurrencyFormatter::format()` — no hardcoded `$`.

## Changes

- **`FinancialService::getPayments()`** — adds `Amount_formatted`, `Nondeductible_formatted`
- **`FinancialService::getPledgesByGroupKey()`** — adds `amount_formatted`, `nonDeductible_formatted` per fund; `total_formatted` on header
- **`FinancialService::getPledgeorPayment()`** — adds `Amount_formatted`, `NonDeductible_formatted` per fund; `total_formatted`
- **`DepositService::getDepositItemsByType()`** — adds `sumAmount_formatted` (serves `GET /deposits/{id}/payments`)
- **`finance-payments.php` `GET /payments/family/{id}/list`** — adds `Amount_formatted`, `Nondeductible_formatted`
- **OA annotations** updated for `/payments/family/{id}/list` and `/payments/pledges/{groupKey}`
- **Cypress specs** — adds Phase 4 contract assertions (`*_formatted` siblings) to existing tests

## Intentional exclusions

- `getDepositsForExport()` (CSV re-import path) intentionally left raw-only per Phase 4 spec
- `GET /payments/` OA annotation left as `type="object"` (was already opaque pre-PR)

## Testing

PHP syntax validation: ✅ 3 files  
Biome lint: ✅ 0 errors (3 pre-existing warnings in unrelated JS files)  
Cypress: assertions added; verified field names match PHP keys exactly
