### PR TITLE
fix(i18n): translate Public/Private Calendar names in calendar sidebar

### DIFF
--- a/webpack/event-calendars.js
+++ b/webpack/event-calendars.js
@@ -326,7 +326,7 @@ window.calendarPropertiesModal = {
     window.calendarPropertiesModal.calendar = calendar;
     const bootboxmessage = window.calendarPropertiesModal.getBootboxContent(calendar);
     window.calendarPropertiesModal.modal = bootbox.dialog({
-      title: getLocalizedCalendarName(calendar.Name),
+      title: escapeHtml(getLocalizedCalendarName(calendar.Name)),
       message: bootboxmessage,
       show: true,
       buttons: window.calendarPropertiesModal.getButtons(),

--- a/webpack/event-calendars.js
+++ b/webpack/event-calendars.js
@@ -612,6 +612,19 @@ function GetCalendarSourceId(calendarType, calendarID) {
 }
 
 /**
+ * Escape a string for safe insertion into HTML context.
+ * Mirrors the same utility in event-form.js / system-settings-panel.js.
+ */
+function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+/**
  * Translate a calendar name when it matches one of the two DB-seeded default
  * calendar names ("Public Calendar", "Private Calendar"). Custom user-defined
  * names are returned unchanged (i18next.t passthrough returns the key as-is
@@ -652,7 +665,7 @@ function getCalendarFilterElement(calendar, type) {
     '"></span>' +
     '<div class="flex-fill">' +
     '<div class="fw-medium small d-flex align-items-center">' +
-    getLocalizedCalendarName(calendar.Name) +
+    escapeHtml(getLocalizedCalendarName(calendar.Name)) +
     publicBadge +
     "</div>" +
     "</div>" +
@@ -664,7 +677,7 @@ function getCalendarFilterElement(calendar, type) {
     '" data-calendarid="' +
     calendar.Id +
     '" aria-label="Toggle ' +
-    getLocalizedCalendarName(calendar.Name) +
+    escapeHtml(getLocalizedCalendarName(calendar.Name)) +
     ' calendar visibility"/>' +
     "</div>" +
     "</div>" +

--- a/webpack/event-calendars.js
+++ b/webpack/event-calendars.js
@@ -326,7 +326,7 @@ window.calendarPropertiesModal = {
     window.calendarPropertiesModal.calendar = calendar;
     const bootboxmessage = window.calendarPropertiesModal.getBootboxContent(calendar);
     window.calendarPropertiesModal.modal = bootbox.dialog({
-      title: calendar.Name,
+      title: getLocalizedCalendarName(calendar.Name),
       message: bootboxmessage,
       show: true,
       buttons: window.calendarPropertiesModal.getButtons(),
@@ -612,6 +612,24 @@ function GetCalendarSourceId(calendarType, calendarID) {
 }
 
 /**
+ * Translate a calendar name when it matches one of the two DB-seeded default
+ * calendar names ("Public Calendar", "Private Calendar"). Custom user-defined
+ * names are returned unchanged (i18next.t passthrough returns the key as-is
+ * for unknown strings). The explicit literal calls register these two msgids
+ * for the i18next-cli extractor so they reach the translation pipeline.
+ */
+function getLocalizedCalendarName(name) {
+  switch (name) {
+    case "Public Calendar":
+      return i18next.t("Public Calendar");
+    case "Private Calendar":
+      return i18next.t("Private Calendar");
+    default:
+      return name;
+  }
+}
+
+/**
  * Build a sidebar list-group item for a calendar with a BS5 form-switch toggle.
  */
 function getCalendarFilterElement(calendar, type) {
@@ -634,7 +652,7 @@ function getCalendarFilterElement(calendar, type) {
     '"></span>' +
     '<div class="flex-fill">' +
     '<div class="fw-medium small d-flex align-items-center">' +
-    calendar.Name +
+    getLocalizedCalendarName(calendar.Name) +
     publicBadge +
     "</div>" +
     "</div>" +
@@ -646,7 +664,7 @@ function getCalendarFilterElement(calendar, type) {
     '" data-calendarid="' +
     calendar.Id +
     '" aria-label="Toggle ' +
-    calendar.Name +
+    getLocalizedCalendarName(calendar.Name) +
     ' calendar visibility"/>' +
     "</div>" +
     "</div>" +


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

**Root cause:** The two default user calendars ("Public Calendar" / "Private Calendar") are seeded as literal English strings in the `calendars` DB table (`src/mysql/install/Install.sql` lines 210–211). The calendar sidebar (`webpack/event-calendars.js`) rendered `calendar.Name` directly from the API without going through `i18next`, while system calendars (Birthdays, Anniversaries, Fundraisers) get localized names via `gettext()` in their PHP `SystemCalendar` classes. The i18next-cli extractor only scans literal string args to `i18next.t()`; the DB term extractor does not scan the `calendars` table, so neither name was in the translation catalog.

**What changed:** `webpack/event-calendars.js`
- Added `getLocalizedCalendarName(name)` helper with explicit literal `i18next.t("Public Calendar")` / `i18next.t("Private Calendar")` calls. Literal calls are required for the i18next-cli extractor to register these msgids in the POEditor pipeline. Custom user-created names fall through the `default` branch (i18next returns the key as-is for unknown strings).
- Applied the helper at three render points: sidebar list label, toggle switch aria-label (name portion), and the calendar Properties modal title.

**Locale files:** Not modified — extraction and translation are handled by the automated POEditor workflow outside this repo.

**Testing:** `npm run lint` exit 0 (3 pre-existing warnings in unrelated files); `npm run build:webpack` compiled successfully.

**Note on reviewer finding:** The reviewer noted the `aria-label` surrounding text ("Toggle … calendar visibility") is still hardcoded English — a pre-existing gap not introduced by this PR. A follow-up to wrap the whole attribute in `i18next.t("Toggle {{name}} calendar visibility", {name})` would be the clean fix.