### PR TITLE
Fix calendar modal dispose/transition race causing null focus crash

### DIFF
--- a/webpack/calendar-event-editor.js
+++ b/webpack/calendar-event-editor.js
@@ -54,30 +54,45 @@ function cleanup() {
   destroyForm();
 
   if (currentModal) {
-    // Remove fade class to prevent Bootstrap transition callbacks from firing
-    // after dispose() nulls the internal element reference.
+    const modalToDispose = currentModal;
+    const elToWatch = modalEl;
+
     if (modalEl) {
       modalEl.classList.remove("fade", "show");
       modalEl.removeAttribute("role");
     }
-    // Bootstrap's Modal#dispose() disposes the backdrop, deactivates the
-    // focus trap, then calls super.dispose() — in that order. If disposing
-    // mid-transition throws partway through (see comment below), the focus
-    // trap's document-level focusin/keydown listeners never get removed and
-    // stay bound to this now-detached modal element. The next modal's focus
-    // then trips that stale listener, which reaches into removed DOM and can
-    // call .focus() on null (flaky — depends on transition timing). Deactivate
-    // the focus trap independently first so it always runs regardless of
-    // what dispose() does.
+    // Deactivate the focus trap immediately regardless of transition state —
+    // this only removes a document-level listener and is always safe.
     try {
-      currentModal._focustrap?.deactivate();
+      modalToDispose._focustrap?.deactivate();
     } catch (_e) {
       // ignore — best-effort cleanup
     }
-    try {
-      currentModal.dispose();
-    } catch (_e) {
-      // dispose() can throw if called during a show/hide transition
+
+    const disposeModal = () => {
+      try {
+        modalToDispose.dispose();
+      } catch (_e) {
+        // ignore — best-effort cleanup
+      }
+    };
+
+    // We call dispose() directly instead of hide() (see closeModal() above),
+    // which is safe once the modal has finished showing. But Bootstrap's
+    // show() queues an internal `transitionComplete` callback (_showElement()
+    // in modal.js) that fires once the dialog's CSS transition ends and
+    // reads `this._config`/`this._focustrap` on the modal instance. dispose()
+    // nulls every own property on that instance (see BaseComponent#dispose).
+    // If we dispose() while still mid show-transition (e.g. the test fills
+    // the form and clicks Save fast enough to close before the fade-in
+    // finishes), that queued callback fires *after* dispose() and throws
+    // "Cannot read properties of null (reading 'focus')" on the now-null
+    // `_config`. Defer disposal until Bootstrap's own `shown.bs.modal` event
+    // confirms that callback has already run.
+    if (modalToDispose._isTransitioning && elToWatch) {
+      elToWatch.addEventListener("shown.bs.modal", disposeModal, { once: true });
+    } else {
+      disposeModal();
     }
     currentModal = null;
   }


### PR DESCRIPTION
## Summary
- Real fix for the `standard.calendar.spec.js` "Cannot read properties of null (reading 'focus')" flake that has been hitting different tests across CI runs (see #9531, which papers over the symptom instead of fixing it).

## Root cause
`cleanup()` in `webpack/calendar-event-editor.js` calls Bootstrap's `Modal#dispose()` synchronously, bypassing `hide()` (intentionally, per the existing code comment — `hide()` doesn't reliably complete on our dynamically-swapped modal content). `BaseComponent#dispose()` immediately nulls every own property on the instance, including `_config`.

Bootstrap's `show()` queues an internal `transitionComplete` callback (in `_showElement()`, `modal.js`) that fires once the dialog's CSS transition ends (or its fallback timer, ~300ms) and reads `this._config.focus` before calling `this._focustrap.activate()`. If `cleanup()`/`dispose()` runs before that queued callback fires — e.g. a test (or a fast real user) fills the form and clicks Save before the modal's fade-in finishes — the callback fires *after* dispose() and throws `Cannot read properties of null (reading 'focus')` on the now-null `_config`. Cypress attributes this uncaught error to whichever test happens to be running when it fires, which is why it appeared to hit different, unrelated tests across different CI runs.

## Fix
Defer the actual `dispose()` call until Bootstrap's own `shown.bs.modal` event confirms the show-transition (and its queued callback) has already run, instead of racing it. The focus-trap deactivation still happens immediately (that part was always safe — it only removes a `document`-level listener).

## Why not PR #9531's approach
#9531 identifies the same root cause but "fixes" it by adding a Cypress `uncaught:exception` regex filter that swallows the error message instead of preventing it. That leaves the actual bug live for real users (anyone who clicks Save fast enough still hits this JS error), and the broad regex risks silently hiding unrelated future bugs with the same message. This PR fixes the underlying race so the error can't happen at all — no filter needed.

## Testing
- `npm run build:webpack` ✅
- `npm run lint` ✅
- `cypress/e2e/ui/events/standard.calendar.spec.js` — 14 consecutive full runs (~196 individual test executions) locally with zero recurrences of the focus/`_config` crash (previously reproduced ~40% of runs before this fix)