### PR TITLE
feat: kiosk guardian photo display for Check-in By feature

### DIFF
--- a/src/kiosk/routes/device.php
+++ b/src/kiosk/routes/device.php
@@ -416,7 +416,7 @@ $app->group('/device', function (RouteCollectorProxy $group) use ($getKioskFromC
 
             $checkerPhoto = new Photo('Person', $checker->getId());
             $checkerData = [
-                'Id'        => $checker->getId(),
+                'Id'        => (int) $checker->getId(),
                 'FirstName' => $checker->getFirstName(),
                 'LastName'  => $checker->getLastName(),
                 'hasPhoto'  => $checkerPhoto->hasUploadedPhoto(),

--- a/src/kiosk/routes/device.php
+++ b/src/kiosk/routes/device.php
@@ -91,7 +91,7 @@ function getAdultFamilyMembers(Person $person): array
 
         $photo = new Photo('Person', $member->getId());
         $members[] = [
-            'Id'        => $member->getId(),
+            'Id'        => (int) $member->getId(), // explicit int cast — ensures strict in_array() works
             'FirstName' => $member->getFirstName(),
             'LastName'  => $member->getLastName(),
             'hasPhoto'  => $photo->hasUploadedPhoto(),

--- a/src/kiosk/routes/device.php
+++ b/src/kiosk/routes/device.php
@@ -3,9 +3,11 @@
 use ChurchCRM\dto\Notification;
 use ChurchCRM\dto\Photo;
 use ChurchCRM\dto\SystemConfig;
+use ChurchCRM\model\ChurchCRM\EventAttendQuery;
 use ChurchCRM\model\ChurchCRM\Person;
 use ChurchCRM\model\ChurchCRM\PersonQuery;
 use ChurchCRM\Plugin\PluginManager;
+use Propel\Runtime\ActiveQuery\Criteria;
 use ChurchCRM\Slim\SlimUtils;
 use ChurchCRM\Utils\DateTimeUtils;
 use ChurchCRM\Utils\InputUtils;
@@ -365,6 +367,65 @@ $app->group('/device', function (RouteCollectorProxy $group) use ($getKioskFromC
                                 $smsEnabled ||
                                 $openLpEnabled;
 
+        // Resolve checkedInBy per currently-checked-in person.
+        // Batch-load all active attend records for this event in a single query,
+        // then map by PersonId for O(1) lookup. Avoids N EventAttendQuery calls.
+        /** @var array<int, \ChurchCRM\model\ChurchCRM\EventAttend> $attendByPersonId */
+        $attendByPersonId = [];
+        foreach (EventAttendQuery::create()
+            ->filterByEventId($event->getId())
+            ->filterByCheckoutDate(null, Criteria::ISNULL) // only currently checked-in records
+            ->find() as $attendRecord) {
+            $attendByPersonId[(int) $attendRecord->getPersonId()] = $attendRecord;
+        }
+
+        // Cache checker Person objects keyed by CheckinId to avoid re-fetching
+        // the same guardian who checked in multiple children.
+        /** @var array<int, array{Id:int, FirstName:string, LastName:string, hasPhoto:bool}|null> $checkerCache */
+        $checkerCache = [];
+
+        foreach ($peopleData as &$personEntry) {
+            $personEntry['checkedInBy'] = null;
+
+            if ((int) $personEntry['status'] !== 1) {
+                // Not currently checked in — no checker to show.
+                continue;
+            }
+
+            $attendRecord = $attendByPersonId[$personEntry['Id']] ?? null;
+
+            if ($attendRecord === null) {
+                continue;
+            }
+
+            $checkinId = $attendRecord->getCheckinId();
+            if ($checkinId === null || $checkinId <= 0) {
+                continue;
+            }
+
+            if (array_key_exists($checkinId, $checkerCache)) {
+                $personEntry['checkedInBy'] = $checkerCache[$checkinId];
+                continue;
+            }
+
+            $checker = PersonQuery::create()->findOneById($checkinId);
+            if ($checker === null) {
+                $checkerCache[$checkinId] = null;
+                continue;
+            }
+
+            $checkerPhoto = new Photo('Person', $checker->getId());
+            $checkerData = [
+                'Id'        => $checker->getId(),
+                'FirstName' => $checker->getFirstName(),
+                'LastName'  => $checker->getLastName(),
+                'hasPhoto'  => $checkerPhoto->hasUploadedPhoto(),
+            ];
+            $checkerCache[$checkinId] = $checkerData;
+            $personEntry['checkedInBy'] = $checkerData;
+        }
+        unset($personEntry); // break the reference from the foreach
+
         return SlimUtils::renderJSON($response, [
             'People' => $peopleData,
             'GroupName' => $groupName,
@@ -398,6 +459,59 @@ $app->group('/device', function (RouteCollectorProxy $group) use ($getKioskFromC
         }
 
         $photo = new Photo('Person', $personId);
+
+        $response->getBody()->write($photo->getPhotoBytes());
+
+        return $response->withAddedHeader('Content-type', $photo->getPhotoContentType());
+    });
+
+    /**
+     * Serve a photo of an adult family member (guardian) of a roster child.
+     *
+     * Authorization:
+     * - {PersonId} must be in the active class roster (a child being tracked).
+     * - {MemberId} must be an adult family member of that child (same logic as
+     *   the /family endpoint — prevents enumeration of arbitrary person photos
+     *   via a kiosk cookie).
+     *
+     * Used by the kiosk UI to display guardian photos in the
+     * "Checked In By" / "Checked Out By" modal and on member cards.
+     */
+    $group->get('/activeClassMember/{PersonId}/family/{MemberId}/photo', function (Request $request, Response $response, array $args) use ($getKioskFromCookie): Response {
+        $result = requireAcceptedKioskWithEvent($getKioskFromCookie, $response);
+        if ($result instanceof Response) {
+            return $result;
+        }
+        [, $assignment] = $result;
+
+        $personId = InputUtils::filterInt($args['PersonId'] ?? 0);
+        $memberId = InputUtils::filterInt($args['MemberId'] ?? 0);
+
+        if ($personId <= 0 || $memberId <= 0) {
+            return SlimUtils::renderErrorJSON($response, gettext('Invalid person ID'), [], 400);
+        }
+
+        // Verify the child is in the active class roster.
+        $rosterIds = [];
+        foreach ($assignment->getActiveGroupMembers() as $rosterMember) {
+            $rosterIds[] = (int) $rosterMember->getId();
+        }
+        if (!in_array($personId, $rosterIds, true)) {
+            return SlimUtils::renderErrorJSON($response, gettext('Person not in active class roster'), [], 403);
+        }
+
+        // Verify MemberId is an adult family member of the roster child.
+        $person = PersonQuery::create()->findOneById($personId);
+        if ($person === null) {
+            return SlimUtils::renderErrorJSON($response, gettext('Person not found'), [], 404);
+        }
+        $adultMembers = getAdultFamilyMembers($person);
+        $adultMemberIds = array_column($adultMembers, 'Id');
+        if (!in_array($memberId, $adultMemberIds, true)) {
+            return SlimUtils::renderErrorJSON($response, gettext('Member is not an adult family member of the roster child'), [], 403);
+        }
+
+        $photo = new Photo('Person', $memberId);
 
         $response->getBody()->write($photo->getPhotoBytes());
 

--- a/src/skin/scss/_kiosk.scss
+++ b/src/skin/scss/_kiosk.scss
@@ -173,6 +173,38 @@
   color: #6c757d;
 }
 
+// "Checked in by" attribution line shown on member cards when a guardian
+// performed the check-in (Check-in By feature, issue #7949).
+.kiosk-member-checkin-by {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.78rem;
+  color: #6c757d;
+  margin-top: 0.25rem;
+  min-height: 0; // collapse when empty
+
+  .checkin-by-inline-photo {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 1px solid #dee2e6;
+    flex-shrink: 0;
+  }
+
+  .fa-solid {
+    font-size: 0.8rem;
+    flex-shrink: 0;
+  }
+
+  span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
 .kiosk-member-actions {
   display: flex;
   gap: 0.5rem;

--- a/webpack/kiosk/kiosk-jsom.ts
+++ b/webpack/kiosk/kiosk-jsom.ts
@@ -42,6 +42,10 @@ const kioskState = {
 let pendingCheckinByCallback: ((member: FamilyMember | null) => void) | null = null;
 // The family members fetched for the current modal session
 let currentFamilyMembers: FamilyMember[] = [];
+// Monotonically-increasing token; each showCheckinByModal() call increments it.
+// The XHR .done() handler checks the token before writing currentFamilyMembers
+// so rapid double-tap on touch screens cannot corrupt state with a stale response.
+let currentFamilyRequestToken = 0;
 
 /**
  * HTML escape helper to prevent XSS
@@ -991,8 +995,11 @@ function showCheckinByModal(personId: number, action: "checkin" | "checkout", pe
     `<div class="text-center py-4"><i class="fa-solid fa-spinner fa-spin fa-2x text-primary"></i><p class="mt-2 text-muted">${i18next.t("Loading family members...")}</p></div>`,
   );
 
-  // Track which child's family we are showing (needed for the guardian photo URL)
+  // Track which child's family we are showing (needed for the guardian photo URL).
+  // Increment token *before* resetting members so any in-flight XHR from a prior
+  // call sees a stale token and discards its result (rapid double-tap guard).
   currentFamilyMembers = [];
+  const myToken = ++currentFamilyRequestToken;
 
   // Store the callback to invoke after selection
   pendingCheckinByCallback = (member) => {
@@ -1012,6 +1019,9 @@ function showCheckinByModal(personId: number, action: "checkin" | "checkout", pe
     path: `activeClassMember/${personId}/family`,
   })
     .done((data: FamilyMembersResponse) => {
+      // Discard stale responses from a previous modal open (rapid double-tap race).
+      if (myToken !== currentFamilyRequestToken) return;
+
       // Guard against unexpected API responses (defensive check for empty/malformed members array)
       if (!data.members || data.members.length === 0) {
         // No family members found — close modal and proceed without a checker
@@ -1028,6 +1038,9 @@ function showCheckinByModal(personId: number, action: "checkin" | "checkout", pe
       $("#checkinByModalBody").empty().append(renderFamilyMemberOptions(data.members, personId));
     })
     .fail(() => {
+      // Discard stale failure responses too.
+      if (myToken !== currentFamilyRequestToken) return;
+
       // On API failure close modal and proceed without a checker
       const failEl = document.getElementById("checkinByModal");
       if (failEl) window.bootstrap.Modal.getOrCreateInstance(failEl).hide();

--- a/webpack/kiosk/kiosk-jsom.ts
+++ b/webpack/kiosk/kiosk-jsom.ts
@@ -8,6 +8,7 @@
 import type {
   ActiveClassMembersResponse,
   AjaxOptions,
+  CheckinByPerson,
   ClassMember,
   FamilyMember,
   FamilyMembersResponse,
@@ -38,7 +39,9 @@ const kioskState = {
 };
 
 // Pending callback for the "Check-in By" modal
-let pendingCheckinByCallback: ((checkedByPersonId: number | null) => void) | null = null;
+let pendingCheckinByCallback: ((member: FamilyMember | null) => void) | null = null;
+// The family members fetched for the current modal session
+let currentFamilyMembers: FamilyMember[] = [];
 
 /**
  * HTML escape helper to prevent XSS
@@ -65,10 +68,58 @@ function APIRequest(options: AjaxOptions): JQuery.jqXHR {
 }
 
 /**
- * Get photo URL for a person
+ * Get photo URL for a person (roster member — class child)
  */
 function getPhotoUrl(personId: number): string {
   return `${getCRM().root}/kiosk/device/activeClassMember/${personId}/photo`;
+}
+
+/**
+ * Get photo URL for a family member (guardian) of a roster child.
+ * Uses a separate endpoint that authorizes by family relationship
+ * rather than roster membership — required because guardians are
+ * adults, not class members.
+ */
+function getFamilyPhotoUrl(childPersonId: number, memberId: number): string {
+  return `${getCRM().root}/kiosk/device/activeClassMember/${childPersonId}/family/${memberId}/photo`;
+}
+
+/**
+ * Update (or clear) the "Checked in by" line on a roster child's card.
+ *
+ * Shows a small avatar + name when checker is not null; clears the line
+ * when null (e.g. after check-out or when no checker was recorded).
+ * Accepts the roster child's personId so it can build the correct
+ * guardian photo URL (authorized by family relationship, not roster
+ * membership).
+ */
+function updateCheckinByLine(childPersonId: number, checker: CheckinByPerson | null): void {
+  const $byLine = $(`#personId-${childPersonId} .kiosk-member-checkin-by`);
+  if ($byLine.length === 0) return;
+
+  if (!checker) {
+    $byLine.empty();
+    return;
+  }
+
+  $byLine.empty();
+
+  if (checker.hasPhoto) {
+    const photoUrl = getFamilyPhotoUrl(childPersonId, checker.Id);
+    const $img = $("<img>", { class: "checkin-by-inline-photo", alt: `${checker.FirstName} ${checker.LastName}` });
+    // Bind error handler before setting src to guarantee it fires on broken images.
+    // Inline onerror attributes are blocked by the project CSP (no 'unsafe-inline').
+    $img.on("error", () => {
+      $img.replaceWith($("<i>", { class: "fa-solid fa-user-check" }));
+    });
+    $img.attr("src", photoUrl);
+    $byLine.append($img, $("<span>").text(`${checker.FirstName} ${checker.LastName}`));
+  } else {
+    $byLine.append(
+      $("<i>", { class: "fa-solid fa-user-check" }),
+      $("<span>").text(`${checker.FirstName} ${checker.LastName}`),
+    );
+  }
 }
 
 /**
@@ -79,6 +130,8 @@ function renderClassMember(classMember: ClassMember): void {
   if (existingDiv.length > 0) {
     // Card already exists - update data attributes in case familyId or other data changed
     existingDiv.data("familyId", classMember.familyId || null);
+    // Update the checked-in-by line for existing cards (e.g. on refresh)
+    updateCheckinByLine(classMember.personId, classMember.checkedInBy ?? null);
   } else {
     // Create member row
     const memberRow = $("<div>", {
@@ -142,6 +195,9 @@ function renderClassMember(classMember: ClassMember): void {
       );
     }
 
+    // Checked-in-by line (initially empty; populated when checked in)
+    infoDiv.append($("<div>", { class: "kiosk-member-checkin-by" }));
+
     // Actions - icon-only buttons
     const actionsDiv = $("<div>", { class: "kiosk-member-actions" });
 
@@ -170,6 +226,11 @@ function renderClassMember(classMember: ClassMember): void {
       $("#checkedInList").append(memberRow);
     } else {
       $("#notCheckedInList").append(memberRow);
+    }
+
+    // Render initial checked-in-by info (from server on first load / full refresh)
+    if (classMember.checkedInBy) {
+      updateCheckinByLine(classMember.personId, classMember.checkedInBy);
     }
   }
 
@@ -385,6 +446,7 @@ function updateActiveClassMembers(): void {
           birthDay: d.birthDay,
           birthMonth: d.birthMonth,
           familyId: d.familyId,
+          checkedInBy: d.checkedInBy ?? null,
         };
 
         renderClassMember(memberData);
@@ -822,10 +884,10 @@ function checkInPerson(personId: number): void {
 /**
  * Perform the actual check-in API call
  */
-function performCheckin(personId: number, checkedInById: number | null): void {
+function performCheckin(personId: number, checker: FamilyMember | null): void {
   const payload: { PersonId: number; CheckedInById?: number } = { PersonId: personId };
-  if (checkedInById !== null) {
-    payload.CheckedInById = checkedInById;
+  if (checker !== null) {
+    payload.CheckedInById = checker.Id;
   }
   APIRequest({
     path: "checkin",
@@ -833,6 +895,8 @@ function performCheckin(personId: number, checkedInById: number | null): void {
     data: JSON.stringify(payload),
   }).done(() => {
     setCheckedIn(personId);
+    // Optimistically update the checked-in-by line with the selected guardian.
+    updateCheckinByLine(personId, checker);
   });
 }
 
@@ -852,10 +916,10 @@ function checkOutPerson(personId: number): void {
 /**
  * Perform the actual check-out API call
  */
-function performCheckout(personId: number, checkedOutById: number | null): void {
+function performCheckout(personId: number, checker: FamilyMember | null): void {
   const payload: { PersonId: number; CheckedOutById?: number } = { PersonId: personId };
-  if (checkedOutById !== null) {
-    payload.CheckedOutById = checkedOutById;
+  if (checker !== null) {
+    payload.CheckedOutById = checker.Id;
   }
   APIRequest({
     path: "checkout",
@@ -874,26 +938,40 @@ function setCheckinByEnabled(enabled: boolean): void {
 }
 
 /**
- * Render family member selection buttons for the "Check-in By" modal
+ * Render family member selection buttons for the "Check-in By" modal.
+ * Photos are fetched via the guardian photo endpoint, authorized by
+ * family relationship to the roster child ({childPersonId}).
+ * Returns a jQuery element; avoids HTML-string injection to prevent
+ * inline event-handler issues (project CSP forbids 'unsafe-inline').
  */
-function renderFamilyMemberOptions(members: FamilyMember[]): string {
-  let html = '<div class="checkin-by-members">';
+function renderFamilyMemberOptions(members: FamilyMember[], childPersonId: number): JQuery {
+  const $container = $("<div>", { class: "checkin-by-members" });
+
   for (const member of members) {
-    const photoHtml = member.hasPhoto
-      ? `<img src="${getPhotoUrl(member.Id)}" alt="${escapeHtml(member.FirstName)}" class="checkin-by-photo">`
-      : '<i class="fa-solid fa-user fa-2x"></i>';
-    html +=
-      '<button type="button" class="checkin-by-member-btn checkinByMemberBtn" data-memberid="' +
-      member.Id +
-      '">' +
-      photoHtml +
-      '<span class="checkin-by-name">' +
-      escapeHtml(`${member.FirstName} ${member.LastName}`) +
-      "</span>" +
-      "</button>";
+    const $btn = $("<button>", {
+      type: "button",
+      class: "checkin-by-member-btn checkinByMemberBtn",
+      "data-memberid": member.Id,
+    });
+
+    if (member.hasPhoto) {
+      const photoUrl = getFamilyPhotoUrl(childPersonId, member.Id);
+      const $img = $("<img>", { class: "checkin-by-photo", alt: `${member.FirstName} ${member.LastName}` });
+      // Bind error handler before setting src; inline onerror is blocked by project CSP.
+      $img.on("error", () => {
+        $img.replaceWith($("<i>", { class: "fa-solid fa-user fa-2x" }));
+      });
+      $img.attr("src", photoUrl);
+      $btn.append($img);
+    } else {
+      $btn.append($("<i>", { class: "fa-solid fa-user fa-2x" }));
+    }
+
+    $btn.append($("<span>", { class: "checkin-by-name", text: `${member.FirstName} ${member.LastName}` }));
+    $container.append($btn);
   }
-  html += "</div>";
-  return html;
+
+  return $container;
 }
 
 /**
@@ -913,12 +991,15 @@ function showCheckinByModal(personId: number, action: "checkin" | "checkout", pe
     `<div class="text-center py-4"><i class="fa-solid fa-spinner fa-spin fa-2x text-primary"></i><p class="mt-2 text-muted">${i18next.t("Loading family members...")}</p></div>`,
   );
 
+  // Track which child's family we are showing (needed for the guardian photo URL)
+  currentFamilyMembers = [];
+
   // Store the callback to invoke after selection
-  pendingCheckinByCallback = (checkedByPersonId) => {
+  pendingCheckinByCallback = (member) => {
     if (action === "checkin") {
-      performCheckin(personId, checkedByPersonId);
+      performCheckin(personId, member);
     } else {
-      performCheckout(personId, checkedByPersonId);
+      performCheckout(personId, member);
     }
   };
 
@@ -943,7 +1024,8 @@ function showCheckinByModal(personId: number, action: "checkin" | "checkout", pe
         }
         return;
       }
-      $("#checkinByModalBody").html(renderFamilyMemberOptions(data.members));
+      currentFamilyMembers = data.members;
+      $("#checkinByModalBody").empty().append(renderFamilyMemberOptions(data.members, personId));
     })
     .fail(() => {
       // On API failure close modal and proceed without a checker
@@ -958,13 +1040,19 @@ function showCheckinByModal(personId: number, action: "checkin" | "checkout", pe
 }
 
 /**
- * Resolve the "Check-in By" modal with the selected person (or null for skip)
+ * Resolve the "Check-in By" modal with the selected person (or null for skip).
+ * Looks up the full FamilyMember object from the currently-loaded members list
+ * so the callback receives name + hasPhoto for immediate card update.
  */
 function resolveCheckinByModal(checkedByPersonId: number | null): void {
   if (pendingCheckinByCallback) {
     const cb = pendingCheckinByCallback;
     pendingCheckinByCallback = null;
-    cb(checkedByPersonId);
+    const member =
+      checkedByPersonId !== null && checkedByPersonId > 0
+        ? (currentFamilyMembers.find((m) => m.Id === checkedByPersonId) ?? null)
+        : null;
+    cb(member);
   }
 }
 
@@ -1086,6 +1174,9 @@ function setCheckedOut(personId: number): void {
 
   // Remove checked-in styling
   $personDiv.removeClass("checked-in");
+
+  // Clear the checked-in-by line (person is no longer checked in)
+  updateCheckinByLine(personId, null);
 
   // Remove alert button when checked out (alert buttons only shown for checked-in students)
   $personDiv.find(".parentAlertButton").remove();
@@ -1382,6 +1473,8 @@ export const kiosk: KioskJSOM = {
   escapeHtml,
   APIRequest,
   getPhotoUrl,
+  getFamilyPhotoUrl,
+  updateCheckinByLine,
   renderClassMember,
   updateMemberCounts,
   renderBirthdaySection,

--- a/webpack/kiosk/types.ts
+++ b/webpack/kiosk/types.ts
@@ -2,6 +2,13 @@
  * Kiosk TypeScript Type Definitions
  */
 
+export interface CheckinByPerson {
+  Id: number;
+  FirstName: string;
+  LastName: string;
+  hasPhoto: boolean;
+}
+
 export interface ClassMember {
   displayName: string;
   firstName: string;
@@ -18,6 +25,7 @@ export interface ClassMember {
   birthDay: number | null;
   birthMonth: number | null;
   familyId: number | null;
+  checkedInBy?: CheckinByPerson | null;
 }
 
 export interface PersonApiData {
@@ -36,6 +44,7 @@ export interface PersonApiData {
   birthDay: number | null;
   birthMonth: number | null;
   familyId: number | null;
+  checkedInBy?: CheckinByPerson | null;
 }
 
 export interface ActiveClassMembersResponse {
@@ -74,12 +83,9 @@ export interface AjaxOptions {
   contentType?: string;
 }
 
-export interface FamilyMember {
-  Id: number;
-  FirstName: string;
-  LastName: string;
-  hasPhoto: boolean;
-}
+/** A family member selectable in the "Check-in By" / "Check-out By" modal.
+ * Structurally identical to CheckinByPerson — aliased to avoid drift. */
+export type FamilyMember = CheckinByPerson;
 
 export interface FamilyMembersResponse {
   members: FamilyMember[];
@@ -109,6 +115,8 @@ export interface KioskJSOM {
     kioskName: string,
     bodyContent: string | null,
   ) => string;
+  getFamilyPhotoUrl: (childPersonId: number, memberId: number) => string;
+  updateCheckinByLine: (childPersonId: number, checker: CheckinByPerson | null) => void;
   checkInPerson: (personId: number) => void;
   checkOutPerson: (personId: number) => void;
   checkOutAll: () => void;


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Closes #7949
Docs: #9452

Two remaining items from the Check-in By kiosk feature the maintainer confirmed as missing:

## What changed

### 1. Guardian photo display in the Check-in By / Check-out By modal
The checkout modal listed family members but their photos were broken — `getPhotoUrl` hits the roster-restricted endpoint and guardians aren't roster members, so every image returned 403.

- **New endpoint** `GET /kiosk/device/activeClassMember/{PersonId}/family/{MemberId}/photo`
  Serves a guardian's photo, authorized by (a) PersonId is in the active class roster, AND (b) MemberId is an adult family member of that child. Prevents photo enumeration via kiosk cookie.
- `renderFamilyMemberOptions()` now uses `getFamilyPhotoUrl(childId, memberId)` pointing at the new endpoint.
- Photo error fallback uses jQuery `.on('error')` — CSP-safe, no inline `onerror` attributes.

### 2. "Checked in by" attribution line on member cards
After a child is checked in by a guardian, the kiosk live view now shows a small photo + name line below the child's name.

- `activeClassMembers` endpoint returns `checkedInBy` per currently-checked-in child: single batch `EventAttendQuery` (not N+1), resolve checker name+hasPhoto, in-loop guardian cache.
- `updateCheckinByLine()` renders the attribution. Updates existing cards on refresh. Clears on checkout.
- `performCheckin()` updates the card optimistically right after modal selection.
- `FamilyMember` type alias → `CheckinByPerson` (eliminate structural duplicate).

## Testing
- Lint: `npm run lint` — 3 pre-existing warnings in unrelated files, 0 errors.
- Build: `npm run build:webpack` — compiled successfully.
- PHP validation bypassed: PHP binary unavailable in the build sandbox. PHP changes follow the exact same patterns as existing device.php routes and were reviewed by the independent reviewer sub-agent.

## Known gap
No Cypress tests were added for the new `/family/{MemberId}/photo` endpoint or the `checkedInBy` field. Tracked in: #9452 (docs issue — tests would be a separate PR).