### PR TITLE
Fix race condition in church-info state field updates

### DIFF
--- a/webpack/church-info.js
+++ b/webpack/church-info.js
@@ -93,6 +93,8 @@ document.addEventListener("DOMContentLoaded", () => {
   // ── Generic state field builder ─────────────────────────────────────────
   // Reused for both church state and default state containers.
 
+  const stateFieldTokens = new WeakMap();
+
   function buildStateSelect(fieldId, fieldName, states, selectedValue) {
     const $select = $(`<select id="${fieldId}" name="${fieldName}" class="form-control" style="width:100%"></select>`);
     const blankLabel = window.i18next ? `— ${i18next.t("Select State")} —` : "— Select State —";
@@ -115,6 +117,15 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   function updateStateField(container, fieldId, fieldName, countryCode, selectedValue) {
+    // Two calls can race against the same container — e.g. the page-load fetch
+    // for the seeded country's states is still in flight when the country is
+    // changed again before it resolves. Tag each call with a token so a
+    // response that's no longer the latest request for this container is
+    // dropped instead of clobbering newer state.
+    const token = (stateFieldTokens.get(container) || 0) + 1;
+    stateFieldTokens.set(container, token);
+    const isStale = () => stateFieldTokens.get(container) !== token;
+
     if (!countryCode) {
       container.innerHTML = "";
       container.appendChild(buildStateInput(fieldId, fieldName, selectedValue)[0]);
@@ -127,6 +138,7 @@ document.addEventListener("DOMContentLoaded", () => {
       url: `${window.CRM.root}/api/public/data/countries/${countryCode.toLowerCase()}/states`,
     })
       .done((data) => {
+        if (isStale()) return;
         container.innerHTML = "";
         if (data && Object.keys(data).length > 0) {
           const $select = buildStateSelect(fieldId, fieldName, data, selectedValue);
@@ -137,6 +149,7 @@ document.addEventListener("DOMContentLoaded", () => {
         }
       })
       .fail(() => {
+        if (isStale()) return;
         container.innerHTML = "";
         container.appendChild(buildStateInput(fieldId, fieldName, selectedValue)[0]);
       });


### PR DESCRIPTION
## Summary
- Fixes a flaky CI failure: "Admin - Church Information Page › Generate Coordinates button and live map preview › should not call geocoder when no address fields are filled"

## Changes
- `updateStateField()` in `webpack/church-info.js` now tags each call with a per-container request token
- Stale AJAX responses (a superseded `.done()`/`.fail()` callback) are dropped instead of overwriting the container

## Why
The church-info page fetches states for the seeded default country asynchronously on page load. If that fetch resolves *after* the country/state fields are changed (or cleared) again, its callback unconditionally overwrote the state field with the seeded church's real state — even after being cleared. This is timing-dependent (fast in local dev, slow enough to race in CI), which is why the test only flaked in CI and passed consistently locally.

## Files Changed
- `webpack/church-info.js` — request-token guard in `updateStateField()`

## Testing
- `npm run build:webpack` ✅
- `npm run lint` ✅
- `cypress/e2e/ui/admin/admin.church-info.spec.js` — 29/29 passing locally (no regression; the original race doesn't reproduce locally since network calls are effectively instant)