### PR TITLE
feat(upgrade-wizard): redesign What you'll gain step — always latest, stacked notes, cleaner advanced mode

### DIFF
--- a/cypress/e2e/ui/admin/system-upgrade.spec.js
+++ b/cypress/e2e/ui/admin/system-upgrade.spec.js
@@ -457,12 +457,12 @@ describe("System Upgrade Page", () => {
             // This tests the server-rendered badge visible before wizard interaction.
             // We rely on the PHP view rendering the badge when $isUpdateAvailable === false.
             cy.visit("/admin/system/upgrade");
-            // The page always shows at least one badge; when up to date it has bg-success-lt
-            // We cannot intercept the PHP page render, so we assert that if the
-            // bg-success-lt badge exists it carries the expected text.
+            // The version-info card shows a bg-success-lt badge when up to date.
+            // Exclude #recommendedBadge (new wizard element with the same classes that is
+            // always rendered but controlled by JS visibility, not server-state).
             cy.get("body").then(($body) => {
-                if ($body.find(".badge.bg-success-lt.text-success").length) {
-                    cy.get(".badge.bg-success-lt.text-success").should("contain", "Up to Date");
+                if ($body.find(".badge.bg-success-lt.text-success:not(#recommendedBadge)").length) {
+                    cy.get(".badge.bg-success-lt.text-success:not(#recommendedBadge)").should("contain", "Up to Date");
                 }
             });
         });

--- a/cypress/e2e/ui/admin/system-upgrade.spec.js
+++ b/cypress/e2e/ui/admin/system-upgrade.spec.js
@@ -193,7 +193,7 @@ describe("System Upgrade Page", () => {
             cy.get("#retryDownload").should("be.visible");
         });
 
-        it("should render upgrade path panel when multiple releases behind", () => {
+        it("should show security callout and stacked release notes when multiple releases behind", () => {
             cy.intercept("GET", "**/admin/api/upgrade/preview", {
                 statusCode: 200,
                 body: {
@@ -236,10 +236,21 @@ describe("System Upgrade Page", () => {
             cy.get("#skipBackup").click();
 
             cy.wait("@previewRequest", { timeout: 10000 });
-            cy.get("#upgradePathPanel").should("not.have.class", "d-none");
-            cy.get("#upgradePathSummary").should("contain", "3");
-            cy.get("#upgradePathAccordion .badge.bg-primary-lt.text-primary").should("contain", "Installing next release");
-            cy.get("#proceedToDownload").should("be.visible");
+
+            // Security callout must be visible (replaces old upgrade-path info panel)
+            cy.get("#securityRecommendationCallout").should("not.have.class", "d-none");
+
+            // Stacked release notes: all 3 versions should be rendered
+            cy.get("#whatsNewNotes .version-notes-block").should("have.length", 3);
+
+            // Default target is the latest version (5.0.3)
+            cy.get("#whatsNewVersion").should("contain", "5.0.3");
+            cy.get("#recommendedBadge").should("not.have.class", "d-none");
+
+            // "Installing next release" badge must NOT appear anywhere
+            cy.get("#whatsNewContent").should("not.contain", "Installing next release");
+
+            cy.get("#proceedToDownload").should("be.visible").and("contain", "5.0.3");
         });
 
         it("should show changelog link in What's New step", () => {
@@ -588,35 +599,39 @@ describe("System Upgrade Page", () => {
             cy.get("#whatsNewContent").should("not.have.class", "d-none");
 
             // Open the advanced selector collapse by its visible text label.
-            // The link uses href='#advancedVersionCollapse' (no data-bs-target),
-            // so we select by text content to avoid href URL-resolution issues.
-            cy.contains('a[data-bs-toggle="collapse"]', 'Advanced: choose a specific target version').click();
+            cy.contains('a[data-bs-toggle="collapse"]', 'Advanced: Install a specific version instead').click();
             cy.get("#advancedVersionCollapse").should("have.class", "show", { timeout: 5000 });
             cy.get("#targetVersionSelect").should("be.visible");
 
-            // Options should include default + all upgrade path entries
-            cy.get("#targetVersionSelect option").should("have.length", 4); // 1 default + 3 versions
+            // Options: 1 latest (Recommended) + 2 non-latest = 3 total
+            cy.get("#targetVersionSelect option").should("have.length", 3);
 
-            // Select version 5.0.3
-            cy.get("#targetVersionSelect").select("5.0.3");
+            // Select non-latest version 5.0.2 — should update version heading and notes
+            cy.get("#targetVersionSelect").select("5.0.2");
 
-            // Release notes heading should update to 5.0.3
-            cy.get("#whatsNewVersion").should("contain", "5.0.3");
-            cy.get("#whatsNewNotes").should("contain", "5.0.3 another fix");
+            // Release notes heading should update to 5.0.2
+            cy.get("#whatsNewVersion").should("contain", "5.0.2");
+            cy.get("#whatsNewNotes").should("contain", "5.0.2 feature");
+
+            // Recommended badge should be hidden when non-latest is selected
+            cy.get("#recommendedBadge").should("have.class", "d-none");
+
+            // Warning banner should be visible
+            cy.get("#advancedWarningBanner").should("not.have.class", "d-none");
         });
 
-        it("should send ?version= query param when specific version is chosen", () => {
+        it("should send ?version= query param when specific non-latest version is chosen", () => {
             cy.intercept("GET", "**/admin/api/upgrade/preview", {
                 statusCode: 200,
                 body: multiReleaseFixture,
             }).as("previewRequest");
 
-            cy.intercept("GET", "**/admin/api/upgrade/download-latest-release?version=5.0.3", {
+            cy.intercept("GET", "**/admin/api/upgrade/download-latest-release?version=5.0.2", {
                 statusCode: 200,
                 body: {
-                    fileName: "ChurchCRM-5.0.3.zip",
-                    fullPath: "/tmp/ChurchCRM-5.0.3.zip",
-                    releaseNotes: "## 5.0.3\n\n- Another fix\n",
+                    fileName: "ChurchCRM-5.0.2.zip",
+                    fullPath: "/tmp/ChurchCRM-5.0.2.zip",
+                    releaseNotes: "## 5.0.2\n\n- Feature\n",
                     sha1: "aabbcc112233",
                 },
             }).as("downloadSpecific");
@@ -627,21 +642,21 @@ describe("System Upgrade Page", () => {
 
             cy.wait("@previewRequest", { timeout: 10000 });
 
-            // Open advanced selector and pick 5.0.3
-            cy.contains('a[data-bs-toggle="collapse"]', 'Advanced: choose a specific target version').click();
+            // Open advanced selector and pick non-latest 5.0.2
+            cy.contains('a[data-bs-toggle="collapse"]', 'Advanced: Install a specific version instead').click();
             cy.get("#advancedVersionCollapse").should("have.class", "show", { timeout: 5000 });
-            cy.get("#targetVersionSelect").select("5.0.3");
+            cy.get("#targetVersionSelect").select("5.0.2");
 
             // Proceed to download step
             cy.get("#proceedToDownload").click();
 
-            // Verify that the download request used the ?version= param
+            // Verify that the download request used the ?version= param for 5.0.2
             cy.wait("@downloadSpecific", { timeout: 15000 });
             cy.get("#downloadStatus .alert-success").should("be.visible");
-            cy.get("#updateFileName").should("contain", "ChurchCRM-5.0.3.zip");
+            cy.get("#updateFileName").should("contain", "ChurchCRM-5.0.2.zip");
         });
 
-        it("should expand upgrade path accordion and show entry details", () => {
+        it("should render stacked version blocks with deep-link anchors", () => {
             cy.intercept("GET", "**/admin/api/upgrade/preview", {
                 statusCode: 200,
                 body: multiReleaseFixture,
@@ -653,21 +668,19 @@ describe("System Upgrade Page", () => {
 
             cy.wait("@previewRequest", { timeout: 10000 });
 
-            // Upgrade path panel should be visible (3 releases ahead)
-            cy.get("#upgradePathPanel").should("not.have.class", "d-none");
+            // All 3 versions should be rendered as stacked blocks (newest-first)
+            cy.get("#whatsNewNotes .version-notes-block").should("have.length", 3);
 
-            // Expand the upgrade path collapse by its visible text label.
-            // Same reason as above: use text-content selector, not [href='#...'].
-            cy.contains('a[data-bs-toggle="collapse"]', 'Show full upgrade path').click();
-            cy.get("#upgradePathCollapse").should("have.class", "show", { timeout: 5000 });
+            // Each block should have a deep-link anchor id (e.g. v5-0-3)
+            cy.get("#whatsNewNotes #v5-0-3").should("exist");
+            cy.get("#whatsNewNotes #v5-0-2").should("exist");
+            cy.get("#whatsNewNotes #v5-0-1").should("exist");
 
-            // Should render 3 accordion entries
-            cy.get("#upgradePathAccordion .upgrade-path-entry").should("have.length", 3);
+            // Each block should have a "Full release notes" link
+            cy.get("#whatsNewNotes .version-notes-block").first().find("a").should("contain", "Full release notes");
 
-            // Expand the first entry and verify release notes render
-            cy.get("#upgradePathAccordion .upgrade-path-entry").first().find(".upgrade-path-header").click();
-            cy.get("#upgradePathAccordion .upgrade-path-entry").first().find(".upgrade-path-notes").should("have.class", "show", { timeout: 5000 });
-            cy.get("#upgradePathAccordion .upgrade-path-entry").first().find(".release-notes").should("contain", "5.0.1");
+            // Release notes content should be rendered
+            cy.get("#whatsNewNotes").should("contain", "5.0.3 another fix");
         });
     });
 });

--- a/cypress/e2e/ui/admin/upgrade-wizard-whats-new.spec.js
+++ b/cypress/e2e/ui/admin/upgrade-wizard-whats-new.spec.js
@@ -121,10 +121,12 @@ describe("Upgrade Wizard — What you'll gain redesign", () => {
                 .and("contain", "security fixes");
         });
 
-        it("does NOT show the 'Installing next release' badge anywhere", () => {
+        it("shows #recommendedBadge with 'Recommended' text", () => {
             reachWhatsNewStep("@previewRequest");
 
-            cy.get("#whatsNewContent").should("not.contain", "Installing next release");
+            cy.get("#recommendedBadge")
+                .should("not.have.class", "d-none")
+                .and("contain", "Recommended");
         });
 
         it("CTA reads 'Download & Apply 99.0.0'", () => {

--- a/cypress/e2e/ui/admin/upgrade-wizard-whats-new.spec.js
+++ b/cypress/e2e/ui/admin/upgrade-wizard-whats-new.spec.js
@@ -1,0 +1,322 @@
+/**
+ * Upgrade Wizard — What you'll gain (redesigned step) — new spec
+ *
+ * All scenarios intercept /admin/api/upgrade/preview (the app's server-side
+ * proxy for GitHub releases data) and return a mocked "future version" of
+ * 99.0.0 so the tests are completely decoupled from real GitHub release data.
+ *
+ * Scenarios:
+ *   (a) single-version-behind  — one release separates installed from latest
+ *   (b) multi-version-behind   — three skipped releases rendered as stacked blocks
+ *   (c) advanced picker warning — non-latest selection triggers red banner + CTA update
+ */
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+/** Single version behind: current → 99.0.0 (one jump) */
+const singleVersionFixture = {
+    installedVersion: "5.0.0",
+    nextVersion: "99.0.0",
+    latestVersion: "99.0.0",
+    nextReleaseNotes:
+        "## 99.0.0 — Future Release\n\n- Groundbreaking new feature\n- Security patch: CVE-9999-0001\n",
+    nextChangelogUrl: "https://github.com/ChurchCRM/CRM/blob/master/changelog/99.0.0.md",
+    releasesAhead: 1,
+    latestReleaseNotes: "",
+    latestChangelogUrl: "https://github.com/ChurchCRM/CRM/blob/master/changelog/99.0.0.md",
+    upgradePath: [
+        {
+            version: "99.0.0",
+            type: "major",
+            notes: "## 99.0.0 — Future Release\n\n- Groundbreaking new feature\n- Security patch: CVE-9999-0001\n",
+            changelogUrl: "https://github.com/ChurchCRM/CRM/blob/master/changelog/99.0.0.md",
+            isNext: true,
+        },
+    ],
+};
+
+/** Multi-version behind: current → 97.0.0 → 98.0.0 → 99.0.0 (three jumps) */
+const multiVersionFixture = {
+    installedVersion: "5.0.0",
+    nextVersion: "97.0.0",
+    latestVersion: "99.0.0",
+    nextReleaseNotes: "## 97.0.0\n\n- Intermediate release A\n",
+    nextChangelogUrl: "https://github.com/ChurchCRM/CRM/blob/master/changelog/97.0.0.md",
+    releasesAhead: 3,
+    latestReleaseNotes: "",
+    latestChangelogUrl: "https://github.com/ChurchCRM/CRM/blob/master/changelog/99.0.0.md",
+    upgradePath: [
+        {
+            version: "97.0.0",
+            type: "major",
+            notes: "## 97.0.0\n\n- Intermediate release A\n",
+            changelogUrl: "https://github.com/ChurchCRM/CRM/blob/master/changelog/97.0.0.md",
+            isNext: true,
+        },
+        {
+            version: "98.0.0",
+            type: "major",
+            notes: "## 98.0.0\n\n- Intermediate release B with security fix\n",
+            changelogUrl: "https://github.com/ChurchCRM/CRM/blob/master/changelog/98.0.0.md",
+            isNext: false,
+        },
+        {
+            version: "99.0.0",
+            type: "major",
+            notes: "## 99.0.0 — Future Release\n\n- Latest stable with critical security patch\n",
+            changelogUrl: "https://github.com/ChurchCRM/CRM/blob/master/changelog/99.0.0.md",
+            isNext: false,
+        },
+    ],
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Navigate to the What you'll gain step via the wizard. */
+function reachWhatsNewStep(previewAlias) {
+    cy.get("#acceptWarnings").click();
+    cy.get("#step-backup").should("be.visible");
+    cy.get("#skipBackup").click();
+    cy.wait(previewAlias, { timeout: 10000 });
+    cy.get("#whatsNewContent").should("not.have.class", "d-none");
+}
+
+// ── Suite ─────────────────────────────────────────────────────────────────────
+
+describe("Upgrade Wizard — What you'll gain redesign", () => {
+    beforeEach(() => {
+        cy.setupAdminSession();
+    });
+
+    // ── (a) Single version behind ─────────────────────────────────────────────
+
+    describe("(a) Single version behind — 99.0.0", () => {
+        beforeEach(() => {
+            cy.intercept("GET", "**/admin/api/upgrade/preview", {
+                statusCode: 200,
+                body: singleVersionFixture,
+            }).as("previewRequest");
+
+            cy.visit("/admin/system/upgrade");
+        });
+
+        it("always defaults to the latest available version", () => {
+            reachWhatsNewStep("@previewRequest");
+
+            // Target version shown in heading should be the latest (99.0.0)
+            cy.get("#whatsNewVersion").should("contain", "99.0.0");
+        });
+
+        it("shows the green Recommended badge on the latest target", () => {
+            reachWhatsNewStep("@previewRequest");
+
+            cy.get("#recommendedBadge").should("not.have.class", "d-none").and("contain", "Recommended");
+        });
+
+        it("shows the security recommendation callout", () => {
+            reachWhatsNewStep("@previewRequest");
+
+            cy.get("#securityRecommendationCallout")
+                .should("not.have.class", "d-none")
+                .and("contain", "security fixes");
+        });
+
+        it("does NOT show the 'Installing next release' badge anywhere", () => {
+            reachWhatsNewStep("@previewRequest");
+
+            cy.get("#whatsNewContent").should("not.contain", "Installing next release");
+        });
+
+        it("CTA reads 'Download & Apply 99.0.0'", () => {
+            reachWhatsNewStep("@previewRequest");
+
+            cy.get("#proceedToDownload")
+                .should("be.visible")
+                .and("contain", "Download & Apply")
+                .and("contain", "99.0.0");
+        });
+
+        it("renders a version block for 99.0.0 with the correct content", () => {
+            reachWhatsNewStep("@previewRequest");
+
+            cy.get("#whatsNewNotes .version-notes-block").should("have.length", 1);
+            cy.get("#whatsNewNotes .version-notes-block").first().should("contain", "99.0.0");
+        });
+
+        it("renders a deep-link anchor for 99.0.0", () => {
+            reachWhatsNewStep("@previewRequest");
+
+            cy.get("#whatsNewNotes #v99-0-0").should("exist");
+        });
+
+        it("shows a Full release notes link for the version block", () => {
+            reachWhatsNewStep("@previewRequest");
+
+            cy.get("#whatsNewNotes .version-notes-block").first().find("a").should("contain", "Full release notes");
+        });
+    });
+
+    // ── (b) Multi-version behind ──────────────────────────────────────────────
+
+    describe("(b) Multi-version behind — three skipped releases to 99.0.0", () => {
+        beforeEach(() => {
+            cy.intercept("GET", "**/admin/api/upgrade/preview", {
+                statusCode: 200,
+                body: multiVersionFixture,
+            }).as("previewRequest");
+
+            cy.visit("/admin/system/upgrade");
+        });
+
+        it("stacks release notes for all skipped versions (newest first)", () => {
+            reachWhatsNewStep("@previewRequest");
+
+            cy.get("#whatsNewNotes .version-notes-block").should("have.length", 3);
+
+            // Verify newest-first order: 99.0.0, 98.0.0, 97.0.0
+            cy.get("#whatsNewNotes .version-notes-block").eq(0).should("contain", "99.0.0");
+            cy.get("#whatsNewNotes .version-notes-block").eq(1).should("contain", "98.0.0");
+            cy.get("#whatsNewNotes .version-notes-block").eq(2).should("contain", "97.0.0");
+        });
+
+        it("renders a deep-link anchor for each skipped version", () => {
+            reachWhatsNewStep("@previewRequest");
+
+            cy.get("#whatsNewNotes #v99-0-0").should("exist");
+            cy.get("#whatsNewNotes #v98-0-0").should("exist");
+            cy.get("#whatsNewNotes #v97-0-0").should("exist");
+        });
+
+        it("each version block has a Full release notes link to GitHub", () => {
+            reachWhatsNewStep("@previewRequest");
+
+            cy.get("#whatsNewNotes .version-notes-block").each(($block) => {
+                cy.wrap($block)
+                    .find("a")
+                    .should("have.attr", "href")
+                    .and("include", "github.com");
+            });
+        });
+
+        it("default target is latest (99.0.0) with Recommended badge", () => {
+            reachWhatsNewStep("@previewRequest");
+
+            cy.get("#whatsNewVersion").should("contain", "99.0.0");
+            cy.get("#recommendedBadge").should("not.have.class", "d-none");
+        });
+
+        it("security callout is visible when multi-version behind", () => {
+            reachWhatsNewStep("@previewRequest");
+
+            cy.get("#securityRecommendationCallout").should("not.have.class", "d-none");
+        });
+    });
+
+    // ── (c) Advanced picker warning banner ───────────────────────────────────
+
+    describe("(c) Advanced picker — selecting a non-latest version shows warning", () => {
+        beforeEach(() => {
+            cy.intercept("GET", "**/admin/api/upgrade/preview", {
+                statusCode: 200,
+                body: multiVersionFixture,
+            }).as("previewRequest");
+
+            cy.visit("/admin/system/upgrade");
+        });
+
+        it("advanced panel is collapsed by default", () => {
+            reachWhatsNewStep("@previewRequest");
+
+            cy.get("#advancedVersionCollapse").should("not.have.class", "show");
+        });
+
+        it("expands the advanced section when toggle is clicked", () => {
+            reachWhatsNewStep("@previewRequest");
+
+            cy.contains('a[data-bs-toggle="collapse"]', "Advanced: Install a specific version instead").click();
+            cy.get("#advancedVersionCollapse").should("have.class", "show", { timeout: 5000 });
+            cy.get("#targetVersionSelect").should("be.visible");
+        });
+
+        it("lists the latest version as the default Recommended option", () => {
+            reachWhatsNewStep("@previewRequest");
+
+            cy.contains('a[data-bs-toggle="collapse"]', "Advanced: Install a specific version instead").click();
+            cy.get("#advancedVersionCollapse").should("have.class", "show", { timeout: 5000 });
+
+            // First option should be 99.0.0 (Recommended) and selected
+            cy.get("#targetVersionSelect option").first().should("contain", "99.0.0").and("contain", "Recommended");
+            cy.get("#targetVersionSelect").should("have.value", "99.0.0");
+        });
+
+        it("shows a red security warning banner when a non-latest version is selected", () => {
+            reachWhatsNewStep("@previewRequest");
+
+            cy.contains('a[data-bs-toggle="collapse"]', "Advanced: Install a specific version instead").click();
+            cy.get("#advancedVersionCollapse").should("have.class", "show", { timeout: 5000 });
+
+            // Select a non-latest version
+            cy.get("#targetVersionSelect").select("98.0.0");
+
+            // Red warning banner should appear
+            cy.get("#advancedWarningBanner")
+                .should("not.have.class", "d-none")
+                .and("have.class", "alert-danger");
+            cy.get("#advancedWarningText").should("contain", "98.0.0").and("contain", "99.0.0");
+        });
+
+        it("hides the Recommended badge when a non-latest version is selected", () => {
+            reachWhatsNewStep("@previewRequest");
+
+            cy.contains('a[data-bs-toggle="collapse"]', "Advanced: Install a specific version instead").click();
+            cy.get("#advancedVersionCollapse").should("have.class", "show", { timeout: 5000 });
+            cy.get("#targetVersionSelect").select("98.0.0");
+
+            cy.get("#recommendedBadge").should("have.class", "d-none");
+        });
+
+        it("CTA updates to the chosen non-latest version", () => {
+            reachWhatsNewStep("@previewRequest");
+
+            cy.contains('a[data-bs-toggle="collapse"]', "Advanced: Install a specific version instead").click();
+            cy.get("#advancedVersionCollapse").should("have.class", "show", { timeout: 5000 });
+            cy.get("#targetVersionSelect").select("98.0.0");
+
+            cy.get("#proceedToDownload")
+                .should("contain", "Download & Apply")
+                .and("contain", "98.0.0");
+        });
+
+        it("notes stack is trimmed to the chosen version (only 97.0.0 and 98.0.0 shown)", () => {
+            reachWhatsNewStep("@previewRequest");
+
+            cy.contains('a[data-bs-toggle="collapse"]', "Advanced: Install a specific version instead").click();
+            cy.get("#advancedVersionCollapse").should("have.class", "show", { timeout: 5000 });
+            cy.get("#targetVersionSelect").select("98.0.0");
+
+            // Should show only 98.0.0 and 97.0.0 (not 99.0.0)
+            cy.get("#whatsNewNotes .version-notes-block").should("have.length", 2);
+            cy.get("#whatsNewNotes").should("not.contain", "99.0.0");
+        });
+
+        it("restores default state when the latest version is re-selected", () => {
+            reachWhatsNewStep("@previewRequest");
+
+            cy.contains('a[data-bs-toggle="collapse"]', "Advanced: Install a specific version instead").click();
+            cy.get("#advancedVersionCollapse").should("have.class", "show", { timeout: 5000 });
+
+            // Pick non-latest first
+            cy.get("#targetVersionSelect").select("98.0.0");
+            cy.get("#advancedWarningBanner").should("not.have.class", "d-none");
+
+            // Revert to latest
+            cy.get("#targetVersionSelect").select("99.0.0");
+
+            // Warning gone, Recommended badge restored, all 3 blocks back
+            cy.get("#advancedWarningBanner").should("have.class", "d-none");
+            cy.get("#recommendedBadge").should("not.have.class", "d-none");
+            cy.get("#whatsNewNotes .version-notes-block").should("have.length", 3);
+            cy.get("#proceedToDownload").should("contain", "99.0.0");
+        });
+    });
+});

--- a/cypress/e2e/ui/admin/upgrade-wizard-whats-new.spec.js
+++ b/cypress/e2e/ui/admin/upgrade-wizard-whats-new.spec.js
@@ -121,14 +121,6 @@ describe("Upgrade Wizard — What you'll gain redesign", () => {
                 .and("contain", "security fixes");
         });
 
-        it("shows #recommendedBadge with 'Recommended' text", () => {
-            reachWhatsNewStep("@previewRequest");
-
-            cy.get("#recommendedBadge")
-                .should("not.have.class", "d-none")
-                .and("contain", "Recommended");
-        });
-
         it("CTA reads 'Download & Apply 99.0.0'", () => {
             reachWhatsNewStep("@previewRequest");
 

--- a/cypress/e2e/ui/admin/upgrade-wizard-whats-new.spec.js
+++ b/cypress/e2e/ui/admin/upgrade-wizard-whats-new.spec.js
@@ -143,6 +143,12 @@ describe("Upgrade Wizard — What you'll gain redesign", () => {
             cy.get("#whatsNewNotes .version-notes-block").first().should("contain", "99.0.0");
         });
 
+        it("does NOT show the advanced picker when only one version ahead (nothing to downgrade to)", () => {
+            reachWhatsNewStep("@previewRequest");
+
+            cy.get("#advancedVersionPanel").should("have.class", "d-none");
+        });
+
         it("renders a deep-link anchor for 99.0.0", () => {
             reachWhatsNewStep("@previewRequest");
 
@@ -317,6 +323,69 @@ describe("Upgrade Wizard — What you'll gain redesign", () => {
             cy.get("#recommendedBadge").should("not.have.class", "d-none");
             cy.get("#whatsNewNotes .version-notes-block").should("have.length", 3);
             cy.get("#proceedToDownload").should("contain", "99.0.0");
+        });
+    });
+
+    // ── (d) Prerelease / dev build ahead of latest stable (Case 1) ──────────────
+
+    describe("(d) Running a pre-release build ahead of latest stable", () => {
+        const prereleaseMockFixture = {
+            installedVersion: "99.5.0-dev",
+            nextVersion: "99.0.0",
+            latestVersion: "99.0.0",
+            nextReleaseNotes: "## 99.0.0\n\n- Latest stable release\n- Security patch included\n",
+            nextChangelogUrl: "https://github.com/ChurchCRM/CRM/blob/master/changelog/99.0.0.md",
+            releasesAhead: 0,
+            latestReleaseNotes: "## 99.0.0\n\n- Latest stable release\n",
+            latestChangelogUrl: "https://github.com/ChurchCRM/CRM/blob/master/changelog/99.0.0.md",
+            upgradePath: [],
+            isAheadOfStable: true,
+        };
+
+        beforeEach(() => {
+            cy.intercept("GET", "**/admin/api/upgrade/preview", {
+                statusCode: 200,
+                body: prereleaseMockFixture,
+            }).as("previewRequest");
+
+            cy.visit("/admin/system/upgrade");
+        });
+
+        it("shows a pre-release warning banner", () => {
+            reachWhatsNewStep("@previewRequest");
+
+            cy.get("#whatsNewContent .alert-warning").should("be.visible").and("contain", "pre-release");
+        });
+
+        it("shows the stable version in the version heading", () => {
+            reachWhatsNewStep("@previewRequest");
+
+            cy.get("#whatsNewVersion").should("contain", "99.0.0");
+        });
+
+        it("CTA reads 'Install stable 99.0.0'", () => {
+            reachWhatsNewStep("@previewRequest");
+
+            cy.get("#proceedToDownload").should("be.visible").and("contain", "Install stable").and("contain", "99.0.0");
+        });
+
+        it("renders a version block for the stable target", () => {
+            reachWhatsNewStep("@previewRequest");
+
+            cy.get("#whatsNewNotes .version-notes-block").should("have.length", 1);
+            cy.get("#whatsNewNotes .version-notes-block").first().should("contain", "99.0.0");
+        });
+
+        it("does NOT show security callout in prerelease mode", () => {
+            reachWhatsNewStep("@previewRequest");
+
+            cy.get("#securityRecommendationCallout").should("have.class", "d-none");
+        });
+
+        it("does NOT show the advanced version picker in prerelease mode", () => {
+            reachWhatsNewStep("@previewRequest");
+
+            cy.get("#advancedVersionPanel").should("have.class", "d-none");
         });
     });
 });

--- a/src/admin/views/upgrade.php
+++ b/src/admin/views/upgrade.php
@@ -206,53 +206,54 @@ $orphanedCount = count($integrityCheckData['orphanedFiles'] ?? []);
                             </div>
 
                             <div id="whatsNewContent" class="d-none">
-                                <!-- Upgrade path panel (shown when ≥2 releases behind) -->
-                                <div id="upgradePathPanel" class="d-none mb-4">
-                                    <div class="alert alert-info d-flex align-items-center gap-2 mb-2">
-                                        <i class="fa fa-layer-group"></i>
-                                        <span id="upgradePathSummary"></span>
-                                    </div>
-                                    <a href="#upgradePathCollapse" class="collapse-toggle d-inline-flex align-items-center gap-1 text-secondary text-decoration-none small fw-medium mb-2"
+                                <!-- Advanced: install a specific version (collapsed by default, JS hides entirely when not applicable) -->
+                                <div class="mb-3 d-none" id="advancedVersionPanel">
+                                    <a href="#advancedVersionCollapse" class="collapse-toggle d-inline-flex align-items-center gap-1 text-warning text-decoration-none small fw-medium"
                                         data-bs-toggle="collapse" aria-expanded="false">
                                         <i class="fa fa-chevron-down"></i>
-                                        <?= gettext('Show full upgrade path') ?>
-                                    </a>
-                                    <div id="upgradePathCollapse" class="collapse">
-                                        <div id="upgradePathAccordion" class="upgrade-path-list mb-2"></div>
-                                    </div>
-                                </div>
-
-                                <!-- Next release notes -->
-                                <div class="d-flex align-items-center justify-content-between mb-2">
-                                    <h4 class="mb-0">
-                                        <i class="fa fa-tag me-1 text-primary"></i>
-                                        <span id="whatsNewHeading"></span>
-                                    </h4>
-                                    <a id="whatsNewChangelogLink" href="#" target="_blank" rel="noopener noreferrer" class="btn btn-ghost-secondary btn-sm d-none">
-                                        <i class="fa fa-external-link me-1"></i><?= gettext('Full changelog') ?>
-                                    </a>
-                                </div>
-                                <div id="whatsNewNotes" class="release-notes p-3 border rounded mb-4"></div>
-
-                                <!-- Advanced: target version selector -->
-                                <div class="mb-4">
-                                    <a href="#advancedVersionCollapse" class="collapse-toggle d-inline-flex align-items-center gap-1 text-secondary text-decoration-none small fw-medium"
-                                        data-bs-toggle="collapse" aria-expanded="false">
-                                        <i class="fa fa-chevron-down"></i>
-                                        <?= gettext('Advanced: choose a specific target version') ?>
+                                        <i class="fa fa-triangle-exclamation ms-1 me-1"></i>
+                                        <?= gettext('Advanced: Install a specific version instead') ?>
                                     </a>
                                     <div id="advancedVersionCollapse" class="collapse mt-2">
                                         <div class="card card-sm">
                                             <div class="card-body">
-                                                <p class="text-secondary small mb-2"><?= gettext('By default the wizard downloads the next recommended release. You may instead choose any available version below.') ?></p>
-                                                <select class="form-select form-select-sm" id="targetVersionSelect" style="max-width: 220px;"></select>
+                                                <p class="text-secondary small mb-2"><?= gettext('By default the wizard upgrades to the latest version. You may instead choose a specific version below.') ?></p>
+                                                <select class="form-select form-select-sm mb-2" id="targetVersionSelect" style="max-width: 280px;"></select>
+                                                <div id="advancedWarningBanner" class="alert alert-danger d-none mb-0 py-2">
+                                                    <i class="fa fa-shield-halved me-1"></i>
+                                                    <span id="advancedWarningText"></span>
+                                                </div>
                                             </div>
                                         </div>
                                     </div>
                                 </div>
 
+                                <!-- Security recommendation callout (shown by JS when upgrade is available) -->
+                                <div id="securityRecommendationCallout" class="alert alert-warning d-none mb-3">
+                                    <div class="d-flex align-items-start gap-2">
+                                        <i class="fa fa-shield-halved fa-lg mt-1 flex-shrink-0"></i>
+                                        <span><?= gettext('Every ChurchCRM release includes security fixes. We strongly recommend always upgrading to the latest version.') ?></span>
+                                    </div>
+                                </div>
+
+                                <!-- What you'll gain heading -->
+                                <div class="d-flex align-items-center justify-content-between mb-2">
+                                    <h4 class="mb-0">
+                                        <i class="fa fa-arrow-up me-1 text-success"></i>
+                                        <?= gettext("What you'll gain") ?> &mdash;
+                                        <span id="whatsNewVersion" class="text-primary fw-semibold"></span>
+                                        <span id="recommendedBadge" class="badge bg-success-lt text-success ms-1 d-none"><?= gettext('Recommended') ?></span>
+                                    </h4>
+                                    <a id="whatsNewChangelogLink" href="#" target="_blank" rel="noopener noreferrer" class="btn btn-ghost-secondary btn-sm d-none">
+                                        <i class="fa fa-external-link me-1"></i><?= gettext('Full changelog') ?>
+                                    </a>
+                                </div>
+
+                                <!-- Release notes container: stacked blocks (upgrade) or single note (up-to-date/prerelease), JS-rendered -->
+                                <div id="whatsNewNotes" class="mb-4"></div>
+
                                 <button class="btn btn-primary" id="proceedToDownload">
-                                    <i class="fa fa-cloud-arrow-down me-1"></i><?= gettext('Download & Install') ?>
+                                    <i class="fa fa-cloud-arrow-down me-1"></i><?= gettext('Download & Apply') ?>
                                 </button>
                             </div>
 

--- a/webpack/upgrade-wizard-app.js
+++ b/webpack/upgrade-wizard-app.js
@@ -354,7 +354,10 @@ function renderWhatsNew(data) {
   selectedTargetVersion = null;
   prereleaseTargetVersion = null;
   // Remove any banners injected by a previous render (e.g. wizard re-entry).
-  $("#whatsNewContent .alert-success, #whatsNewContent .alert-warning, #whatsNewContent .js-uptodate-banner").remove();
+  // IMPORTANT: use .js-dynamic-banner — do NOT sweep .alert-warning or .alert-success
+  // broadly, as #securityRecommendationCallout is a permanent static element that must
+  // survive across renders (it is shown/hidden via the d-none toggle, never removed).
+  $("#whatsNewContent .js-dynamic-banner").remove();
   $("#proceedToDownload")
     .removeClass("d-none")
     .html(`<i class="fa fa-cloud-arrow-down me-1"></i>${i18next.t("Download & Apply")}`);
@@ -372,7 +375,7 @@ function renderWhatsNew(data) {
     $("#whatsNewNotes").html(buildVersionBlock(nextVersion, null, nextReleaseNotes, nextChangelogUrl));
 
     $("#whatsNewContent").prepend(
-      `<div class="alert alert-warning d-flex align-items-center gap-2 mb-3">
+      `<div class="alert alert-warning d-flex align-items-center gap-2 mb-3 js-dynamic-banner">
         <i class="fa fa-triangle-exclamation fa-lg"></i>
         <span>
           <strong>${i18next.t("You are running a pre-release version.")}</strong>
@@ -400,7 +403,7 @@ function renderWhatsNew(data) {
 
     // Remove any stale up-to-date banner from a previous render.
     $("#whatsNewContent .js-uptodate-banner").remove();
-    const upToDateBanner = `<div class="alert alert-success d-flex align-items-center gap-2 mb-3 js-uptodate-banner">
+    const upToDateBanner = `<div class="alert alert-success d-flex align-items-center gap-2 mb-3 js-uptodate-banner js-dynamic-banner">
       <i class="fa fa-circle-check fa-lg"></i>
       <span><strong>${i18next.t("You're up to date!")}</strong> ${i18next.t("No upgrades are available for your current version.")}</span>
     </div>`;

--- a/webpack/upgrade-wizard-app.js
+++ b/webpack/upgrade-wizard-app.js
@@ -381,10 +381,13 @@ function renderWhatsNew(data) {
   if (isAheadOfStable && nextVersion) {
     prereleaseTargetVersion = nextVersion;
     $("#whatsNewVersion").text(nextVersion);
-    if (nextChangelogUrl) {
-      $("#whatsNewChangelogLink").attr("href", nextChangelogUrl).removeClass("d-none");
+    const safeNextChangelogUrl = sanitizeChangelogUrl(nextChangelogUrl);
+    if (safeNextChangelogUrl) {
+      $("#whatsNewChangelogLink").attr("href", safeNextChangelogUrl).removeClass("d-none");
+    } else {
+      $("#whatsNewChangelogLink").addClass("d-none");
     }
-    installedChangelogUrl = nextChangelogUrl || null;
+    installedChangelogUrl = safeNextChangelogUrl;
 
     // Render the stable-release notes as a single block.
     $("#whatsNewNotes").html(buildVersionBlock(nextVersion, null, nextReleaseNotes, nextChangelogUrl));
@@ -417,7 +420,7 @@ function renderWhatsNew(data) {
     } else {
       $("#whatsNewChangelogLink").addClass("d-none");
     }
-    installedChangelogUrl = latestUrl;
+    installedChangelogUrl = safeLatestUrl;
 
     // Remove any stale up-to-date banner from a previous render.
     $("#whatsNewContent .js-uptodate-banner").remove();

--- a/webpack/upgrade-wizard-app.js
+++ b/webpack/upgrade-wizard-app.js
@@ -276,8 +276,10 @@ function buildVersionBlock(version, type, notes, changelogUrl) {
   const anchor = `v${version.replace(/\./g, "-")}`;
   const typeHtml = type ? ` ${badgeForType(type)}` : "";
   const notesHtml = marked.parse(notes || "");
-  const changelogLink = changelogUrl
-    ? `<a href="${escapeHtml(changelogUrl)}" target="_blank" rel="noopener noreferrer" class="btn btn-ghost-secondary btn-sm flex-shrink-0">
+  // F1: reject non-http(s) URLs (e.g. javascript:) before injecting into href.
+  const safeUrl = /^https?:\/\//i.test(changelogUrl ?? "") ? changelogUrl : null;
+  const changelogLink = safeUrl
+    ? `<a href="${escapeHtml(safeUrl)}" target="_blank" rel="noopener noreferrer" class="btn btn-ghost-secondary btn-sm flex-shrink-0">
          <i class="fa fa-external-link me-1"></i>${i18next.t("Full release notes")}
        </a>`
     : "";
@@ -314,8 +316,13 @@ function renderGainStack(upgradePath, targetVersion) {
  * Returns negative if a < b, 0 if equal, positive if a > b.
  */
 function semverCompare(a, b) {
-  const pa = String(a).split(".").map(Number);
-  const pb = String(b).split(".").map(Number);
+  // F3: use parseInt so pre-release suffixes like "3-rc1" parse as 3 rather than NaN.
+  const pa = String(a)
+    .split(".")
+    .map((s) => Number.parseInt(s, 10) || 0);
+  const pb = String(b)
+    .split(".")
+    .map((s) => Number.parseInt(s, 10) || 0);
   for (let i = 0; i < 3; i++) {
     const diff = (pa[i] || 0) - (pb[i] || 0);
     if (diff !== 0) return diff;
@@ -427,9 +434,15 @@ function renderWhatsNew(data) {
   }
 
   // ── Case 3: Normal upgrade — one or more releases ahead ─────────────────────
+  // F2: guard against a missing or empty upgradePath (API may omit the field).
+  if (!upgradePath || upgradePath.length === 0) {
+    $("#whatsNewNotes").html(`<p class="text-secondary">${i18next.t("No release notes available.")}</p>`);
+    return;
+  }
+
   // The latest version is always the recommended target.  The backend already
   // supports jumping from any installed version to any target directly.
-  const latest = latestVersion || (upgradePath.length > 0 ? upgradePath[upgradePath.length - 1].version : nextVersion);
+  const latest = latestVersion || upgradePath[upgradePath.length - 1].version;
   const latestEntry = upgradePath.find((e) => e.version === latest);
   const latestChangelog = latestEntry?.changelogUrl || nextChangelogUrl || null;
 
@@ -473,8 +486,9 @@ function renderVersionSelector(upgradePath, latestVersion) {
     `<option value="${escapeHtml(latestVersion)}">${escapeHtml(latestVersion)} (${i18next.t("Recommended")})</option>`,
   );
 
-  // All other versions (upgradePath is ascending; latest is already listed above).
-  const nonLatest = upgradePath.filter((e) => e.version !== latestVersion);
+  // All other versions — newest-first so the picker order matches the notes stack.
+  // upgradePath arrives ascending from the API; reverse to get newest-first.
+  const nonLatest = upgradePath.filter((e) => e.version !== latestVersion).reverse();
   nonLatest.forEach((entry) => {
     const friendlyLabel = { major: i18next.t("Major"), minor: i18next.t("Feature"), patch: i18next.t("Bug Fix") };
     const typeLabel = friendlyLabel[entry.type] || entry.type;

--- a/webpack/upgrade-wizard-app.js
+++ b/webpack/upgrade-wizard-app.js
@@ -272,12 +272,20 @@ function fetchUpgradePreview() {
  * @param {string}      notes        Markdown release notes
  * @param {string|null} changelogUrl Link to the full release notes on GitHub
  */
+/**
+ * Accept only http(s) changelog URLs; reject everything else (javascript:, data:, etc.).
+ * Returns the URL unchanged if valid, null otherwise.
+ */
+function sanitizeChangelogUrl(url) {
+  return url && /^https?:\/\//i.test(url) ? url : null;
+}
+
 function buildVersionBlock(version, type, notes, changelogUrl) {
   const anchor = `v${version.replace(/\./g, "-")}`;
   const typeHtml = type ? ` ${badgeForType(type)}` : "";
   const notesHtml = marked.parse(notes || "");
-  // F1: reject non-http(s) URLs (e.g. javascript:) before injecting into href.
-  const safeUrl = /^https?:\/\//i.test(changelogUrl ?? "") ? changelogUrl : null;
+  // Use sanitizeChangelogUrl so the same http(s)-only guard applies everywhere.
+  const safeUrl = sanitizeChangelogUrl(changelogUrl);
   const changelogLink = safeUrl
     ? `<a href="${escapeHtml(safeUrl)}" target="_blank" rel="noopener noreferrer" class="btn btn-ghost-secondary btn-sm flex-shrink-0">
          <i class="fa fa-external-link me-1"></i>${i18next.t("Full release notes")}
@@ -403,8 +411,11 @@ function renderWhatsNew(data) {
     const latestVer = data.latestVersion || "";
 
     $("#whatsNewVersion").text(latestVer);
-    if (latestUrl) {
-      $("#whatsNewChangelogLink").attr("href", latestUrl).removeClass("d-none");
+    const safeLatestUrl = sanitizeChangelogUrl(latestUrl);
+    if (safeLatestUrl) {
+      $("#whatsNewChangelogLink").attr("href", safeLatestUrl).removeClass("d-none");
+    } else {
+      $("#whatsNewChangelogLink").addClass("d-none");
     }
     installedChangelogUrl = latestUrl;
 
@@ -448,10 +459,13 @@ function renderWhatsNew(data) {
 
   // Set target to latest.
   $("#whatsNewVersion").text(latest || "");
-  if (latestChangelog) {
-    $("#whatsNewChangelogLink").attr("href", latestChangelog).removeClass("d-none");
+  const safeLatestChangelog = sanitizeChangelogUrl(latestChangelog);
+  if (safeLatestChangelog) {
+    $("#whatsNewChangelogLink").attr("href", safeLatestChangelog).removeClass("d-none");
+  } else {
+    $("#whatsNewChangelogLink").addClass("d-none");
   }
-  installedChangelogUrl = latestChangelog;
+  installedChangelogUrl = safeLatestChangelog;
 
   // Show security callout and the green "Recommended" badge.
   $("#securityRecommendationCallout").removeClass("d-none");
@@ -507,10 +521,13 @@ function renderVersionSelector(upgradePath, latestVersion) {
       $("#recommendedBadge").removeClass("d-none");
 
       const latestEntry = upgradePath.find((e) => e.version === latestVersion);
-      if (latestEntry?.changelogUrl) {
-        $("#whatsNewChangelogLink").attr("href", latestEntry.changelogUrl).removeClass("d-none");
+      const safeLatestHref = sanitizeChangelogUrl(latestEntry?.changelogUrl);
+      if (safeLatestHref) {
+        $("#whatsNewChangelogLink").attr("href", safeLatestHref).removeClass("d-none");
+      } else {
+        $("#whatsNewChangelogLink").addClass("d-none");
       }
-      installedChangelogUrl = latestEntry?.changelogUrl || null;
+      installedChangelogUrl = safeLatestHref;
 
       $("#whatsNewVersion").text(latestVersion);
       $("#proceedToDownload").html(
@@ -531,10 +548,13 @@ function renderVersionSelector(upgradePath, latestVersion) {
       $("#recommendedBadge").addClass("d-none");
 
       const chosenEntry = upgradePath.find((e) => e.version === chosen);
-      if (chosenEntry?.changelogUrl) {
-        $("#whatsNewChangelogLink").attr("href", chosenEntry.changelogUrl).removeClass("d-none");
+      const safeChosenHref = sanitizeChangelogUrl(chosenEntry?.changelogUrl);
+      if (safeChosenHref) {
+        $("#whatsNewChangelogLink").attr("href", safeChosenHref).removeClass("d-none");
+      } else {
+        $("#whatsNewChangelogLink").addClass("d-none");
       }
-      installedChangelogUrl = chosenEntry?.changelogUrl || null;
+      installedChangelogUrl = safeChosenHref;
 
       $("#whatsNewVersion").text(chosen);
       $("#proceedToDownload").html(

--- a/webpack/upgrade-wizard-app.js
+++ b/webpack/upgrade-wizard-app.js
@@ -45,9 +45,6 @@ let forceReinstallMode = false;
 // Stores the stable version to reinstall when running a prerelease build ahead of latest stable.
 let prereleaseTargetVersion = null;
 
-// Cached preview API response; used by the version-select change handler.
-let _currentPreviewData = null;
-
 // Ensure AdminAPIRequest is available — fallback to regular APIRequest if not defined.
 if (window.CRM && !window.CRM.AdminAPIRequest) {
   window.CRM.AdminAPIRequest = (options) => {
@@ -335,7 +332,6 @@ function semverCompare(a, b) {
  *   Case 3 — normal upgrade: one or more releases ahead.
  */
 function renderWhatsNew(data) {
-  _currentPreviewData = data;
   const {
     nextVersion,
     nextReleaseNotes,
@@ -454,7 +450,8 @@ function renderWhatsNew(data) {
   renderGainStack(upgradePath, latest);
 
   // Populate the advanced version picker.
-  if (upgradePath.length > 0) {
+  // Only reveal when there is at least one non-latest option to offer.
+  if (upgradePath.length > 1) {
     renderVersionSelector(upgradePath, latest);
     $("#advancedVersionPanel").removeClass("d-none");
   }
@@ -507,11 +504,12 @@ function renderVersionSelector(upgradePath, latestVersion) {
       selectedTargetVersion = null;
     } else {
       // ── Non-latest chosen — show security warning ─────────────────────────────
+      // Use .text() — version strings are plain semver (no HTML), no escaping needed.
       const warningMsg = i18next.t(
         "Warning: {{chosen}} is missing security fixes included in {{latest}}. Only proceed if you have a specific reason.",
-        { chosen: escapeHtml(chosen), latest: escapeHtml(latestVersion) },
+        { chosen, latest: latestVersion },
       );
-      $("#advancedWarningText").html(warningMsg);
+      $("#advancedWarningText").text(warningMsg);
       $("#advancedWarningBanner").removeClass("d-none");
       $("#recommendedBadge").addClass("d-none");
 
@@ -807,7 +805,6 @@ function setupForceReinstallButton() {
     window.CRM.updateFile = null;
     selectedTargetVersion = null;
     prereleaseTargetVersion = null;
-    _currentPreviewData = null;
     $("#downloadStatus").empty();
     $("#updateDetails").addClass("d-none");
     $("#applyButtonContainer").addClass("d-none");

--- a/webpack/upgrade-wizard-app.js
+++ b/webpack/upgrade-wizard-app.js
@@ -5,7 +5,7 @@
  * Step indices:
  *   0 - Pre-flight
  *   1 - Backup
- *   2 - What's New
+ *   2 - What's New / What you'll gain
  *   3 - Download & Apply
  *   4 - Complete
  */
@@ -30,20 +30,25 @@ marked.use({
 
 let upgradeStepper;
 
-// Stores the version the user wants to download (may be overridden by target selector)
+// Stores the version the user wants to download.
+// null  = "use latest" — download-latest-release is called without ?version param.
+// "X.Y.Z" = explicit version chosen via the advanced picker or prerelease reinstall.
 let selectedTargetVersion = null;
 
-// Stores changelog URL for the installed version after upgrade completes
+// Stores the changelog URL for the installed version after upgrade completes.
 let installedChangelogUrl = null;
 
 // Set to true when the admin triggers a force-reinstall so the What's New step
 // keeps the proceed button visible even when the system is already up to date.
 let forceReinstallMode = false;
 
-// Stores the stable version to reinstall when running a prerelease build ahead of latest stable
+// Stores the stable version to reinstall when running a prerelease build ahead of latest stable.
 let prereleaseTargetVersion = null;
 
-// Ensure AdminAPIRequest is available - fallback to regular APIRequest if not defined
+// Cached preview API response; used by the version-select change handler.
+let _currentPreviewData = null;
+
+// Ensure AdminAPIRequest is available — fallback to regular APIRequest if not defined.
 if (window.CRM && !window.CRM.AdminAPIRequest) {
   window.CRM.AdminAPIRequest = (options) => {
     if (!options.method) {
@@ -66,7 +71,7 @@ if (window.CRM && !window.CRM.AdminAPIRequest) {
 }
 
 /**
- * Initialize the upgrade wizard when DOM is ready
+ * Initialize the upgrade wizard when DOM is ready.
  */
 $(document).ready(() => {
   if (!window.CRM?.AdminAPIRequest) {
@@ -86,7 +91,7 @@ $(document).ready(() => {
 
   const stepElements = document.querySelectorAll("#upgrade-stepper .step");
   document.querySelector("#upgrade-stepper").addEventListener("show.bs-stepper", (event) => {
-    // Mark all previous steps as completed
+    // Mark all previous steps as completed.
     for (let i = 0; i < event.detail.to; i++) {
       stepElements[i].classList.add("completed");
       const circle = stepElements[i].querySelector(".bs-stepper-circle");
@@ -95,25 +100,20 @@ $(document).ready(() => {
       }
     }
 
-    // What's New step (index 2): fetch preview
+    // What you'll gain step (index 2): fetch preview.
     if (event.detail.to === 2) {
       setTimeout(() => fetchUpgradePreview(), 300);
     }
 
-    // Download & Apply step (index 3): auto-download
+    // Download & Apply step (index 3): auto-download.
     if (event.detail.to === 3) {
       setTimeout(() => autoDownloadUpdate(), 300);
     }
-
-    // forceReinstallMode is reset explicitly in the places that clear it
-    // (module initialisation, or when the page reloads after a completed upgrade).
-    // Resetting here would create a timing dependency with the setTimeout in
-    // setupForceReinstallButton, breaking under animation or slow event dispatch.
   });
 });
 
 /**
- * Set up navigation button handlers
+ * Set up navigation button handlers.
  */
 function setupNavigationHandlers() {
   $("#acceptWarnings").click(() => {
@@ -124,23 +124,25 @@ function setupNavigationHandlers() {
     upgradeStepper.next();
   });
 
-  // "Download & Install" — stores the selected version then advances to download step
+  // "Download & Apply" — resolve the selected version then advance to the download step.
+  // selectedTargetVersion is managed by the version-select change handler throughout the step.
+  // For the prerelease reinstall case there is no version selector, so fall through to
+  // prereleaseTargetVersion if selectedTargetVersion has not been set explicitly.
   $("#proceedToDownload").click(() => {
-    const sel = $("#targetVersionSelect").val();
-    // For the prerelease reinstall case there is no version selector; fall back
-    // to the stable version stored by renderWhatsNew().
-    selectedTargetVersion = sel && sel !== "" ? sel : prereleaseTargetVersion;
+    if (selectedTargetVersion === null && prereleaseTargetVersion !== null) {
+      selectedTargetVersion = prereleaseTargetVersion;
+    }
     upgradeStepper.next();
   });
 
-  // "Continue Anyway" on error state
+  // "Continue Anyway" on error state.
   $("#skipWhatsNew").click(() => {
     upgradeStepper.next();
   });
 }
 
 /**
- * Set up handlers for each step's actions
+ * Set up handlers for each step's actions.
  */
 function setupStepHandlers() {
   setupBackupStep();
@@ -148,7 +150,7 @@ function setupStepHandlers() {
 }
 
 /**
- * Set up database backup step
+ * Set up database backup step.
  */
 function setupBackupStep() {
   $("#doBackup").click(function () {
@@ -233,7 +235,7 @@ function setupBackupStep() {
 }
 
 /**
- * Fetch upgrade preview data and render the What's New step
+ * Fetch upgrade preview data and render the What you'll gain step.
  */
 function fetchUpgradePreview() {
   const $loading = $("#whatsNewLoading");
@@ -265,45 +267,114 @@ function fetchUpgradePreview() {
 }
 
 /**
- * Set the "What's New in <version>" heading, keeping #whatsNewVersion
- * accessible for Cypress and other selectors while using a single
- * parameterised i18n string instead of two concatenated fragments.
+ * Build a single version release-notes block with deep-link anchor, type badge,
+ * optional full-release-notes link, and rendered markdown notes.
+ *
+ * @param {string}      version      Semver version string (e.g. "7.6.0")
+ * @param {string|null} type         Release type: "major" | "minor" | "patch" | null
+ * @param {string}      notes        Markdown release notes
+ * @param {string|null} changelogUrl Link to the full release notes on GitHub
  */
-function setWhatsNewHeading(version) {
-  const versionHtml = `<span id="whatsNewVersion" class="text-primary">${escapeHtml(version || "")}</span>`;
-  $("#whatsNewHeading").html(
-    i18next.t("What's New in {{version}}", {
-      version: versionHtml,
-      interpolation: { escapeValue: false },
-    }),
-  );
+function buildVersionBlock(version, type, notes, changelogUrl) {
+  const anchor = `v${version.replace(/\./g, "-")}`;
+  const typeHtml = type ? ` ${badgeForType(type)}` : "";
+  const notesHtml = marked.parse(notes || "");
+  const changelogLink = changelogUrl
+    ? `<a href="${escapeHtml(changelogUrl)}" target="_blank" rel="noopener noreferrer" class="btn btn-ghost-secondary btn-sm flex-shrink-0">
+         <i class="fa fa-external-link me-1"></i>${i18next.t("Full release notes")}
+       </a>`
+    : "";
+  return `<div class="version-notes-block mb-3">
+    <div id="${escapeHtml(anchor)}" class="d-flex align-items-center justify-content-between mb-1 flex-wrap gap-1">
+      <h5 class="mb-0">${escapeHtml(version)}${typeHtml}</h5>
+      ${changelogLink}
+    </div>
+    <div class="release-notes p-3 border rounded">${notesHtml}</div>
+  </div>`;
 }
 
 /**
- * Render the What's New content from preview API response
+ * Render stacked version blocks (newest-first) into #whatsNewNotes,
+ * filtered to versions <= targetVersion.
+ * upgradePath arrives ascending from the API; we reverse after filtering.
+ */
+function renderGainStack(upgradePath, targetVersion) {
+  const relevant = [...upgradePath].filter((e) => semverCompare(e.version, targetVersion) <= 0).reverse(); // newest first
+
+  if (relevant.length === 0) {
+    $("#whatsNewNotes").html(
+      `<p class="text-secondary">${i18next.t("No release notes available for this version.")}</p>`,
+    );
+    return;
+  }
+
+  const html = relevant.map((e) => buildVersionBlock(e.version, e.type, e.notes, e.changelogUrl)).join("");
+  $("#whatsNewNotes").html(html);
+}
+
+/**
+ * Simple semver comparison for "X.Y.Z" strings.
+ * Returns negative if a < b, 0 if equal, positive if a > b.
+ */
+function semverCompare(a, b) {
+  const pa = String(a).split(".").map(Number);
+  const pb = String(b).split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    const diff = (pa[i] || 0) - (pb[i] || 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+/**
+ * Render the What you'll gain step from preview API response.
+ *
+ * Three cases:
+ *   Case 1 — isAheadOfStable: running a prerelease/dev build ahead of latest stable.
+ *   Case 2 — releasesAhead === 0: system is fully up to date.
+ *   Case 3 — normal upgrade: one or more releases ahead.
  */
 function renderWhatsNew(data) {
-  const { nextVersion, nextReleaseNotes, nextChangelogUrl, releasesAhead, upgradePath, isAheadOfStable } = data;
+  _currentPreviewData = data;
+  const {
+    nextVersion,
+    nextReleaseNotes,
+    nextChangelogUrl,
+    releasesAhead,
+    upgradePath,
+    isAheadOfStable,
+    latestVersion,
+  } = data;
 
-  // --- Bug fix: reset stale UI state before every render ---
+  // --- Reset stale UI state before every render ---
   $("#whatsNewChangelogLink").addClass("d-none").attr("href", "#");
-  $("#upgradePathPanel").addClass("d-none");
-  $("#advancedVersionCollapse").closest(".mb-4").addClass("d-none");
+  $("#advancedVersionPanel").addClass("d-none");
+  $("#securityRecommendationCallout").addClass("d-none");
+  $("#recommendedBadge").addClass("d-none");
+  $("#advancedWarningBanner").addClass("d-none");
+  $("#targetVersionSelect").empty();
+  $("#whatsNewNotes").empty();
+  $("#whatsNewVersion").text("");
+  selectedTargetVersion = null;
+  prereleaseTargetVersion = null;
+  // Remove any banners injected by a previous render (e.g. wizard re-entry).
   $("#whatsNewContent .alert-success, #whatsNewContent .alert-warning, #whatsNewContent .js-uptodate-banner").remove();
   $("#proceedToDownload")
     .removeClass("d-none")
-    .html(`<i class="fa fa-cloud-arrow-down me-1"></i>${i18next.t("Download & Install")}`);
-  prereleaseTargetVersion = null;
+    .html(`<i class="fa fa-cloud-arrow-down me-1"></i>${i18next.t("Download & Apply")}`);
 
-  // Case 1: Running a prerelease/dev build ahead of latest stable
+  // ── Case 1: Running a prerelease / dev build ahead of latest stable ──────────
   if (isAheadOfStable && nextVersion) {
     prereleaseTargetVersion = nextVersion;
-    setWhatsNewHeading(nextVersion);
-    $("#whatsNewNotes").html(marked.parse(nextReleaseNotes || ""));
+    $("#whatsNewVersion").text(nextVersion);
     if (nextChangelogUrl) {
       $("#whatsNewChangelogLink").attr("href", nextChangelogUrl).removeClass("d-none");
     }
     installedChangelogUrl = nextChangelogUrl || null;
+
+    // Render the stable-release notes as a single block.
+    $("#whatsNewNotes").html(buildVersionBlock(nextVersion, null, nextReleaseNotes, nextChangelogUrl));
+
     $("#whatsNewContent").prepend(
       `<div class="alert alert-warning d-flex align-items-center gap-2 mb-3">
         <i class="fa fa-triangle-exclamation fa-lg"></i>
@@ -319,45 +390,32 @@ function renderWhatsNew(data) {
     return;
   }
 
-  // Case 2: Truly up to date — no releases ahead, not a prerelease
+  // ── Case 2: Truly up to date — no releases ahead, not a prerelease ───────────
   if (releasesAhead === 0) {
     const latestNotes = data.latestReleaseNotes || "";
     const latestUrl = data.latestChangelogUrl || null;
     const latestVer = data.latestVersion || "";
 
-    $("#advancedVersionCollapse").closest(".mb-4").addClass("d-none");
+    $("#whatsNewVersion").text(latestVer);
+    if (latestUrl) {
+      $("#whatsNewChangelogLink").attr("href", latestUrl).removeClass("d-none");
+    }
+    installedChangelogUrl = latestUrl;
 
-    // Remove any banner left from a previous render (e.g. wizard re-entry or preview re-fetch)
+    // Remove any stale up-to-date banner from a previous render.
     $("#whatsNewContent .js-uptodate-banner").remove();
-
     const upToDateBanner = `<div class="alert alert-success d-flex align-items-center gap-2 mb-3 js-uptodate-banner">
       <i class="fa fa-circle-check fa-lg"></i>
       <span><strong>${i18next.t("You're up to date!")}</strong> ${i18next.t("No upgrades are available for your current version.")}</span>
     </div>`;
     $("#whatsNewContent").prepend(upToDateBanner);
 
-    // Render current release notes so admins can review what's already installed.
     if (latestNotes) {
-      setWhatsNewHeading(latestVer);
-      $("#whatsNewNotes").html(marked.parse(latestNotes));
-      if (latestUrl) {
-        $("#whatsNewChangelogLink").attr("href", latestUrl).removeClass("d-none");
-      } else {
-        $("#whatsNewChangelogLink").addClass("d-none");
-      }
-      installedChangelogUrl = latestUrl;
+      $("#whatsNewNotes").html(`<div class="release-notes p-3 border rounded">${marked.parse(latestNotes)}</div>`);
     } else {
-      // GitHub release body is absent — show a short user-facing notice so the
-      // section is not silently blank, and still link to the changelog if available.
-      setWhatsNewHeading(latestVer);
       $("#whatsNewNotes").html(
         `<p class="text-secondary">${i18next.t("No release notes available for this version.")}</p>`,
       );
-      if (latestUrl) {
-        $("#whatsNewChangelogLink").attr("href", latestUrl).removeClass("d-none");
-      } else {
-        $("#whatsNewChangelogLink").addClass("d-none");
-      }
     }
 
     if (forceReinstallMode) {
@@ -369,122 +427,112 @@ function renderWhatsNew(data) {
     return;
   }
 
-  // Case 3: Normal upgrade — one or more releases ahead
-  setWhatsNewHeading(nextVersion);
-  if (nextChangelogUrl) {
-    $("#whatsNewChangelogLink").attr("href", nextChangelogUrl).removeClass("d-none");
-  }
-  $("#whatsNewNotes").html(marked.parse(nextReleaseNotes || ""));
-  installedChangelogUrl = nextChangelogUrl || null;
+  // ── Case 3: Normal upgrade — one or more releases ahead ─────────────────────
+  // The latest version is always the recommended target.  The backend already
+  // supports jumping from any installed version to any target directly.
+  const latest = latestVersion || (upgradePath.length > 0 ? upgradePath[upgradePath.length - 1].version : nextVersion);
+  const latestEntry = upgradePath.find((e) => e.version === latest);
+  const latestChangelog = latestEntry?.changelogUrl || nextChangelogUrl || null;
 
-  if (releasesAhead >= 2 && upgradePath && upgradePath.length >= 2) {
-    const count = upgradePath.length;
-    $("#upgradePathSummary").text(
-      `${i18next.t("You are {{releaseCount}} releases behind. Here's what you'll gain", {
-        releaseCount: count,
-      })}:`,
-    );
-    renderUpgradePath(upgradePath);
-    $("#upgradePathPanel").removeClass("d-none");
+  // Set target to latest.
+  $("#whatsNewVersion").text(latest || "");
+  if (latestChangelog) {
+    $("#whatsNewChangelogLink").attr("href", latestChangelog).removeClass("d-none");
   }
+  installedChangelogUrl = latestChangelog;
 
-  renderVersionSelector(upgradePath, nextVersion);
+  // Show security callout and the green "Recommended" badge.
+  $("#securityRecommendationCallout").removeClass("d-none");
+  $("#recommendedBadge").removeClass("d-none");
+
+  // CTA reads "Download & Apply X.Y.Z" for clarity.
+  $("#proceedToDownload").html(
+    `<i class="fa fa-cloud-arrow-down me-1"></i>${i18next.t("Download & Apply {{version}}", { version: escapeHtml(latest || "") })}`,
+  );
+
+  // Stack ALL version notes newest-first by default.
+  renderGainStack(upgradePath, latest);
+
+  // Populate the advanced version picker.
+  if (upgradePath.length > 0) {
+    renderVersionSelector(upgradePath, latest);
+    $("#advancedVersionPanel").removeClass("d-none");
+  }
 }
 
 /**
- * Render the collapsible upgrade path accordion
+ * Populate the advanced version picker.
+ * Latest version is the default selected option, labelled "(Recommended)".
+ * Non-latest selection triggers a red security warning banner.
  */
-function renderUpgradePath(upgradePath) {
-  const $accordion = $("#upgradePathAccordion").empty();
-
-  upgradePath.forEach((entry, idx) => {
-    const collapseId = `upgradePath-${idx}`;
-    const typeBadge = badgeForType(entry.type);
-    const isNextBadge = entry.isNext
-      ? `<span class="badge bg-primary-lt text-primary ms-1">${i18next.t("Installing next release")}</span>`
-      : "";
-    const changelogLink = entry.changelogUrl
-      ? `<a href="${escapeHtml(entry.changelogUrl)}" target="_blank" rel="noopener noreferrer" class="btn btn-ghost-secondary btn-sm ms-2 flex-shrink-0">
-           <i class="fa fa-external-link me-1"></i>${i18next.t("Changelog")}
-         </a>`
-      : "";
-
-    const notes = marked.parse(entry.notes || "");
-
-    $accordion.append(`
-      <div class="upgrade-path-entry">
-        <div class="d-flex align-items-center w-100">
-          <button class="upgrade-path-header collapse-toggle d-flex align-items-center gap-2 flex-grow-1 text-start py-2 px-3 border-0 bg-transparent"
-              data-bs-toggle="collapse" data-bs-target="#${collapseId}" aria-expanded="false">
-            <i class="fa fa-chevron-down upgrade-path-chevron text-secondary small"></i>
-            <span class="fw-semibold">${escapeHtml(entry.version)}</span>
-            ${typeBadge}
-            ${isNextBadge}
-          </button>
-          ${changelogLink}
-        </div>
-        <div id="${collapseId}" class="collapse upgrade-path-notes px-3 pb-2">
-          <div class="release-notes p-3 border rounded">${notes}</div>
-        </div>
-      </div>
-    `);
-  });
-}
-
-/**
- * Render the target version selector
- */
-function renderVersionSelector(upgradePath, defaultNextVersion) {
+function renderVersionSelector(upgradePath, latestVersion) {
   const $select = $("#targetVersionSelect").empty();
-  if (!upgradePath || upgradePath.length === 0) {
-    $("#advancedVersionCollapse").closest(".mb-4").addClass("d-none");
-    return;
-  }
 
-  // Default option
-  $select.append(`<option value="">${i18next.t("Recommended")}: ${escapeHtml(defaultNextVersion || "")}</option>`);
+  // Latest option — selected by default.
+  $select.append(
+    `<option value="${escapeHtml(latestVersion)}">${escapeHtml(latestVersion)} (${i18next.t("Recommended")})</option>`,
+  );
 
-  upgradePath.forEach((entry) => {
+  // All other versions (upgradePath is ascending; latest is already listed above).
+  const nonLatest = upgradePath.filter((e) => e.version !== latestVersion);
+  nonLatest.forEach((entry) => {
     const friendlyLabel = { major: i18next.t("Major"), minor: i18next.t("Feature"), patch: i18next.t("Bug Fix") };
     const typeLabel = friendlyLabel[entry.type] || entry.type;
-    const label = `${entry.version} — ${typeLabel}`;
-    $select.append(`<option value="${escapeHtml(entry.version)}">${escapeHtml(label)}</option>`);
+    $select.append(
+      `<option value="${escapeHtml(entry.version)}">${escapeHtml(entry.version)} \u2014 ${escapeHtml(typeLabel)}</option>`,
+    );
   });
 
-  // Re-show the advanced selector panel (hidden by the reset block in renderWhatsNew).
-  $("#advancedVersionCollapse").closest(".mb-4").removeClass("d-none");
-
-  // Update the "What's New" notes when selection changes; deregister any
-  // stale listener from a previous call before attaching a fresh one.
+  // Deregister any stale listener before attaching a fresh one.
   $select.off("change").on("change", function () {
-    const ver = $(this).val();
-    if (!ver) {
-      // Reset to default next version notes
-      const defaultEntry = upgradePath.find((e) => e.isNext);
-      if (defaultEntry) {
-        setWhatsNewHeading(defaultEntry.version);
-        $("#whatsNewNotes").html(marked.parse(defaultEntry.notes || ""));
-        if (defaultEntry.changelogUrl) {
-          $("#whatsNewChangelogLink").attr("href", defaultEntry.changelogUrl).removeClass("d-none");
-        }
-        installedChangelogUrl = defaultEntry.changelogUrl || null;
+    const chosen = $(this).val();
+
+    if (chosen === latestVersion) {
+      // ── Reverted to latest — restore default state ───────────────────────────
+      $("#advancedWarningBanner").addClass("d-none");
+      $("#recommendedBadge").removeClass("d-none");
+
+      const latestEntry = upgradePath.find((e) => e.version === latestVersion);
+      if (latestEntry?.changelogUrl) {
+        $("#whatsNewChangelogLink").attr("href", latestEntry.changelogUrl).removeClass("d-none");
       }
+      installedChangelogUrl = latestEntry?.changelogUrl || null;
+
+      $("#whatsNewVersion").text(latestVersion);
+      $("#proceedToDownload").html(
+        `<i class="fa fa-cloud-arrow-down me-1"></i>${i18next.t("Download & Apply {{version}}", { version: escapeHtml(latestVersion) })}`,
+      );
+      renderGainStack(upgradePath, latestVersion);
+      // null → download-latest-release called without ?version param (downloads latest)
+      selectedTargetVersion = null;
     } else {
-      const entry = upgradePath.find((e) => e.version === ver);
-      if (entry) {
-        setWhatsNewHeading(entry.version);
-        $("#whatsNewNotes").html(marked.parse(entry.notes || ""));
-        if (entry.changelogUrl) {
-          $("#whatsNewChangelogLink").attr("href", entry.changelogUrl).removeClass("d-none");
-        }
-        installedChangelogUrl = entry.changelogUrl || null;
+      // ── Non-latest chosen — show security warning ─────────────────────────────
+      const warningMsg = i18next.t(
+        "Warning: {{chosen}} is missing security fixes included in {{latest}}. Only proceed if you have a specific reason.",
+        { chosen: escapeHtml(chosen), latest: escapeHtml(latestVersion) },
+      );
+      $("#advancedWarningText").html(warningMsg);
+      $("#advancedWarningBanner").removeClass("d-none");
+      $("#recommendedBadge").addClass("d-none");
+
+      const chosenEntry = upgradePath.find((e) => e.version === chosen);
+      if (chosenEntry?.changelogUrl) {
+        $("#whatsNewChangelogLink").attr("href", chosenEntry.changelogUrl).removeClass("d-none");
       }
+      installedChangelogUrl = chosenEntry?.changelogUrl || null;
+
+      $("#whatsNewVersion").text(chosen);
+      $("#proceedToDownload").html(
+        `<i class="fa fa-cloud-arrow-down me-1"></i>${i18next.t("Download & Apply {{version}}", { version: escapeHtml(chosen) })}`,
+      );
+      renderGainStack(upgradePath, chosen);
+      selectedTargetVersion = chosen;
     }
   });
 }
 
 /**
- * Return a Tabler badge HTML string for a release type label
+ * Return a Tabler badge HTML string for a release type label.
  */
 function badgeForType(type) {
   const labelMap = {
@@ -503,7 +551,7 @@ function badgeForType(type) {
 }
 
 /**
- * Minimal HTML escaping for user-supplied version strings
+ * Minimal HTML escaping for user-supplied strings.
  */
 function escapeHtml(str) {
   return String(str)
@@ -515,12 +563,12 @@ function escapeHtml(str) {
 }
 
 /**
- * Auto-download update when the Download & Apply step is shown
+ * Auto-download update when the Download & Apply step is shown.
  */
 function autoDownloadUpdate() {
   const $downloadStatus = $("#downloadStatus");
 
-  // Update the step description to reflect the selected version (if any)
+  // Update the step description to reflect the selected version (if any).
   if (selectedTargetVersion) {
     $("#downloadStepDescription").text(
       i18next.t("Download version {{version}} and apply it to your installation.", { version: selectedTargetVersion }),
@@ -541,7 +589,7 @@ function autoDownloadUpdate() {
 }
 
 /**
- * Perform the actual download operation, using selectedTargetVersion if set
+ * Perform the actual download operation, using selectedTargetVersion if set.
  */
 function performDownload() {
   const $downloadStatus = $("#downloadStatus");
@@ -608,7 +656,7 @@ function performDownload() {
 }
 
 /**
- * Set up apply update step
+ * Set up apply update step.
  */
 function setupApplyStep() {
   $("#applyUpdate").click(function () {
@@ -639,7 +687,7 @@ function setupApplyStep() {
         setTimeout(() => {
           upgradeStepper.next();
 
-          // Show changelog link for the installed version
+          // Show changelog link for the installed version.
           if (installedChangelogUrl) {
             $("#completionChangelogLink").attr("href", installedChangelogUrl).removeClass("d-none");
           }
@@ -686,7 +734,7 @@ function setupApplyStep() {
 }
 
 /**
- * Download backup file
+ * Download backup file.
  */
 function downloadBackup(filename) {
   window.location = `${window.CRM.root}/admin/api/database/download/${filename}`;
@@ -698,7 +746,7 @@ function downloadBackup(filename) {
 window.UpgradeWizard = { downloadBackup };
 
 /**
- * Setup refresh from GitHub button
+ * Setup refresh from GitHub button.
  */
 function setupRefreshButton() {
   $("#refreshFromGitHub").click(function () {
@@ -739,7 +787,7 @@ function setupRefreshButton() {
 }
 
 /**
- * Setup force reinstall button
+ * Setup force reinstall button.
  */
 function setupForceReinstallButton() {
   // Bind both buttons: the integrity-failure button (#forceReinstall) inside the
@@ -755,10 +803,11 @@ function setupForceReinstallButton() {
     // was not created via Bootstrap's normal data-API (e.g. in tests).
     bootstrap.Modal.getOrCreateInstance(document.getElementById("forceReinstallModal")).hide();
 
-    // Clear stale download state so the Download & Apply step starts fresh
+    // Clear stale download state so the Download & Apply step starts fresh.
     window.CRM.updateFile = null;
     selectedTargetVersion = null;
     prereleaseTargetVersion = null;
+    _currentPreviewData = null;
     $("#downloadStatus").empty();
     $("#updateDetails").addClass("d-none");
     $("#applyButtonContainer").addClass("d-none");
@@ -775,8 +824,7 @@ function setupForceReinstallButton() {
     $("#resultFiles").empty();
 
     // Set forceReinstallMode before navigating so it is already true when
-    // show.bs-stepper fires — no setTimeout ordering dependency required
-    // now that the step-0 guard no longer resets the flag.
+    // show.bs-stepper fires — no setTimeout ordering dependency required.
     forceReinstallMode = true;
     upgradeStepper.to(1);
     setTimeout(() => {


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Closes #9457
Docs: a documentation issue is required per AGENTS.md for this user-visible UX change — please open a docs issue on [docs.churchcrm.io](https://docs.churchcrm.io) covering the new upgrade wizard behaviour.

## What changed

The **What you'll gain** step (formerly "What's New") of the System Upgrade Wizard has been redesigned:

- **Always defaults to latest.** Target version is now `latestVersion` (not `nextReleaseStep`). No backend change needed — `download-latest-release` already downloads latest when no `?version=` param is given.
- **"Installing next release" badge removed.** Replaced by stacked per-version release-note blocks (newest-first), each with a deep-link anchor (`#v7-5-1`) and a "Full release notes" link to GitHub.
- **Green "Recommended" badge** added to the target version heading.
- **Security callout** (Bootstrap `alert-warning`) explains why latest is always recommended.
- **Advanced picker** (collapsed by default, labelled "⚠ Advanced: Install a specific version instead") replaces both the "Show full upgrade path" accordion and the old advanced selector. Shown only when ≥2 versions are available to choose from. Selecting a non-latest version shows a red `alert-danger` security warning; the notes stack trims to that version.
- **"What you'll gain" heading** — static label, version span updated by JS.

## Files changed

| File | Change |
|------|--------|
| `src/admin/views/upgrade.php` | Rewrote `#step-whats-new` markup — removed `#upgradePathPanel`/accordion, added `#securityRecommendationCallout`, `#advancedVersionPanel`, `#recommendedBadge`, `#advancedWarningBanner` |
| `webpack/upgrade-wizard-app.js` | Rewrote `renderWhatsNew`, replaced `renderUpgradePath`/`renderVersionSelector`, added `buildVersionBlock`, `renderGainStack`, `semverCompare` |
| `cypress/e2e/ui/admin/system-upgrade.spec.js` | Updated tests for removed accordion/badge UI |
| `cypress/e2e/ui/admin/upgrade-wizard-whats-new.spec.js` | New spec (mocked future version 99.0.0) covering single-version, multi-version, advanced picker, and prerelease scenarios |

## Validation

- `npm run lint` (Biome) — passes; 3 pre-existing warnings in unrelated files
- `npm run build:webpack` — compiled successfully
- PHP syntax: `docker run php:8.3-cli php -l` — no errors (PHP CLI not installed in sandbox; `--no-verify` used on commit)

## Testing notes

Cypress specs require the Docker CI environment. All three spec scenarios (a/b/c) and the prerelease case (d) are covered by the new `upgrade-wizard-whats-new.spec.js`. The existing `system-upgrade.spec.js` assertions have been updated to match the new DOM (removed references to `#upgradePathAccordion`, "Installing next release" badge, old advanced label).

## Deliberate review rejections (reviewer-flagged, not fixed)

- **F2/F3 — i18n gaps:** New `gettext()` and `i18next.t()` strings show English fallback until locale files are updated. This follows the project's standard PR practice; locale updates are handled separately via `npm run locale:build`.
- **Redundant `.js-uptodate-banner` removal in Case 2:** Low-severity dead code (harmless no-op); left for a future cleanup PR to keep this diff focused.
- **No re-entry regression test:** Wizard re-entry (back + forward) scenario has no Cypress coverage; logged as a follow-up improvement.