### PR TITLE
Fix issue #9488: add dropdownParent:"body" to remaining TomSelect-in-modal call sites

### DIFF
--- a/cypress/e2e/ui/groups/standard.group-member-dropdown.spec.js
+++ b/cypress/e2e/ui/groups/standard.group-member-dropdown.spec.js
@@ -1,0 +1,139 @@
+/// <reference types="cypress" />
+
+/**
+ * Regression tests for TomSelect dropdownParent:"body" in GroupView modals.
+ *
+ * Issue #9488 — Several TomSelect dropdowns inside Bootstrap 5 modals (and one
+ * page-level select inside a card with potential overflow constraints) were
+ * rendered without `dropdownParent: "body"`, causing the dropdown list to be
+ * clipped or hidden by `overflow: hidden` on ancestor containers.
+ *
+ * This spec covers:
+ *  1. The "Add Member" personSearch TomSelect (#addGroupMember) on the group
+ *     view page — a page-level select inside a card that needs dropdownParent
+ *     so its dropdown is not clipped by the card layout.
+ *  2. The "Copy Members to Group" _showGroupAndRoleModal TomSelect — a group
+ *     select rendered inside a programmatic Bootstrap 5 modal.
+ *
+ * The key assertion is that the TomSelect dropdown is appended as a DIRECT
+ * child of <body> when opened (`body > .ts-dropdown` is visible), not nested
+ * inside a `.card` or `.modal-content` ancestor. This is only true when
+ * `dropdownParent: "body"` is set on the TomSelect instance.
+ */
+describe("GroupView TomSelect dropdownParent regression (#9488)", () => {
+    let testGroupId;
+    const uniqueSeed = Date.now().toString();
+    const testGroupName = `DropdownParent Test ${uniqueSeed}`;
+
+    before(() => {
+        // Create a test group so we have a predictable group view to load.
+        // Use API-key auth so we don't depend on cy.session() being properly
+        // initialised in a before() hook (cy.session() is designed for beforeEach().
+        cy.makePrivateAdminAPICall(
+            "POST",
+            "/api/groups/",
+            { groupName: testGroupName, description: "" },
+            200,
+        ).then((resp) => {
+            testGroupId = resp.body.Id;
+        });
+    });
+
+    after(() => {
+        if (testGroupId) {
+            cy.makePrivateAdminAPICall("DELETE", `/api/groups/${testGroupId}`, null, 200);
+        }
+    });
+
+    beforeEach(() => {
+        cy.setupStandardSession();
+        cy.on("uncaught:exception", () => false);
+    });
+
+    // ------------------------------------------------------------------ //
+    // 1. "Add Member" personSearch (page-level select, bug #2 fix)
+    // ------------------------------------------------------------------ //
+    it("Add Member personSearch: dropdown appends to body (dropdownParent:\"body\")", () => {
+        cy.visit(`/groups/view/${testGroupId}`);
+
+        // Wait for the page to be ready
+        cy.window().should("have.property", "CRM");
+        cy.window().its("CRM.localesLoaded").should("eq", true);
+
+        // TomSelect should have been initialized on #addGroupMember
+        cy.get("#addGroupMember").closest(".ts-wrapper").should("exist");
+
+        // Click the TomSelect control to open the dropdown
+        cy.get("#addGroupMember").closest(".ts-wrapper").find(".ts-control").click();
+
+        // The dropdown MUST be a direct child of <body> — not nested inside the card.
+        // Without dropdownParent:"body", it would be inside .ts-wrapper inside .card-body.
+        cy.get("body > .ts-dropdown").should("exist").and("be.visible");
+
+        // Typing ≥2 chars triggers the remote load callback
+        cy.get("body > .ts-dropdown input[type='text'], .ts-wrapper input[type='text']")
+            .first()
+            .type("Ad", { delay: 50 });
+
+        // The dropdown remains body-mounted during and after the load
+        cy.get("body > .ts-dropdown").should("exist");
+
+        // Close by pressing Escape
+        cy.get("body").type("{esc}");
+        cy.get("body > .ts-dropdown").should("not.be.visible");
+    });
+
+    // ------------------------------------------------------------------ //
+    // 2. _showGroupAndRoleModal (modal TomSelect, bug #2 fix)
+    // ------------------------------------------------------------------ //
+    it("Copy Members to Group modal: group TomSelect dropdown appends to body", () => {
+        cy.visit(`/groups/view/${testGroupId}`);
+
+        cy.window().should("have.property", "CRM");
+        cy.window().its("CRM.localesLoaded").should("eq", true);
+
+        // The "Copy Members to Group" button appears on role pill dropdowns.
+        // If no role pills are rendered (group has only the default Member role
+        // which may be hidden), trigger the modal via the JS API directly.
+        cy.window().then((win) => {
+            // Manually trigger _showGroupAndRoleModal via the global function
+            // which is defined in the page scope of GroupView.js (used by the
+            // copy/move-role-to-group click handlers).
+            // _showGroupAndRoleModal is not exported; invoke it via a click on
+            // a .copy-role-to-group element, or use the window eval trick.
+            // Fall back: call the underlying groups.get() to verify API is live.
+            //
+            // The safest approach: click the first .copy-role-to-group button
+            // if it exists; otherwise skip with a note.
+            const copyBtns = win.document.querySelectorAll(".copy-role-to-group");
+            if (copyBtns.length > 0) {
+                copyBtns[0].click();
+            } else {
+                // No role pills visible — use cy.window() to call the function
+                win.eval(
+                    `(function() {
+                        if (typeof _showGroupAndRoleModal === 'function') {
+                            _showGroupAndRoleModal('Test modal', function() {});
+                        }
+                    })()`,
+                );
+            }
+        });
+
+        // The Bootstrap 5 modal should appear
+        cy.get(".modal.show", { timeout: 8000 }).should("be.visible");
+
+        // Wait for TomSelect to init (it fires after shown.bs.modal)
+        cy.get(".modal.show .ts-wrapper", { timeout: 10000 }).should("exist");
+
+        // Open the group TomSelect dropdown
+        cy.get(".modal.show .ts-control").first().click();
+
+        // Dropdown MUST be a direct child of <body> — not clipped by modal-content
+        cy.get("body > .ts-dropdown").should("exist").and("be.visible");
+
+        // Close the modal
+        cy.get(".modal.show .btn-close").click();
+        cy.get(".modal.show").should("not.exist");
+    });
+});

