### PR TITLE
feat: add capture/ — standalone Playwright visual capture system

### DIFF
--- a/capture/.gitignore
+++ b/capture/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+# Local video/screenshot output — never commit raw capture assets
+*.webm
+*.mp4
+*.png
+out/
+tmp/

--- a/capture/README.md
+++ b/capture/README.md
@@ -79,11 +79,11 @@ npm run docker:ci:new-system:start
 
 # 2. Complete the wizard at http://localhost (set church name, admin password)
 
-# 3. Seed with clean demo data via Node
-node -e "
+# 3. Seed with clean demo data
+cd capture && node - << 'EOF'
 const { chromium } = require('@playwright/test');
-const { login } = require('./capture/helpers/auth');
-const { importDemoData } = require('./capture/helpers/seed');
+const { login } = require('./helpers/auth');
+const { importDemoData } = require('./helpers/seed');
 (async () => {
   const browser = await chromium.launch();
   const page = await (await browser.newContext()).newPage();
@@ -92,7 +92,8 @@ const { importDemoData } = require('./capture/helpers/seed');
   await browser.close();
   console.log('Seeded!');
 })();
-"
+EOF
+cd ..
 ```
 
 This imports from `src/admin/demo/` (people.json, groups.json, events.csv, finance.json)

--- a/capture/README.md
+++ b/capture/README.md
@@ -1,0 +1,191 @@
+# ChurchCRM Visual Capture System
+
+Standalone Playwright-based system for producing video and screenshot assets used in social-media tutorials (YouTube Shorts, Reels, TikTok).
+
+This folder is completely independent of `cypress/` and must never modify or share its `package.json`.
+
+---
+
+## Quick Start
+
+```bash
+# 1. Install dependencies (inside this folder only)
+cd capture
+npm install
+npm run install:browsers   # downloads Playwright's Chromium
+
+# 2. Start a ChurchCRM Docker stack with demo data (see Docker section below)
+cd ..
+npm run docker:dev:start   # or: npm run docker:ci:new-system:start
+
+# 3. Run a scene
+node capture/scenes/pledge_tracking.js --out-dir /tmp/capture-test --scene-id demo
+```
+
+Output files will be in `/tmp/capture-test/`:
+
+| File | Description |
+|------|-------------|
+| `demo_raw.webm` | Full scene recording — **always produced** |
+| `demo_pledge_summary.png` | Named still captured mid-scene — optional per scene |
+
+---
+
+## CLI Contract
+
+Every scene is a self-contained Node script with the same interface:
+
+```
+node capture/scenes/<name>.js --out-dir <dir> --scene-id <id>
+```
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `--out-dir` | ✅ | Directory where output files are written (created if absent) |
+| `--scene-id` | ✅ | Prefix for all output filenames, e.g. `demo` |
+
+### Output filenames
+
+- **Mandatory**: `<scene-id>_raw.webm` — the full recording
+- **Optional**: `<scene-id>_<label>.png` — named still(s) captured during the scene
+
+### Exit codes
+
+- `0` — scene completed successfully; `.webm` verified non-empty
+- Non-zero — failure, with a clear message on stderr
+
+---
+
+## Docker Environments
+
+### PATH A — Demo-seeded stack (quick iteration)
+
+```bash
+npm run docker:dev:start
+```
+
+Starts ChurchCRM and replays `cypress/data/seed.sql`.  Data is ready immediately.
+Contains test-run artifacts (test users, generated data) — fine for development but not
+ideal for polished tutorial recordings.
+
+Credentials: `admin / changeme`  
+Base URL: `http://localhost`
+
+### PATH B — Fresh install + demo import (preferred for capture)
+
+```bash
+# 1. Start a fresh-install stack (no Config.php → triggers setup wizard)
+npm run docker:ci:new-system:start
+
+# 2. Complete the wizard at http://localhost (set church name, admin password)
+
+# 3. Seed with clean demo data via Node
+node -e "
+const { chromium } = require('@playwright/test');
+const { login } = require('./capture/helpers/auth');
+const { importDemoData } = require('./capture/helpers/seed');
+(async () => {
+  const browser = await chromium.launch();
+  const page = await (await browser.newContext()).newPage();
+  await login(page);
+  await importDemoData(page, { force: true });
+  await browser.close();
+  console.log('Seeded!');
+})();
+"
+```
+
+This imports from `src/admin/demo/` (people.json, groups.json, events.csv, finance.json)
+producing clean, photogenic data with no test artifacts.
+
+**DB reset between captures:**
+
+- PATH A: `npm run docker:test:reset:db` (replays seed.sql)
+- PATH B: `npm run docker:ci:new-system:down && npm run docker:ci:new-system:start` (full teardown + restart)
+
+---
+
+## Configuration
+
+| Environment variable | Default | Description |
+|----------------------|---------|-------------|
+| `CAPTURE_BASE_URL` | `http://localhost` | ChurchCRM base URL |
+| `CAPTURE_ADMIN_USERNAME` | `admin` | Admin username (matches Cypress docker.config.ts) |
+| `CAPTURE_ADMIN_PASSWORD` | `changeme` | Admin password |
+| `CAPTURE_OUTPUT_ROOT` | `./out` | Default output directory for ad-hoc runs |
+
+---
+
+## How Capture Differs from Cypress
+
+| | `capture/` | `cypress/` |
+|--|------------|------------|
+| **Purpose** | Produce video/screenshot assets for tutorials | Automated regression testing |
+| **Output** | `.webm` recordings + named `.png` stills | Pass/fail test results |
+| **Run style** | One Node script per scene, no test runner | Cypress runner (mocha-based) |
+| **Dark theme** | Forced dark (photogenic) | Default app theme |
+| **Viewport** | 390×844 mobile (parameterisable) | 1920×1080 desktop |
+| **Shared** | Nothing — completely separate `package.json` | — |
+
+---
+
+## Adding a New Scene
+
+1. Copy `scenes/pledge_tracking.js` to `scenes/<your_scene>.js`.
+2. Update the `--out-dir` / `--scene-id` usage comment at the top.
+3. Replace the interaction block (steps 3–8) with your scene's navigation and interactions.
+4. Use helpers:
+   - `login(page)` — authenticate
+   - `forceDarkTheme(page)` — re-apply after each navigation
+   - `smoothMouseMove(page, from, to, steps, durationMs)` — natural mouse movement
+   - `pause(ms)` — readability beat
+   - `typeSlowly(page, selector, text, delayMs)` — human-paced typing
+   - `page.screenshot({ path })` — named still at any moment
+
+The CLI contract, exit codes, and output naming are handled by the scaffold — you only
+write the interaction steps.
+
+---
+
+## Dark Theme
+
+ChurchCRM's dark theme sets `data-bs-theme="dark"` on `<html>`.  The real toggle is
+`window.CRM.theme.setMode('dark')` (defined in `src/Include/Header.php`).
+
+`helpers/theme.js` calls this toggle after each navigation and also installs an init
+script that stamps the attribute before the first paint (FOWT-safe).  Do not invent
+your own theme mechanism — always call `forceDarkTheme(page)` from this helper.
+
+---
+
+## Viewport
+
+Default is **390×844** (mobile portrait — ideal for Shorts/Reels/TikTok).
+
+For desktop-only views, override in your scene:
+
+```js
+const context = await browser.newContext({
+  viewport: { width: 1280, height: 800 },
+  recordVideo: { dir: outDir, size: { width: 1280, height: 800 } },
+});
+```
+
+---
+
+## File Structure
+
+```
+capture/
+  package.json             # standalone deps — playwright, minimist
+  capture.config.js        # BASE_URL, DEFAULT_VIEWPORT, OUTPUT_ROOT, DEFAULT_CREDENTIALS
+  .gitignore               # excludes node_modules and local video output
+  helpers/
+    auth.js                # login(page, credentials) — ported from Cypress
+    theme.js               # installDarkThemeInitScript(), forceDarkTheme()
+    interaction.js         # smoothMouseMove(), pause(), typeSlowly()
+    seed.js                # importDemoData() + Docker setup documentation
+  scenes/
+    pledge_tracking.js     # example scene — Pledge Tracking
+  README.md                # this file
+```

