### PR TITLE
Fix: Move Birthday and Anniversary badge text to second line

### DIFF
--- a/src/skin/js/MainDashboard.js
+++ b/src/skin/js/MainDashboard.js
@@ -301,7 +301,7 @@ export function initializeMainDashboard() {
               i18next.t("ago") +
               "</span>";
           }
-          return row.Birthday + " " + badge;
+          return row.Birthday + '<div class="small lh-1 mt-1">' + badge + '</div>';
         },
       },
     ],
@@ -415,7 +415,7 @@ export function initializeMainDashboard() {
               i18next.t("ago") +
               "</span>";
           }
-          return data + badge;
+          return data + '<div class="small lh-1 mt-1">' + badge + '</div>';
         },
       },
     ],

--- a/src/skin/js/MainDashboard.js
+++ b/src/skin/js/MainDashboard.js
@@ -301,7 +301,7 @@ export function initializeMainDashboard() {
               i18next.t("ago") +
               "</span>";
           }
-          return row.Birthday + '<div class="small lh-1 mt-1">' + badge + '</div>';
+          return row.Birthday + '<div class="small lh-1 mt-1">' + badge + "</div>";
         },
       },
     ],
@@ -415,7 +415,7 @@ export function initializeMainDashboard() {
               i18next.t("ago") +
               "</span>";
           }
-          return data + '<div class="small lh-1 mt-1">' + badge + '</div>';
+          return data + '<div class="small lh-1 mt-1">' + badge + "</div>";
         },
       },
     ],


### PR DESCRIPTION
## Summary
Fixed Birthday and Anniversary badge formatting by moving the time badge text to a second line for better visual consistency and readability.

## Changes
- Wrapped Birthday and Anniversary badges in `<div class="small lh-1 mt-1">` wrapper
- Badge text (e.g., "in 4 days") now displays on a separate line below the date
- Improves layout consistency across dashboard widgets

## Why
User feedback indicated the "in X days" badge should be on a separate line for cleaner presentation, matching the unified visual standard across dashboard widgets.

## Files Changed
- `src/skin/js/MainDashboard.js` — Birthday and Anniversary render functions

## Testing
- Birthday and Anniversary widgets display badges on second line
- Text wraps correctly on all screen sizes
- Badge styling remains consistent

🤖 Generated with Claude Code