### PR TITLE
Fix unhandled promise rejection in dashboard cart sync

### DIFF
--- a/src/skin/js/MainDashboard.js
+++ b/src/skin/js/MainDashboard.js
@@ -583,16 +583,22 @@ export function initializeMainDashboard() {
           path: "families/familiesInCart",
           suppressErrorDialog: true,
         }),
-      ]).then((responses) => {
-        const cartData = responses[0];
-        const familiesData = responses[1];
+      ])
+        .then((responses) => {
+          const cartData = responses[0];
+          const familiesData = responses[1];
 
-        const peopleInCart = cartData.PeopleCart || [];
-        const familiesInCart = familiesData.familiesInCart || [];
-        const groupsInCart = cartData.GroupCart || [];
+          const peopleInCart = cartData.PeopleCart || [];
+          const familiesInCart = familiesData.familiesInCart || [];
+          const groupsInCart = cartData.GroupCart || [];
 
-        window.CRM.cartManager.syncButtonStates(peopleInCart, familiesInCart, groupsInCart);
-      });
+          window.CRM.cartManager.syncButtonStates(peopleInCart, familiesInCart, groupsInCart);
+        })
+        .catch(() => {
+          // suppressErrorDialog above already silences the UI; still need a
+          // handler here so a denied request (e.g. a zero-permission user)
+          // doesn't surface as an unhandled promise rejection.
+        });
     }
   }
 


### PR DESCRIPTION
## Summary
- Fixes `security/no-permission-user.spec.js` › "Log Out returns to the login page" — deterministically reproducible locally, not flaky.

## Changes
- `syncCartButtons()` in `src/skin/js/MainDashboard.js` now has a `.catch()` on its `Promise.all()` chain.

## Why
`syncCartButtons()` fires on every draw of the dashboard's "latest person"/"latest families" tables, issuing `cart/` and `families/familiesInCart` API requests via `Promise.all([...]).then(...)` with no `.catch()`. For a zero-permission user, both requests return 403, rejecting the promise. With no handler, this became an unhandled promise rejection — Cypress attributes uncaught JS errors to whichever test happens to be running when they fire, so the failure appeared to land on an unrelated later test ("Log Out") rather than the dashboard visit that actually triggered it. `suppressErrorDialog: true` already silences the visible error dialog; the missing `.catch()` just needed a no-op handler to match that intent.

## Files Changed
- `src/skin/js/MainDashboard.js` — add `.catch()` to `syncCartButtons()`'s promise chain

## Testing
- `npm run build:webpack` ✅
- `npm run lint` ✅
- `cypress/e2e/ui/security/no-permission-user.spec.js` — 25/25 passing locally (previously failed deterministically on every run before this fix)