--- a/capture/capture.config.js
+++ b/capture/capture.config.js
@@ -1,0 +1,34 @@
+/**
+ * capture.config.js — shared constants for all capture scenes
+ *
+ * Credentials mirror cypress/configs/docker.config.ts (admin.username / admin.password).
+ * Override via environment variables — never hardcode secrets in scene files.
+ *
+ * Environment variables:
+ *   CAPTURE_BASE_URL           – app base URL (default: http://localhost)
+ *   CAPTURE_ADMIN_USERNAME     – admin username (default: admin)
+ *   CAPTURE_ADMIN_PASSWORD     – admin password (default: changeme)
+ *   CAPTURE_OUTPUT_ROOT        – default output root for ad-hoc runs (default: ./out)
+ */
+
+'use strict';
+
+const BASE_URL = process.env.CAPTURE_BASE_URL || 'http://localhost';
+
+/** Default viewport: mobile/vertical (matches primary target for Shorts/Reels/TikTok). */
+const DEFAULT_VIEWPORT = { width: 390, height: 844 };
+
+/** Default output root for ad-hoc local runs. CLI --out-dir overrides this. */
+const OUTPUT_ROOT = process.env.CAPTURE_OUTPUT_ROOT || './out';
+
+/**
+ * Default credentials — sourced from environment, falling back to the same
+ * values as cypress/configs/docker.config.ts so local Docker stacks work
+ * out of the box without any configuration.
+ */
+const DEFAULT_CREDENTIALS = {
+  username: process.env.CAPTURE_ADMIN_USERNAME || 'admin',
+  password: process.env.CAPTURE_ADMIN_PASSWORD || 'changeme',
+};
+
+module.exports = { BASE_URL, DEFAULT_VIEWPORT, OUTPUT_ROOT, DEFAULT_CREDENTIALS };

