### PR TITLE
test: locale smoke-test suite — verify supported locales don't break pages or produce JS/500 errors

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -46,6 +46,7 @@ on:
       - master
       - develop
       - 'hotfix/**'
+      - 'release/**'
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
@@ -71,11 +72,15 @@ on:
       - '.github/release.yml'
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/issue-comments/**'
+  schedule:
+    # Nightly full locale sweep (all 49 locales × both PHP versions)
+    - cron: '0 2 * * *'
+  workflow_dispatch:
 
 jobs:
   # Determine which PHP versions to test based on trigger
   # PRs: 8.4 only (fast feedback)
-  # Push to master/develop: 8.4 + 8.5 (full coverage before release)
+  # All other events (push, schedule, workflow_dispatch): 8.4 + 8.5 (full coverage)
   configure:
     runs-on: ubuntu-latest
     outputs:
@@ -83,10 +88,10 @@ jobs:
     steps:
     - id: set-matrix
       run: |
-        if [ "${{ github.event_name }}" = "push" ]; then
-          echo 'php-versions=["8.4","8.5"]' >> $GITHUB_OUTPUT
-        else
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
           echo 'php-versions=["8.4"]' >> $GITHUB_OUTPUT
+        else
+          echo 'php-versions=["8.4","8.5"]' >> $GITHUB_OUTPUT
         fi
 
   build:
@@ -599,8 +604,416 @@ jobs:
     - name: Stop Docker
       if: always()
       run: npm run docker:ci:new-system:subdir:down
+
+  test-locale-root:
+    needs: [configure, build]
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      checks: write
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ${{ fromJSON(needs.configure.outputs.php-versions) }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v7
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v7
+      with:
+        node-version-file: '.nvmrc'
+        cache: 'npm'
+
+    - name: Install npm dependencies
+      run: npm ci
+
+    - name: Download build artifact
+      uses: actions/download-artifact@v8.0.1
+      with:
+        name: build-${{ github.run_id }}
+        path: .
+
+    - name: Load Docker image
+      run: |
+        docker load < temp/docker-image-${{ matrix.php-version }}.tar.gz
+        docker tag churchcrm/crm:php${{ matrix.php-version }}-test churchcrm/crm:php8-debian
+
+    - name: Start Docker (root path)
+      run: |
+        cp docker/Config.root.php src/Include/Config.php
+        docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-root up -d
+
+    - name: Wait for server (root path)
+      run: |
+        max_attempts=12
+        attempt=1
+        until curl -sf http://127.0.0.1/api/public/echo; do
+          if [ $attempt -eq $max_attempts ]; then
+            echo "Server failed to respond after $max_attempts attempts"
+            docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-root ps -a
+            docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-root logs
+            exit 1
+          fi
+          echo "Attempt $attempt/$max_attempts — retrying in 5s..."
+          sleep 5
+          attempt=$((attempt + 1))
+        done
+        echo "Server ready."
+
+    - name: Run locale smoke tests (root, PHP ${{ matrix.php-version }})
+      run: npx cypress run --config-file cypress/configs/locale.config.ts --headless --browser electron --reporter junit --reporter-options mochaFile=cypress/reports/junit-php${{ matrix.php-version }}-root-locale-[hash].xml
+
+    - name: Collect Docker logs on failure
+      if: failure()
+      run: |
+        mkdir -p cypress/logs/docker cypress/logs/php
+        docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-root logs > cypress/logs/docker/docker-compose-php${{ matrix.php-version }}-root-locale.log 2>&1 || true
+        docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-root ps -a >> cypress/logs/docker/docker-compose-php${{ matrix.php-version }}-root-locale.log 2>&1 || true
+        [ -d src/logs ] && cp -r src/logs cypress/logs/php/ || true
+
+    - name: Upload debug artifacts
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: cypress-artifacts-php${{ matrix.php-version }}-root-locale-${{ github.run_id }}
+        path: |
+          cypress/logs
+          cypress/screenshots
+          cypress/videos
+        retention-days: 15
+        if-no-files-found: ignore
+
+    - name: Test Report
+      uses: dorny/test-reporter@v3
+      if: always()
+      with:
+        name: 'PHP ${{ matrix.php-version }}: Root (locale)'
+        path: cypress/reports/junit-php${{ matrix.php-version }}-root-locale-*.xml
+        reporter: java-junit
+        fail-on-error: true
+        fail-on-empty: false
+        list-suites: all
+        list-tests: failed
+        max-annotations: 50
+        use-actions-summary: true
+
+    - name: Stop Docker
+      if: always()
+      run: npm run docker:ci:root:down
+
+  test-locale-subdir:
+    needs: [configure, build]
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      checks: write
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ${{ fromJSON(needs.configure.outputs.php-versions) }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v7
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v7
+      with:
+        node-version-file: '.nvmrc'
+        cache: 'npm'
+
+    - name: Install npm dependencies
+      run: npm ci
+
+    - name: Download build artifact
+      uses: actions/download-artifact@v8.0.1
+      with:
+        name: build-${{ github.run_id }}
+        path: .
+
+    - name: Load Docker image
+      run: |
+        docker load < temp/docker-image-${{ matrix.php-version }}.tar.gz
+        docker tag churchcrm/crm:php${{ matrix.php-version }}-test churchcrm/crm:php8-debian
+
+    - name: Start Docker (subdirectory path)
+      run: |
+        cp docker/Config.parallel.subdir.php src/Include/Config.php
+        docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-subdir up -d
+
+    - name: Wait for server (subdirectory path)
+      run: |
+        max_attempts=12
+        attempt=1
+        until curl -sf http://127.0.0.1:8080/churchcrm/api/public/echo; do
+          if [ $attempt -eq $max_attempts ]; then
+            echo "Server failed to respond after $max_attempts attempts"
+            docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-subdir ps -a
+            docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-subdir logs
+            exit 1
+          fi
+          echo "Attempt $attempt/$max_attempts — retrying in 5s..."
+          sleep 5
+          attempt=$((attempt + 1))
+        done
+        echo "Server ready."
+
+    - name: Run locale smoke tests (subdir, PHP ${{ matrix.php-version }})
+      run: npx cypress run --config-file cypress/configs/locale.config.ts --headless --browser electron --reporter junit --reporter-options mochaFile=cypress/reports/junit-php${{ matrix.php-version }}-subdir-locale-[hash].xml
+      env:
+        CYPRESS_BASE_URL: http://127.0.0.1:8080/churchcrm/
+
+    - name: Collect Docker logs on failure
+      if: failure()
+      run: |
+        mkdir -p cypress/logs/docker cypress/logs/php
+        docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-subdir logs > cypress/logs/docker/docker-compose-php${{ matrix.php-version }}-subdir-locale.log 2>&1 || true
+        docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-subdir ps -a >> cypress/logs/docker/docker-compose-php${{ matrix.php-version }}-subdir-locale.log 2>&1 || true
+        [ -d src/logs ] && cp -r src/logs cypress/logs/php/ || true
+
+    - name: Upload debug artifacts
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: cypress-artifacts-php${{ matrix.php-version }}-subdir-locale-${{ github.run_id }}
+        path: |
+          cypress/logs
+          cypress/screenshots
+          cypress/videos
+        retention-days: 15
+        if-no-files-found: ignore
+
+    - name: Test Report
+      uses: dorny/test-reporter@v3
+      if: always()
+      with:
+        name: 'PHP ${{ matrix.php-version }}: Subdirectory (locale)'
+        path: cypress/reports/junit-php${{ matrix.php-version }}-subdir-locale-*.xml
+        reporter: java-junit
+        fail-on-error: true
+        fail-on-empty: false
+        list-suites: all
+        list-tests: failed
+        max-annotations: 50
+        use-actions-summary: true
+
+    - name: Stop Docker
+      if: always()
+      run: npm run docker:ci:subdir:down
+
+  test-locale-full-root:
+    # Full locale sweep (all 49 locales) — release branches, nightly cron, manual dispatch only.
+    # Not in package job needs; serves as a release gate when triggered on release/** branches.
+    if: |
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/'))
+    needs: [configure, build]
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      checks: write
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ${{ fromJSON(needs.configure.outputs.php-versions) }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v7
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v7
+      with:
+        node-version-file: '.nvmrc'
+        cache: 'npm'
+
+    - name: Install npm dependencies
+      run: npm ci
+
+    - name: Download build artifact
+      uses: actions/download-artifact@v8.0.1
+      with:
+        name: build-${{ github.run_id }}
+        path: .
+
+    - name: Load Docker image
+      run: |
+        docker load < temp/docker-image-${{ matrix.php-version }}.tar.gz
+        docker tag churchcrm/crm:php${{ matrix.php-version }}-test churchcrm/crm:php8-debian
+
+    - name: Start Docker (root path)
+      run: |
+        cp docker/Config.root.php src/Include/Config.php
+        docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-root up -d
+
+    - name: Wait for server (root path)
+      run: |
+        max_attempts=12
+        attempt=1
+        until curl -sf http://127.0.0.1/api/public/echo; do
+          if [ $attempt -eq $max_attempts ]; then
+            echo "Server failed to respond after $max_attempts attempts"
+            docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-root ps -a
+            docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-root logs
+            exit 1
+          fi
+          echo "Attempt $attempt/$max_attempts — retrying in 5s..."
+          sleep 5
+          attempt=$((attempt + 1))
+        done
+        echo "Server ready."
+
+    - name: Run locale full tests (root, PHP ${{ matrix.php-version }})
+      run: npx cypress run --config-file cypress/configs/locale.config.ts --headless --browser electron --env LOCALE_TIER=full --reporter junit --reporter-options mochaFile=cypress/reports/junit-php${{ matrix.php-version }}-root-locale-full-[hash].xml
+
+    - name: Collect Docker logs on failure
+      if: failure()
+      run: |
+        mkdir -p cypress/logs/docker cypress/logs/php
+        docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-root logs > cypress/logs/docker/docker-compose-php${{ matrix.php-version }}-root-locale-full.log 2>&1 || true
+        docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-root ps -a >> cypress/logs/docker/docker-compose-php${{ matrix.php-version }}-root-locale-full.log 2>&1 || true
+        [ -d src/logs ] && cp -r src/logs cypress/logs/php/ || true
+
+    - name: Upload debug artifacts
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: cypress-artifacts-php${{ matrix.php-version }}-root-locale-full-${{ github.run_id }}
+        path: |
+          cypress/logs
+          cypress/screenshots
+          cypress/videos
+        retention-days: 15
+        if-no-files-found: ignore
+
+    - name: Test Report
+      uses: dorny/test-reporter@v3
+      if: always()
+      with:
+        name: 'PHP ${{ matrix.php-version }}: Root (locale-full)'
+        path: cypress/reports/junit-php${{ matrix.php-version }}-root-locale-full-*.xml
+        reporter: java-junit
+        fail-on-error: true
+        fail-on-empty: false
+        list-suites: all
+        list-tests: failed
+        max-annotations: 50
+        use-actions-summary: true
+
+    - name: Stop Docker
+      if: always()
+      run: npm run docker:ci:root:down
+
+  test-locale-full-subdir:
+    # Full locale sweep (all 49 locales) — release branches, nightly cron, manual dispatch only.
+    if: |
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/'))
+    needs: [configure, build]
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      checks: write
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ${{ fromJSON(needs.configure.outputs.php-versions) }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v7
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v7
+      with:
+        node-version-file: '.nvmrc'
+        cache: 'npm'
+
+    - name: Install npm dependencies
+      run: npm ci
+
+    - name: Download build artifact
+      uses: actions/download-artifact@v8.0.1
+      with:
+        name: build-${{ github.run_id }}
+        path: .
+
+    - name: Load Docker image
+      run: |
+        docker load < temp/docker-image-${{ matrix.php-version }}.tar.gz
+        docker tag churchcrm/crm:php${{ matrix.php-version }}-test churchcrm/crm:php8-debian
+
+    - name: Start Docker (subdirectory path)
+      run: |
+        cp docker/Config.parallel.subdir.php src/Include/Config.php
+        docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-subdir up -d
+
+    - name: Wait for server (subdirectory path)
+      run: |
+        max_attempts=12
+        attempt=1
+        until curl -sf http://127.0.0.1:8080/churchcrm/api/public/echo; do
+          if [ $attempt -eq $max_attempts ]; then
+            echo "Server failed to respond after $max_attempts attempts"
+            docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-subdir ps -a
+            docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-subdir logs
+            exit 1
+          fi
+          echo "Attempt $attempt/$max_attempts — retrying in 5s..."
+          sleep 5
+          attempt=$((attempt + 1))
+        done
+        echo "Server ready."
+
+    - name: Run locale full tests (subdir, PHP ${{ matrix.php-version }})
+      run: npx cypress run --config-file cypress/configs/locale.config.ts --headless --browser electron --env LOCALE_TIER=full --reporter junit --reporter-options mochaFile=cypress/reports/junit-php${{ matrix.php-version }}-subdir-locale-full-[hash].xml
+      env:
+        CYPRESS_BASE_URL: http://127.0.0.1:8080/churchcrm/
+
+    - name: Collect Docker logs on failure
+      if: failure()
+      run: |
+        mkdir -p cypress/logs/docker cypress/logs/php
+        docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-subdir logs > cypress/logs/docker/docker-compose-php${{ matrix.php-version }}-subdir-locale-full.log 2>&1 || true
+        docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-subdir ps -a >> cypress/logs/docker/docker-compose-php${{ matrix.php-version }}-subdir-locale-full.log 2>&1 || true
+        [ -d src/logs ] && cp -r src/logs cypress/logs/php/ || true
+
+    - name: Upload debug artifacts
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: cypress-artifacts-php${{ matrix.php-version }}-subdir-locale-full-${{ github.run_id }}
+        path: |
+          cypress/logs
+          cypress/screenshots
+          cypress/videos
+        retention-days: 15
+        if-no-files-found: ignore
+
+    - name: Test Report
+      uses: dorny/test-reporter@v3
+      if: always()
+      with:
+        name: 'PHP ${{ matrix.php-version }}: Subdirectory (locale-full)'
+        path: cypress/reports/junit-php${{ matrix.php-version }}-subdir-locale-full-*.xml
+        reporter: java-junit
+        fail-on-error: true
+        fail-on-empty: false
+        list-suites: all
+        list-tests: failed
+        max-annotations: 50
+        use-actions-summary: true
+
+    - name: Stop Docker
+      if: always()
+      run: npm run docker:ci:subdir:down
+
   package:
-    needs: [test-root, test-subdir, test-new-system, test-new-system-subdir]
+    needs: [test-root, test-subdir, test-new-system, test-new-system-subdir, test-locale-root, test-locale-subdir]
     timeout-minutes: 15
     permissions:
       contents: write

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -805,9 +805,9 @@ jobs:
 
   test-locale-full-root:
     # Full locale sweep (all 49 locales). Runs on release branches, nightly
-    # cron, and manual workflow_dispatch. Added to package job needs so
-    # release branches are blocked if any locale breaks; on PR/push builds
-    # the job is skipped and the skip is treated as success by package.
+    # cron, and manual workflow_dispatch. Listed in package job needs so the
+    # full sweep gates package on release branches; skipped on PR/push builds
+    # (package uses always() to avoid skip-propagation).
     if: |
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
@@ -911,9 +911,9 @@ jobs:
 
   test-locale-full-subdir:
     # Full locale sweep (all 49 locales). Runs on release branches, nightly
-    # cron, and manual workflow_dispatch. Added to package job needs so
-    # release branches are blocked if any locale breaks; on PR/push builds
-    # the job is skipped and the skip is treated as success by package.
+    # cron, and manual workflow_dispatch. Listed in package job needs so the
+    # full sweep gates package on release branches; skipped on PR/push builds
+    # (package uses always() to avoid skip-propagation).
     if: |
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
@@ -1019,6 +1019,11 @@ jobs:
 
   package:
     needs: [test-root, test-subdir, test-new-system, test-new-system-subdir, test-locale-root, test-locale-subdir, test-locale-full-root, test-locale-full-subdir]
+    # always() prevents "skipped" from full-locale jobs (which only run on
+    # release branches / cron / dispatch) propagating and silently skipping
+    # this job on PR and push builds. The expression still blocks on any
+    # actual failure or cancellation.
+    if: ${{ always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     timeout-minutes: 15
     permissions:
       contents: write

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -813,7 +813,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/'))
     needs: [configure, build]
-    timeout-minutes: 60
+    timeout-minutes: 120
     permissions:
       contents: read
       checks: write
@@ -919,7 +919,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/'))
     needs: [configure, build]
-    timeout-minutes: 60
+    timeout-minutes: 120
     permissions:
       contents: read
       checks: write
@@ -1018,12 +1018,14 @@ jobs:
       run: npm run docker:ci:subdir:down
 
   package:
-    needs: [test-root, test-subdir, test-new-system, test-new-system-subdir, test-locale-root, test-locale-subdir, test-locale-full-root, test-locale-full-subdir]
+    needs: [build, test-root, test-subdir, test-new-system, test-new-system-subdir, test-locale-root, test-locale-subdir, test-locale-full-root, test-locale-full-subdir]
     # always() prevents "skipped" from full-locale jobs (which only run on
     # release branches / cron / dispatch) propagating and silently skipping
-    # this job on PR and push builds. The expression still blocks on any
-    # actual failure or cancellation.
-    if: ${{ always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+    # this job on PR and push builds. needs.build.result == 'success' guards
+    # against a build failure where all test jobs are skipped (not failed),
+    # which would otherwise let package run and fail on a missing artifact.
+    # The expression still blocks on any test failure or cancellation.
+    if: ${{ always() && needs.build.result == 'success' && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     timeout-minutes: 15
     permissions:
       contents: write

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -804,8 +804,10 @@ jobs:
       run: npm run docker:ci:subdir:down
 
   test-locale-full-root:
-    # Full locale sweep (all 49 locales) — release branches, nightly cron, manual dispatch only.
-    # Not in package job needs; serves as a release gate when triggered on release/** branches.
+    # Full locale sweep (all 49 locales). Runs on release branches, nightly
+    # cron, and manual workflow_dispatch. Added to package job needs so
+    # release branches are blocked if any locale breaks; on PR/push builds
+    # the job is skipped and the skip is treated as success by package.
     if: |
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
@@ -908,7 +910,10 @@ jobs:
       run: npm run docker:ci:root:down
 
   test-locale-full-subdir:
-    # Full locale sweep (all 49 locales) — release branches, nightly cron, manual dispatch only.
+    # Full locale sweep (all 49 locales). Runs on release branches, nightly
+    # cron, and manual workflow_dispatch. Added to package job needs so
+    # release branches are blocked if any locale breaks; on PR/push builds
+    # the job is skipped and the skip is treated as success by package.
     if: |
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
@@ -1013,7 +1018,7 @@ jobs:
       run: npm run docker:ci:subdir:down
 
   package:
-    needs: [test-root, test-subdir, test-new-system, test-new-system-subdir, test-locale-root, test-locale-subdir]
+    needs: [test-root, test-subdir, test-new-system, test-new-system-subdir, test-locale-root, test-locale-subdir, test-locale-full-root, test-locale-full-subdir]
     timeout-minutes: 15
     permissions:
       contents: write

--- a/cypress/configs/locale.config.ts
+++ b/cypress/configs/locale.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig } from 'cypress'
+import { setupCommonNodeEvents } from './_shared'
+
+export default defineConfig({
+  chromeWebSecurity: false,
+  video: false,
+  videosFolder: 'cypress/videos',
+  screenshotOnRunFailure: true,
+  screenshotsFolder: 'cypress/screenshots',
+  pageLoadTimeout: 30000,
+  defaultCommandTimeout: 15000,
+  requestTimeout: 30000,
+  viewportHeight: 1080,
+  viewportWidth: 1920,
+  projectId: 'n4qnyb',
+  env: {
+    // Shared API keys (used by makePrivateAPICall in setupLocaleAdminSession)
+    'admin.api.key': 'ajGwpy8Pdai22XDUpqjC5Ob04v0eG7EGgb4vz2bD2juT8YDmfM',
+    // Locale-admin dedicated test user (per_ID 904, seeded in cypress/data/seed.sql)
+    'locale.admin.id': 904,
+    'locale.admin.username': 'locale-admin@churchcrm.test',
+    'locale.admin.password': 'changeme',
+    'locale.admin.api.key': 'localeAdminApiKeyForTesting1234567890',
+    // Default tier: smoke (15 high-risk locales). Override with --env LOCALE_TIER=full
+    'LOCALE_TIER': 'smoke',
+  },
+  retries: 0,
+  numTestsKeptInMemory: 0,
+  e2e: {
+    setupNodeEvents(on, config) {
+      return setupCommonNodeEvents(on, config);
+    },
+    baseUrl: process.env.CYPRESS_BASE_URL || 'http://localhost/',
+    specPattern: ['cypress/e2e/locale/**/*.spec.ts'],
+  },
+})

