### PR TITLE
fix(#9488): add dropdownParent:"body" to remaining TomSelect-in-modal call sites

### DIFF
--- a/cypress/e2e/api/private/standard/private.calendar.events-checkin.spec.js
+++ b/cypress/e2e/api/private/standard/private.calendar.events-checkin.spec.js
@@ -316,7 +316,7 @@ describe("API Event Check-in Endpoints", () => {
 
             // Regression: the check-in/out flow now optionally records WHO
             // checked the person out (parent picking up child, etc.) via the
-            // checkedOutById field. The bootbox prompt in event-checkin.js
+            // checkedOutById field. The native BS5 modal in event-checkin.js
             // sends this; verify the API persists it on the EventAttend row.
             it("Records checkedOutById when supplied", () => {
                 expect(testEventId, "before() must have populated testEventId").to.be.a("number");

--- a/cypress/e2e/ui/groups/standard.tomselect-dropdownparent.spec.js
+++ b/cypress/e2e/ui/groups/standard.tomselect-dropdownparent.spec.js
@@ -1,0 +1,163 @@
+/// <reference types="cypress" />
+
+/**
+ * Regression tests for TomSelect `dropdownParent: "body"` fix — issue #9488.
+ *
+ * Without `dropdownParent: "body"`, TomSelect dropdowns inside Bootstrap 5
+ * modal containers (or cards with `overflow: hidden`) are clipped/invisible.
+ * This fix was applied to the remaining call sites after #9483.
+ *
+ * The key assertion: after a TomSelect dropdown opens, the `.ts-dropdown`
+ * element must be a direct child of `<body>` — proving `dropdownParent: "body"`
+ * is in effect.
+ */
+describe("TomSelect dropdownParent:body — remaining call sites (#9488)", () => {
+    beforeEach(() => {
+        cy.setupStandardSession();
+        cy.on("uncaught:exception", () => false);
+    });
+
+    /**
+     * GroupView.js `.personSearch` "Add Member" picker.
+     * This is the NEW call site identified in the audit comment on issue #9488.
+     * Group 9 (Church Board) is always present in seed data.
+     */
+    it("GroupView .personSearch (Add Member) TomSelect dropdown renders as a direct child of body", () => {
+        cy.visit("/groups/view/9");
+
+        // Wait for CRM globals and locales
+        cy.window().should("have.property", "CRM");
+        cy.window().its("CRM.localesLoaded").should("eq", true);
+
+        // Wait for TomSelect to initialize on the Add Member picker
+        cy.get("#addGroupMember", { timeout: 10000 }).should("exist");
+
+        // The TomSelect wrapper sits as the parent of #addGroupMember after init.
+        // Click the visible ts-control (the search input rendered by TomSelect).
+        cy.get("#addGroupMember")
+            .closest(".ts-wrapper")
+            .find(".ts-control")
+            .click();
+
+        // Key assertion: the dropdown must be appended to <body>,
+        // NOT trapped inside the card DOM tree.
+        cy.get("body > .ts-dropdown", { timeout: 5000 }).should("exist").and("be.visible");
+
+        // Clean up
+        cy.get("body").type("{esc}");
+    });
+
+    /**
+     * person-group-manager.js `handleAddToGroup` modal.
+     * Person 1 (Church Admin) always exists in seed data. The "Assign New Group"
+     * action (#addGroup) is rendered for all persons with edit rights.
+     * person-group-manager.js is unconditionally loaded on person-view.php.
+     */
+    it("person-group-manager handleAddToGroup modal TomSelect renders as a direct child of body", () => {
+        cy.visit("/people/view/1");
+
+        // Wait for CRM globals and person-group-manager to be ready
+        cy.window().should("have.property", "CRM");
+        cy.window().its("CRM.localesLoaded").should("eq", true);
+        cy.window().its("CRM.currentPersonID").should("exist");
+
+        // Click the "Assign New Group" dropdown item.
+        // It lives inside a dropdown-menu but the document-level click listener in
+        // person-group-manager.js fires via closest() delegation even on hidden items.
+        cy.get("#addGroup, #addGroupFromEmpty", { timeout: 10000 })
+            .first()
+            .click({ force: true });
+
+        // The modal should appear
+        cy.get(".modal.show", { timeout: 10000 }).should("exist");
+
+        // Wait for TomSelect to initialise (gated on shown.bs.modal)
+        cy.get(".modal.show .ts-control", { timeout: 10000 }).should("exist").click();
+
+        // Key assertion: dropdown must be a direct child of <body>
+        cy.get("body > .ts-dropdown", { timeout: 5000 }).should("exist").and("be.visible");
+
+        // Close modal
+        cy.get(".modal.show .btn-close, .modal.show [data-bs-dismiss='modal']")
+            .first()
+            .click({ force: true });
+        cy.get(".modal.show", { timeout: 5000 }).should("not.exist");
+    });
+});
+
+/**
+ * event-checkin.js `openCheckoutByDialog` — the bootbox→native BS5 modal migration.
+ *
+ * Creates a transient test event, checks in person 1 via API, then verifies that
+ * clicking "Check Out" opens a native Bootstrap 5 modal whose TomSelect search
+ * renders as a direct child of <body>.
+ */
+describe("event-checkin.js openCheckoutByDialog TomSelect dropdownParent:body (#9488)", () => {
+    let testEventId;
+
+    before(() => {
+        // Create a fresh event and pre-check-in person 1 so the checkout button appears
+        cy.makePrivateAdminAPICall("POST", "/api/events/quick-create", { eventTypeId: 1 }, 200).then(
+            (resp) => {
+                testEventId = resp.body.eventId;
+                cy.makePrivateAdminAPICall(
+                    "POST",
+                    `/api/events/${testEventId}/checkin`,
+                    { personId: 1 },
+                    200,
+                );
+            },
+        );
+    });
+
+    after(() => {
+        if (testEventId) {
+            // Person 1 was checked in but not checked out (test cancelled the dialog).
+            // checkout-all first so the event has no checked-in attendees,
+            // then delete (delete is blocked while active attendees remain).
+            cy.makePrivateAdminAPICall("POST", `/api/events/${testEventId}/checkout-all`, {}, 200);
+            cy.makePrivateAdminAPICall("DELETE", `/api/events/${testEventId}`, {}, 200);
+        }
+    });
+
+    beforeEach(() => {
+        cy.setupStandardSession();
+        cy.on("uncaught:exception", () => false);
+    });
+
+    it("checkout dialog (native BS5 modal) TomSelect renders as a direct child of body", () => {
+        cy.visit(`/event/checkin/${testEventId}`);
+
+        cy.window().should("have.property", "CRM");
+        cy.window().its("CRM.localesLoaded").should("eq", true);
+
+        // Person 1 is checked in; their row appears in the server-rendered
+        // "People Checked In" table. The checkout button is inside the action
+        // dropdown — use force:true to click it without opening the dropdown.
+        cy.get("tr[data-person-id='1'] .checkout-btn", { timeout: 10000 })
+            .should("exist")
+            .click({ force: true });
+
+        // Native BS5 modal should open (no bootbox)
+        cy.get(".modal.show", { timeout: 10000 }).should("exist");
+        cy.get(".modal.show .modal-title").should("contain.text", "Check out");
+
+        // Wait for TomSelect to initialise inside shown.bs.modal
+        cy.get(".modal.show .ts-wrapper", { timeout: 10000 }).should("exist");
+        cy.get(".modal.show .ts-control").click();
+
+        // Key assertion: dropdown is a direct child of <body>
+        cy.get("body > .ts-dropdown", { timeout: 5000 }).should("exist").and("be.visible");
+
+        // Cancel without actually checking out (avoid side effects)
+        cy.get(".modal.show #checkoutCancelBtn").click({ force: true });
+        cy.window().then((win) => {
+            const el = win.document.querySelector('[id^="crm-checkout-by-modal"]');
+            if (el) {
+                const instance = win.bootstrap?.Modal?.getInstance(el);
+                if (instance) instance.hide();
+            }
+        });
+        cy.get('[id^="crm-checkout-by-modal"]', { timeout: 5000 }).should("not.exist");
+    });
+});

--- a/src/skin/js/GroupView.js
+++ b/src/skin/js/GroupView.js
@@ -94,6 +94,7 @@ function _showRoleModal(title, callback) {
     "shown.bs.modal",
     () => {
       new window.TomSelect(roleEl, {
+        dropdownParent: "body",
         onChange: (value) => {
           selectedRoleId = value || null;
         },
@@ -150,6 +151,7 @@ function _showGroupAndRoleModal(title, callback) {
         new window.TomSelect(groupEl, {
           placeholder: i18next.t("Search groups..."),
           items: [],
+          dropdownParent: "body",
           onChange: (value) => {
             selectedGroupId = value || null;
             if (!value) {
@@ -180,6 +182,7 @@ function _showGroupAndRoleModal(title, callback) {
               roleWrapper.classList.remove("d-none");
               result.confirm.disabled = false;
               new window.TomSelect(roleEl, {
+                dropdownParent: "body",
                 onChange: (v) => {
                   selectedRoleId = v || null;
                 },
@@ -446,6 +449,7 @@ function initializeGroupView() {
       valueField: "objid",
       labelField: "text",
       searchField: "text",
+      dropdownParent: "body",
       load: (query, callback) => {
         if (query.length < 2) return callback();
         fetch(window.CRM.root + "/api/persons/search/" + encodeURIComponent(query))

--- a/src/skin/js/sundayschool-actions.js
+++ b/src/skin/js/sundayschool-actions.js
@@ -94,6 +94,7 @@
           new window.TomSelect(groupEl, {
             placeholder: i18next.t("Search groups..."),
             items: [],
+            dropdownParent: "body",
             onChange: (value) => {
               selectedGroupId = value || null;
               if (!value) {
@@ -123,6 +124,7 @@
                 roleWrapper.classList.remove("d-none");
                 result.confirm.disabled = false;
                 new window.TomSelect(roleEl, {
+                  dropdownParent: "body",
                   onChange: (v) => {
                     selectedRoleId = v || null;
                   },

--- a/webpack/event-checkin.js
+++ b/webpack/event-checkin.js
@@ -484,83 +484,158 @@ $(() => {
 
   function openCheckoutByDialog(personId, personName, checkinId, checkinName) {
     const safeName = window.CRM.escapeHtml(String(personName));
-    const dialog = bootbox.dialog({
-      title: `${i18next.t("Check out")}: ${safeName}`,
-      message:
-        '<p class="mb-2">' +
-        i18next.t("Optional — record who is checking this person out (e.g. a parent picking up a child).") +
-        "</p>" +
-        '<div class="input-group">' +
-        '<select class="form-select" id="checkoutBySelect" placeholder="' +
-        i18next.t("Search for supervisor...") +
-        '"></select>' +
-        '<button type="button" class="btn btn-outline-secondary" id="assignMeCheckout" title="' +
-        i18next.t("Assign to me") +
-        '">' +
-        '<i class="fa-solid fa-user-check"></i>' +
-        "</button>" +
-        "</div>" +
-        '<small class="text-muted mt-2 d-block">' +
-        i18next.t("Leave blank to check out without recording the supervisor.") +
-        "</small>",
-      buttons: {
-        cancel: {
-          label: `<i class="ti ti-x"></i> ${i18next.t("Cancel")}`,
-          className: "btn-link",
-        },
-        skip: {
-          label: `<i class="ti ti-check"></i> ${i18next.t("Skip & Check Out")}`,
-          className: "btn-outline-warning",
-          callback: () => {
-            performCheckout(personId, null);
-          },
-        },
-        confirm: {
-          label: `<i class="fa-solid fa-user-check"></i> ${i18next.t("Confirm Check Out")}`,
-          className: "btn-primary",
-          callback: () => {
-            const val = $("#checkoutBySelect").val();
-            const supervisorId = val ? parseInt(val, 10) : null;
-            performCheckout(personId, supervisorId);
-          },
-        },
-      },
-    });
 
-    // Initialize TomSelect on the supervisor search field once the modal is shown
-    dialog.on("shown.bs.modal", () => {
-      const el = document.getElementById("checkoutBySelect");
-      if (!el || el.tomselect) return;
-      const ts = new TomSelect(el, {
-        valueField: "objid",
-        labelField: "text",
-        searchField: "text",
-        placeholder: i18next.t("Search for supervisor..."),
-        load: (query, callback) => {
-          if (query.length < 2) return callback();
-          fetch(`${window.CRM.root}/api/persons/search/${encodeURIComponent(query)}`)
-            .then((res) => res.json())
-            .then((data) => callback(data.map((p) => ({ objid: p.objid, text: p.text }))))
-            .catch(() => callback());
-        },
-      });
+    // Build a unique modal ID so concurrent calls don't conflict.
+    // Uses a native BS5 modal (not bootbox) so TomSelect's dropdownParent: "body"
+    // works correctly — bootbox v6 has incompatibilities with that option.
+    const modalId = `crm-checkout-by-modal-${Date.now()}`;
 
-      // Pre-populate with the person who checked them in (if available)
-      if (checkinId && checkinName) {
-        ts.addOption({ objid: checkinId, text: checkinName });
-        ts.setValue(checkinId);
-      }
+    const bodyHtml =
+      '<p class="mb-2">' +
+      i18next.t("Optional — record who is checking this person out (e.g. a parent picking up a child).") +
+      "</p>" +
+      '<div class="input-group">' +
+      '<select class="form-select" id="checkoutBySelect" placeholder="' +
+      i18next.t("Search for supervisor...") +
+      '"></select>' +
+      '<button type="button" class="btn btn-outline-secondary" id="assignMeCheckout" title="' +
+      i18next.t("Assign to me") +
+      '">' +
+      '<i class="fa-solid fa-user-check"></i>' +
+      "</button>" +
+      "</div>" +
+      '<small class="text-muted mt-2 d-block">' +
+      i18next.t("Leave blank to check out without recording the supervisor.") +
+      "</small>";
 
-      // "Assign to me" button in checkout dialog
-      $("#assignMeCheckout").on("click", () => {
-        const userId = window.CRM.userId;
-        const userName = window.CRM.userName;
-        if (userId && userName) {
-          ts.addOption({ objid: userId, text: userName });
-          ts.setValue(userId);
+    const existing = document.getElementById(modalId);
+    if (existing) existing.remove();
+
+    const wrapper = document.createElement("div");
+    wrapper.id = modalId;
+    wrapper.className = "modal fade";
+    wrapper.setAttribute("tabindex", "-1");
+    wrapper.setAttribute("aria-modal", "true");
+    wrapper.setAttribute("role", "dialog");
+    wrapper.setAttribute("aria-labelledby", `${modalId}-title`);
+    wrapper.innerHTML =
+      '<div class="modal-dialog modal-dialog-centered">' +
+      '<div class="modal-content">' +
+      '<div class="modal-header">' +
+      `<h5 class="modal-title" id="${modalId}-title">` +
+      i18next.t("Check out") +
+      ": " +
+      safeName +
+      "</h5>" +
+      '<button type="button" class="btn-close" data-bs-dismiss="modal"></button>' +
+      "</div>" +
+      '<div class="modal-body">' +
+      bodyHtml +
+      "</div>" +
+      '<div class="modal-footer">' +
+      '<button type="button" class="btn btn-link" id="checkoutCancelBtn" data-bs-dismiss="modal">' +
+      '<i class="ti ti-x"></i> ' +
+      i18next.t("Cancel") +
+      "</button>" +
+      '<button type="button" class="btn btn-outline-warning" id="checkoutSkipBtn">' +
+      '<i class="ti ti-check"></i> ' +
+      i18next.t("Skip & Check Out") +
+      "</button>" +
+      '<button type="button" class="btn btn-primary" id="checkoutConfirmBtn">' +
+      '<i class="fa-solid fa-user-check"></i> ' +
+      i18next.t("Confirm Check Out") +
+      "</button>" +
+      "</div></div></div>";
+
+    document.body.appendChild(wrapper);
+    const bsModal = new window.bootstrap.Modal(wrapper, { backdrop: "static" });
+
+    let tomSelectInstance = null;
+
+    // Destroy TomSelect and remove modal element once hidden
+    wrapper.addEventListener(
+      "hidden.bs.modal",
+      () => {
+        if (tomSelectInstance) {
+          try {
+            tomSelectInstance.destroy();
+          } catch (_e) {
+            // ignore
+          }
+          tomSelectInstance = null;
         }
-      });
+        try {
+          bsModal.dispose();
+        } catch (_e) {
+          // ignore
+        }
+        if (wrapper.parentNode) wrapper.remove();
+      },
+      { once: true },
+    );
+
+    // Initialize TomSelect once the modal is fully visible (needs layout dimensions).
+    // shown.bs.modal fires after the CSS transition, so elements are measured correctly.
+    wrapper.addEventListener(
+      "shown.bs.modal",
+      () => {
+        const el = wrapper.querySelector("#checkoutBySelect");
+        if (!el || el.tomselect) return;
+        tomSelectInstance = new TomSelect(el, {
+          valueField: "objid",
+          labelField: "text",
+          searchField: "text",
+          placeholder: i18next.t("Search for supervisor..."),
+          dropdownParent: "body",
+          load: (query, callback) => {
+            if (query.length < 2) return callback();
+            fetch(`${window.CRM.root}/api/persons/search/${encodeURIComponent(query)}`)
+              .then((res) => res.json())
+              .then((data) => callback(data.map((p) => ({ objid: p.objid, text: p.text }))))
+              .catch(() => callback());
+          },
+        });
+
+        // Pre-populate with the person who checked them in (if available)
+        if (checkinId && checkinName) {
+          tomSelectInstance.addOption({ objid: checkinId, text: checkinName });
+          tomSelectInstance.setValue(checkinId);
+        }
+
+        // "Assign to me" button: set the current logged-in user as supervisor
+        const assignMeBtn = wrapper.querySelector("#assignMeCheckout");
+        if (assignMeBtn) {
+          assignMeBtn.addEventListener("click", () => {
+            const userId = window.CRM.userId;
+            const userName = window.CRM.userName;
+            if (userId && userName) {
+              tomSelectInstance.addOption({ objid: userId, text: userName });
+              tomSelectInstance.setValue(userId);
+            }
+          });
+        }
+      },
+      { once: true },
+    );
+
+    // Skip: check out without recording a supervisor
+    const skipBtn = wrapper.querySelector("#checkoutSkipBtn");
+    skipBtn.addEventListener("click", () => {
+      bsModal.hide();
+      performCheckout(personId, null);
     });
+
+    // Confirm: check out with the selected supervisor (read via TomSelect API)
+    const confirmBtn = wrapper.querySelector("#checkoutConfirmBtn");
+    confirmBtn.addEventListener("click", () => {
+      const el = wrapper.querySelector("#checkoutBySelect");
+      const val = el?.tomselect ? el.tomselect.getValue() : null;
+      const supervisorId = val ? parseInt(val, 10) : null;
+      bsModal.hide();
+      performCheckout(personId, supervisorId);
+    });
+
+    bsModal.show();
   }
 
   function performCheckout(personId, checkedOutById) {

--- a/webpack/people/person-group-manager.js
+++ b/webpack/people/person-group-manager.js
@@ -126,6 +126,7 @@ function handleAddToGroup(personId) {
         new window.TomSelect(groupEl, {
           placeholder: i18next.t("Search groups..."),
           items: [],
+          dropdownParent: "body",
           onChange: (value) => {
             selectedGroupId = value || null;
             if (!value) {
@@ -188,6 +189,7 @@ function loadRoles(groupId, roleEl, roleWrapper, confirmBtn, onRoleSelected) {
     confirmBtn.disabled = false;
 
     new window.TomSelect(roleEl, {
+      dropdownParent: "body",
       onChange: (value) => {
         onRoleSelected(value || null);
       },
@@ -233,6 +235,7 @@ function handleChangeRole(personId, groupId, currentRoleId) {
       "shown.bs.modal",
       () => {
         const ts = new window.TomSelect(roleEl, {
+          dropdownParent: "body",
           onChange: (value) => {
             selectedRoleId = value || null;
           },


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Closes #9488. Continues the fix started in #9483.

All TomSelect instances inside Bootstrap 5 modal containers (or cards with `overflow: hidden`) were clipping their dropdowns because `dropdownParent` was not set. This PR fixes all remaining call sites identified in the issue audit.

**Changes:**
- `src/skin/js/GroupView.js`: `dropdownParent: "body"` added to `_showRoleModal` (role picker), `_showGroupAndRoleModal` (group + role pickers), and `.personSearch` "Add Member" page-level picker. Note: the `.personSearch` element is a page-level `<select>` on `group-view.php`, not inside a modal — a `shown.bs.modal` gate is not applicable here; `dropdownParent` is the correct and sufficient fix.
- `webpack/people/person-group-manager.js`: `dropdownParent: "body"` added to `handleAddToGroup` group picker, `loadRoles` role picker, and `handleChangeRole` role picker.
- `src/skin/js/sundayschool-actions.js`: `dropdownParent: "body"` added to `showGroupAndRoleModal` group and role pickers.
- `webpack/event-checkin.js`: migrated `openCheckoutByDialog()` from `bootbox.dialog` to a hand-built native Bootstrap 5 modal (mirrors `CRMJSOM.js` `promptSelection` pattern from #9483). TomSelect is now initialised inside `shown.bs.modal` with `dropdownParent: "body"`; `hidden.bs.modal` handles teardown (destroy TomSelect → dispose modal → remove element).
- `cypress/e2e/ui/groups/standard.tomselect-dropdownparent.spec.js`: new regression spec with 3 tests asserting `body > .ts-dropdown` (the visible effect of `dropdownParent: "body"`): GroupView personSearch, person-group-manager Add to Group modal, and event-checkin checkout dialog (creates a transient event, checks in person 1 via API, verifies the native BS5 modal + TomSelect, cleans up).

**Validation:** `npm run lint` (Biome) and `npm run build:webpack` pass cleanly.