--- a/capture/helpers/auth.js
+++ b/capture/helpers/auth.js
@@ -1,0 +1,52 @@
+/**
+ * helpers/auth.js — authentication helper for capture scenes
+ *
+ * Ported from cypress/support/ui-commands.js (setupLoginSession / setupAdminSession).
+ * Uses the same form-based login flow ChurchCRM ships: POST to /login, fill
+ * input[name=User] and input[name=Password], then wait until the URL is no
+ * longer at the session/begin (login) page.
+ *
+ * Credentials are read from capture.config.js (which reads env vars), so no
+ * secrets ever appear in scene files.
+ */
+
+'use strict';
+
+const { BASE_URL, DEFAULT_CREDENTIALS } = require('../capture.config');
+
+/**
+ * Log in to ChurchCRM using the standard login form.
+ *
+ * Call this once after creating the page (before recording meaningful frames).
+ * The page must be inside a context with the correct baseURL already applied,
+ * or pass absolute URLs.
+ *
+ * @param {import('playwright').Page} page
+ * @param {{ username?: string, password?: string }} [credentials]
+ *   Defaults to DEFAULT_CREDENTIALS from capture.config.js (admin/changeme).
+ * @returns {Promise<void>}
+ */
+async function login(page, credentials = {}) {
+  const username = credentials.username || DEFAULT_CREDENTIALS.username;
+  const password = credentials.password || DEFAULT_CREDENTIALS.password;
+
+  // Navigate to the login page.  ChurchCRM's login form lives at /login and
+  // also at /session/begin — /login is the canonical entry point.
+  await page.goto(`${BASE_URL}/login`, { waitUntil: 'networkidle' });
+
+  // Fill in credentials exactly as Cypress does in setupLoginSession.
+  await page.fill('input[name=User]', username);
+  await page.fill('input[name=Password]', password);
+  await page.keyboard.press('Enter');
+
+  // Wait until the URL leaves the session/begin (login) page.
+  await page.waitForFunction(
+    () => !window.location.href.includes('/session/begin'),
+    { timeout: 30_000 }
+  );
+
+  // Give the page a moment to settle after redirect.
+  await page.waitForLoadState('networkidle');
+}
+
+module.exports = { login };