--- a/src/skin/js/GroupView.js
+++ b/src/skin/js/GroupView.js
@@ -93,11 +93,23 @@ function _showRoleModal(title, callback) {
   result.el.addEventListener(
     "shown.bs.modal",
     () => {
-      new window.TomSelect(roleEl, {
+      var ts = new window.TomSelect(roleEl, {
+        dropdownParent: "body",
         onChange: (value) => {
           selectedRoleId = value || null;
         },
       });
+      // Destroy the TomSelect to remove body > .ts-dropdown when the modal closes.
+      // Must use a closure reference because wrapper.remove() leaves ts.dropdown in <body>.
+      result.el.addEventListener(
+        "hidden.bs.modal",
+        () => {
+          try {
+            ts.destroy();
+          } catch (e) {}
+        },
+        { once: true },
+      );
     },
     { once: true },
   );
@@ -146,10 +158,13 @@ function _showGroupAndRoleModal(title, callback) {
       () => {
         var roleWrapper = document.getElementById("gv-role-wrapper");
         var roleEl = document.getElementById("gv-role-select");
+        var tsGroup = null;
+        var tsRole = null;
 
-        new window.TomSelect(groupEl, {
+        tsGroup = new window.TomSelect(groupEl, {
           placeholder: i18next.t("Search groups..."),
           items: [],
+          dropdownParent: "body",
           onChange: (value) => {
             selectedGroupId = value || null;
             if (!value) {
@@ -158,7 +173,12 @@ function _showGroupAndRoleModal(title, callback) {
               return;
             }
             // Load roles for selected group
-            if (roleEl.tomselect) roleEl.tomselect.destroy();
+            if (tsRole) {
+              try {
+                tsRole.destroy();
+              } catch (e) {}
+              tsRole = null;
+            }
             roleEl.innerHTML = "";
             roleWrapper.classList.add("d-none");
 
@@ -179,7 +199,8 @@ function _showGroupAndRoleModal(title, callback) {
               );
               roleWrapper.classList.remove("d-none");
               result.confirm.disabled = false;
-              new window.TomSelect(roleEl, {
+              tsRole = new window.TomSelect(roleEl, {
+                dropdownParent: "body",
                 onChange: (v) => {
                   selectedRoleId = v || null;
                 },
@@ -188,6 +209,19 @@ function _showGroupAndRoleModal(title, callback) {
             });
           },
         });
+        // Destroy TomSelect instances on close so body > .ts-dropdown is removed.
+        result.el.addEventListener(
+          "hidden.bs.modal",
+          () => {
+            try {
+              if (tsGroup) tsGroup.destroy();
+            } catch (e) {}
+            try {
+              if (tsRole) tsRole.destroy();
+            } catch (e) {}
+          },
+          { once: true },
+        );
       },
       { once: true },
     );
@@ -446,6 +480,7 @@ function initializeGroupView() {
       valueField: "objid",
       labelField: "text",
       searchField: "text",
+      dropdownParent: "body",
       load: (query, callback) => {
         if (query.length < 2) return callback();
         fetch(window.CRM.root + "/api/persons/search/" + encodeURIComponent(query))

--- a/src/skin/js/sundayschool-actions.js
+++ b/src/skin/js/sundayschool-actions.js
@@ -90,10 +90,13 @@
         () => {
           var roleWrapper = document.getElementById("ss-role-wrapper");
           var roleEl = document.getElementById("ss-role-select");
+          var tsGroup = null;
+          var tsRole = null;
 
-          new window.TomSelect(groupEl, {
+          tsGroup = new window.TomSelect(groupEl, {
             placeholder: i18next.t("Search groups..."),
             items: [],
+            dropdownParent: "body",
             onChange: (value) => {
               selectedGroupId = value || null;
               if (!value) {
@@ -101,7 +104,12 @@
                 result.confirm.disabled = true;
                 return;
               }
-              if (roleEl.tomselect) roleEl.tomselect.destroy();
+              if (tsRole) {
+                try {
+                  tsRole.destroy();
+                } catch (e) {}
+                tsRole = null;
+              }
               roleEl.innerHTML = "";
               roleWrapper.classList.add("d-none");
 
@@ -122,7 +130,8 @@
                 );
                 roleWrapper.classList.remove("d-none");
                 result.confirm.disabled = false;
-                new window.TomSelect(roleEl, {
+                tsRole = new window.TomSelect(roleEl, {
+                  dropdownParent: "body",
                   onChange: (v) => {
                     selectedRoleId = v || null;
                   },
@@ -131,6 +140,19 @@
               });
             },
           });
+          // Destroy TomSelect instances on close so body > .ts-dropdown is removed.
+          result.el.addEventListener(
+            "hidden.bs.modal",
+            () => {
+              try {
+                if (tsGroup) tsGroup.destroy();
+              } catch (e) {}
+              try {
+                if (tsRole) tsRole.destroy();
+              } catch (e) {}
+            },
+            { once: true },
+          );
         },
         { once: true },
       );

--- a/webpack/event-checkin.js
+++ b/webpack/event-checkin.js
@@ -536,6 +536,7 @@ $(() => {
         labelField: "text",
         searchField: "text",
         placeholder: i18next.t("Search for supervisor..."),
+        dropdownParent: "body",
         load: (query, callback) => {
           if (query.length < 2) return callback();
           fetch(`${window.CRM.root}/api/persons/search/${encodeURIComponent(query)}`)
@@ -559,6 +560,13 @@ $(() => {
           ts.addOption({ objid: userId, text: userName });
           ts.setValue(userId);
         }
+      });
+
+      // Destroy TomSelect when the dialog closes so body > .ts-dropdown is removed.
+      dialog.one("hidden.bs.modal", () => {
+        try {
+          ts.destroy();
+        } catch (_e) {}
       });
     });
   }

--- a/webpack/people/person-group-manager.js
+++ b/webpack/people/person-group-manager.js
@@ -123,9 +123,10 @@ function handleAddToGroup(personId) {
         const roleWrapper = document.getElementById("pgm-role-wrapper");
         const roleEl = document.getElementById("pgm-role-select");
 
-        new window.TomSelect(groupEl, {
+        const tsGroup = new window.TomSelect(groupEl, {
           placeholder: i18next.t("Search groups..."),
           items: [],
+          dropdownParent: "body",
           onChange: (value) => {
             selectedGroupId = value || null;
             if (!value) {
@@ -138,6 +139,21 @@ function handleAddToGroup(personId) {
             });
           },
         });
+        // Destroy TomSelect instances on close so body > .ts-dropdown is removed.
+        el.addEventListener(
+          "hidden.bs.modal",
+          () => {
+            try {
+              tsGroup.destroy();
+            } catch (_e) {}
+            if (roleEl.tomselect) {
+              try {
+                roleEl.tomselect.destroy();
+              } catch (_e) {}
+            }
+          },
+          { once: true },
+        );
       },
       { once: true },
     );
@@ -188,6 +204,7 @@ function loadRoles(groupId, roleEl, roleWrapper, confirmBtn, onRoleSelected) {
     confirmBtn.disabled = false;
 
     new window.TomSelect(roleEl, {
+      dropdownParent: "body",
       onChange: (value) => {
         onRoleSelected(value || null);
       },
@@ -233,6 +250,7 @@ function handleChangeRole(personId, groupId, currentRoleId) {
       "shown.bs.modal",
       () => {
         const ts = new window.TomSelect(roleEl, {
+          dropdownParent: "body",
           onChange: (value) => {
             selectedRoleId = value || null;
           },
@@ -241,6 +259,16 @@ function handleChangeRole(personId, groupId, currentRoleId) {
         if (currentRoleId) {
           ts.setValue(String(currentRoleId), true);
         }
+        // Destroy TomSelect on close to remove body > .ts-dropdown.
+        el.addEventListener(
+          "hidden.bs.modal",
+          () => {
+            try {
+              ts.destroy();
+            } catch (_e) {}
+          },
+          { once: true },
+        );
       },
       { once: true },
     );


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Fixes #9488

Applies the same `dropdownParent: "body"` fix from PR #9483 (CRMJSOM.js) to all remaining TomSelect-in-modal call sites.

## Changes

- **GroupView.js** — `_showRoleModal`, `_showGroupAndRoleModal` (3 modal TomSelect calls), and the `.personSearch` #addGroupMember page-level card select
- **person-group-manager.js** — `handleAddToGroup` (group select), `loadRoles` (role select), `handleChangeRole` (role select)
- **sundayschool-actions.js** — `showGroupAndRoleModal` (group + role selects)
- **event-checkin.js** — `openCheckoutByDialog` #checkoutBySelect

Each modal-hosted TomSelect also gets a `hidden.bs.modal` cleanup handler registered inside `shown.bs.modal` (via closure) that calls `ts.destroy()` on close, removing the orphaned `body > .ts-dropdown` nodes that `dropdownParent: "body"` would otherwise leave behind when `wrapper.remove()` runs.

## Note: `.personSearch` bug #3 (shown.bs.modal gate)

Issue commenter DawoudIO flagged `#addGroupMember` as also needing a `shown.bs.modal` gate (bug #3). Inspection of `src/groups/views/group-view.php` confirms the element is a page-level select inside the Members card — **not inside a modal**. There is no `shown.bs.modal` event to gate on. With `dropdownParent: "body"` applied, the dropdown is appended to `<body>` and positioned correctly regardless of the card's layout. No gate is added for this site.

## Testing

- `npm run lint` — 0 errors
- `npm run build:webpack` — compiled successfully
- `npx biome format src/skin/js/GroupView.js src/skin/js/sundayschool-actions.js` — no fixes needed
- New Cypress spec: `cypress/e2e/ui/groups/standard.group-member-dropdown.spec.js`
  - Asserts `body > .ts-dropdown` is visible when the Add Member picker is opened
  - Asserts `body > .ts-dropdown` is visible when the _showGroupAndRoleModal modal is open