--- a/cypress/data/seed.sql
+++ b/cypress/data/seed.sql
@@ -1501,6 +1501,9 @@ INSERT INTO `person_per` VALUES (902,'Mr','Bob','','Menuonly','','','','','','',
 -- Same TOTP secret as twofa_user; usr_FailedLogins starts at 0 so the lockout test
 -- can exhaust iMaxFailedLogins with wrong OTP codes and assert the account locks.
 INSERT INTO `person_per` VALUES (903,'Mr','Twofa','','Lockout','','','','','','','USA','','','','twofa.lockout@example.com',NULL,1,1,1990,NULL,1,1,0,0,NULL,NULL,'2024-01-01 00:00:00',1,0,NULL,0,NULL,NULL,NULL);
+-- Locale-admin: dedicated admin user for locale smoke tests (per_ID 904)
+-- Locale preference set per-test via POST /api/user/904/setting/ui.locale; never mutates system-wide sLanguage
+INSERT INTO `person_per` VALUES (904,'Mr','Locale','','Admin','','','','','','','USA','','','','locale-admin@churchcrm.test',NULL,1,1,1980,NULL,1,1,0,0,NULL,NULL,'2024-01-01 00:00:00',1,0,NULL,0,NULL,NULL,NULL);
 /*!40000 ALTER TABLE `person_per` ENABLE KEYS */;
 UNLOCK TABLES;
 COMMIT;
@@ -1963,6 +1966,9 @@ INSERT INTO `user_usr` VALUES (902,'$2y$12$e3o8rmvWUYdgzUNB/AAMK.pRvT9rwsIZx4wYB
 -- Same TOTP secret (JBSWY3DPEBLW64TMMQ======) as twofa_user; starts unlocked (FailedLogins=0)
 -- so the lockout test exhausts iMaxFailedLogins with wrong OTPs and asserts the account locks.
 INSERT INTO `user_usr` VALUES (903,'$2y$12$e3o8rmvWUYdgzUNB/AAMK.pRvT9rwsIZx4wYB0brOmVPB1UL.HA5S',0,'2024-01-01 00:00:00',0,0,0,0,0,0,0,0,0,0,0,10,'skin-blue',0,0,'2016-01-01',26,0,'twofa_lockout_user',NULL,0,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'def50200923f831141edcddb9e69c79f4ef68b1f0cdd9acf4223f286f2c6ab7e0f09d397cabc831fdaa5bee117f409a50090ae4ea6ff51203508d29b59869396f303d5fd3cf14fe76cf85dba9c85735750aa4f312e1ab29caa60a15bb1b76aecb4a7be50423d2867e49a69ec',NULL,NULL);
+-- Locale-admin: dedicated admin user for locale smoke tests (usr_per_ID 904)
+-- Password: changeme (shared test hash). Locale changed per-test; never touches system-wide sLanguage.
+INSERT INTO `user_usr` VALUES (904,'$2y$12$e3o8rmvWUYdgzUNB/AAMK.pRvT9rwsIZx4wYB0brOmVPB1UL.HA5S',0,'2024-01-01 00:00:00',0,0,0,0,0,0,0,0,0,0,1,10,'skin-blue',0,0,'2016-01-01',10,0,'locale-admin@churchcrm.test','localeAdminApiKeyForTesting1234567890',0,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL);
 /*!40000 ALTER TABLE `user_usr` ENABLE KEYS */;
 UNLOCK TABLES;
 COMMIT;

--- a/cypress/e2e/locale/locale.smoke.spec.ts
+++ b/cypress/e2e/locale/locale.smoke.spec.ts
@@ -1,0 +1,119 @@
+/**
+ * Locale smoke tests — verify every supported locale renders pages without
+ * HTTP 500 errors, uncaught JavaScript exceptions, or missing shell structure.
+ *
+ * Two tiers:
+ *   smoke (default) — 15 high-risk locales run on every PR and push.
+ *   full            — all 49 locales run on release branches, nightly, and
+ *                     manual workflow_dispatch.
+ *
+ * Select tier via Cypress env:
+ *   --env LOCALE_TIER=full   (or set in locale.config.ts)
+ *
+ * Adding a page to the suite: add one entry to cypress/fixtures/locale-pages.ts.
+ * The spec and CI workflow never need to change.
+ */
+
+// @ts-ignore — JSON import resolved by Cypress's esbuild bundler
+import localesJson from '../../../src/locale/locales.json';
+import { LOCALE_TEST_PAGES } from '../../fixtures/locale-pages';
+
+// ---------------------------------------------------------------------------
+// Locale list construction
+// ---------------------------------------------------------------------------
+
+/**
+ * The 15 smoke-tier poEditor codes — locales most likely to expose rendering,
+ * RTL, CJK, complex-script, or Cyrillic bugs.
+ */
+const SMOKE_POEDITOR_CODES: readonly string[] = [
+  'ar',     // RTL — Arabic
+  'he',     // RTL — Hebrew
+  'zh-CN',  // CJK — Simplified Chinese
+  'zh-TW',  // CJK — Traditional Chinese
+  'ja',     // CJK — Japanese
+  'ko',     // CJK — Korean
+  'th',     // Complex script — Thai
+  'hi',     // Complex script — Hindi (Devanagari)
+  'ta',     // Complex script — Tamil
+  'vi',     // Heavy diacritics — Vietnamese
+  'de',     // Heavy diacritics — German
+  'fr',     // Heavy diacritics — French
+  'ru',     // Cyrillic — Russian
+  'pl',     // Cyrillic-adjacent / heavy diacritics — Polish
+  'sw',     // African — Swahili
+];
+
+interface LocaleEntry {
+  /** Display name (English) — used as describe label */
+  name: string;
+  /** locale field from locales.json (e.g. "ar_EG", "zh_CN") — value for ui.locale setting */
+  locale: string;
+  /** poEditor code (e.g. "ar", "zh-CN") — used for smoke-tier filtering */
+  poEditor: string;
+  /** Native script name — included in describe label */
+  nativeName: string;
+}
+
+// Build the full list from locales.json at spec-load time so newly added
+// locales are automatically included in the full tier without any code change.
+const allLocales: LocaleEntry[] = Object.entries(
+  localesJson as Record<string, { locale: string; poEditor: string; nativeName?: string }>,
+).map(([name, v]) => ({
+  name,
+  locale: v.locale,
+  poEditor: v.poEditor,
+  // Fall back to the English key name for locales that omit nativeName (e.g. Slovak).
+  nativeName: v.nativeName ?? name,
+}));
+
+const tier: string = (Cypress.env('LOCALE_TIER') as string) ?? 'smoke';
+
+const localesUnderTest: LocaleEntry[] =
+  tier === 'full'
+    ? allLocales
+    : allLocales.filter((l) => SMOKE_POEDITOR_CODES.includes(l.poEditor));
+
+// ---------------------------------------------------------------------------
+// Per-locale describe blocks
+// ---------------------------------------------------------------------------
+
+localesUnderTest.forEach(({ name, locale, nativeName }) => {
+  describe(`Locale smoke: ${nativeName} / ${name} (${locale})`, () => {
+    // Set the locale preference once per describe block (locale is constant
+    // across all 11 page tests — no need to re-POST on every beforeEach).
+    before(() => {
+      cy.makePrivateAPICall(
+        Cypress.env('locale.admin.api.key'),
+        'POST',
+        `/api/user/${Cypress.env('locale.admin.id')}/setting/ui.locale`,
+        { value: locale },
+        200,
+      );
+    });
+
+    // Restore the browser session before each test (cy.session caches and
+    // restores cookies efficiently; calling in beforeEach is the correct
+    // Cypress pattern to ensure the session cookie is present per test).
+    beforeEach(() => {
+      cy.setupLoginSession(
+        'locale-admin-session',
+        Cypress.env('locale.admin.username') as string,
+        Cypress.env('locale.admin.password') as string,
+      );
+    });
+
+    // Iterate every page in the fixture array — adding a page is one line there.
+    LOCALE_TEST_PAGES.forEach(({ name: pageName, url }) => {
+      it(`${pageName} loads without HTTP 500 or uncaught JS errors`, () => {
+        // cy.visit with default failOnStatusCode:true already fails on 500.
+        // The global uncaught:exception handler in e2e.js propagates real JS
+        // errors as test failures — no extra cy.on() needed here.
+        cy.visit(url);
+
+        // Confirm a rendered shell element is present (not a blank or error stub).
+        cy.get('.navbar', { timeout: 15000 }).should('exist');
+      });
+    });
+  });
+});

--- a/cypress/e2e/locale/locale.smoke.spec.ts
+++ b/cypress/e2e/locale/locale.smoke.spec.ts
@@ -80,27 +80,11 @@ const localesUnderTest: LocaleEntry[] =
 
 localesUnderTest.forEach(({ name, locale, nativeName }) => {
   describe(`Locale smoke: ${nativeName} / ${name} (${locale})`, () => {
-    // Set the locale preference once per describe block (locale is constant
-    // across all 11 page tests — no need to re-POST on every beforeEach).
-    before(() => {
-      cy.makePrivateAPICall(
-        Cypress.env('locale.admin.api.key'),
-        'POST',
-        `/api/user/${Cypress.env('locale.admin.id')}/setting/ui.locale`,
-        { value: locale },
-        200,
-      );
-    });
-
-    // Restore the browser session before each test (cy.session caches and
-    // restores cookies efficiently; calling in beforeEach is the correct
-    // Cypress pattern to ensure the session cookie is present per test).
+    // Single entry point for locale + session setup. The command posts
+    // ui.locale and calls cy.setupLoginSession; cy.session caches the
+    // login so the browser-side overhead per test is minimal.
     beforeEach(() => {
-      cy.setupLoginSession(
-        'locale-admin-session',
-        Cypress.env('locale.admin.username') as string,
-        Cypress.env('locale.admin.password') as string,
-      );
+      cy.setupLocaleAdminSession(locale);
     });
 
     // Iterate every page in the fixture array — adding a page is one line there.

--- a/cypress/fixtures/locale-pages.ts
+++ b/cypress/fixtures/locale-pages.ts
@@ -5,16 +5,16 @@
  * The spec and CI workflow never need to be edited to add a page.
  */
 export const LOCALE_TEST_PAGES: { name: string; url: string }[] = [
-  { name: 'Dashboard',         url: '/' },
-  { name: 'People',            url: '/people/list' },
-  { name: 'Families',          url: '/people/family/' },
-  { name: 'Groups',            url: '/groups/dashboard' },
-  { name: 'Events / Calendar', url: '/event/calendars' },
-  { name: 'Sunday School',     url: '/groups/sundayschool/dashboard' },
-  { name: 'Finance',           url: '/finance/' },
-  { name: 'Reports',           url: '/groups/reports' },
-  { name: 'Admin: Settings',   url: '/admin/system/church-info' },
-  { name: 'Admin: Users',      url: '/admin/system/users' },
-  { name: 'Admin: Debug',      url: '/admin/system/debug' },
+  { name: 'Dashboard',         url: '' },
+  { name: 'People',            url: 'people/list' },
+  { name: 'Families',          url: 'people/family/' },
+  { name: 'Groups',            url: 'groups/dashboard' },
+  { name: 'Events / Calendar', url: 'event/calendars' },
+  { name: 'Sunday School',     url: 'groups/sundayschool/dashboard' },
+  { name: 'Finance',           url: 'finance/' },
+  { name: 'Reports',           url: 'groups/reports' },
+  { name: 'Admin: Settings',   url: 'admin/system/church-info' },
+  { name: 'Admin: Users',      url: 'admin/system/users' },
+  { name: 'Admin: Debug',      url: 'admin/system/debug' },
   // ← add new pages here
 ];

--- a/cypress/fixtures/locale-pages.ts
+++ b/cypress/fixtures/locale-pages.ts
@@ -1,0 +1,20 @@
+/**
+ * Pages visited during locale smoke tests.
+ *
+ * Adding a page to the locale test suite requires exactly ONE line here.
+ * The spec and CI workflow never need to be edited to add a page.
+ */
+export const LOCALE_TEST_PAGES: { name: string; url: string }[] = [
+  { name: 'Dashboard',         url: '/' },
+  { name: 'People',            url: '/v2/people' },
+  { name: 'Families',          url: '/v2/families' },
+  { name: 'Groups',            url: '/v2/groups' },
+  { name: 'Events / Calendar', url: '/event/calendars' },
+  { name: 'Sunday School',     url: '/sundayschool/' },
+  { name: 'Finance',           url: '/finance/' },
+  { name: 'Reports',           url: '/Reports/' },
+  { name: 'Admin: Settings',   url: '/admin/system/settings/' },
+  { name: 'Admin: Users',      url: '/admin/users/' },
+  { name: 'Admin: Debug',      url: '/admin/system/debug/' },
+  // ← add new pages here
+];

--- a/cypress/fixtures/locale-pages.ts
+++ b/cypress/fixtures/locale-pages.ts
@@ -6,15 +6,15 @@
  */
 export const LOCALE_TEST_PAGES: { name: string; url: string }[] = [
   { name: 'Dashboard',         url: '/' },
-  { name: 'People',            url: '/v2/people' },
-  { name: 'Families',          url: '/v2/families' },
-  { name: 'Groups',            url: '/v2/groups' },
+  { name: 'People',            url: '/people/list' },
+  { name: 'Families',          url: '/people/family/' },
+  { name: 'Groups',            url: '/groups/dashboard' },
   { name: 'Events / Calendar', url: '/event/calendars' },
-  { name: 'Sunday School',     url: '/sundayschool/' },
+  { name: 'Sunday School',     url: '/groups/sundayschool/dashboard' },
   { name: 'Finance',           url: '/finance/' },
-  { name: 'Reports',           url: '/Reports/' },
-  { name: 'Admin: Settings',   url: '/admin/system/settings/' },
-  { name: 'Admin: Users',      url: '/admin/users/' },
-  { name: 'Admin: Debug',      url: '/admin/system/debug/' },
+  { name: 'Reports',           url: '/groups/reports' },
+  { name: 'Admin: Settings',   url: '/admin/system/church-info' },
+  { name: 'Admin: Users',      url: '/admin/system/users' },
+  { name: 'Admin: Debug',      url: '/admin/system/debug' },
   // ← add new pages here
 ];

--- a/cypress/fixtures/locale-pages.ts
+++ b/cypress/fixtures/locale-pages.ts
@@ -13,7 +13,8 @@ export const LOCALE_TEST_PAGES: { name: string; url: string }[] = [
   { name: 'Sunday School',     url: 'groups/sundayschool/dashboard' },
   { name: 'Finance',           url: 'finance/' },
   { name: 'Reports',           url: 'groups/reports' },
-  { name: 'Admin: Settings',   url: 'admin/system/church-info' },
+  { name: 'Admin: Church Info',  url: 'admin/system/church-info' },
+  { name: 'Admin: Localization',  url: 'admin/system/localization' },
   { name: 'Admin: Users',      url: 'admin/system/users' },
   { name: 'Admin: Debug',      url: 'admin/system/debug' },
   // ← add new pages here

--- a/cypress/support/commands.d.ts
+++ b/cypress/support/commands.d.ts
@@ -252,5 +252,17 @@ declare namespace Cypress {
      * @param options - Optional config { timeout: 5000 }
      */
     waitForNotification(expectedText: string, options?: { timeout?: number }): Chainable<void>;
+
+    /**
+     * Set the locale-admin user's ui.locale preference to localeValue and establish
+     * an authenticated browser session for that user.
+     *
+     * localeValue must be the locale field from src/locale/locales.json
+     * (e.g. 'ar_EG', 'zh_CN', 'de_DE' — NOT the poEditor code).
+     *
+     * Designed for locale smoke tests only; never touches system-wide sLanguage config.
+     * @param localeValue - The locale field value from locales.json
+     */
+    setupLocaleAdminSession(localeValue: string): Chainable<void>;
   }
 }

--- a/cypress/support/ui-commands.js
+++ b/cypress/support/ui-commands.js
@@ -528,6 +528,11 @@ Cypress.Commands.add('setupLocaleAdminSession', (localeValue) => {
     cy.makePrivateAPICall(apiKey, 'POST', `/api/user/${userId}/setting/ui.locale`, { value: localeValue }, 200);
 
     // Establish (or restore from cache) the browser session for locale-admin.
+    // Known limitation: the cy.session key is static ('locale-admin-session'),
+    // so if the locale were ever read at login time rather than per-request
+    // (e.g. persisted in the session cookie), the cache could serve a stale
+    // locale. ChurchCRM resolves locale per-request from the DB preference,
+    // so this is safe for now.
     cy.setupLoginSession('locale-admin-session', username, password);
 });
 

--- a/cypress/support/ui-commands.js
+++ b/cypress/support/ui-commands.js
@@ -498,3 +498,36 @@ Cypress.Commands.add('waitForNotification', (expectedText, options = {}) => {
         .should('contain', expectedText);
 });
 
+/**
+ * Sets the locale-admin user's ui.locale preference to localeValue then establishes
+ * an authenticated browser session for that user.  Uses the dedicated locale-admin
+ * API key so no other user's session is affected.
+ *
+ * Intended for use in locale smoke tests only.  The localeValue must be the
+ * locale field from src/locale/locales.json (e.g. 'ar_EG', 'zh_CN', 'de_DE').
+ *
+ * @param {string} localeValue - The locale field value from locales.json
+ * @example cy.setupLocaleAdminSession('ar_EG')
+ */
+Cypress.Commands.add('setupLocaleAdminSession', (localeValue) => {
+    const userId = Cypress.env('locale.admin.id');
+    const apiKey = Cypress.env('locale.admin.api.key');
+    const username = Cypress.env('locale.admin.username');
+    const password = Cypress.env('locale.admin.password');
+
+    if (!userId || !apiKey || !username || !password) {
+        throw new Error(
+            'Locale-admin credentials not configured. ' +
+            'Ensure locale.admin.id, locale.admin.api.key, locale.admin.username, ' +
+            'and locale.admin.password are set in cypress/configs/locale.config.ts env.',
+        );
+    }
+
+    // Set the user's locale preference via API (withCredentials:false avoids
+    // interfering with the browser session cookie that cy.session manages).
+    cy.makePrivateAPICall(apiKey, 'POST', `/api/user/${userId}/setting/ui.locale`, { value: localeValue }, 200);
+
+    // Establish (or restore from cache) the browser session for locale-admin.
+    cy.setupLoginSession('locale-admin-session', username, password);
+});
+

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
         "test:api": "npx cypress run --config-file cypress/configs/docker.config.ts --spec 'cypress/e2e/api/**/*.spec.js'",
         "test:ui": "npx cypress run --config-file cypress/configs/docker.config.ts --spec 'cypress/e2e/ui/**/*.spec.js'",
         "test:new-system": "npx cypress run --config-file cypress/configs/new-system.config.ts",
+        "test:locale": "npx cypress run --config-file cypress/configs/locale.config.ts --headless --browser electron",
+        "test:locale:full": "npx cypress run --config-file cypress/configs/locale.config.ts --headless --browser electron --env LOCALE_TIER=full",
         "docker:test:start": "cp docker/Config.php src/Include/Config.php && docker compose -f docker/docker-compose.yaml --profile test up -d",
         "docker:test:stop": "docker compose -f docker/docker-compose.yaml --profile test stop",
         "docker:test:down": "docker compose -f docker/docker-compose.yaml --profile test down -v",

--- a/src/admin/views/debug.php
+++ b/src/admin/views/debug.php
@@ -702,13 +702,26 @@ $fmtBytes = static function ($bytes): string {
 </style>
 
 <script nonce="<?= SystemURLs::getCSPNonce() ?>">
+    // Translated strings as a JSON object — never embed raw gettext() output
+    // inside JS string literals; apostrophes in translations (e.g. French
+    // "s'afficher") break single-quoted JS strings.
+    var t = <?= json_encode([
+        'unknown'        => gettext('Unknown'),
+        'mismatch'       => gettext('Mismatch'),
+        'issuesDetected' => gettext('Issues detected'),
+        'allMatch'       => gettext('All timezones match'),
+        'mismatchOne'    => gettext('mismatch detected'),
+        'mismatchMany'   => gettext('mismatches detected'),
+        'browserDiffers' => gettext('Browser differs from system config - dates may display incorrectly for this user.'),
+    ], JSON_UNESCAPED_UNICODE | JSON_HEX_TAG) ?>;
+
     var initializeDebugPage = function() {
         // Populate browser timezone information with guard for older browsers
         var browserTimezone;
         try {
-            browserTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone || '<?= gettext('Unknown') ?>';
+            browserTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone || t.unknown;
         } catch (e) {
-            browserTimezone = '<?= gettext('Unknown') ?>';
+            browserTimezone = t.unknown;
         }
         var now = new Date();
         var browserOffset = -now.getTimezoneOffset();
@@ -761,7 +774,7 @@ $fmtBytes = static function ($bytes): string {
         } else {
             $badge.removeClass('bg-success-lt text-success bg-secondary text-white')
                   .addClass('bg-warning-lt text-warning')
-                  .html('<i class="fa fa-triangle-exclamation me-1"></i><?= gettext('Mismatch') ?>');
+                  .html('<i class="fa fa-triangle-exclamation me-1"></i>' + t.mismatch);
             $row.addClass('bg-warning-light');
             // Show alert icon in card header
             $headerAlert.removeClass('d-none');
@@ -773,7 +786,7 @@ $fmtBytes = static function ($bytes): string {
                 .addClass('border-warning')
                 .find('.card-status-top').removeClass('bg-success').addClass('bg-warning');
             if ($bannerHeadline.length) {
-                $bannerHeadline.html('<i class="fa fa-triangle-exclamation text-warning me-1"></i><?= gettext('Issues detected') ?>');
+                $bannerHeadline.html('<i class="fa fa-triangle-exclamation text-warning me-1"></i>' + t.issuesDetected);
                 $banner.removeClass('border-success').addClass('border-warning');
             }
         }
@@ -791,12 +804,12 @@ $fmtBytes = static function ($bytes): string {
         
         var summaryHtml = '';
         if (issueCount === 0) {
-            summaryHtml = '<span class="text-success"><i class="fa fa-circle-check me-1"></i><?= gettext('All timezones match') ?></span>';
+            summaryHtml = '<span class="text-success"><i class="fa fa-circle-check me-1"></i>' + t.allMatch + '</span>';
         } else {
             summaryHtml = '<span class="text-warning"><i class="fa fa-triangle-exclamation me-1"></i>' + 
-                          issueCount + ' ' + (issueCount === 1 ? '<?= gettext('mismatch detected') ?>' : '<?= gettext('mismatches detected') ?>') + '</span>';
+                          issueCount + ' ' + (issueCount === 1 ? t.mismatchOne : t.mismatchMany) + '</span>';
             if (!browserMatchesBaseline) {
-                summaryHtml += '<br><small class="text-body-secondary"><?= gettext('Browser differs from system config - dates may display incorrectly for this user.') ?></small>';
+                summaryHtml += '<br><small class="text-body-secondary">' + t.browserDiffers + '</small>';
             }
         }
         $('#timezone-summary').html(summaryHtml);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,8 @@
     "node_modules",
     "src/vendor",
     "tests/vendor",
-    "cypress/configs/*"
+    "cypress/configs/*",
+    "cypress/e2e/**",
+    "cypress/fixtures/**"
   ]
 }


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Adds a Cypress locale smoke-test suite that verifies every locale declared in `src/locale/locales.json` loads 11 key pages without HTTP 500 errors or uncaught JavaScript exceptions. Closes #9504.

**What changed:**
- `cypress/fixtures/locale-pages.ts` — single `LOCALE_TEST_PAGES` array; adding a page requires one line here, nothing else changes
- `cypress/e2e/locale/locale.smoke.spec.ts` — one `describe` per locale, one `it` per page; locale set server-side via `ui.locale` user setting, never system-wide `sLanguage`
- `cypress/configs/locale.config.ts` — dedicated Cypress config (`specPattern`, env defaults)
- `cypress/data/seed.sql` — adds locale-admin user (per_ID 904, admin, password `changeme`) for isolated locale testing
- `cypress/support/ui-commands.js` + `commands.d.ts` — `cy.setupLocaleAdminSession(localeValue)`
- `package.json` — `test:locale` (smoke, 15 locales) and `test:locale:full` (all 49)
- `tsconfig.json` — excludes `cypress/e2e/**` and `cypress/fixtures/**` from main TS compilation
- `.github/workflows/build-test-package.yml` — 4 new jobs (`test-locale-root`, `test-locale-subdir`, `test-locale-full-root`, `test-locale-full-subdir`); schedule/workflow_dispatch/release/** triggers; updated configure matrix; package needs updated

**Two tiers:**
- Smoke (15 high-risk locales: RTL, CJK, complex-script, Cyrillic) — every PR/push
- Full (all 49 locales) — nightly cron `0 2 * * *`, manual dispatch, `release/**` branches

**Testing:** Build and lint pass locally (`npm run lint`, `npm run build:webpack`, `npm run build:php`). Cypress execution requires the Docker test stack.