--- a/capture/helpers/interaction.js
+++ b/capture/helpers/interaction.js
@@ -1,0 +1,72 @@
+/**
+ * helpers/interaction.js — human-paced interaction primitives for visual capture
+ *
+ * These helpers exist to make recordings look natural.  They are NOT test
+ * assertions; they deliberately slow things down for a viewer's eye.
+ */
+
+'use strict';
+
+/**
+ * Linearly interpolate a single axis.
+ * @param {number} start
+ * @param {number} end
+ * @param {number} t  – 0..1
+ * @returns {number}
+ */
+function lerp(start, end, t) {
+  return start + (end - start) * t;
+}
+
+/**
+ * Move the mouse smoothly from `from` to `to` over `durationMs` milliseconds,
+ * taking `steps` intermediate positions.  Never teleports.
+ *
+ * @param {import('playwright').Page} page
+ * @param {{ x: number, y: number }} from
+ * @param {{ x: number, y: number }} to
+ * @param {number} steps     – number of intermediate mouse positions (default 30)
+ * @param {number} durationMs – total movement time in ms (default 600)
+ */
+async function smoothMouseMove(page, from, to, steps = 30, durationMs = 600) {
+  const delayPerStep = durationMs / steps;
+  for (let i = 0; i <= steps; i++) {
+    const t = i / steps;
+    const x = Math.round(lerp(from.x, to.x, t));
+    const y = Math.round(lerp(from.y, to.y, t));
+    await page.mouse.move(x, y);
+    if (delayPerStep > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delayPerStep));
+    }
+  }
+}
+
+/**
+ * Pause for a deliberate readability beat — lets viewers absorb what they see.
+ *
+ * @param {number} ms – milliseconds to pause (default 800)
+ */
+async function pause(ms = 800) {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Type text into a selector at a human-paced delay between each character.
+ * Uses page.locator().type() with per-character delay so keystrokes appear
+ * natural in the recording.
+ *
+ * @param {import('playwright').Page} page
+ * @param {string} selector  – CSS / Playwright selector
+ * @param {string} text      – text to type
+ * @param {number} delayMs   – delay between characters in ms (default 80)
+ */
+async function typeSlowly(page, selector, text, delayMs = 80) {
+  const locator = page.locator(selector);
+  await locator.click();
+  for (const char of text) {
+    await page.keyboard.type(char);
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+}
+
+module.exports = { smoothMouseMove, pause, typeSlowly };

--- a/capture/helpers/interaction.js
+++ b/capture/helpers/interaction.js
@@ -52,8 +52,8 @@ async function pause(ms = 800) {
 
 /**
  * Type text into a selector at a human-paced delay between each character.
- * Uses page.locator().type() with per-character delay so keystrokes appear
- * natural in the recording.
+ * Clicks the selector to focus, then types each character with a deliberate
+ * delay between keystrokes using page.keyboard.type() in a loop.
  *
  * @param {import('playwright').Page} page
  * @param {string} selector  – CSS / Playwright selector

--- a/capture/helpers/seed.js
+++ b/capture/helpers/seed.js
@@ -27,7 +27,7 @@
  *
  * ── importDemoData() ──────────────────────────────────────────────────────────
  *
- * Calls POST /api/demo/load (src/admin/routes/api/demo.php) with the
+ * Calls POST /admin/api/demo/load (src/admin/routes/api/demo.php) with the
  * recommended flags.  Guards:
  *   - The endpoint requires the database to have exactly 1 person (the admin
  *     created by the setup wizard) unless force:true is passed.
@@ -78,7 +78,7 @@ async function importDemoData(page, options = {}) {
     force = false,
   } = options;
 
-  const response = await page.request.post(`${BASE_URL}/api/demo/load`, {
+  const response = await page.request.post(`${BASE_URL}/admin/api/demo/load`, {
     data: { includeFinancial, includeEvents, includeSundaySchool, force },
     headers: { 'Content-Type': 'application/json' },
   });

--- a/capture/helpers/seed.js
+++ b/capture/helpers/seed.js
@@ -1,0 +1,108 @@
+/**
+ * helpers/seed.js — demo data seeding for capture scenes
+ *
+ * ── Two Docker paths ──────────────────────────────────────────────────────────
+ *
+ * PATH A — Demo-seeded stack (quick iteration):
+ *   npm run docker:dev:start
+ *   The dev compose mounts cypress/data/seed.sql which pre-populates the DB
+ *   with test users, families, groups, and finance data.  Fast to start; data
+ *   is present immediately.  Contains test-run artifacts.
+ *
+ * PATH B — Fresh install + demo import (preferred for capture):
+ *   1. npm run docker:ci:new-system:start
+ *      Starts ChurchCRM without any Config.php (triggers setup wizard).
+ *   2. Complete the setup wizard in the browser (http://localhost) — set
+ *      church name, admin password, and database credentials.
+ *   3. Call importDemoData() below (or run the scene with CAPTURE_FORCE_DEMO=1)
+ *      to populate realistic people, families, groups, events, and finance data
+ *      from src/admin/demo/.
+ *   4. Run scenes — data is clean, photogenic, and has no test artifacts.
+ *
+ *   DB reset (between captures):
+ *     npm run docker:test:reset:db
+ *     This replays cypress/data/seed.sql — use for PATH A only.
+ *     For PATH B, tear down and recreate the stack:
+ *       npm run docker:ci:new-system:down && npm run docker:ci:new-system:start
+ *
+ * ── importDemoData() ──────────────────────────────────────────────────────────
+ *
+ * Calls POST /api/demo/load (src/admin/routes/api/demo.php) with the
+ * recommended flags.  Guards:
+ *   - The endpoint requires the database to have exactly 1 person (the admin
+ *     created by the setup wizard) unless force:true is passed.
+ *   - Admin authentication is required (cookie session from a prior login, or
+ *     pass credentials to login() first).
+ *
+ * The function accepts a Playwright page that is already authenticated (call
+ * login() first).  It makes the API request via page.request so it shares the
+ * authenticated browser session.
+ *
+ * @example
+ *   const { login } = require('./auth');
+ *   const { importDemoData } = require('./seed');
+ *
+ *   // After starting a fresh-install Docker stack and running the wizard:
+ *   await login(page);
+ *   await importDemoData(page, { force: false }); // fails if DB has > 1 person
+ *   // – or –
+ *   await importDemoData(page, { force: true });   // skips the fresh-install guard
+ */
+
+'use strict';
+
+const { BASE_URL } = require('../capture.config');
+
+/**
+ * Trigger ChurchCRM's built-in demo importer via the admin API.
+ *
+ * Imports:
+ *   - People & families (src/admin/demo/people.json)
+ *   - Groups (src/admin/demo/groups.json)
+ *   - Events with attendance (src/admin/demo/events.csv + attendees.csv)
+ *   - Financial data: funds, fundraisers, pledges, deposits (finance.json)
+ *   - Sunday school groups
+ *
+ * @param {import('playwright').Page} page
+ *   An authenticated Playwright page (call login() before this).
+ * @param {{ includeFinancial?: boolean, includeEvents?: boolean,
+ *           includeSundaySchool?: boolean, force?: boolean }} [options]
+ * @returns {Promise<object>} The API response body.
+ * @throws {Error} if the API returns a non-200 status.
+ */
+async function importDemoData(page, options = {}) {
+  const {
+    includeFinancial = true,
+    includeEvents = true,
+    includeSundaySchool = true,
+    force = false,
+  } = options;
+
+  const response = await page.request.post(`${BASE_URL}/api/demo/load`, {
+    data: { includeFinancial, includeEvents, includeSundaySchool, force },
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+  const body = await response.json().catch(() => ({}));
+
+  if (!response.ok()) {
+    throw new Error(
+      `Demo data import failed (HTTP ${response.status()}): ${body.message || JSON.stringify(body)}`
+    );
+  }
+
+  if (!body.success) {
+    throw new Error(
+      `Demo data import returned success:false — ${body.message || JSON.stringify(body.errors)}`
+    );
+  }
+
+  console.log(
+    `[seed] Demo data imported in ${body.elapsedSeconds}s:`,
+    JSON.stringify(body.imported)
+  );
+
+  return body;
+}
+
+module.exports = { importDemoData };

--- a/capture/helpers/theme.js
+++ b/capture/helpers/theme.js
@@ -1,0 +1,72 @@
+/**
+ * helpers/theme.js — dark-theme forcing for capture scenes
+ *
+ * ChurchCRM's real dark-theme mechanism (src/Include/Header.php):
+ *   - Server renders data-bs-theme="dark" on <html> when the user's
+ *     ui.style setting is 'dark'.
+ *   - A synchronous inline <head> script exposes window.CRM.theme.setMode()
+ *     which applies / removes data-bs-theme="dark" on <html> client-side.
+ *
+ * Strategy for capture:
+ *  1. page.addInitScript() stamps data-bs-theme="dark" on documentElement
+ *     as early as possible (before any CSS paints), preventing flash-of-
+ *     wrong-theme (FOWT) for the very first navigation.
+ *  2. After each navigation (goto), call forceDarkTheme(page) which invokes
+ *     window.CRM.theme.setMode('dark') — the real toggle — so the theme is
+ *     enforced at the app layer and not just via an attribute.
+ *  3. We verify the attribute is present before recording key frames.
+ *
+ * Do NOT invent a new mechanism (localStorage key, cookie, etc.).
+ * This code exclusively uses the API defined in Header.php.
+ */
+
+'use strict';
+
+/**
+ * Install an init script on this page that stamps data-bs-theme="dark" on
+ * <html> as early as possible — before any stylesheets are evaluated.
+ *
+ * Call this ONCE immediately after page creation (before the first goto).
+ * It survives across same-context navigations.
+ *
+ * @param {import('playwright').Page} page
+ */
+async function installDarkThemeInitScript(page) {
+  await page.addInitScript(() => {
+    // Run synchronously before any script / CSS evaluation.
+    document.documentElement.setAttribute('data-bs-theme', 'dark');
+  });
+}
+
+/**
+ * Force dark theme after a page navigation.
+ *
+ * Calls the real ChurchCRM toggle (window.CRM.theme.setMode('dark')) so the
+ * app layer is aligned with the attribute.  Falls back to setting the
+ * attribute directly if CRM.theme is not yet initialised (e.g. very early in
+ * page load).  Then asserts the attribute is present.
+ *
+ * @param {import('playwright').Page} page
+ */
+async function forceDarkTheme(page) {
+  // Wait for the page to be interactive enough for CRM globals to exist.
+  await page.waitForLoadState('domcontentloaded');
+
+  await page.evaluate(() => {
+    if (window.CRM && window.CRM.theme && typeof window.CRM.theme.setMode === 'function') {
+      // Use the real app toggle defined in src/Include/Header.php.
+      window.CRM.theme.setMode('dark');
+    } else {
+      // Fallback: stamp the attribute that the real toggle would set.
+      document.documentElement.setAttribute('data-bs-theme', 'dark');
+    }
+  });
+
+  // Verify dark theme is active before the scene records meaningful frames.
+  await page.waitForFunction(
+    () => document.documentElement.getAttribute('data-bs-theme') === 'dark',
+    { timeout: 5_000 }
+  );
+}
+
+module.exports = { installDarkThemeInitScript, forceDarkTheme };

--- a/capture/package-lock.json
+++ b/capture/package-lock.json
@@ -1,0 +1,82 @@
+{
+  "name": "churchcrm-capture",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "churchcrm-capture",
+      "version": "1.0.0",
+      "dependencies": {
+        "@playwright/test": "^1.45.0",
+        "minimist": "^1.2.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/capture/package.json
+++ b/capture/package.json
@@ -4,7 +4,7 @@
   "description": "Standalone Playwright-based visual capture system for ChurchCRM — produces video/screenshot assets for tutorials",
   "private": true,
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "scripts": {
     "install:browsers": "npx playwright install chromium"

--- a/capture/package.json
+++ b/capture/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "churchcrm-capture",
+  "version": "1.0.0",
+  "description": "Standalone Playwright-based visual capture system for ChurchCRM — produces video/screenshot assets for tutorials",
+  "private": true,
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "install:browsers": "npx playwright install chromium"
+  },
+  "dependencies": {
+    "@playwright/test": "^1.45.0",
+    "minimist": "^1.2.8"
+  }
+}

--- a/capture/scenes/pledge_tracking.js
+++ b/capture/scenes/pledge_tracking.js
@@ -1,0 +1,237 @@
+/**
+ * scenes/pledge_tracking.js — visual capture: Pledge Tracking
+ *
+ * CLI contract (required by external orchestrators):
+ *   node capture/scenes/pledge_tracking.js --out-dir <dir> --scene-id <id>
+ *
+ * Outputs:
+ *   <out-dir>/<scene-id>_raw.webm           – full scene recording (mandatory)
+ *   <out-dir>/<scene-id>_pledge_summary.png – named still at summary totals (optional)
+ *
+ * Exit behaviour:
+ *   - Non-zero + clear stderr message on any failure.
+ *   - Exit 0 only after verifying the .webm exists and has non-zero size.
+ *
+ * Requires: ChurchCRM running at BASE_URL (see capture.config.js).
+ *           npm install inside capture/ to install Playwright.
+ *           Playwright Chromium browser: npm run install:browsers
+ */
+
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const { execSync } = require('child_process');
+const { chromium } = require('@playwright/test');
+const minimist = require('minimist');
+
+const { BASE_URL, DEFAULT_VIEWPORT } = require('../capture.config');
+const { login } = require('../helpers/auth');
+const { installDarkThemeInitScript, forceDarkTheme } = require('../helpers/theme');
+const { smoothMouseMove, pause, typeSlowly } = require('../helpers/interaction');
+
+// ── CLI argument parsing ───────────────────────────────────────────────────────
+const argv = minimist(process.argv.slice(2), { string: ['out-dir', 'scene-id'] });
+const outDir = argv['out-dir'];
+const sceneId = argv['scene-id'];
+
+if (!outDir || !sceneId) {
+  process.stderr.write(
+    'Error: --out-dir and --scene-id are required.\n' +
+    'Usage: node capture/scenes/pledge_tracking.js --out-dir <dir> --scene-id <id>\n'
+  );
+  process.exit(1);
+}
+
+// Ensure output directory exists.
+fs.mkdirSync(outDir, { recursive: true });
+
+// ── Viewport for this scene (mobile/vertical) ─────────────────────────────────
+const VIEWPORT = DEFAULT_VIEWPORT; // 390×844
+
+// ── Main capture function ──────────────────────────────────────────────────────
+async function run() {
+  const browser = await chromium.launch({ headless: true });
+
+  // Playwright records video per-context.  One context = one video file.
+  const context = await browser.newContext({
+    viewport: VIEWPORT,
+    recordVideo: {
+      dir: outDir,
+      size: VIEWPORT,
+    },
+    // Ignore HTTPS errors for local Docker setups.
+    ignoreHTTPSErrors: true,
+  });
+
+  const page = await context.newPage();
+
+  // Install init script BEFORE the first navigation so the very first paint
+  // is already dark (FOWT-safe).
+  await installDarkThemeInitScript(page);
+
+  try {
+    // ── 1. Log in ──────────────────────────────────────────────────────────
+    await login(page);
+
+    // ── 2. Force dark theme using ChurchCRM's real toggle ─────────────────
+    // window.CRM.theme.setMode('dark') is defined in src/Include/Header.php
+    await forceDarkTheme(page);
+    await pause(500);
+
+    // ── 3. Navigate to Pledge Tracking ────────────────────────────────────
+    await page.goto(`${BASE_URL}/PledgeDetails.php`, { waitUntil: 'networkidle' });
+    await forceDarkTheme(page);   // re-apply after navigation
+    await pause(1000);             // let viewer absorb the page
+
+    // ── 4. Slow scroll — reveal pledge summary section ───────────────────
+    //  Scroll down gently so the viewer can read the totals.
+    const viewportHeight = VIEWPORT.height;
+    const scrollSteps = 20;
+    for (let i = 1; i <= scrollSteps; i++) {
+      await page.evaluate((scrollY) => window.scrollTo(0, scrollY), (i / scrollSteps) * 400);
+      await pause(60);
+    }
+    await pause(800);
+
+    // ── 5. Smooth mouse moves over summary totals ─────────────────────────
+    //  Move across the summary area to highlight figures.
+    const centerX = Math.round(VIEWPORT.width / 2);
+    await smoothMouseMove(
+      page,
+      { x: 30, y: 300 },
+      { x: centerX, y: 350 },
+      25,
+      700
+    );
+    await pause(600);
+
+    await smoothMouseMove(
+      page,
+      { x: centerX, y: 350 },
+      { x: VIEWPORT.width - 30, y: 350 },
+      25,
+      700
+    );
+    await pause(600);
+
+    // ── 6. Named screenshot at the summary view ───────────────────────────
+    const screenshotPath = path.join(outDir, `${sceneId}_pledge_summary.png`);
+    await page.screenshot({ path: screenshotPath, fullPage: false });
+    console.log(`[capture] Screenshot saved: ${screenshotPath}`);
+    await pause(500);
+
+    // ── 7. Click a pledge fund row if one is visible ───────────────────────
+    //  Attempt to interact with the first clickable row; skip gracefully if
+    //  no data is loaded (captures still work with an empty pledge list).
+    try {
+      const firstRow = page.locator('table tbody tr').first();
+      const rowCount = await firstRow.count();
+      if (rowCount > 0) {
+        const rowBox = await firstRow.boundingBox();
+        if (rowBox) {
+          await smoothMouseMove(
+            page,
+            { x: centerX, y: rowBox.y + rowBox.height / 2 - 60 },
+            { x: centerX, y: rowBox.y + rowBox.height / 2 },
+            20,
+            500
+          );
+          await pause(400);
+          await firstRow.click();
+          await page.waitForLoadState('networkidle');
+          await forceDarkTheme(page);
+          await pause(1200);
+        }
+      }
+    } catch (_e) {
+      // No table rows or click failed — not fatal, continue.
+    }
+
+    // ── 8. Final scroll back to top ────────────────────────────────────────
+    for (let i = scrollSteps; i >= 0; i--) {
+      await page.evaluate((scrollY) => window.scrollTo(0, scrollY), (i / scrollSteps) * 400);
+      await pause(40);
+    }
+    await pause(800);
+
+  } finally {
+    // Closing the context flushes the video to disk.
+    await context.close();
+    await browser.close();
+  }
+
+  // ── 9. Move the recorded video to the required output path ────────────────
+  //  Playwright saves the video with an auto-generated UUID filename inside
+  //  outDir.  We locate it (newest .webm in outDir) and rename to the
+  //  canonical <scene-id>_raw.webm name.
+  const rawWebmPath = path.join(outDir, `${sceneId}_raw.webm`);
+
+  const webmFiles = fs
+    .readdirSync(outDir)
+    .filter((f) => f.endsWith('.webm') && !f.startsWith(sceneId))
+    .map((f) => ({ f, mtime: fs.statSync(path.join(outDir, f)).mtimeMs }))
+    .sort((a, b) => b.mtime - a.mtime);
+
+  if (webmFiles.length === 0) {
+    // Playwright may already have named it after page.video().path() resolution.
+    // Check if rawWebmPath itself already exists (shouldn't, but guard anyway).
+    if (!fs.existsSync(rawWebmPath)) {
+      throw new Error('No .webm file was produced in the output directory.');
+    }
+  } else {
+    const srcWebm = path.join(outDir, webmFiles[0].f);
+    fs.renameSync(srcWebm, rawWebmPath);
+    console.log(`[capture] Video saved: ${rawWebmPath}`);
+  }
+
+  // ── 10. Verify output ──────────────────────────────────────────────────────
+  verifyOutput(rawWebmPath);
+}
+
+/**
+ * Verify the output .webm file is non-empty and, if ffprobe is available,
+ * has a non-zero duration.
+ *
+ * @param {string} webmPath
+ */
+function verifyOutput(webmPath) {
+  if (!fs.existsSync(webmPath)) {
+    throw new Error(`Expected output file not found: ${webmPath}`);
+  }
+
+  const { size } = fs.statSync(webmPath);
+  if (size === 0) {
+    throw new Error(`Output file is empty (0 bytes): ${webmPath}`);
+  }
+  console.log(`[capture] Verified: ${webmPath} (${size} bytes)`);
+
+  // Attempt duration check via ffprobe; skip gracefully if not installed.
+  try {
+    const result = execSync(
+      `ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 "${webmPath}"`,
+      { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }
+    ).trim();
+
+    const duration = parseFloat(result);
+    if (isNaN(duration) || duration <= 0) {
+      throw new Error(`Video has zero or invalid duration (${result}): ${webmPath}`);
+    }
+    console.log(`[capture] Duration: ${duration.toFixed(2)}s ✓`);
+  } catch (e) {
+    if (e.message.includes('zero or invalid duration')) {
+      throw e; // ffprobe ran but duration is bad — re-throw
+    }
+    // ffprobe not installed or other exec error — rely on size check above.
+    console.log('[capture] ffprobe not available; duration check skipped (size check passed).');
+  }
+}
+
+// ── Entry point ────────────────────────────────────────────────────────────────
+run().then(() => {
+  console.log('[capture] Scene complete. ✓');
+  process.exit(0);
+}).catch((err) => {
+  process.stderr.write(`[capture] FAILED: ${err.message}\n${err.stack || ''}\n`);
+  process.exit(1);
+});

--- a/capture/scenes/pledge_tracking.js
+++ b/capture/scenes/pledge_tracking.js
@@ -21,14 +21,14 @@
 
 const path = require('path');
 const fs = require('fs');
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 const { chromium } = require('@playwright/test');
 const minimist = require('minimist');
 
 const { BASE_URL, DEFAULT_VIEWPORT } = require('../capture.config');
 const { login } = require('../helpers/auth');
 const { installDarkThemeInitScript, forceDarkTheme } = require('../helpers/theme');
-const { smoothMouseMove, pause, typeSlowly } = require('../helpers/interaction');
+const { smoothMouseMove, pause } = require('../helpers/interaction');
 
 // ── CLI argument parsing ───────────────────────────────────────────────────────
 const argv = minimist(process.argv.slice(2), { string: ['out-dir', 'scene-id'] });
@@ -86,10 +86,10 @@ async function run() {
 
     // ── 4. Slow scroll — reveal pledge summary section ───────────────────
     //  Scroll down gently so the viewer can read the totals.
-    const viewportHeight = VIEWPORT.height;
     const scrollSteps = 20;
+    const scrollTarget = VIEWPORT.height * 0.5; // scroll half a viewport
     for (let i = 1; i <= scrollSteps; i++) {
-      await page.evaluate((scrollY) => window.scrollTo(0, scrollY), (i / scrollSteps) * 400);
+      await page.evaluate((scrollY) => window.scrollTo(0, scrollY), (i / scrollSteps) * scrollTarget);
       await pause(60);
     }
     await pause(800);
@@ -150,7 +150,7 @@ async function run() {
 
     // ── 8. Final scroll back to top ────────────────────────────────────────
     for (let i = scrollSteps; i >= 0; i--) {
-      await page.evaluate((scrollY) => window.scrollTo(0, scrollY), (i / scrollSteps) * 400);
+      await page.evaluate((scrollY) => window.scrollTo(0, scrollY), (i / scrollSteps) * scrollTarget);
       await pause(40);
     }
     await pause(800);
@@ -208,8 +208,9 @@ function verifyOutput(webmPath) {
 
   // Attempt duration check via ffprobe; skip gracefully if not installed.
   try {
-    const result = execSync(
-      `ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 "${webmPath}"`,
+    const result = execFileSync(
+      'ffprobe',
+      ['-v', 'error', '-show_entries', 'format=duration', '-of', 'default=noprint_wrappers=1:nokey=1', webmPath],
       { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }
     ).trim();
 

--- a/capture/scenes/pledge_tracking.js
+++ b/capture/scenes/pledge_tracking.js
@@ -52,7 +52,7 @@ const VIEWPORT = DEFAULT_VIEWPORT; // 390×844
 // ── Main capture function ──────────────────────────────────────────────────────
 async function run() {
   const browser = await chromium.launch({ headless: true });
-
+  try {
   // Playwright records video per-context.  One context = one video file.
   const context = await browser.newContext({
     viewport: VIEWPORT,
@@ -158,6 +158,8 @@ async function run() {
   } finally {
     // Closing the context flushes the video to disk.
     await context.close();
+  }
+  } finally {
     await browser.close();
   }
 
@@ -220,11 +222,13 @@ function verifyOutput(webmPath) {
     }
     console.log(`[capture] Duration: ${duration.toFixed(2)}s ✓`);
   } catch (e) {
-    if (e.message.includes('zero or invalid duration')) {
-      throw e; // ffprobe ran but duration is bad — re-throw
+    if (e.code === 'ENOENT') {
+      // ffprobe not installed — rely on size check above.
+      console.log('[capture] ffprobe not available; duration check skipped (size check passed).');
+      return;
     }
-    // ffprobe not installed or other exec error — rely on size check above.
-    console.log('[capture] ffprobe not available; duration check skipped (size check passed).');
+    // ffprobe ran but failed (corrupt video, non-zero exit, bad duration…)
+    throw e;
   }
 }
 


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Adds a standalone `capture/` directory (sibling to `cypress/`) implementing a Playwright-based system for producing video/screenshot assets for social-media tutorials (Shorts/Reels/TikTok).

**What changed:**
- `capture/package.json` — own deps (playwright, minimist); `cypress/` completely untouched
- `capture/capture.config.js` — BASE_URL, 390×844 default viewport, credentials from env (defaults match `cypress/configs/docker.config.ts`)
- `capture/helpers/auth.js` — `login(page)` ported from Cypress `setupLoginSession` UI flow
- `capture/helpers/interaction.js` — `smoothMouseMove`, `pause`, `typeSlowly`
- `capture/helpers/theme.js` — `forceDarkTheme(page)` via real app toggle `window.CRM.theme.setMode("dark")` (defined in `src/Include/Header.php`); no invented mechanism
- `capture/helpers/seed.js` — `importDemoData()` via `POST /admin/api/demo/load`; documents both Docker paths (demo-seeded vs fresh-install)
- `capture/scenes/pledge_tracking.js` — complete example scene; CLI: `node capture/scenes/pledge_tracking.js --out-dir <dir> --scene-id <id>`; produces `<id>_raw.webm` + `<id>_pledge_summary.png`
- `capture/README.md` — npm install, CLI contract, Docker setup, adding new scenes

**Testing:** Playwright installed and Chromium downloaded; CLI arg validation, module loading, and error paths verified. Full e2e run (produces `.webm`) requires `npm run docker:dev:start` + `npm run docker:dev:build` against a running stack (Docker healthcheck infra constraint in this sandbox prevents automated CI run of the scene itself).