### PR TITLE
fix: remove dead hasNoAdminPermissions() and document permission architecture (#9097)

### DIFF
--- a/src/ChurchCRM/model/ChurchCRM/User.php
+++ b/src/ChurchCRM/model/ChurchCRM/User.php
@@ -56,7 +56,44 @@ class User extends BaseUser
     // The naming convention is `isXxxEnabled()` for all permissions,
     // regardless of which storage layer backs the raw flag.
     //
-    // See #8667, #8458 for the consolidation rationale.
+    // ── Two-tier storage architecture ───────────────────────────────
+    //
+    // Permissions are stored in two places:
+    //
+    //   TIER 1 — user_usr boolean columns (fast, indexed, ORM-generated getters):
+    //     usr_Admin, usr_EditSelf, usr_AddRecords, usr_EditRecords,
+    //     usr_DeleteRecords, usr_MenuOptions, usr_ManageGroups,
+    //     usr_Finance, usr_ManageFundraisers, usr_Notes.
+    //     These are the "core" record permissions accessible via isXxx() getters
+    //     (e.g. isAddRecords(), isFinance()) or the corresponding isXxxEnabled()
+    //     helper that applies the admin bypass and the EditSelf-exclusive guard.
+    //
+    //   TIER 2 — userconfig_ucfg rows (per-user config table, name/value pairs):
+    //     bAddEvent    → isAddEventEnabled() / canManageEvents()
+    //     bEmailMailto → isEmailEnabled()
+    //     These are read via isEnabledSecurity('bXxx') which scans the user's
+    //     UserConfig collection. They appear in the UserEditor under the
+    //     Permissions card (AddEvent) or the User Config table (bEmailMailto).
+    //
+    // ── EditSelf-exclusive invariant ────────────────────────────────
+    //
+    // EditSelf is an exclusive mode. When isEditSelfExclusive() is true
+    // (non-admin + EditSelf=1), ALL module permissions — both Tier 1 and
+    // Tier 2 — evaluate to false, regardless of stored flags. This invariant
+    // is enforced at three layers:
+    //   1. DB write-time: UserService::normalizeAccessMode() (server) and
+    //      user-editor.js (client) zero all module perms before saving.
+    //   2. Read-time: every isXxxEnabled() method short-circuits on
+    //      isEditSelfExclusive() before checking the stored flag.
+    //   3. Entry gate: AuthMiddleware and PageInit redirect EditSelf-exclusive
+    //      users to /external/limited-access before any route runs.
+    //
+    // Zero-permission users (all flags 0, EditSelf=0) are NOT blocked at the
+    // entry gate — they retain read-only access under the read-default policy
+    // (#9003). Writes are denied by per-page/per-route role middleware.
+    //
+    // See #8667, #8458 for the consolidation rationale; #9003 for read-default;
+    // #9079 for the EditSelf-exclusive enforcement.
     // ─────────────────────────────────────────────────────────────────
 
     // -- Per-user permissions (backed by user_usr columns) --
@@ -223,33 +260,6 @@ class User extends BaseUser
             'canViewEvents'       => $this->canViewEvents(),
             'canManageEvents'     => $this->canManageEvents(),
         ];
-    }
-
-    /**
-     * Check if the user lacks all functional admin permissions.
-     * Users with no permissions (or only EditSelf) cannot use the admin interface
-     * and should be redirected to a self-service flow or blocked.
-     *
-     * @see https://github.com/ChurchCRM/CRM/issues/8617
-     */
-    public function hasNoAdminPermissions(): bool
-    {
-        if ($this->isAdmin()) {
-            return false;
-        }
-        if ($this->isEditSelf()) {
-            // EditSelf is exclusive — no module permissions apply
-            return true;
-        }
-
-        return !$this->isAddRecords()
-            && !$this->isEditRecords()
-            && !$this->isDeleteRecords()
-            && !$this->isMenuOptions()
-            && !$this->isManageGroups()
-            && !$this->isFinance()
-            && !$this->isManageFundraisers()
-            && !$this->isNotes();
     }
 
     /**


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Both bugs from #9097 were **already resolved** by subsequent PRs. Investigation found only one remaining artifact: the dead `hasNoAdminPermissions()` method.

**Bug 1** (EditSelf + module-perm silent lockout): fixed by #9079 — access-mode redesign. `UserService::normalizeAccessMode()` (server) and `user-editor.js` (client) zero all module perms when EditSelf is selected. Covered by `admin.user-editor.access-mode.spec.js`.

**Bug 2** (userconfig-only perms blocking gate): fixed by #9003 — read-default policy. Gates now use `isEditSelfExclusive()`, not `hasNoAdminPermissions()`. Zero-perm users get read-only access. `bCreateDirectory` removed in #9183.

**Changes:**
- Remove `hasNoAdminPermissions()` (26 lines of dead code with buggy EditSelf early-return). `no-permission-user.spec.js` already calls it "removed."
- Expand class-level doc block with two-tier storage architecture (Tier 1: `user_usr` columns; Tier 2: `userconfig_ucfg` rows) and EditSelf-exclusive invariant enforcement layers.

No schema migration, no behaviour change.

Fixes #9097