### PR TITLE
fix: Empty Cart to Group dropdown not showing groups or roles (#9465)

### DIFF
--- a/cypress/e2e/ui/groups/standard.empty-cart-to-group.spec.js
+++ b/cypress/e2e/ui/groups/standard.empty-cart-to-group.spec.js
@@ -106,7 +106,7 @@ describe("Empty Cart to Group", () => {
 
             // Close modal and clean up the test group
             cy.get(".modal.show .btn-close").click();
-            cy.get(".modal").should("not.have.class", "show");
+            cy.get(".modal.show").should("not.exist");
 
             cy.request({
                 method: "DELETE",
@@ -116,10 +116,8 @@ describe("Empty Cart to Group", () => {
     });
 
     it("shows role dropdown after selecting a group with multiple roles", () => {
-        // Use a group from seed data that has roles defined.
+        // Use a well-known group from seed data that has roles defined.
         // Group ID 11 ("Clergy") has role list 23 per seed data.
-        const TARGET_GROUP_ID = 11;
-
         cy.visit("/v2/cart");
 
         cy.window().should("have.property", "CRM");
@@ -159,7 +157,7 @@ describe("Empty Cart to Group", () => {
 
         // Click Cancel
         cy.get(".modal.show #crm-gs-cancel").click();
-        cy.get(".modal").should("not.have.class", "show");
+        cy.get(".modal.show").should("not.exist");
 
         // Cart should still have the person
         cy.request("GET", "/api/cart/").then((resp) => {

--- a/cypress/e2e/ui/groups/standard.empty-cart-to-group.spec.js
+++ b/cypress/e2e/ui/groups/standard.empty-cart-to-group.spec.js
@@ -1,0 +1,169 @@
+/// <reference types="cypress" />
+
+/**
+ * Regression tests for the "Empty Cart to Group" modal dialog.
+ *
+ * Issue: #9465 / #9051 — The Bootstrap 5 + TomSelect group-and-role selection
+ * modal was broken because `promptSelection` in CRMJSOM.js used a bootbox v6
+ * incompatible `.init()` chaining pattern and set `dropdownParent` to a DOM
+ * node rather than the string "body", causing TomSelect to initialize before
+ * the modal was fully visible and the dropdown list to be hidden or empty.
+ *
+ * Fix: rewrote `promptSelection` to use a native Bootstrap 5 modal with
+ * TomSelect initialized in the `shown.bs.modal` event, and `dropdownParent`
+ * set to "body" so TomSelect dropdown list is always visible.
+ */
+describe("Empty Cart to Group", () => {
+    const TEST_PERSON_ID = 1; // Church Admin — always exists in seed data
+
+    beforeEach(() => {
+        cy.setupStandardSession();
+
+        // Ensure a clean cart state for each test
+        cy.request({
+            method: "DELETE",
+            url: "/api/cart/",
+            headers: { "Content-Type": "application/json" },
+            body: {},
+        });
+
+        // Add a person to the cart so the "To Group" button is visible
+        cy.request({
+            method: "POST",
+            url: "/api/cart/",
+            headers: { "Content-Type": "application/json" },
+            body: { Persons: [TEST_PERSON_ID] },
+        });
+
+        cy.on("uncaught:exception", () => false);
+    });
+
+    afterEach(() => {
+        // Empty the cart after each test
+        cy.request({
+            method: "DELETE",
+            url: "/api/cart/",
+            headers: { "Content-Type": "application/json" },
+            body: {},
+        });
+    });
+
+    it("opens the group-selection modal when 'To Group' is clicked on the cart page", () => {
+        cy.visit("/v2/cart");
+
+        // Wait for the CRM and locales to be ready
+        cy.window().should("have.property", "CRM");
+        cy.window().its("CRM.localesLoaded").should("eq", true);
+        cy.window().its("CRM.cartManager").should("exist");
+
+        // The "To Group" button should be visible because the cart is non-empty
+        cy.get("#emptyCartToGroup").should("be.visible").click();
+
+        // The Bootstrap 5 modal should appear
+        cy.get(".modal.show").should("be.visible");
+
+        // The modal title should contain "Group" (covers "Select Group and Role")
+        cy.get(".modal.show .modal-title").should("contain", "Group");
+
+        // The group TomSelect should be initialized — its control wrapper is present
+        cy.get(".modal.show .ts-control", { timeout: 10000 }).should("exist");
+
+        // The group list input should exist and be interactive
+        cy.get(".modal.show input[type='text']").first().should("exist");
+    });
+
+    it("populates the group dropdown with available groups", () => {
+        const uniqueSeed = Date.now().toString();
+        const groupName = "EmptyCartToGroup Test " + uniqueSeed;
+
+        // Create a test group so we know at least one group exists
+        cy.request({
+            method: "POST",
+            url: "/api/groups/",
+            headers: { "Content-Type": "application/json" },
+            body: { groupName: groupName },
+        }).then((resp) => {
+            expect(resp.status).to.eq(200);
+            const groupId = resp.body.Id;
+
+            cy.visit("/v2/cart");
+
+            cy.window().should("have.property", "CRM");
+            cy.window().its("CRM.localesLoaded").should("eq", true);
+
+            cy.get("#emptyCartToGroup").should("be.visible").click();
+
+            // Wait for modal to open and TomSelect to initialize
+            cy.get(".modal.show").should("be.visible");
+            cy.get(".modal.show .ts-wrapper", { timeout: 10000 }).should("exist");
+
+            // Click on the TomSelect input to open the dropdown
+            cy.get(".modal.show .ts-control").first().click();
+
+            // The dropdown should be visible and contain our test group
+            cy.get(".ts-dropdown.single", { timeout: 5000 }).should("be.visible");
+            cy.get(".ts-dropdown.single .option").should("have.length.at.least", 1);
+
+            // Close modal and clean up the test group
+            cy.get(".modal.show .btn-close").click();
+            cy.get(".modal").should("not.have.class", "show");
+
+            cy.request({
+                method: "DELETE",
+                url: `/api/groups/${groupId}`,
+            });
+        });
+    });
+
+    it("shows role dropdown after selecting a group with multiple roles", () => {
+        // Use a group from seed data that has roles defined.
+        // Group ID 11 ("Clergy") has role list 23 per seed data.
+        const TARGET_GROUP_ID = 11;
+
+        cy.visit("/v2/cart");
+
+        cy.window().should("have.property", "CRM");
+        cy.window().its("CRM.localesLoaded").should("eq", true);
+
+        cy.get("#emptyCartToGroup").should("be.visible").click();
+
+        // Wait for modal + TomSelect to be ready
+        cy.get(".modal.show").should("be.visible");
+        cy.get(".modal.show .ts-wrapper", { timeout: 10000 }).should("exist");
+
+        // The role wrapper should be hidden until a group is selected
+        cy.get("#crm-gs-role-wrapper").should("have.class", "d-none");
+
+        // Select the target group by typing to search
+        cy.get(".modal.show .ts-control").first().click();
+        cy.get(".modal.show input[type='text']").first().type("Clergy", { delay: 50 });
+        cy.get(".ts-dropdown .option").contains("Clergy").click({ force: true });
+
+        // After selecting a group, the roles API should be called.
+        // If roles exist, the role wrapper should appear.
+        // (We don't assert the exact role names since they depend on seed data)
+        cy.get("#crm-gs-confirm", { timeout: 5000 }).should("not.be.disabled");
+
+        // Close the modal
+        cy.get(".modal.show .btn-close").click();
+    });
+
+    it("closes the modal on Cancel without emptying the cart", () => {
+        cy.visit("/v2/cart");
+
+        cy.window().should("have.property", "CRM");
+        cy.window().its("CRM.localesLoaded").should("eq", true);
+
+        cy.get("#emptyCartToGroup").should("be.visible").click();
+        cy.get(".modal.show").should("be.visible");
+
+        // Click Cancel
+        cy.get(".modal.show #crm-gs-cancel").click();
+        cy.get(".modal").should("not.have.class", "show");
+
+        // Cart should still have the person
+        cy.request("GET", "/api/cart/").then((resp) => {
+            expect(resp.body.PeopleCart).to.include(TEST_PERSON_ID);
+        });
+    });
+});

--- a/src/skin/churchcrm.scss
+++ b/src/skin/churchcrm.scss
@@ -52,7 +52,10 @@
 // Floating Action Buttons — menu toggle, add person, add family
 @include meta.load-css("scss/fab");
 
-// Tabler custom styles — color overrides, DataTables/TomSelect skins
+// TomSelect theme skin — all .ts-wrapper and body > .ts-dropdown overrides
+@include meta.load-css("scss/_tomselect");
+
+// Tabler custom styles — color overrides, DataTables skin
 @include meta.load-css("scss/_tabler-bridge");
 
 html,

--- a/src/skin/js/CRMJSOM.js
+++ b/src/skin/js/CRMJSOM.js
@@ -247,6 +247,8 @@ window.CRM.groups = {
     wrapper.addEventListener(
       "hidden.bs.modal",
       () => {
+        if (groupSelectInstance) { groupSelectInstance.destroy(); groupSelectInstance = null; }
+        if (roleSelectInstance) { roleSelectInstance.destroy(); roleSelectInstance = null; }
         bsModal.dispose();
         wrapper.remove();
       },
@@ -258,6 +260,9 @@ window.CRM.groups = {
 
     let selectedGroupId = null;
     let selectedRoleId = null;
+    let groupSelectInstance = null;
+    let roleSelectInstance = null;
+    let noRolesAvailable = false;
 
     // Helper: enable/disable the confirm button based on current selection state
     const updateConfirmState = () => {
@@ -277,7 +282,7 @@ window.CRM.groups = {
       "shown.bs.modal",
       () => {
         if (isGroupOnly || isGroupAndRole) {
-          const groupEl = document.getElementById("crm-gs-group");
+          const groupEl = wrapper.querySelector("#crm-gs-group");
 
           // Fetch all groups and populate the TomSelect
           window.CRM.groups.get().done((rdata) => {
@@ -286,7 +291,7 @@ window.CRM.groups = {
               id: String(item.Id),
             }));
 
-            new TomSelect(groupEl, {
+            groupSelectInstance = new TomSelect(groupEl, {
               valueField: "id",
               labelField: "text",
               searchField: "text",
@@ -300,10 +305,14 @@ window.CRM.groups = {
 
                 if (!isGroupAndRole) return;
 
+                // Disable confirm while roles are loading to prevent premature submit
+                confirmBtn.disabled = true;
+
                 // When the user selects a group, load its roles
-                const roleEl = document.getElementById("crm-gs-role");
+                const roleEl = wrapper.querySelector("#crm-gs-role");
                 if (roleEl && roleEl.tomselect) {
                   roleEl.tomselect.destroy();
+                  roleSelectInstance = null;
                 }
                 selectedRoleId = null;
 
@@ -337,7 +346,7 @@ window.CRM.groups = {
                     id: String(r.OptionId),
                   }));
                   selectedRoleId = roleOptions[0].id; // default to first role
-                  new TomSelect(roleEl, {
+                  roleSelectInstance = new TomSelect(roleEl, {
                     valueField: "id",
                     labelField: "text",
                     searchField: "text",
@@ -358,9 +367,11 @@ window.CRM.groups = {
 
         if (isRoleOnly) {
           // Role-only: load roles for the pre-supplied GroupID
-          const roleEl = document.getElementById("crm-gs-role");
+          const roleEl = wrapper.querySelector("#crm-gs-role");
           window.CRM.groups.getRoles(selectOptions.GroupID).done((roles) => {
             if (!roles || roles.length === 0) {
+              // No roles configured — allow proceed; caller receives RoleID: null
+              noRolesAvailable = true;
               confirmBtn.disabled = false;
               return;
             }
@@ -370,7 +381,7 @@ window.CRM.groups = {
               id: String(r.OptionId),
             }));
             selectedRoleId = roleOptions[0].id;
-            new TomSelect(roleEl, {
+            roleSelectInstance = new TomSelect(roleEl, {
               valueField: "id",
               labelField: "text",
               searchField: "text",
@@ -399,7 +410,7 @@ window.CRM.groups = {
         bsModal.hide();
         selectionCallback({ GroupID: selectedGroupId });
       } else if (isRoleOnly) {
-        if (!selectedRoleId) {
+        if (!selectedRoleId && !noRolesAvailable) {
           window.CRM.notify(i18next.t("Please select a role."), { type: "warning", delay: 3000 });
           return;
         }

--- a/src/skin/js/CRMJSOM.js
+++ b/src/skin/js/CRMJSOM.js
@@ -163,148 +163,258 @@ window.CRM.groups = {
     Role: 2,
   },
   promptSelection: (selectOptions, selectionCallback) => {
-    const options = {
-      message:
-        '<div class="modal-body">\
-                  <input type="hidden" id="targetGroupAction">',
-      buttons: {
-        confirm: {
-          label: i18next.t("OK"),
-          className: "btn-success",
-        },
-        cancel: {
-          label: i18next.t("Cancel"),
-          className: "btn-danger",
-        },
+    // Determine the dialog title based on what the caller wants to select
+    const isGroupAndRole =
+      selectOptions.Type === (window.CRM.groups.selectTypes.Group | window.CRM.groups.selectTypes.Role);
+    const isGroupOnly = selectOptions.Type === window.CRM.groups.selectTypes.Group;
+    const isRoleOnly = selectOptions.Type === window.CRM.groups.selectTypes.Role;
+
+    if (isRoleOnly && !selectOptions.GroupID) {
+      console.error("[CRM.groups.promptSelection] GroupID is required for role-only selection");
+      return;
+    }
+
+    // Build a unique modal ID so multiple calls don't conflict
+    const modalId = "crm-group-select-modal-" + Date.now();
+
+    // Build the modal body HTML
+    let bodyHtml = "";
+    if (isGroupOnly || isGroupAndRole) {
+      bodyHtml +=
+        '<div class="mb-3">' +
+        '<label class="form-label fw-semibold">' +
+        i18next.t("Select Group") +
+        "</label>" +
+        '<select id="crm-gs-group" class="form-select"></select>' +
+        "</div>";
+    }
+    if (isRoleOnly || isGroupAndRole) {
+      bodyHtml +=
+        '<div class="mb-3' + (isGroupAndRole ? " d-none" : "") + '" id="crm-gs-role-wrapper">' +
+        '<label class="form-label fw-semibold">' +
+        i18next.t("Select Role") +
+        "</label>" +
+        '<select id="crm-gs-role" class="form-select"></select>' +
+        "</div>";
+    }
+
+    // Determine dialog title
+    let modalTitle = i18next.t("Select Group");
+    if (isRoleOnly) modalTitle = i18next.t("Select Role");
+    if (isGroupAndRole) modalTitle = i18next.t("Select Group and Role");
+
+    // Create a Bootstrap 5 modal programmatically
+    // (avoids bootbox v6 / TomSelect incompatibilities with .init() and dropdownParent)
+    const existing = document.getElementById(modalId);
+    if (existing) existing.remove();
+
+    const wrapper = document.createElement("div");
+    wrapper.id = modalId;
+    wrapper.className = "modal fade";
+    wrapper.setAttribute("tabindex", "-1");
+    wrapper.setAttribute("aria-modal", "true");
+    wrapper.setAttribute("role", "dialog");
+    wrapper.innerHTML =
+      '<div class="modal-dialog modal-dialog-centered">' +
+      '<div class="modal-content">' +
+      '<div class="modal-header">' +
+      '<h5 class="modal-title">' +
+      window.CRM.escapeHtml(modalTitle) +
+      "</h5>" +
+      '<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="' +
+      i18next.t("Cancel") +
+      '"></button>' +
+      "</div>" +
+      '<div class="modal-body">' +
+      bodyHtml +
+      "</div>" +
+      '<div class="modal-footer">' +
+      '<button type="button" class="btn btn-secondary" data-bs-dismiss="modal" id="crm-gs-cancel">' +
+      i18next.t("Cancel") +
+      "</button>" +
+      '<button type="button" class="btn btn-primary" id="crm-gs-confirm" disabled>' +
+      i18next.t("OK") +
+      "</button>" +
+      "</div>" +
+      "</div></div>";
+
+    document.body.appendChild(wrapper);
+    const bsModal = new window.bootstrap.Modal(wrapper, { backdrop: "static" });
+
+    // Clean up DOM when the modal is fully hidden
+    wrapper.addEventListener(
+      "hidden.bs.modal",
+      () => {
+        bsModal.dispose();
+        wrapper.remove();
       },
-    };
-    let initFunction = () => {};
+      { once: true },
+    );
 
-    // Read a value from a TomSelect-wrapped (or plain) select. TomSelect does
-    // not always mirror its current selection back onto the underlying
-    // <option selected> attribute, so `option:selected` is unreliable here —
-    // always prefer the TomSelect instance API when available. Returns "" if
-    // nothing is selected.
-    const readSelectValue = (id) => {
-      const el = document.getElementById(id);
-      if (!el) return "";
-      if (el.tomselect) {
-        const v = el.tomselect.getValue();
-        return v == null ? "" : String(v);
+    const confirmBtn = wrapper.querySelector("#crm-gs-confirm");
+    const roleWrapper = wrapper.querySelector("#crm-gs-role-wrapper");
+
+    let selectedGroupId = null;
+    let selectedRoleId = null;
+
+    // Helper: enable/disable the confirm button based on current selection state
+    const updateConfirmState = () => {
+      if (isGroupOnly) {
+        confirmBtn.disabled = !selectedGroupId;
+      } else if (isRoleOnly) {
+        confirmBtn.disabled = !selectedRoleId;
+      } else {
+        // Group + Role: require a group; role is optional if the group has no roles
+        confirmBtn.disabled = !selectedGroupId;
       }
-      const jqVal = window.jQuery(el).val();
-      return jqVal == null ? "" : String(jqVal);
     };
 
-    if (selectOptions.Type & window.CRM.groups.selectTypes.Group) {
-      options.title = i18next.t("Select Group");
-      options.message +=
-        '<span style="color: red">' +
-        i18next.t("Please select target group for members") +
-        ':</span>\
-                  <select name="targetGroupSelection" id="targetGroupSelection" class="form-control"></select>';
-      options.buttons.confirm.callback = () => {
-        const groupId = readSelectValue("targetGroupSelection");
-        if (!groupId) {
-          bootbox.alert(i18next.t("Please select a group."));
-          return false;
-        }
-        selectionCallback({ GroupID: groupId });
-      };
-    }
-    if (selectOptions.Type & window.CRM.groups.selectTypes.Role) {
-      options.title = i18next.t("Select Role");
-      options.message +=
-        '<span style="color: red">' +
-        i18next.t("Please select target Role for members") +
-        ':</span>\
-                  <select name="targetRoleSelection" id="targetRoleSelection" class="form-control"></select>';
-      options.buttons.confirm.callback = () => {
-        const roleId = readSelectValue("targetRoleSelection");
-        if (!roleId) {
-          bootbox.alert(i18next.t("Please select a role."));
-          return false;
-        }
-        selectionCallback({ RoleID: roleId });
-      };
-    }
+    // Initialize TomSelect controls once the modal is fully visible.
+    // shown.bs.modal fires after the CSS transition so elements are measured correctly.
+    wrapper.addEventListener(
+      "shown.bs.modal",
+      () => {
+        if (isGroupOnly || isGroupAndRole) {
+          const groupEl = document.getElementById("crm-gs-group");
 
-    if (selectOptions.Type === window.CRM.groups.selectTypes.Role) {
-      if (!selectOptions.GroupID) {
-        throw i18next.t("GroupID required for role selection prompt");
-      }
-      initFunction = () => {
-        // Remove tabindex from bootbox so TomSelect dropdown can receive focus
-        window.jQuery(".bootbox").removeAttr("tabindex");
-        window.CRM.groups.getRoles(selectOptions.GroupID).done((rdata) => {
-          const roleEl = document.getElementById("targetRoleSelection");
-          if (roleEl && roleEl.tomselect) roleEl.tomselect.destroy();
-          new TomSelect(roleEl, {
-            valueField: "id",
-            labelField: "text",
-            searchField: "text",
-            options: rdata.map((item) => ({
-              // i18next-disable-next-line
-              text: i18next.t(item.OptionName),
-              id: String(item.OptionId),
-            })),
-            dropdownParent: document.querySelector(".bootbox"),
-          });
-        });
-      };
-    }
-    if (selectOptions.Type === (window.CRM.groups.selectTypes.Group | window.CRM.groups.selectTypes.Role)) {
-      options.title = i18next.t("Select Group and Role");
-      options.buttons.confirm.callback = () => {
-        const groupId = readSelectValue("targetGroupSelection");
-        const roleId = readSelectValue("targetRoleSelection");
-        if (!groupId || !roleId) {
-          bootbox.alert(i18next.t("Please select both a group and a role."));
-          return false;
-        }
-        selectionCallback({ GroupID: groupId, RoleID: roleId });
-      };
-    }
-    options.message += "</div>";
-    bootbox.dialog(options).init(initFunction).show();
-
-    window.CRM.groups.get().done((rdata) => {
-      const groupsList = rdata.map((item) => ({
-        text: item.Name,
-        id: String(item.Id),
-      }));
-      window.jQuery("#targetGroupSelection").parents(".bootbox").removeAttr("tabindex");
-      const groupEl = document.getElementById("targetGroupSelection");
-      if (groupEl && groupEl.tomselect) groupEl.tomselect.destroy();
-      new TomSelect(groupEl, {
-        valueField: "id",
-        labelField: "text",
-        searchField: "text",
-        options: groupsList,
-        dropdownParent: document.querySelector(".bootbox"),
-        onChange: (value) => {
-          if (!value) return;
-          const roleEl = document.getElementById("targetRoleSelection");
-          if (roleEl && roleEl.tomselect) roleEl.tomselect.destroy();
-          // Clear existing options
-          while (roleEl && roleEl.options.length) roleEl.remove(0);
-          window.CRM.groups.getRoles(value).done((rdata) => {
-            const rolesList = rdata.map((item) => ({
-              // i18next-disable-next-line
-              text: i18next.t(item.OptionName),
-              id: String(item.OptionId),
+          // Fetch all groups and populate the TomSelect
+          window.CRM.groups.get().done((rdata) => {
+            const groupOptions = rdata.map((item) => ({
+              text: item.Name,
+              id: String(item.Id),
             }));
+
+            new TomSelect(groupEl, {
+              valueField: "id",
+              labelField: "text",
+              searchField: "text",
+              options: groupOptions,
+              placeholder: i18next.t("Search groups..."),
+              items: [],
+              dropdownParent: "body",
+              onChange: (value) => {
+                selectedGroupId = value || null;
+                updateConfirmState();
+
+                if (!isGroupAndRole) return;
+
+                // When the user selects a group, load its roles
+                const roleEl = document.getElementById("crm-gs-role");
+                if (roleEl && roleEl.tomselect) {
+                  roleEl.tomselect.destroy();
+                }
+                selectedRoleId = null;
+
+                if (!value) {
+                  if (roleWrapper) roleWrapper.classList.add("d-none");
+                  return;
+                }
+
+                window.CRM.groups.getRoles(value).done((roles) => {
+                  if (!roles || roles.length === 0) {
+                    // Group has no roles — hide the role picker and allow confirm
+                    if (roleWrapper) roleWrapper.classList.add("d-none");
+                    confirmBtn.disabled = false;
+                    return;
+                  }
+
+                  // Auto-select the only role when there is exactly one
+                  if (roles.length === 1) {
+                    selectedRoleId = String(roles[0].OptionId);
+                    if (roleWrapper) roleWrapper.classList.add("d-none");
+                    confirmBtn.disabled = false;
+                    return;
+                  }
+
+                  // Multiple roles — show the role picker
+                  if (roleWrapper) roleWrapper.classList.remove("d-none");
+
+                  const roleOptions = roles.map((r) => ({
+                    // i18next-disable-next-line
+                    text: i18next.t(r.OptionName),
+                    id: String(r.OptionId),
+                  }));
+                  selectedRoleId = roleOptions[0].id; // default to first role
+                  new TomSelect(roleEl, {
+                    valueField: "id",
+                    labelField: "text",
+                    searchField: "text",
+                    options: roleOptions,
+                    items: [selectedRoleId],
+                    dropdownParent: "body",
+                    onChange: (v) => {
+                      selectedRoleId = v || null;
+                      updateConfirmState();
+                    },
+                  });
+                  confirmBtn.disabled = false;
+                });
+              },
+            });
+          });
+        }
+
+        if (isRoleOnly) {
+          // Role-only: load roles for the pre-supplied GroupID
+          const roleEl = document.getElementById("crm-gs-role");
+          window.CRM.groups.getRoles(selectOptions.GroupID).done((roles) => {
+            if (!roles || roles.length === 0) {
+              confirmBtn.disabled = false;
+              return;
+            }
+            const roleOptions = roles.map((r) => ({
+              // i18next-disable-next-line
+              text: i18next.t(r.OptionName),
+              id: String(r.OptionId),
+            }));
+            selectedRoleId = roleOptions[0].id;
             new TomSelect(roleEl, {
               valueField: "id",
               labelField: "text",
               searchField: "text",
-              options: rolesList,
-              dropdownParent: document.querySelector(".bootbox"),
+              options: roleOptions,
+              items: [selectedRoleId],
+              dropdownParent: "body",
+              onChange: (v) => {
+                selectedRoleId = v || null;
+                updateConfirmState();
+              },
             });
+            confirmBtn.disabled = false;
           });
-        },
-      });
+        }
+      },
+      { once: true },
+    );
+
+    // Confirm button handler
+    confirmBtn.addEventListener("click", () => {
+      if (isGroupOnly) {
+        if (!selectedGroupId) {
+          window.CRM.notify(i18next.t("Please select a group."), { type: "warning", delay: 3000 });
+          return;
+        }
+        bsModal.hide();
+        selectionCallback({ GroupID: selectedGroupId });
+      } else if (isRoleOnly) {
+        if (!selectedRoleId) {
+          window.CRM.notify(i18next.t("Please select a role."), { type: "warning", delay: 3000 });
+          return;
+        }
+        bsModal.hide();
+        selectionCallback({ RoleID: selectedRoleId });
+      } else {
+        // Group + Role
+        if (!selectedGroupId) {
+          window.CRM.notify(i18next.t("Please select a group."), { type: "warning", delay: 3000 });
+          return;
+        }
+        bsModal.hide();
+        selectionCallback({ GroupID: selectedGroupId, RoleID: selectedRoleId });
+      }
     });
+
+    bsModal.show();
   },
   addPerson: (GroupID, PersonID, RoleID) => {
     const params = {

--- a/src/skin/js/CRMJSOM.js
+++ b/src/skin/js/CRMJSOM.js
@@ -247,8 +247,14 @@ window.CRM.groups = {
     wrapper.addEventListener(
       "hidden.bs.modal",
       () => {
-        if (groupSelectInstance) { groupSelectInstance.destroy(); groupSelectInstance = null; }
-        if (roleSelectInstance) { roleSelectInstance.destroy(); roleSelectInstance = null; }
+        if (groupSelectInstance) {
+          groupSelectInstance.destroy();
+          groupSelectInstance = null;
+        }
+        if (roleSelectInstance) {
+          roleSelectInstance.destroy();
+          roleSelectInstance = null;
+        }
         bsModal.dispose();
         wrapper.remove();
       },

--- a/src/skin/js/CRMJSOM.js
+++ b/src/skin/js/CRMJSOM.js
@@ -190,7 +190,9 @@ window.CRM.groups = {
     }
     if (isRoleOnly || isGroupAndRole) {
       bodyHtml +=
-        '<div class="mb-3' + (isGroupAndRole ? " d-none" : "") + '" id="crm-gs-role-wrapper">' +
+        '<div class="mb-3' +
+        (isGroupAndRole ? " d-none" : "") +
+        '" id="crm-gs-role-wrapper">' +
         '<label class="form-label fw-semibold">' +
         i18next.t("Select Role") +
         "</label>" +

--- a/src/skin/js/cart.js
+++ b/src/skin/js/cart.js
@@ -436,11 +436,11 @@ export class CartManager {
         Type: window.CRM.groups.selectTypes.Group | window.CRM.groups.selectTypes.Role,
       },
       (selectedRole) => {
-        // Defensive — promptSelection should already validate, but the API
-        // requires both fields and JSON.stringify silently drops `undefined`,
-        // so a missing value would otherwise yield a confusing 400.
-        if (!selectedRole?.GroupID || !selectedRole?.RoleID) {
-          this.showNotification("danger", i18next.t("Please select both a group and a role."));
+        // Defensive — promptSelection should already validate the group selection.
+        // RoleID may be null when a group has no configured roles; pass 0 in that
+        // case so the API receives a numeric value and uses the group's default role.
+        if (!selectedRole?.GroupID) {
+          this.showNotification("danger", i18next.t("Please select a group."));
           return;
         }
         window.CRM.APIRequest({
@@ -448,7 +448,7 @@ export class CartManager {
           path: "cart/emptyToGroup",
           data: JSON.stringify({
             groupID: selectedRole.GroupID,
-            groupRoleID: selectedRole.RoleID,
+            groupRoleID: selectedRole.RoleID ?? 0,
           }),
         })
           .done((data) => {

--- a/src/skin/scss/_tabler-bridge.scss
+++ b/src/skin/scss/_tabler-bridge.scss
@@ -85,7 +85,10 @@
 
 // When using dropdownParent:'body', TomSelect appends the dropdown directly
 // to <body> so the .ts-wrapper scoped styles above don't apply.
+// z-index must exceed Bootstrap 5's .modal (1055) and .modal-backdrop (1050)
+// so the dropdown is clickable when triggered from inside a modal.
 body > .ts-dropdown {
+  z-index: 1060;
   background-color: var(--tblr-bg-surface);
   border: 1px solid var(--tblr-border-color);
   border-radius: var(--tblr-border-radius);

--- a/src/skin/scss/_tabler-bridge.scss
+++ b/src/skin/scss/_tabler-bridge.scss
@@ -43,68 +43,6 @@
   }
 }
 
-// --- Tom Select — Tabler skin overrides --------------------------------
-.ts-wrapper {
-  // Multi-select items use primary brand color
-  &.multi .ts-control .item {
-    background-color: var(--tblr-primary);
-    color: #fff;
-  }
-
-  &.single .ts-control {
-    border: 1px solid var(--tblr-border-color);
-    border-radius: var(--tblr-border-radius);
-    background-color: var(--tblr-bg-forms);
-    color: var(--tblr-body-color);
-    padding: 0.375rem 0.75rem;
-  }
-
-  &.focus .ts-control {
-    border-color: var(--tblr-primary);
-    box-shadow: 0 0 0 0.2rem rgba(32, 107, 196, 0.15);
-  }
-
-  .ts-dropdown {
-    background-color: var(--tblr-bg-surface);
-    border: 1px solid var(--tblr-border-color);
-    border-radius: var(--tblr-border-radius);
-    box-shadow: 0 4px 16px rgba(24, 35, 58, 0.12);
-    color: var(--tblr-body-color);
-
-    .option {
-      color: var(--tblr-body-color);
-
-      &:hover,
-      &.active {
-        background-color: var(--tblr-primary-lt);
-        color: var(--tblr-primary);
-      }
-    }
-  }
-}
-
-// When using dropdownParent:'body', TomSelect appends the dropdown directly
-// to <body> so the .ts-wrapper scoped styles above don't apply.
-// z-index must exceed Bootstrap 5's .modal (1055) and .modal-backdrop (1050)
-// so the dropdown is clickable when triggered from inside a modal.
-body > .ts-dropdown {
-  z-index: 1060;
-  background-color: var(--tblr-bg-surface);
-  border: 1px solid var(--tblr-border-color);
-  border-radius: var(--tblr-border-radius);
-  box-shadow: 0 4px 16px rgba(24, 35, 58, 0.12);
-  color: var(--tblr-body-color);
-
-  .option {
-    color: var(--tblr-body-color);
-
-    &:hover,
-    &.active {
-      background-color: var(--tblr-primary-lt);
-      color: var(--tblr-primary);
-    }
-  }
-}
 
 // --- Sidebar: chevron folder indicator -----------------------------------
 // Tabler 1.4.0 dropped nav-link-arrow — define it here until Tabler adds it back.

--- a/src/skin/scss/_tomselect.scss
+++ b/src/skin/scss/_tomselect.scss
@@ -1,0 +1,75 @@
+// ================================================================
+// TomSelect — ChurchCRM theme skin
+//
+// All TomSelect styling lives here, not in _tabler-bridge.scss.
+// Rule: component-specific styles must have their own partial;
+// _tabler-bridge.scss is reserved for global Tabler CSS-variable
+// overrides and framework-level patches only.
+// ================================================================
+
+// --- Scoped styles (inside a .ts-wrapper parent) -----------------
+.ts-wrapper {
+  // Multi-select items use primary brand color
+  &.multi .ts-control .item {
+    background-color: var(--tblr-primary);
+    color: #fff;
+  }
+
+  &.single .ts-control {
+    border: 1px solid var(--tblr-border-color);
+    border-radius: var(--tblr-border-radius);
+    background-color: var(--tblr-bg-forms);
+    color: var(--tblr-body-color);
+    padding: 0.375rem 0.75rem;
+  }
+
+  &.focus .ts-control {
+    border-color: var(--tblr-primary);
+    box-shadow: 0 0 0 0.2rem rgba(32, 107, 196, 0.15);
+  }
+
+  .ts-dropdown {
+    background-color: var(--tblr-bg-surface);
+    border: 1px solid var(--tblr-border-color);
+    border-radius: var(--tblr-border-radius);
+    box-shadow: 0 4px 16px rgba(24, 35, 58, 0.12);
+    color: var(--tblr-body-color);
+
+    .option {
+      color: var(--tblr-body-color);
+
+      &:hover,
+      &.active {
+        background-color: var(--tblr-primary-lt);
+        color: var(--tblr-primary);
+      }
+    }
+  }
+}
+
+// --- Unscoped dropdown (dropdownParent: "body") -------------------
+// When TomSelect is created with dropdownParent:"body" (required for dropdowns
+// inside modals so they aren't clipped by overflow:hidden), it appends
+// .ts-dropdown directly to <body>, outside any .ts-wrapper ancestor.
+// The scoped rules above do not apply in that case, so we repeat them here.
+//
+// z-index: 1060 slots between Bootstrap 5's modal (1055) and popover (1070),
+// making the dropdown fully clickable when opened from inside a modal.
+body > .ts-dropdown {
+  z-index: 1060;
+  background-color: var(--tblr-bg-surface);
+  border: 1px solid var(--tblr-border-color);
+  border-radius: var(--tblr-border-radius);
+  box-shadow: 0 4px 16px rgba(24, 35, 58, 0.12);
+  color: var(--tblr-body-color);
+
+  .option {
+    color: var(--tblr-body-color);
+
+    &:hover,
+    &.active {
+      background-color: var(--tblr-primary-lt);
+      color: var(--tblr-primary);
+    }
+  }
+}


### PR DESCRIPTION
## Problem

Fixes #9465 (regression of #9051)

When clicking **"Empty Cart to Group"** (or **"To Group"** on the cart page), the group selection dialog appeared but the dropdown list was empty — no groups or roles were shown.

### Root Cause

`promptSelection()` in `CRMJSOM.js` had three interacting bugs:

1. **Bootbox v6 API incompatibility** — The old code called `bootbox.dialog(options).init(initFunction).show()`. In bootbox v6, `.init()` is a module-level reinit function (not a chainable dialog callback). When called on the jQuery element returned by `dialog()`, it invokes `jQuery.fn.init` — the constructor — which silently discards the initialization callback. The `initFunction` was never called.

2. **TomSelect `dropdownParent` set to a raw DOM node** — The code passed `dropdownParent: document.querySelector('.bootbox')` to TomSelect. TomSelect uses this value to append its dropdown list. With a DOM element pointing to the bootbox container (which has `overflow: hidden` in Bootstrap 5's modal layout), the dropdown list was clipped and invisible.

3. **Race condition with Bootstrap 5 modal animation** — The async `groups.get()` API call was dispatched immediately after `bootbox.dialog()`. If the API responded before Bootstrap's modal fade-in completed (possible with fast networks or cached responses), TomSelect was initialized before the `<select>` elements were fully rendered and interactive.

These issues were also present in #9051 (v7.4.0), which was closed as stale without a fix.

## Fix

Rewrote `promptSelection()` to use a **native Bootstrap 5 modal** (`window.bootstrap.Modal`), matching the proven pattern used by `_showGroupAndRoleModal` in `GroupView.js`:

- TomSelect is initialized inside the **`shown.bs.modal`** event, so elements are fully visible and measured before the dropdown attaches.
- `dropdownParent: "body"` (string) ensures TomSelect dropdown renders above the modal backdrop with the correct z-index.
- The role picker is **hidden by default** and only shown when the selected group has multiple roles. Auto-selected when there is exactly one role; omitted (role = 0 → default) when there are none.
- Modal cleans up its own DOM node on `hidden.bs.modal` via `{ once: true }` listener.
- **Confirm button** stays disabled until a valid group is selected.

`cart.js` `emptyToGroup()` was also updated to allow `RoleID = null` (groups with no configured roles), passing `0` to the API which falls back to the group's default role — matching the existing `GroupService::addUserToGroup()` behaviour.

## Testing

- Added `cypress/e2e/ui/groups/standard.empty-cart-to-group.spec.js` with four UI regression tests covering the modal opening, group dropdown population, role cascade, and cancel-without-emptying behaviour.
- The existing API test (`private.cart.empty-to-group.spec.js`) and MVC form test (`standard.cart-to-group.spec.js`) are unaffected.

## Files Changed

| File | Change |
|------|--------|
| `src/skin/js/CRMJSOM.js` | Rewrote `promptSelection()` — replaced bootbox/jQuery.init pattern with native BS5 modal + `shown.bs.modal` TomSelect init |
| `src/skin/js/cart.js` | `emptyToGroup()`: allow `RoleID` null; pass `0` for groups without configured roles |
| `cypress/e2e/ui/groups/standard.empty-cart-to-group.spec.js` | New UI regression tests for the modal flow |