### PR TITLE
Fix flaky #event-title-input timeout in calendar event modal tests

### DIFF
--- a/cypress/e2e/ui/events/standard.calendar.spec.js
+++ b/cypress/e2e/ui/events/standard.calendar.spec.js
@@ -14,6 +14,13 @@ function openNewEventModal() {
         const today = new Date().toISOString().split("T")[0]; // YYYY-MM-DD
         win.showNewEventForm({ startStr: today, endStr: today, allDay: true });
     });
+    // showNewEventForm() fires 3 concurrent, unmocked API calls (calendars,
+    // event types, groups) before rendering the form — real backend latency
+    // under CI load can occasionally exceed Cypress's default ~4s command
+    // timeout even though the app itself is behaving correctly (it just shows
+    // its loading spinner longer). Wait here once, with a generous bound, so
+    // every call site below doesn't have to race that latency individually.
+    cy.get("#event-title-input", { timeout: 15000 }).should("exist");
 }
 
 describe("Standard Calendar", () => {


### PR DESCRIPTION
## Summary
Fixes an intermittent Cypress failure where `standard.calendar.spec.js` timed out waiting for `#event-title-input` after opening the new-event modal.

## Changes
- Centralized a 15s `cy.get("#event-title-input", { timeout: 15000 })` wait inside the shared `openNewEventModal()` test helper, used by all 14 tests in the spec.

## Why
`showNewEventForm()` fires 3 concurrent, unmocked API calls (calendars, event types, groups) before the form renders. Under CI/Docker load, real backend latency for these calls can occasionally exceed Cypress's default ~4s command timeout even though the app is behaving correctly (it just shows its loading spinner longer). This matches the real-world UX: the same loading spinner is visible in the live app before the modal opens.

Confirmed this is not a regression: `git stash`/reproduction on baseline master shows the same intermittent timeout. Also checked `/api/groups/` for an N+1 query pattern — it already uses batched aggregate queries, so this isn't a backend perf bug. Checked the ORM query log for individual slow queries — none found; the delay is from 3 concurrent round-trips plus client rendering under CI load, not a single slow query.

## Files Changed
- `cypress/e2e/ui/events/standard.calendar.spec.js` — raised wait timeout in `openNewEventModal()` helper

## Testing
- ✅ Ran `standard.calendar.spec.js` 4 consecutive times locally (14/14 passing each run, ~28-38s per run)
- No `#event-title-input` timeouts observed across all runs