### PR TITLE
Fix issue #9559: Boot plugin system in /api Slim app

### DIFF
--- a/src/api/index.php
+++ b/src/api/index.php
@@ -2,6 +2,8 @@
 
 require_once __DIR__ . '/../Include/LoadConfigs.php';
 
+use ChurchCRM\dto\SystemURLs;
+use ChurchCRM\Plugin\PluginManager;
 use ChurchCRM\Slim\Middleware\AuthMiddleware;
 use ChurchCRM\Slim\Middleware\CorsMiddleware;
 use ChurchCRM\Slim\Middleware\VersionMiddleware;
@@ -27,6 +29,10 @@ SlimUtils::registerDefaultJsonErrorHandler($errorMiddleware);
 $app->add(new CorsMiddleware());
 $app->add(AuthMiddleware::class);
 $app->add(VersionMiddleware::class);
+
+// Initialize plugin system so hook-based plugins (e.g. HookManager::doAction(Hooks::CRON_RUN)
+// from the background timer job endpoint) have their listeners registered
+PluginManager::init(SystemURLs::getDocumentRoot() . '/plugins');
 
 // Group routes for better organization
 require __DIR__ . '/routes/calendar/events.php';


### PR DESCRIPTION
## What Changed

`src/api/index.php` never called `PluginManager::init()`, unlike every other Slim entry point (`Header.php`, `PageInit.php`, `src/plugins/index.php`, `src/kiosk/index.php`). Because of that, `POST /api/background/timerjobs` — which fires `HookManager::doAction(Hooks::CRON_RUN)` — ran with zero plugin listeners registered. Scheduled work for every hook-based plugin, including core's own `external-backup` plugin, has been silently non-functional since this hook-based cron dispatch was introduced.

The fix boots the plugin system in `src/api/index.php` right after the app's middleware is registered, mirroring the existing `PluginManager::init(SystemURLs::getDocumentRoot() . '/plugins')` pattern used elsewhere.

Fixes #9559

## Type
- [x] 🐛 Bug fix

## Testing
- `npm run build:php:validate` — pass (scoped to the changed file)
- `npm run lint` — pass
- Manual review confirming the call site matches the existing `PluginManager::init()` usage in `Header.php`, `PageInit.php`, `src/plugins/index.php`, and `src/kiosk/index.php`

> Note: no automated test currently exercises `HookManager::doAction(Hooks::CRON_RUN)` end-to-end through `/api/background/timerjobs`; verification was manual review against the sibling entry points that already boot the plugin system correctly.

## Screenshots
N/A — no UI change.

## Pre-Merge
- [x] Tested locally
- [x] No new warnings
- [x] Build passes
- [x] Backward compatible (or migration documented)


---
_Generated by [Claude Code](https://claude.ai/code/session_01T27MY69QpravhyTzKWTqd6)_