### PR TITLE
ci: rename nightly workflow and move locale smoke tests to nightly

### DIFF
--- a/.github/workflows/build-test-nightly.yml
+++ b/.github/workflows/build-test-nightly.yml
@@ -1,4 +1,4 @@
-name: Nightly Tests
+name: Build, Test and Package (Nightly)
 
 # Consolidated nightly workflow covering all test types that are too heavy or
 # slow to run on every push/PR. This workflow supersedes upgrade-tests.yml

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -88,7 +88,7 @@ jobs:
   # matrix decision:
   #   workflow_dispatch → ["8.4","8.5"]  (manual full-matrix sweep)
   #   everything else   → ["8.4"]        (push, PR, schedule — 8.5 nightly
-  #                                        coverage lives in nightly.yml, PR #9541)
+  #                                        coverage lives in build-test-nightly.yml, PR #9541)
   configure:
     runs-on: ubuntu-latest
     outputs:
@@ -211,7 +211,7 @@ jobs:
             spec: "cypress/e2e/ui-admin/**/*.spec.js"
             config: "cypress/configs/docker-admin.config.ts"
         include:
-          # ui specs sharded 3× (PHP 8.4 only; 8.5 ui covered by nightly.yml)
+          # ui specs sharded 3× (PHP 8.4 only; 8.5 ui covered by build-test-nightly.yml)
           # split-index values are strings to avoid JS falsy coercion of 0
           - php-version: "8.4"
             test-type: { name: ui-shard-0, config: "cypress/configs/docker-ui.config.ts", spec: "cypress/e2e/ui/**/*.spec.js" }
@@ -341,7 +341,7 @@ jobs:
             spec: "cypress/e2e/ui-admin/**/*.spec.js"
             config: "cypress/configs/docker-admin.config.ts"
         include:
-          # ui specs sharded 3× (PHP 8.4 only; 8.5 ui covered by nightly.yml)
+          # ui specs sharded 3× (PHP 8.4 only; 8.5 ui covered by build-test-nightly.yml)
           # split-index values are strings to avoid JS falsy coercion of 0
           - php-version: "8.4"
             test-type: { name: ui-shard-0, config: "cypress/configs/docker-ui.config.ts", spec: "cypress/e2e/ui/**/*.spec.js" }
@@ -663,218 +663,6 @@ jobs:
       if: always()
       run: npm run docker:ci:new-system:subdir:down
 
