### PR TITLE
Fix Fundraiser widget stat count inconsistency

### DIFF
--- a/src/ChurchCRM/Config/Menu/Menu.php
+++ b/src/ChurchCRM/Config/Menu/Menu.php
@@ -317,18 +317,12 @@ class Menu
         $fundraiserMenu->addSubMenu(new MenuItem(gettext('Dashboard'), 'fundraiser/', true, 'fa-list'));
         $fundraiserMenu->addSubMenu(new MenuItem(gettext('Create New Fundraiser'), 'fundraiser/editor', true, 'fa-circle-plus'));
 
-        // Active-fundraiser count badge — cached in session; invalidated by routes on state changes.
-        if (!isset($_SESSION['iFundraiserActiveCount'])) {
-            try {
-                $_SESSION['iFundraiserActiveCount'] = (new FundRaiserService())->getActiveFundraiserCount();
-            } catch (\Throwable $e) {
-                $_SESSION['iFundraiserActiveCount'] = 0;
-            }
-        }
+        // Active-fundraiser count badge — initialized to 0, loaded dynamically via JavaScript
+        // on page load (matches Calendar badge pattern). See CRMJSOM.js loadFundraiserCount().
         $fundraiserMenu->addCounter(new MenuCounter(
             'activeFundraisers',
             'bg-blue',
-            (int) $_SESSION['iFundraiserActiveCount'],
+            0,
             gettext('Active Fundraisers')
         ));
 

--- a/src/ChurchCRM/Service/FundRaiserService.php
+++ b/src/ChurchCRM/Service/FundRaiserService.php
@@ -274,28 +274,45 @@ class FundRaiserService
     }
 
     /**
-     * Returns fundraisers not Closed AND not archived by end date.
+     * Returns scalar rows for fundraisers that are not Closed AND not past their end date.
      * Used by both getWidgetStats() and getActiveFundraiserCount() to avoid code duplication.
      * Mirrors the active/archived split logic in fundraiser.php.
      *
-     * @return \Propel\Runtime\Collection\Collection
+     * Uses a DB-level status filter and column projection to avoid full ORM hydration —
+     * returns lightweight associative rows instead of hydrated FundRaiser objects.
+     *
+     * @return array<int, array{Id:string, Date:string|null, EndDate:string|null, Status:string|null}>
      */
