### PR TITLE
Fix issue #9530: Add logging to silent error handlers (3.1, 3.2)

### DIFF
--- a/src/ChurchCRM/Service/GroupService.php
+++ b/src/ChurchCRM/Service/GroupService.php
@@ -11,6 +11,7 @@ use ChurchCRM\model\ChurchCRM\PersonQuery;
 use ChurchCRM\Service\AuthService;
 use ChurchCRM\Utils\FunctionsUtils;
 use ChurchCRM\Utils\InputUtils;
+use ChurchCRM\Utils\LoggerUtils;
 use Propel\Runtime\Propel;
 
 class GroupService
@@ -103,7 +104,13 @@ class GroupService
             $person2group2role->save();
             $result = true;
         } catch (\Throwable $t) {
-            // do nothing
+            $logger = LoggerUtils::getAppLogger();
+            $logger->warning('Failed to add person to group', [
+                'groupId' => $iGroupID,
+                'personId' => $iPersonID,
+                'roleId' => $iRoleID,
+                'error' => $t->getMessage(),
+            ]);
         }
 
         if ($result) {
@@ -139,7 +146,13 @@ class GroupService
             $person2group2role->save();
             $result = true;
         } catch (\Throwable $t) {
-            // do nothing
+            $logger = LoggerUtils::getAppLogger();
+            $logger->warning('Failed to add person to group (internal import)', [
+                'groupId' => $iGroupID,
+                'personId' => $iPersonID,
+                'roleId' => $iRoleID,
+                'error' => $t->getMessage(),
+            ]);
         }
 
         if ($result) {

--- a/src/ChurchCRM/dto/Notification.php
+++ b/src/ChurchCRM/dto/Notification.php
@@ -5,6 +5,7 @@ namespace ChurchCRM\dto;
 use ChurchCRM\Emails\notifications\NotificationEmail;
 use ChurchCRM\model\ChurchCRM\Person;
 use ChurchCRM\Plugin\PluginManager;
+use ChurchCRM\Utils\LoggerUtils;
 
 class Notification
 {
@@ -102,8 +103,14 @@ class Notification
             $sendEmail = false;
             try {
                 $sendEmail = $this->sendEmail();
-            } catch (\Throwable) {
-                // do nothing
+            } catch (\Throwable $t) {
+                LoggerUtils::getAppLogger()->error('Notification send failed: Email', [
+                    'personId' => $this->person?->getId(),
+                    'personName' => $this->person?->getFullName(),
+                    'eventName' => $this->eventName,
+                    'recipientCount' => count($this->recipients),
+                    'error' => $t->getMessage(),
+                ]);
             }
             $methods[] = 'email: ' . $sendEmail;
         }
@@ -114,8 +121,14 @@ class Notification
             $sendSms = false;
             try {
                 $sendSms = $this->sendSMS();
-            } catch (\Throwable) {
-                // do nothing
+            } catch (\Throwable $t) {
+                LoggerUtils::getAppLogger()->error('Notification send failed: SMS', [
+                    'personId' => $this->person?->getId(),
+                    'personName' => $this->person?->getFullName(),
+                    'eventName' => $this->eventName,
+                    'recipientCount' => count($this->recipients),
+                    'error' => $t->getMessage(),
+                ]);
             }
             $methods[] = 'sms: ' . $sendSms;
         }
@@ -126,8 +139,14 @@ class Notification
             $sendOpenLp = false;
             try {
                 $sendOpenLp = (bool) $this->sendProjector();
-            } catch (\Throwable) {
-                // do nothing
+            } catch (\Throwable $t) {
+                LoggerUtils::getAppLogger()->error('Notification send failed: Projector/OpenLP', [
+                    'personId' => $this->person?->getId(),
+                    'personName' => $this->person?->getFullName(),
+                    'eventName' => $this->eventName,
+                    'projectorText' => $this->projectorText,
+                    'error' => $t->getMessage(),
+                ]);
             }
             $methods[] = 'projector: ' . $sendOpenLp;
         }


### PR DESCRIPTION
## Summary
Add comprehensive logging to critical error paths that were previously silently swallowing exceptions, making it impossible to debug notification failures and group operations.

## Changes

### Category 3.1: GroupService — Silent error swallowing

**Problem**: When adding a person to a group fails, the exception is caught and silently ignored.
- `addUserToGroup()` (line 105-106)
- `addUserToGroupInternal()` (line 141-142)
- Both catch `\Throwable` with `// do nothing` comment

**Impact**: Failed group memberships provide no diagnostic information.

**Solution**: Log warnings with context:
```php
catch (\Throwable $t) {
    $logger = LoggerUtils::getAppLogger();
    $logger->warning('Failed to add person to group', [
        'groupId' => $iGroupID,
        'personId' => $iPersonID,
        'roleId' => $iRoleID,
        'error' => $t->getMessage(),
    ]);
}
```

### Category 3.2: Notification::send() — Silent channel failures

**Problem**: Notifications fail silently on three critical channels:
- Email (line 105-107): Silent catch
- SMS/Vonage (line 117-119): Silent catch
- Projector/OpenLP (line 129-131): Silent catch

**Impact**: Users don't know why notifications weren't delivered.

**Solution**: Log errors with context for each channel:

**Email**: 
```php
catch (\Throwable $t) {
    LoggerUtils::getAppLogger()->error('Notification send failed: Email', [
        'personId' => $this->person?->getId(),
        'personName' => $this->person?->getFullName(),
        'eventName' => $this->eventName,
        'recipientCount' => count($this->recipients),
        'error' => $t->getMessage(),
    ]);
}
```

**SMS** and **Projector** follow the same pattern with channel-specific context.

## Backward Compatibility
- No exceptions thrown (still caught internally)
- Return values unchanged (method still returns array with status/methods)
- Only adds logging for visibility
- Non-breaking change

## Testing
- ✅ PHP syntax: 2 files validated
- ✅ Biome lint: 0 errors
- ✅ Pre-commit hooks: pass

## Impact
- **GroupService**: Failed group additions now logged for debugging
- **Notifications**: Email, SMS, and projector failures now visible in logs
- **Debugging**: Admins can now troubleshoot notification delivery issues instead of guessing why notifications don't arrive

Related: #9530 (Code audit: Anti-patterns & performance)