### PR TITLE
fix: merge split gettext() fragments into full-sentence sprintf() strings (closes #8772)

### DIFF
--- a/src/finance/views/pledges/detail.php
+++ b/src/finance/views/pledges/detail.php
@@ -102,7 +102,7 @@ $methodLabel = $methodLabels[$pledge['method']] ?? InputUtils::escapeHTML($pledg
                     <div class="text-muted small mb-1"><?= gettext('Deposit Slip') ?></div>
                     <div class="fw-bold">
                         <a href="<?= $sRootPath ?>/DepositSlipEditor.php?DepositSlipID=<?= (int) $pledge['depositId'] ?>">
-                            <?= gettext('Deposit #') . (int) $pledge['depositId'] ?>
+                            <?= sprintf(gettext('Deposit #%d'), (int) $pledge['depositId']) ?>
                         </a>
                     </div>
                 </div>

--- a/src/finance/views/pledges/editor.php
+++ b/src/finance/views/pledges/editor.php
@@ -138,7 +138,7 @@ $pledgeDepositId = $isEdit ? ($pledge['depositId'] ?? 0) : $depositId;
                         <?php foreach ($openDeposits as $deposit): ?>
                             <option value="<?= (int) $deposit->getId() ?>"
                                 <?= ($deposit->getId() == $pledgeDepositId) ? 'selected' : '' ?>>
-                                <?= gettext('Deposit #') . (int) $deposit->getId() ?>
+                                <?= sprintf(gettext('Deposit #%d'), (int) $deposit->getId()) ?>
                                 (<?= InputUtils::escapeHTML($deposit->getDate('Y-m-d')) ?>
                                 - <?= InputUtils::escapeHTML($deposit->getType() ?? '') ?>)
                             </option>


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Replaces the split-sentence `gettext()` anti-pattern with full-sentence `sprintf()` calls in the pledge MVC views, giving translators complete context for each msgid.

**Before:**
```php
gettext('Deposit #') . (int) $id  // decontextualised fragment
```
**After:**
```php
sprintf(gettext('Deposit #%d'), (int) $id)  // full sentence
```

**Files changed:**
- `src/finance/views/pledges/editor.php` — deposit dropdown option label
- `src/finance/views/pledges/detail.php` — deposit link label

**Fragments from issue #8772 already fixed in prior commits (per skill docs, 2026-07-24):**
- `QueryView.php` — `%d record(s) returned`, `cannot be more than %d characters long`
- `Reports/FamilyPledgeSummary.php` and `Reports/ReminderReport.php` — `for all funds` / `for fund`
- `ChurchCRM/Service/PersonService.php` — `%1$s of the %2$s family`

**Intentionally excluded:** `MiscUtils::filenameToFontname()` font-style suffixes (`' Bold'`, `' Italic'`, `' Bold Italic'`) — these words are parsed by `fontFromName()` to derive FPDF style codes (`'B'`, `'I'`, `'BI'`) and must remain as English literals to preserve the round-trip.

**locale/messages.po not modified** — extraction of the new `'Deposit #%d'` msgid is handled by the locale automation on its next run, per project i18n workflow (`i18n-localization.md` → "Never rebuild the locale catalog").

Tested: `npm run lint` (0 new errors), `npm run build:php` (2/2 ✅). Pre-commit and pre-push hooks pass.