### PR TITLE
test: fix Bootstrap 5 modal focus-trap in calendar save-path tests

### DIFF
--- a/cypress/e2e/ui/events/standard.calendar.spec.js
+++ b/cypress/e2e/ui/events/standard.calendar.spec.js
@@ -211,7 +211,12 @@ describe("Standard Calendar — save (admin-session)", () => {
 
         cy.visit("event/calendars");
         openNewEventModal();
-        cy.get("#event-title-input").should("be.visible").type(title);
+        // Use invoke("val").trigger("input") instead of .type() to bypass the
+        // Bootstrap 5 modal focus-trap, which can steal keyboard focus mid-delivery
+        // and cause input events to land on the wrong element, leaving event.Title
+        // empty and the save button permanently disabled. trigger("input") fires the
+        // input event listener that updates event.Title and calls fireValidity().
+        cy.get("#event-title-input").should("be.visible").invoke("val", title).trigger("input");
 
         // Pin a calendar. Do NOT touch Event Type — we want the default
         // value to flow through to the payload.
@@ -246,7 +251,12 @@ describe("Standard Calendar — save (admin-session)", () => {
 
         cy.visit("event/calendars");
         openNewEventModal();
-        cy.get("#event-title-input").should("be.visible").type(title);
+        // Use invoke("val").trigger("input") instead of .type() to bypass the
+        // Bootstrap 5 modal focus-trap, which can steal keyboard focus mid-delivery
+        // and cause input events to land on the wrong element, leaving event.Title
+        // empty and the save button permanently disabled. trigger("input") fires the
+        // input event listener that updates event.Title and calls fireValidity().
+        cy.get("#event-title-input").should("be.visible").invoke("val", title).trigger("input");
 
         // Empty-state hint should be visible since no calendar is pinned.
         cy.get("#calendarsEmptyHint").should("be.visible");
@@ -333,7 +343,12 @@ describe("Standard Calendar — save (admin-session)", () => {
 
         cy.visit("event/calendars");
         openNewEventModal();
-        cy.get("#event-title-input").should("be.visible").type(`Modal Advanced ${Date.now()}`);
+        // Use invoke("val").trigger("input") instead of .type() to bypass the
+        // Bootstrap 5 modal focus-trap, which can steal keyboard focus mid-delivery
+        // and cause input events to land on the wrong element, leaving event.Title
+        // empty and the save button permanently disabled. trigger("input") fires the
+        // input event listener that updates event.Title and calls fireValidity().
+        cy.get("#event-title-input").should("be.visible").invoke("val", `Modal Advanced ${Date.now()}`).trigger("input");
         cy.tomSelectByValue("#pinnedCalendarsSelect", "1");
 
         cy.get('[data-bs-target="#eventAdvancedFields"]').click();


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Fixes CI failure in run [31969280731](https://github.com/ChurchCRM/CRM/actions/runs/31969280731): `Standard Calendar — save (admin-session)` test "New event saves without a pinned calendar" timed out with `expected '#eventSaveBtn' not to be 'disabled'`.

**Root cause:** Three save-path tests in `standard.calendar.spec.js` used `cy.get('#event-title-input').type(title)`, which is susceptible to the Bootstrap 5 modal focus-trap stealing keyboard focus mid-delivery. This leaves `event.Title` empty in `event-form.js`, so `validate()` returns false and the save button stays disabled.

**Fix:** Replace `.type()` with `.invoke('val', title).trigger('input')` in all three affected tests under the admin-session describe block. This is the same pattern applied to the "Save button is disabled" test in commit `2292085`, which fixed the same issue but missed these three tests.

**Scope:** Only `cypress/e2e/ui/events/standard.calendar.spec.js` changed. No app code modified. Lines 32 and 54 still use `.type()` — intentional, as those tests don't check save button state and aren't affected by the focus-trap.