### PR TITLE
security: fix GHSA-9fgc-76p2-8mxh — stored XSS via CSV person import

### DIFF
--- a/src/ChurchCRM/utils/CustomFieldUtils.php
+++ b/src/ChurchCRM/utils/CustomFieldUtils.php
@@ -246,7 +246,7 @@ class CustomFieldUtils
 
                 foreach ($groupPeople as $p2g2r) {
                     $person = $p2g2r->getPerson();
-                    echo '<option value="' . $person->getId() . '"' . ($data == $person->getId() ? ' selected' : '') . '>' . $person->getFullName() . '</option>';
+                    echo '<option value="' . $person->getId() . '"' . ($data == $person->getId() ? ' selected' : '') . '>' . InputUtils::escapeHTML($person->getFullName()) . '</option>';
                 }
 
                 echo '</select></div>';

--- a/src/admin/routes/api/import.php
+++ b/src/admin/routes/api/import.php
@@ -662,7 +662,11 @@ $app->group('/api/import', function (RouteCollectorProxy $group): void {
                             $familyProps[$proId] = $value;
                         }
                     } else {
-                        $data[$crmField] = $value;
+                        // Core person/family fields are not prompted and were stored raw
+                        // before this fix. Sanitize at import to strip HTML/script tags so
+                        // that sinks which render names, addresses, etc. without escaping
+                        // cannot be exploited via a crafted CSV (GHSA-9fgc-76p2-8mxh).
+                        $data[$crmField] = InputUtils::sanitizeText($value);
                     }
                 }
 

--- a/src/v2/templates/cart/cartview.php
+++ b/src/v2/templates/cart/cartview.php
@@ -71,11 +71,11 @@ $ListTitleText = gettext('Your cart contains') . ' ' . count($cartPeople) . ' ' 
                     // fetch avatar info and set photo/initials as appropriate.
                     echo '<img data-image-entity-type="person" data-image-entity-id="' . $Person->getId() . '" class="avatar avatar-sm rounded-circle photo-small me-2" alt="" />';
                   ?>
-                  <a href="<?= $Person->getViewURI() ?>"><?= $Person->getFullName() ?></a>
+                  <a href="<?= $Person->getViewURI() ?>"><?= InputUtils::escapeHTML($Person->getFullName()) ?></a>
                 </div>
               </td>
-              <td><?= $Person->getAddress() ?></td>
-              <td><?= $Person->getEmail() ?></td>
+              <td><?= InputUtils::escapeHTML($Person->getAddress()) ?></td>
+              <td><?= InputUtils::escapeHTML($Person->getEmail()) ?></td>
               <td><?= $Person->getClassificationName() ?></td>
               <td><?= $Person->getFamilyRoleName() ?></td>
               <td>


### PR DESCRIPTION
## Summary

Fixes stored XSS vulnerability in the CSV person import workflow. Crafted CSV data could store unsanitized HTML/script content that would execute when names, addresses, or emails were rendered in views such as the cart and custom field dropdowns.

## Changes

- **`src/admin/routes/api/import.php`** — sanitize core person/family fields at import using `InputUtils::sanitizeText()`, stripping HTML/script tags before values are persisted.
- **`src/v2/templates/cart/cartview.php`** — escape `getFullName()`, `getAddress()`, and `getEmail()` at output with `InputUtils::escapeHTML()`.
- **`src/ChurchCRM/utils/CustomFieldUtils.php`** — escape `getFullName()` at output in person-picker `<option>` elements.

## Why

Belt-and-suspenders approach: sanitize at the import sink to prevent storing malicious content, and also escape at every known output sink so that data already in the database (from before this fix) cannot execute on render.

## Testing

- PHP syntax not validated in this container (PHP not installed); no PHP syntax changes introduce new constructs.
- Biome lint passes (3 pre-existing warnings in unrelated JS files).
- Changes are scoped to input sanitization and output escaping — no logic, routing, or schema changes.

## Related

Security advisory: https://github.com/ChurchCRM/CRM/security/advisories/GHSA-9fgc-76p2-8mxh