### PR TITLE
ci(nightly): fix ui-shard spec source — use docker-ui.config.ts

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -148,13 +148,13 @@ jobs:
         include:
           # ui specs sharded 3× — cypress-split balances by spec file
           # split-index values are strings to avoid JS falsy coercion of 0
-          - test-type: { name: ui-shard-0, config: "cypress/configs/docker.config.ts", spec: "cypress/e2e/ui/**/*.spec.js" }
+          - test-type: { name: ui-shard-0, config: "cypress/configs/docker-ui.config.ts", spec: "cypress/e2e/ui/**/*.spec.js" }
             split-index: "0"
             shard-total: 3
-          - test-type: { name: ui-shard-1, config: "cypress/configs/docker.config.ts", spec: "cypress/e2e/ui/**/*.spec.js" }
+          - test-type: { name: ui-shard-1, config: "cypress/configs/docker-ui.config.ts", spec: "cypress/e2e/ui/**/*.spec.js" }
             split-index: "1"
             shard-total: 3
-          - test-type: { name: ui-shard-2, config: "cypress/configs/docker.config.ts", spec: "cypress/e2e/ui/**/*.spec.js" }
+          - test-type: { name: ui-shard-2, config: "cypress/configs/docker-ui.config.ts", spec: "cypress/e2e/ui/**/*.spec.js" }
             split-index: "2"
             shard-total: 3
     steps:
@@ -274,13 +274,13 @@ jobs:
             config: "cypress/configs/docker-admin.config.ts"
         include:
           # split-index values are strings to avoid JS falsy coercion of 0
-          - test-type: { name: ui-shard-0, config: "cypress/configs/docker.config.ts", spec: "cypress/e2e/ui/**/*.spec.js" }
+          - test-type: { name: ui-shard-0, config: "cypress/configs/docker-ui.config.ts", spec: "cypress/e2e/ui/**/*.spec.js" }
             split-index: "0"
             shard-total: 3
-          - test-type: { name: ui-shard-1, config: "cypress/configs/docker.config.ts", spec: "cypress/e2e/ui/**/*.spec.js" }
+          - test-type: { name: ui-shard-1, config: "cypress/configs/docker-ui.config.ts", spec: "cypress/e2e/ui/**/*.spec.js" }
             split-index: "1"
             shard-total: 3
-          - test-type: { name: ui-shard-2, config: "cypress/configs/docker.config.ts", spec: "cypress/e2e/ui/**/*.spec.js" }
+          - test-type: { name: ui-shard-2, config: "cypress/configs/docker-ui.config.ts", spec: "cypress/e2e/ui/**/*.spec.js" }
             split-index: "2"
             shard-total: 3
     steps:


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Follow-up to #9541 (merged) and #9542.

**Root cause:** `cypress-split` reads `specPattern` from the Cypress config, not the `--spec` CLI arg. `docker.config.ts` includes both `api/` and `ui/` specs (157 total). After splitting into 3 shards alphabetically, shard-0 is mostly api specs; `--spec cypress/e2e/ui/**/*.spec.js` then finds 0 matching specs in shard-0 → exit code 1.

**Fix:** Switch all `ui-shard-{0,1,2}` matrix entries in `nightly.yml` to `docker-ui.config.ts`, which carries `specPattern: ['cypress/e2e/ui/**/*.spec.js']` only. `cypress-split` now distributes the ~113 ui specs evenly across shards.

`docker-ui.config.ts` is added in #9542 (**must merge before this PR**).

Depends on: #9542