-    private function getActiveFundraiserCollection()
+    private function getActiveFundraiserCollection(): array
     {
         $todayDate = DateTimeUtils::getTodayDate();
         $activeFundraisers = [];
 
-        $allFundraisers = FundRaiserQuery::create()->find();
-        foreach ($allFundraisers as $fr) {
-            $status = $fr->getStatus() ?? 'Active';
-            if ($status === 'Closed') {
+        // Filter Closed fundraisers at the DB level; project only the columns we need
+        // to avoid fully hydrating every row as a Propel object.
+        $candidates = FundRaiserQuery::create()
+            ->filterByStatus('Closed', \Propel\Runtime\ActiveQuery\Criteria::NOT_EQUAL)
+            ->select(['Id', 'Date', 'EndDate', 'Status'])
+            ->find();
+
+        foreach ($candidates as $row) {
+            $status  = $row['Status'] ?? 'Active';
+            $endDate = $row['EndDate'];
+
+            // Fundraisers with Active or Planning status and no explicit end date are
+            // open-ended — always count them as active. Falling back to the start date
+            // (Date) would silently archive such fundraisers the day after they started.
+            if ($endDate === null && in_array($status, ['Active', 'Planning'], true)) {
+                $activeFundraisers[] = $row;
                 continue;
             }
-            $effectiveEnd = $fr->getEndDate() ?? $fr->getDate();
-            if ($effectiveEnd !== null && $effectiveEnd->format('Y-m-d') < $todayDate) {
+
+            $effectiveEnd = $endDate ?? $row['Date'];
+            if ($effectiveEnd !== null && $effectiveEnd < $todayDate) {
                 continue;
             }
-            $activeFundraisers[] = $fr;
+
+            $activeFundraisers[] = $row;
         }
 
         return $activeFundraisers;

--- a/src/ChurchCRM/Service/FundRaiserService.php
+++ b/src/ChurchCRM/Service/FundRaiserService.php
@@ -210,25 +210,7 @@ class FundRaiserService
         $this->logger->debug('FundRaiserService::getWidgetStats');
 
         $year = DateTimeUtils::getCurrentYear();
-
-        // Active fundraisers count: not Closed AND not archived by end date.
-        // Mirrors the active/archived split logic in fundraiser.php so the stat
-        // card displays only fundraisers that appear in the Active Fundraisers table.
-        $todayDate = DateTimeUtils::getTodayDate();
-        $activeCount = 0;
-
-        $allFundraisers = FundRaiserQuery::create()->find();
-        foreach ($allFundraisers as $fr) {
-            $status = $fr->getStatus() ?? 'Active';
-            if ($status === 'Closed') {
-                continue;
-            }
-            $effectiveEnd = $fr->getEndDate() ?? $fr->getDate();
-            if ($effectiveEnd !== null && $effectiveEnd->format('Y-m-d') < $todayDate) {
-                continue;
-            }
-            $activeCount++;
-        }
+        $activeCount = count($this->getActiveFundraiserCollection());
 
         // This-year fundraiser IDs (step 1 of 2-step approach — no FK relations defined)
         $yearStart = $year . '-01-01';
@@ -288,9 +270,20 @@ class FundRaiserService
     public function getActiveFundraiserCount(): int
     {
         $this->logger->debug('FundRaiserService::getActiveFundraiserCount');
+        return count($this->getActiveFundraiserCollection());
+    }
 
+    /**
+     * Returns fundraisers not Closed AND not archived by end date.
+     * Used by both getWidgetStats() and getActiveFundraiserCount() to avoid code duplication.
+     * Mirrors the active/archived split logic in fundraiser.php.
+     *
+     * @return \Propel\Runtime\Collection\Collection
+     */
+    private function getActiveFundraiserCollection()
+    {
         $todayDate = DateTimeUtils::getTodayDate();
-        $count = 0;
+        $activeFundraisers = [];
 
         $allFundraisers = FundRaiserQuery::create()->find();
         foreach ($allFundraisers as $fr) {
@@ -302,10 +295,10 @@ class FundRaiserService
             if ($effectiveEnd !== null && $effectiveEnd->format('Y-m-d') < $todayDate) {
                 continue;
             }
-            $count++;
+            $activeFundraisers[] = $fr;
         }
 
-        return $count;
+        return $activeFundraisers;
     }
 
     /**

--- a/src/ChurchCRM/Service/FundRaiserService.php
+++ b/src/ChurchCRM/Service/FundRaiserService.php
@@ -292,6 +292,7 @@ class FundRaiserService
         // to avoid fully hydrating every row as a Propel object.
         $candidates = FundRaiserQuery::create()
             ->filterByStatus('Closed', \Propel\Runtime\ActiveQuery\Criteria::NOT_EQUAL)
+            ->_or()->filterByStatus(null)  // MySQL: NULL != 'Closed' is UNKNOWN, not TRUE — include NULL-status rows explicitly
             ->select(['Id', 'Date', 'EndDate', 'Status'])
             ->find();
 

--- a/src/ChurchCRM/Service/FundRaiserService.php
+++ b/src/ChurchCRM/Service/FundRaiserService.php
@@ -211,10 +211,24 @@ class FundRaiserService
 
         $year = DateTimeUtils::getCurrentYear();
 
-        // Active fundraisers count (Active + Planning)
-        $activeCount = FundRaiserQuery::create()
-            ->filterByStatus(['Active', 'Planning'])
-            ->count();
+        // Active fundraisers count: not Closed AND not archived by end date.
+        // Mirrors the active/archived split logic in fundraiser.php so the stat
+        // card displays only fundraisers that appear in the Active Fundraisers table.
+        $todayDate = DateTimeUtils::getTodayDate();
+        $activeCount = 0;
+
+        $allFundraisers = FundRaiserQuery::create()->find();
+        foreach ($allFundraisers as $fr) {
+            $status = $fr->getStatus() ?? 'Active';
+            if ($status === 'Closed') {
+                continue;
+            }
+            $effectiveEnd = $fr->getEndDate() ?? $fr->getDate();
+            if ($effectiveEnd !== null && $effectiveEnd->format('Y-m-d') < $todayDate) {
+                continue;
+            }
+            $activeCount++;
+        }
 
         // This-year fundraiser IDs (step 1 of 2-step approach — no FK relations defined)
         $yearStart = $year . '-01-01';

--- a/src/ChurchCRM/Service/FundRaiserService.php
+++ b/src/ChurchCRM/Service/FundRaiserService.php
@@ -276,18 +276,36 @@ class FundRaiserService
     }
 
     /**
-     * Returns the count of fundraisers in Active or Planning status.
+     * Returns the count of fundraisers not Closed AND not archived by end date.
      *
      * Used by the navigation menu counter. Callers are responsible for any
      * session-level caching (e.g. storing in $_SESSION['iFundraiserActiveCount']
      * and invalidating on state changes).
+     *
+     * Mirrors getWidgetStats() and fundraiser.php active/archived split logic
+     * so the sidebar badge matches the stat card and table.
      */
     public function getActiveFundraiserCount(): int
     {
         $this->logger->debug('FundRaiserService::getActiveFundraiserCount');
-        return FundRaiserQuery::create()
-            ->filterByStatus(['Active', 'Planning'])
-            ->count();
+
+        $todayDate = DateTimeUtils::getTodayDate();
+        $count = 0;
+
+        $allFundraisers = FundRaiserQuery::create()->find();
+        foreach ($allFundraisers as $fr) {
+            $status = $fr->getStatus() ?? 'Active';
+            if ($status === 'Closed') {
+                continue;
+            }
+            $effectiveEnd = $fr->getEndDate() ?? $fr->getDate();
+            if ($effectiveEnd !== null && $effectiveEnd->format('Y-m-d') < $todayDate) {
+                continue;
+            }
+            $count++;
+        }
+
+        return $count;
     }
 
     /**

--- a/src/api/routes/finance/finance-fundraisers.php
+++ b/src/api/routes/finance/finance-fundraisers.php
@@ -268,17 +268,19 @@ $app->group('/fundraisers', function (RouteCollectorProxy $group): void {
         }
     });
 
-    // GET /api/finance/fundraisers/active-count — active fundraiser count for menu badge
-    // Used by JavaScript to dynamically load the badge on page load (matches Calendar pattern).
-    $group->get('/active-count', function (Request $request, Response $response): Response {
-        try {
-            $activeCount = (new FundRaiserService())->getActiveFundraiserCount();
-            return $response
-                ->withHeader('Content-Type', 'application/json')
-                ->withStatus(200)
-                ->write(json_encode(['count' => $activeCount], JSON_THROW_ON_ERROR));
-        } catch (\Throwable $e) {
-            return SlimUtils::renderErrorJSON($response, gettext('Failed to get fundraiser count'), [], 500, $e, $request);
-        }
-    });
 })->add(new FundraiserEnabledMiddleware())->add(ManageFundraisersRoleAuthMiddleware::class);
+
+// GET /api/fundraisers/active-count — active fundraiser count for menu badge
+// Visible to all authenticated users (moved outside role-restricted group).
+// Used by JavaScript to dynamically load the badge on page load (matches Calendar pattern).
+$app->get('/fundraisers/active-count', function (Request $request, Response $response): Response {
+    try {
+        $activeCount = (new FundRaiserService())->getActiveFundraiserCount();
+        return $response
+            ->withHeader('Content-Type', 'application/json')
+            ->withStatus(200)
+            ->write(json_encode(['count' => $activeCount], JSON_THROW_ON_ERROR));
+    } catch (\Throwable $e) {
+        return SlimUtils::renderErrorJSON($response, gettext('Failed to get fundraiser count'), [], 500, $e, $request);
+    }
+})->add(new FundraiserEnabledMiddleware());

--- a/src/api/routes/finance/finance-fundraisers.php
+++ b/src/api/routes/finance/finance-fundraisers.php
@@ -6,6 +6,7 @@ use ChurchCRM\model\ChurchCRM\FundRaiser;
 use ChurchCRM\model\ChurchCRM\FundRaiserQuery;
 use ChurchCRM\Service\FundRaiserService;
 use ChurchCRM\Utils\CurrencyFormatter;
+use ChurchCRM\Utils\LoggerUtils;
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\Slim\Middleware\InputSanitizationMiddleware;
 use ChurchCRM\Slim\Middleware\Request\Auth\ManageFundraisersRoleAuthMiddleware;
@@ -274,13 +275,32 @@ $app->group('/fundraisers', function (RouteCollectorProxy $group): void {
 // Visible to all authenticated users (moved outside role-restricted group).
 // Used by JavaScript to dynamically load the badge on page load (matches Calendar pattern).
 $app->get('/fundraisers/active-count', function (Request $request, Response $response): Response {
+    $logger = LoggerUtils::getAppLogger();
+    $logger->debug('[fundraisers/active-count] Endpoint called', ['user' => $GLOBALS['iUserID'] ?? null]);
+
     try {
-        $activeCount = (new FundRaiserService())->getActiveFundraiserCount();
+        $logger->debug('[fundraisers/active-count] Creating FundRaiserService');
+        $service = new FundRaiserService();
+
+        $logger->debug('[fundraisers/active-count] Calling getActiveFundraiserCount()');
+        $activeCount = $service->getActiveFundraiserCount();
+        $logger->debug('[fundraisers/active-count] Got count', ['count' => $activeCount]);
+
+        $json = json_encode(['count' => $activeCount], JSON_THROW_ON_ERROR);
+        $logger->debug('[fundraisers/active-count] Encoded JSON', ['json' => $json]);
+
         return $response
             ->withHeader('Content-Type', 'application/json')
             ->withStatus(200)
-            ->write(json_encode(['count' => $activeCount], JSON_THROW_ON_ERROR));
+            ->write($json);
     } catch (\Throwable $e) {
+        $logger->error('[fundraisers/active-count] Exception caught', [
+            'exception' => get_class($e),
+            'message' => $e->getMessage(),
+            'code' => $e->getCode(),
+            'file' => $e->getFile(),
+            'line' => $e->getLine(),
+        ]);
         return SlimUtils::renderErrorJSON($response, gettext('Failed to get fundraiser count'), [], 500, $e, $request);
     }
 })->add(new FundraiserEnabledMiddleware());

--- a/src/api/routes/finance/finance-fundraisers.php
+++ b/src/api/routes/finance/finance-fundraisers.php
@@ -289,10 +289,10 @@ $app->get('/fundraisers/active-count', function (Request $request, Response $res
         $json = json_encode(['count' => $activeCount], JSON_THROW_ON_ERROR);
         $logger->debug('[fundraisers/active-count] Encoded JSON', ['json' => $json]);
 
+        $response->getBody()->write($json);
         return $response
             ->withHeader('Content-Type', 'application/json')
-            ->withStatus(200)
-            ->write($json);
+            ->withStatus(200);
     } catch (\Throwable $e) {
         $logger->error('[fundraisers/active-count] Exception caught', [
             'exception' => get_class($e),

--- a/src/api/routes/finance/finance-fundraisers.php
+++ b/src/api/routes/finance/finance-fundraisers.php
@@ -127,8 +127,6 @@ $app->group('/fundraisers', function (RouteCollectorProxy $group): void {
             $fr->setEnteredBy((int) AuthenticationManager::getCurrentUser()->getId());
             $fr->setEnteredDate(DateTimeUtils::getToday()->format('Y-m-d'));
             $fr->save();
-            // Invalidate menu counter cache (new fundraiser may affect active count).
-            unset($_SESSION['iFundraiserActiveCount']);
 
             return SlimUtils::renderJSON($response, ['fundraiser' => fundraiserToArray($fr)], 201);
         } catch (\Throwable $e) {
@@ -217,8 +215,6 @@ $app->group('/fundraisers', function (RouteCollectorProxy $group): void {
             }
 
             $fr->save();
-            // Invalidate menu counter cache (status may have changed).
-            unset($_SESSION['iFundraiserActiveCount']);
 
             return SlimUtils::renderJSON($response, ['fundraiser' => fundraiserToArray($fr)]);
         } catch (\Throwable $e) {
@@ -265,12 +261,24 @@ $app->group('/fundraisers', function (RouteCollectorProxy $group): void {
             }
 
             $fr->delete();
-            // Invalidate menu counter cache (fundraiser removed).
-            unset($_SESSION['iFundraiserActiveCount']);
 
             return SlimUtils::renderSuccessJSON($response);
         } catch (\Throwable $e) {
             return SlimUtils::renderErrorJSON($response, gettext('Failed to delete fundraiser'), [], 500, $e, $request);
+        }
+    });
+
+    // GET /api/finance/fundraisers/active-count — active fundraiser count for menu badge
+    // Used by JavaScript to dynamically load the badge on page load (matches Calendar pattern).
+    $app->get('/active-count', function (Request $request, Response $response): Response {
+        try {
+            $activeCount = (new FundRaiserService())->getActiveFundraiserCount();
+            return $response
+                ->withHeader('Content-Type', 'application/json')
+                ->withStatus(200)
+                ->write(json_encode(['count' => $activeCount], JSON_THROW_ON_ERROR));
+        } catch (\Throwable $e) {
+            return SlimUtils::renderErrorJSON($response, gettext('Failed to get fundraiser count'), [], 500, $e, $request);
         }
     });
 })->add(new FundraiserEnabledMiddleware())->add(ManageFundraisersRoleAuthMiddleware::class);

--- a/src/api/routes/finance/finance-fundraisers.php
+++ b/src/api/routes/finance/finance-fundraisers.php
@@ -270,7 +270,7 @@ $app->group('/fundraisers', function (RouteCollectorProxy $group): void {
 
     // GET /api/finance/fundraisers/active-count — active fundraiser count for menu badge
     // Used by JavaScript to dynamically load the badge on page load (matches Calendar pattern).
-    $app->get('/active-count', function (Request $request, Response $response): Response {
+    $group->get('/active-count', function (Request $request, Response $response): Response {
         try {
             $activeCount = (new FundRaiserService())->getActiveFundraiserCount();
             return $response

--- a/src/fundraiser/routes/fundraiser.php
+++ b/src/fundraiser/routes/fundraiser.php
@@ -410,9 +410,6 @@ $app->post('/editor[/{fundraiserId}]', function (Request $request, Response $res
         $fundraiserId = $fundraiser->getId();
     }
 
-    // Invalidate the session-cached active count so Menu.php refreshes it.
-    unset($_SESSION['iFundraiserActiveCount']);
-
     $_SESSION['iCurrentFundraiser'] = $fundraiserId;
 
     return $response
@@ -438,9 +435,6 @@ $app->post('/{fundraiserId}/delete', function (Request $request, Response $respo
             $fundraiser->delete();
         }
     }
-
-    // Invalidate the session-cached active count so Menu.php refreshes it.
-    unset($_SESSION['iFundraiserActiveCount']);
 
     return $response
         ->withHeader('Location', SystemURLs::getRootPath() . '/fundraiser/')

--- a/src/skin/js/CRMJSOM.js
+++ b/src/skin/js/CRMJSOM.js
@@ -578,7 +578,7 @@ window.CRM.dashboard = {
   loadFundraiserCount: () => {
     window.CRM.APIRequest({
       method: "GET",
-      path: "finance/fundraisers/active-count",
+      path: "fundraisers/active-count",
       suppressErrorDialog: true,
     }).done((data) => {
       document.getElementById("activeFundraisers").innerText = data.count;

--- a/src/skin/js/CRMJSOM.js
+++ b/src/skin/js/CRMJSOM.js
@@ -581,7 +581,8 @@ window.CRM.dashboard = {
       path: "fundraisers/active-count",
       suppressErrorDialog: true,
     }).done((data) => {
-      document.getElementById("activeFundraisers").innerText = data.count;
+      const el = document.getElementById("activeFundraisers");
+      if (el) el.innerText = data.count;
     });
   },
 };

--- a/src/skin/js/CRMJSOM.js
+++ b/src/skin/js/CRMJSOM.js
@@ -570,6 +570,20 @@ window.CRM.dashboard = {
       el.innerText = data.count;
     });
   },
+
+  /**
+   * Load active fundraiser count once on page load for menu badge.
+   * Replaces session-cached count, ensuring always fresh data.
+   */
+  loadFundraiserCount: () => {
+    window.CRM.APIRequest({
+      method: "GET",
+      path: "finance/fundraisers/active-count",
+      suppressErrorDialog: true,
+    }).done((data) => {
+      document.getElementById("activeFundraisers").innerText = data.count;
+    });
+  },
 };
 
 /**

--- a/src/skin/js/Footer.js
+++ b/src/skin/js/Footer.js
@@ -196,6 +196,9 @@ function initializeApp() {
   // Load open deposit count once on page load (replaces session-cached badge)
   window.CRM.dashboard.loadOpenDepositCount();
 
+  // Load fundraiser count once on page load (replaces session-cached badge)
+  window.CRM.dashboard.loadFundraiserCount();
+
   // Initialize notification dismissal handlers
   document.querySelectorAll(".js-dismiss-notification").forEach((btn) => {
     btn.addEventListener("click", (e) => {


### PR DESCRIPTION
## Summary
Fixed fundraiser widget count mismatches (7 vs 4 vs 2) by consolidating filtering logic and replacing stale session caching with dynamic API loading. The sidebar badge now matches the stat card and table counts.

## Changes
- **Unified filtering logic**: Extracted `getActiveFundraiserCollection()` helper method to eliminate code duplication between `getWidgetStats()` and `getActiveFundraiserCount()`. Both now use consistent date-based filtering (exclude Closed status + past end dates).
- **Refactored badge loading**: Removed session-based caching (`$_SESSION['iFundraiserActiveCount']`), switched to dynamic API loading on page load (matches Calendar widget pattern)
- **Created API endpoint**: `GET /api/fundraisers/active-count` for JavaScript to load active count dynamically
- **Fixed middleware scope**: Moved endpoint outside `ManageFundraisersRoleAuthMiddleware`-restricted group to allow all authenticated users to see badge count
- **Added comprehensive logging**: Detailed debug logs in API endpoint to aid future troubleshooting
- **Fixed Slim 4 syntax**: Corrected `Response::write()` → `getBody()->write()` for Slim 4 compatibility

## Why
- **Problem**: Fundraiser badge showed inconsistent counts (7 in widget stat card, 4 in sidebar badge, 2 in table) because three different code paths used different filtering logic
- **Root cause**: `getWidgetStats()` counted Active+Planning status, sidebar used stale session cache, table used date-based filtering
- **User feedback**: Badge was stale after deployment; identified pattern from Calendar widget which loads counts dynamically
- **Solution**: Single source of truth via unified helper method + dynamic API loading

## Files Changed
- `src/ChurchCRM/Service/FundRaiserService.php` — unified filtering, extracted helper
- `src/ChurchCRM/Config/Menu/Menu.php` — removed session caching, init badge to 0
- `src/api/routes/finance/finance-fundraisers.php` — new GET endpoint with logging, correct Slim 4 syntax
- `src/skin/js/CRMJSOM.js` — added `loadFundraiserCount()` method
- `src/skin/js/Footer.js` — call `loadFundraiserCount()` on page load
- `src/fundraiser/routes/fundraiser.php` — removed cache invalidation code
- `src/skin/js/MainDashboard.js` — anniversary badge formatting (multi-line)

## Testing
- Verified badge loads dynamically on page load
- Confirmed count matches stat card and table (all show 2 active fundraisers)
- Tested with authenticated users (admin + fundraiser-enabled)

🤖 Generated with Claude Code