-  test-locale-root:
-    needs: [configure, build]
-    timeout-minutes: 30
-    permissions:
-      contents: read
-      checks: write
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        php-version: ${{ fromJSON(needs.configure.outputs.php-versions) }}
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v7
-
-    - name: Set up Node.js
-      uses: actions/setup-node@v7
-      with:
-        node-version-file: '.nvmrc'
-        cache: 'npm'
-
-    - name: Cache Cypress binary
-      uses: actions/cache@v6
-      with:
-        path: ~/.cache/Cypress
-        key: ${{ runner.os }}-cypress-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: ${{ runner.os }}-cypress-
-
-    - name: Install npm dependencies
-      run: npm ci
-
-    - name: Download build artifact
-      uses: actions/download-artifact@v8.0.1
-      with:
-        name: build-${{ github.run_id }}
-        path: .
-
-    - name: Load Docker image
-      run: |
-        docker load < temp/docker-image-${{ matrix.php-version }}.tar.gz
-        docker tag churchcrm/crm:php${{ matrix.php-version }}-test churchcrm/crm:php8-debian
-
-    - name: Start Docker (root path)
-      run: |
-        cp docker/Config.root.php src/Include/Config.php
-        docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-root up -d
-
-    - name: Wait for server (root path)
-      run: |
-        max_attempts=12
-        attempt=1
-        until curl -sf http://127.0.0.1/api/public/echo; do
-          if [ $attempt -eq $max_attempts ]; then
-            echo "Server failed to respond after $max_attempts attempts"
-            docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-root ps -a
-            docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-root logs
-            exit 1
-          fi
-          echo "Attempt $attempt/$max_attempts — retrying in 5s..."
-          sleep 5
-          attempt=$((attempt + 1))
-        done
-        echo "Server ready."
-
-    - name: Run locale smoke tests (root, PHP ${{ matrix.php-version }})
-      run: npx cypress run --config-file cypress/configs/locale.config.ts --headless --browser electron --reporter junit --reporter-options mochaFile=cypress/reports/junit-php${{ matrix.php-version }}-root-locale-[hash].xml
-
-    - name: Collect Docker logs on failure
-      if: failure()
-      run: |
-        mkdir -p cypress/logs/docker cypress/logs/php
-        docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-root logs > cypress/logs/docker/docker-compose-php${{ matrix.php-version }}-root-locale.log 2>&1 || true
-        docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-root ps -a >> cypress/logs/docker/docker-compose-php${{ matrix.php-version }}-root-locale.log 2>&1 || true
-        [ -d src/logs ] && cp -r src/logs cypress/logs/php/ || true
-
-    - name: Upload debug artifacts
-      if: failure()
-      uses: actions/upload-artifact@v7
-      with:
-        name: cypress-artifacts-php${{ matrix.php-version }}-root-locale-${{ github.run_id }}
-        path: |
-          cypress/logs
-          cypress/screenshots
-          cypress/videos
-        retention-days: 15
-        if-no-files-found: ignore
-
-    - name: Test Report
-      uses: dorny/test-reporter@v3
-      if: always()
-      with:
-        name: 'PHP ${{ matrix.php-version }}: Root (locale)'
-        path: cypress/reports/junit-php${{ matrix.php-version }}-root-locale-*.xml
-        reporter: java-junit
-        fail-on-error: true
-        fail-on-empty: false
-        list-suites: all
-        list-tests: failed
-        max-annotations: 50
-        use-actions-summary: true
-
-    - name: Stop Docker
-      if: always()
-      run: npm run docker:ci:root:down
-
-  test-locale-subdir:
-    needs: [configure, build]
-    timeout-minutes: 30
-    permissions:
-      contents: read
-      checks: write
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        php-version: ${{ fromJSON(needs.configure.outputs.php-versions) }}
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v7
-
-    - name: Set up Node.js
-      uses: actions/setup-node@v7
-      with:
-        node-version-file: '.nvmrc'
-        cache: 'npm'
-
-    - name: Cache Cypress binary
-      uses: actions/cache@v6
-      with:
-        path: ~/.cache/Cypress
-        key: ${{ runner.os }}-cypress-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: ${{ runner.os }}-cypress-
-
-    - name: Install npm dependencies
-      run: npm ci
-
-    - name: Download build artifact
-      uses: actions/download-artifact@v8.0.1
-      with:
-        name: build-${{ github.run_id }}
-        path: .
-
-    - name: Load Docker image
-      run: |
-        docker load < temp/docker-image-${{ matrix.php-version }}.tar.gz
-        docker tag churchcrm/crm:php${{ matrix.php-version }}-test churchcrm/crm:php8-debian
-
-    - name: Start Docker (subdirectory path)
-      run: |
-        cp docker/Config.parallel.subdir.php src/Include/Config.php
-        docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-subdir up -d
-
-    - name: Wait for server (subdirectory path)
-      run: |
-        max_attempts=12
-        attempt=1
-        until curl -sf http://127.0.0.1:8080/churchcrm/api/public/echo; do
-          if [ $attempt -eq $max_attempts ]; then
-            echo "Server failed to respond after $max_attempts attempts"
-            docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-subdir ps -a
-            docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-subdir logs
-            exit 1
-          fi
-          echo "Attempt $attempt/$max_attempts — retrying in 5s..."
-          sleep 5
-          attempt=$((attempt + 1))
-        done
-        echo "Server ready."
-
-    - name: Run locale smoke tests (subdir, PHP ${{ matrix.php-version }})
-      run: npx cypress run --config-file cypress/configs/locale.config.ts --headless --browser electron --reporter junit --reporter-options mochaFile=cypress/reports/junit-php${{ matrix.php-version }}-subdir-locale-[hash].xml
-      env:
-        CYPRESS_BASE_URL: http://127.0.0.1:8080/churchcrm/
-
-    - name: Collect Docker logs on failure
-      if: failure()
-      run: |
-        mkdir -p cypress/logs/docker cypress/logs/php
-        docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-subdir logs > cypress/logs/docker/docker-compose-php${{ matrix.php-version }}-subdir-locale.log 2>&1 || true
-        docker compose -f docker/docker-compose.yaml -f docker/docker-compose.parallel.yaml --profile ci-subdir ps -a >> cypress/logs/docker/docker-compose-php${{ matrix.php-version }}-subdir-locale.log 2>&1 || true
-        [ -d src/logs ] && cp -r src/logs cypress/logs/php/ || true
-
-    - name: Upload debug artifacts
-      if: failure()
-      uses: actions/upload-artifact@v7
-      with:
-        name: cypress-artifacts-php${{ matrix.php-version }}-subdir-locale-${{ github.run_id }}
-        path: |
-          cypress/logs
-          cypress/screenshots
-          cypress/videos
-        retention-days: 15
-        if-no-files-found: ignore
-
-    - name: Test Report
-      uses: dorny/test-reporter@v3
-      if: always()
-      with:
-        name: 'PHP ${{ matrix.php-version }}: Subdirectory (locale)'
-        path: cypress/reports/junit-php${{ matrix.php-version }}-subdir-locale-*.xml
-        reporter: java-junit
-        fail-on-error: true
-        fail-on-empty: false
-        list-suites: all
-        list-tests: failed
-        max-annotations: 50
-        use-actions-summary: true
-
-    - name: Stop Docker
-      if: always()
-      run: npm run docker:ci:subdir:down
-
   test-locale-full-root:
     # Full locale sweep (all 49 locales). Runs on release branches, nightly
     # cron, and manual workflow_dispatch. Listed in package job needs so the
@@ -1104,7 +892,7 @@ jobs:
       run: npm run docker:ci:subdir:down
 
   package:
-    needs: [build, test-root, test-subdir, test-new-system, test-new-system-subdir, test-locale-root, test-locale-subdir, test-locale-full-root, test-locale-full-subdir]
+    needs: [build, test-root, test-subdir, test-new-system, test-new-system-subdir, test-locale-full-root, test-locale-full-subdir]
     # Serialize release uploads per branch so concurrent master builds
     # don't race on gh release upload.
     concurrency:


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

**What changed**

- Renames `.github/workflows/nightly.yml` → `build-test-nightly.yml` for naming consistency with `build-test-package.yml`. Updates the workflow `name:` field to `Build, Test and Package (Nightly)`.
- Updates 3 comment-only references in `build-test-package.yml` to the new filename.
- Removes `test-locale-root` and `test-locale-subdir` from `build-test-package.yml`. Both jobs already exist in `build-test-nightly.yml` (PHP 8.5 nightly). Removes the two jobs from the `package` job's `needs:` list (the gated full-locale jobs remain).

**Trade-off**

PHP 8.4 locale smoke tests no longer run on every push/PR. PHP 8.4 locale coverage is retained via the nightly full-locale sweep (`test-locale-full-root` / `test-locale-full-subdir` in `build-test-package.yml`, cron 02:00 UTC). This is a deliberate trade-off to save ~4 min from every PR check run.