### PR TITLE
Fix issue #9488: dropdownParent:"body" + teardown for remaining TomSelect-in-modal sites

### DIFF
--- a/cypress/e2e/api/private/standard/private.calendar.events-checkin.spec.js
+++ b/cypress/e2e/api/private/standard/private.calendar.events-checkin.spec.js
@@ -316,7 +316,7 @@ describe("API Event Check-in Endpoints", () => {
 
             // Regression: the check-in/out flow now optionally records WHO
             // checked the person out (parent picking up child, etc.) via the
-            // checkedOutById field. The bootbox prompt in event-checkin.js
+            // checkedOutById field. The native BS5 modal in event-checkin.js
             // sends this; verify the API persists it on the EventAttend row.
             it("Records checkedOutById when supplied", () => {
                 expect(testEventId, "before() must have populated testEventId").to.be.a("number");

--- a/cypress/e2e/ui/groups/standard.empty-cart-to-group.spec.js
+++ b/cypress/e2e/ui/groups/standard.empty-cart-to-group.spec.js
@@ -176,16 +176,30 @@ describe("Empty Cart to Group", () => {
         // Click the cart dropdown toggle to show the menu (find by shopping cart icon)
         cy.get(".nav-item.dropdown [data-bs-toggle='dropdown'] .fa-cart-shopping").closest("[data-bs-toggle='dropdown']").click();
 
+        // Register shown.bs.modal listener BEFORE the click so we cannot miss the event.
+        // This flag lets us poll until Bootstrap sets _isTransitioning=false, which
+        // happens in the shown.bs.modal callback — AFTER the transitionend event fires.
+        // Waiting for opacity:'1' alone is insufficient: Cypress microtasks run before
+        // the transitionend macrotask, so Bootstrap's _isTransitioning may still be
+        // true when hide() is called, causing a silent no-op.
+        cy.window().then((win) => {
+            win.__crmGroupModalShown = false;
+            win.document.addEventListener(
+                "shown.bs.modal",
+                () => { win.__crmGroupModalShown = true; },
+                { once: true },
+            );
+        });
+
         cy.get("#emptyCartToGroup").should("be.visible").click();
         cy.get(".modal.show").should("be.visible");
 
-        // Wait for Bootstrap's 300 ms fade-in to complete before hiding.
-        // Bootstrap silently ignores hide() while _isTransitioning=true (show
-        // animation still running). opacity reaches 1 only after the transition.
-        cy.get(".modal.show").should("have.css", "opacity", "1");
+        // Poll until shown.bs.modal has fired — guarantees _isTransitioning === false
+        cy.window().should((win) => {
+            expect(win.__crmGroupModalShown, "shown.bs.modal has not yet fired").to.be.true;
+        });
 
-        // Programmatic hide() is more reliable than synthetic button clicks
-        // for Bootstrap's data-bs-dismiss in headless CI.
+        // Now safe to call hide() — _isTransitioning is definitely false
         cy.window().then((win) => {
             const el = win.document.querySelector('[id^="crm-group-select-modal"]');
             if (el) {

--- a/cypress/e2e/ui/groups/standard.empty-cart-to-group.spec.js
+++ b/cypress/e2e/ui/groups/standard.empty-cart-to-group.spec.js
@@ -179,10 +179,13 @@ describe("Empty Cart to Group", () => {
         cy.get("#emptyCartToGroup").should("be.visible").click();
         cy.get(".modal.show").should("be.visible");
 
-        // Click Cancel
-        cy.get(".modal.show #crm-gs-cancel").click({ force: true });
-        // Bootstrap 5 event delegation (data-bs-dismiss) doesn't always fire with
-        // Cypress synthetic clicks in headless CI. Call hide() directly as a guarantee.
+        // Wait for Bootstrap's 300 ms fade-in to complete before hiding.
+        // Bootstrap silently ignores hide() while _isTransitioning=true (show
+        // animation still running). opacity reaches 1 only after the transition.
+        cy.get(".modal.show").should("have.css", "opacity", "1");
+
+        // Programmatic hide() is more reliable than synthetic button clicks
+        // for Bootstrap's data-bs-dismiss in headless CI.
         cy.window().then((win) => {
             const el = win.document.querySelector('[id^="crm-group-select-modal"]');
             if (el) {

--- a/cypress/e2e/ui/groups/standard.tomselect-dropdownparent.spec.js
+++ b/cypress/e2e/ui/groups/standard.tomselect-dropdownparent.spec.js
@@ -34,16 +34,22 @@ describe("TomSelect dropdownParent:body — remaining call sites (#9488)", () =>
         cy.window().its("CRM.localesLoaded").should("eq", true);
 
         // Wait for TomSelect to initialize on the Add Member picker.
-        // TomSelect hides the original <select> when it wraps it — that is
-        // the reliable signal that init is complete (cy.get().closest() has no retry).
-        cy.get("select#addGroupMember", { timeout: 10000 }).should("not.be.visible");
+        // TomSelect adds the 'tomselected' class to the original <select> when it wraps it.
+        // We use this class (not visibility) as the ready signal because TomSelect's
+        // ts-hidden-accessible style uses clip-path/1px dimensions, not display:none —
+        // so Cypress's :visible check would still return true even after TS init.
+        cy.get("select#addGroupMember", { timeout: 10000 }).should("have.class", "tomselected");
 
         // Click the TomSelect control (the visible input rendered by TomSelect).
         cy.get("select#addGroupMember").closest(".ts-wrapper").find(".ts-control").click();
 
         // Key assertion: the dropdown must be appended to <body>,
         // NOT trapped inside the card DOM tree.
-        cy.get("body > .ts-dropdown", { timeout: 5000 }).should("exist").and("be.visible");
+        // Note: The personSearch TomSelect uses a load callback that requires 2+
+        // characters before fetching from the API, so clicking alone shows no
+        // options. We assert existence (body > .ts-dropdown) to prove the
+        // dropdownParent:"body" fix is in effect.
+        cy.get("body > .ts-dropdown", { timeout: 5000 }).should("exist");
 
         // Clean up
         cy.get("body").type("{esc}");
@@ -157,8 +163,13 @@ describe("event-checkin.js openCheckoutByDialog TomSelect dropdownParent:body (#
         cy.get(".modal.show .ts-wrapper", { timeout: 10000 }).should("exist");
         cy.get(".modal.show .ts-control").click();
 
-        // Key assertion: dropdown is a direct child of <body>
-        cy.get("body > .ts-dropdown", { timeout: 5000 }).should("exist").and("be.visible");
+        // Key assertion: dropdown is a direct child of <body>.
+        // The existence of body > .ts-dropdown proves dropdownParent:"body" is in
+        // effect (if it were missing, the dropdown would live inside .modal-content
+        // and be clipped by overflow:hidden instead). Visibility is not checked here
+        // because the TomSelect load callback requires a 2-char query before fetching
+        // options, and clicking the control alone shows no list items.
+        cy.get("body > .ts-dropdown", { timeout: 5000 }).should("exist");
 
         // Cancel without actually checking out (avoid side effects)
         cy.get(".modal.show #checkoutCancelBtn").click({ force: true });

--- a/cypress/e2e/ui/groups/standard.tomselect-dropdownparent.spec.js
+++ b/cypress/e2e/ui/groups/standard.tomselect-dropdownparent.spec.js
@@ -33,15 +33,13 @@ describe("TomSelect dropdownParent:body — remaining call sites (#9488)", () =>
         cy.window().should("have.property", "CRM");
         cy.window().its("CRM.localesLoaded").should("eq", true);
 
-        // Wait for TomSelect to initialize on the Add Member picker
-        cy.get("#addGroupMember", { timeout: 10000 }).should("exist");
+        // Wait for TomSelect to initialize on the Add Member picker.
+        // TomSelect hides the original <select> when it wraps it — that is
+        // the reliable signal that init is complete (cy.get().closest() has no retry).
+        cy.get("select#addGroupMember", { timeout: 10000 }).should("not.be.visible");
 
-        // The TomSelect wrapper sits as the parent of #addGroupMember after init.
-        // Click the visible ts-control (the search input rendered by TomSelect).
-        cy.get("#addGroupMember")
-            .closest(".ts-wrapper")
-            .find(".ts-control")
-            .click();
+        // Click the TomSelect control (the visible input rendered by TomSelect).
+        cy.get("select#addGroupMember").closest(".ts-wrapper").find(".ts-control").click();
 
         // Key assertion: the dropdown must be appended to <body>,
         // NOT trapped inside the card DOM tree.
@@ -139,12 +137,17 @@ describe("event-checkin.js openCheckoutByDialog TomSelect dropdownParent:body (#
         cy.window().should("have.property", "CRM");
         cy.window().its("CRM.localesLoaded").should("eq", true);
 
-        // Person 1 is checked in; their row appears in the server-rendered
-        // "People Checked In" table. The checkout button is inside the action
-        // dropdown — use force:true to click it without opening the dropdown.
-        cy.get("tr[data-person-id='1'] .checkout-btn", { timeout: 10000 })
+        // Person 1 is checked in; their row is in the server-rendered
+        // "People Checked In" table. Open the action dropdown first so
+        // the .checkout-btn becomes visible, then click it normally.
+        // (Clicking a hidden element with {force:true} is unreliable for
+        // jQuery delegated handlers.)
+        cy.get("tr[data-person-id='1'] [data-bs-toggle='dropdown']", { timeout: 10000 })
             .should("exist")
-            .click({ force: true });
+            .click();
+        cy.get("tr[data-person-id='1'] .checkout-btn")
+            .should("be.visible")
+            .click();
 
         // Native BS5 modal should open (no bootbox)
         cy.get(".modal.show", { timeout: 10000 }).should("exist");

--- a/cypress/e2e/ui/groups/standard.tomselect-dropdownparent.spec.js
+++ b/cypress/e2e/ui/groups/standard.tomselect-dropdownparent.spec.js
@@ -40,8 +40,11 @@ describe("TomSelect dropdownParent:body — remaining call sites (#9488)", () =>
         // so Cypress's :visible check would still return true even after TS init.
         cy.get("select#addGroupMember", { timeout: 10000 }).should("have.class", "tomselected");
 
-        // Click the TomSelect control (the visible input rendered by TomSelect).
-        cy.get("select#addGroupMember").closest(".ts-wrapper").find(".ts-control").click();
+        // TomSelect inserts .ts-wrapper as a NEXT SIBLING of the original <select>
+        // (via insertAdjacentElement('afterend',...)) — NOT as a parent wrapper.
+        // .closest() traverses ancestors only, so it never finds the sibling .ts-wrapper.
+        // Use .next(".ts-wrapper") to reach the sibling correctly.
+        cy.get("select#addGroupMember").next(".ts-wrapper").find(".ts-control").click();
 
         // Key assertion: the dropdown must be appended to <body>,
         // NOT trapped inside the card DOM tree.

--- a/cypress/e2e/ui/groups/standard.tomselect-dropdownparent.spec.js
+++ b/cypress/e2e/ui/groups/standard.tomselect-dropdownparent.spec.js
@@ -1,0 +1,175 @@
+/// <reference types="cypress" />
+
+/**
+ * Regression tests for TomSelect `dropdownParent: "body"` fix — issue #9488.
+ *
+ * Without `dropdownParent: "body"`, TomSelect dropdowns inside Bootstrap 5
+ * modal containers (or cards with `overflow: hidden`) are clipped/invisible.
+ * This fix was applied to the remaining call sites after #9483.
+ *
+ * The key assertion: after a TomSelect dropdown opens, the `.ts-dropdown`
+ * element must be a direct child of `<body>` — proving `dropdownParent: "body"`
+ * is in effect.
+ *
+ * The modal cases also assert that the body-mounted `.ts-dropdown` is torn
+ * down when the modal closes (via the `hidden.bs.modal` → `ts.destroy()`
+ * handlers), so orphaned dropdown nodes do not accumulate per open/close.
+ */
+describe("TomSelect dropdownParent:body — remaining call sites (#9488)", () => {
+    beforeEach(() => {
+        cy.setupStandardSession();
+        cy.on("uncaught:exception", () => false);
+    });
+
+    /**
+     * GroupView.js `.personSearch` "Add Member" picker.
+     * This is the NEW call site identified in the audit comment on issue #9488.
+     * Group 9 (Church Board) is always present in seed data.
+     */
+    it("GroupView .personSearch (Add Member) TomSelect dropdown renders as a direct child of body", () => {
+        cy.visit("/groups/view/9");
+
+        // Wait for CRM globals and locales
+        cy.window().should("have.property", "CRM");
+        cy.window().its("CRM.localesLoaded").should("eq", true);
+
+        // Wait for TomSelect to initialize on the Add Member picker
+        cy.get("#addGroupMember", { timeout: 10000 }).should("exist");
+
+        // The TomSelect wrapper sits as the parent of #addGroupMember after init.
+        // Click the visible ts-control (the search input rendered by TomSelect).
+        cy.get("#addGroupMember")
+            .closest(".ts-wrapper")
+            .find(".ts-control")
+            .click();
+
+        // Key assertion: the dropdown must be appended to <body>,
+        // NOT trapped inside the card DOM tree.
+        cy.get("body > .ts-dropdown", { timeout: 5000 }).should("exist").and("be.visible");
+
+        // Clean up
+        cy.get("body").type("{esc}");
+    });
+
+    /**
+     * person-group-manager.js `handleAddToGroup` modal.
+     * Person 1 (Church Admin) always exists in seed data. The "Assign New Group"
+     * action (#addGroup) is rendered for all persons with edit rights.
+     * person-group-manager.js is unconditionally loaded on person-view.php.
+     */
+    it("person-group-manager handleAddToGroup modal TomSelect renders as a direct child of body", () => {
+        cy.visit("/people/view/1");
+
+        // Wait for CRM globals and person-group-manager to be ready
+        cy.window().should("have.property", "CRM");
+        cy.window().its("CRM.localesLoaded").should("eq", true);
+        cy.window().its("CRM.currentPersonID").should("exist");
+
+        // Click the "Assign New Group" dropdown item.
+        // It lives inside a dropdown-menu but the document-level click listener in
+        // person-group-manager.js fires via closest() delegation even on hidden items.
+        cy.get("#addGroup, #addGroupFromEmpty", { timeout: 10000 })
+            .first()
+            .click({ force: true });
+
+        // The modal should appear
+        cy.get(".modal.show", { timeout: 10000 }).should("exist");
+
+        // Wait for TomSelect to initialise (gated on shown.bs.modal)
+        cy.get(".modal.show .ts-control", { timeout: 10000 }).should("exist").click();
+
+        // Key assertion: dropdown must be a direct child of <body>
+        cy.get("body > .ts-dropdown", { timeout: 5000 }).should("exist").and("be.visible");
+
+        // Close modal
+        cy.get(".modal.show .btn-close, .modal.show [data-bs-dismiss='modal']")
+            .first()
+            .click({ force: true });
+        cy.get(".modal.show", { timeout: 5000 }).should("not.exist");
+
+        // Teardown: hidden.bs.modal must destroy the TomSelect so no orphaned
+        // body > .ts-dropdown node is left behind.
+        cy.get("body > .ts-dropdown", { timeout: 5000 }).should("not.exist");
+    });
+});
+
+/**
+ * event-checkin.js `openCheckoutByDialog` — the bootbox→native BS5 modal migration.
+ *
+ * Creates a transient test event, checks in person 1 via API, then verifies that
+ * clicking "Check Out" opens a native Bootstrap 5 modal whose TomSelect search
+ * renders as a direct child of <body>.
+ */
+describe("event-checkin.js openCheckoutByDialog TomSelect dropdownParent:body (#9488)", () => {
+    let testEventId;
+
+    before(() => {
+        // Create a fresh event and pre-check-in person 1 so the checkout button appears
+        cy.makePrivateAdminAPICall("POST", "/api/events/quick-create", { eventTypeId: 1 }, 200).then(
+            (resp) => {
+                testEventId = resp.body.eventId;
+                cy.makePrivateAdminAPICall(
+                    "POST",
+                    `/api/events/${testEventId}/checkin`,
+                    { personId: 1 },
+                    200,
+                );
+            },
+        );
+    });
+
+    after(() => {
+        if (testEventId) {
+            // Person 1 was checked in but not checked out (test cancelled the dialog).
+            // checkout-all first so the event has no checked-in attendees,
+            // then delete (delete is blocked while active attendees remain).
+            cy.makePrivateAdminAPICall("POST", `/api/events/${testEventId}/checkout-all`, {}, 200);
+            cy.makePrivateAdminAPICall("DELETE", `/api/events/${testEventId}`, {}, 200);
+        }
+    });
+
+    beforeEach(() => {
+        cy.setupStandardSession();
+        cy.on("uncaught:exception", () => false);
+    });
+
+    it("checkout dialog (native BS5 modal) TomSelect renders as a direct child of body", () => {
+        cy.visit(`/event/checkin/${testEventId}`);
+
+        cy.window().should("have.property", "CRM");
+        cy.window().its("CRM.localesLoaded").should("eq", true);
+
+        // Person 1 is checked in; their row appears in the server-rendered
+        // "People Checked In" table. The checkout button is inside the action
+        // dropdown — use force:true to click it without opening the dropdown.
+        cy.get("tr[data-person-id='1'] .checkout-btn", { timeout: 10000 })
+            .should("exist")
+            .click({ force: true });
+
+        // Native BS5 modal should open (no bootbox)
+        cy.get(".modal.show", { timeout: 10000 }).should("exist");
+        cy.get(".modal.show .modal-title").should("contain.text", "Check out");
+
+        // Wait for TomSelect to initialise inside shown.bs.modal
+        cy.get(".modal.show .ts-wrapper", { timeout: 10000 }).should("exist");
+        cy.get(".modal.show .ts-control").click();
+
+        // Key assertion: dropdown is a direct child of <body>
+        cy.get("body > .ts-dropdown", { timeout: 5000 }).should("exist").and("be.visible");
+
+        // Cancel without actually checking out (avoid side effects)
+        cy.get(".modal.show #checkoutCancelBtn").click({ force: true });
+        cy.window().then((win) => {
+            const el = win.document.querySelector('[id^="crm-checkout-by-modal"]');
+            if (el) {
+                const instance = win.bootstrap?.Modal?.getInstance(el);
+                if (instance) instance.hide();
+            }
+        });
+        cy.get('[id^="crm-checkout-by-modal"]', { timeout: 5000 }).should("not.exist");
+
+        // Teardown: hidden.bs.modal destroys the TomSelect and removes the
+        // body-mounted dropdown.
+        cy.get("body > .ts-dropdown", { timeout: 5000 }).should("not.exist");
+    });
+});

--- a/cypress/e2e/ui/groups/standard.tomselect-dropdownparent.spec.js
+++ b/cypress/e2e/ui/groups/standard.tomselect-dropdownparent.spec.js
@@ -163,13 +163,13 @@ describe("event-checkin.js openCheckoutByDialog TomSelect dropdownParent:body (#
         // Cancel without actually checking out (avoid side effects)
         cy.get(".modal.show #checkoutCancelBtn").click({ force: true });
         cy.window().then((win) => {
-            const el = win.document.querySelector('[id^="crm-checkout-by-modal"]');
+            const el = win.document.querySelector("#crm-checkout-by-modal");
             if (el) {
                 const instance = win.bootstrap?.Modal?.getInstance(el);
                 if (instance) instance.hide();
             }
         });
-        cy.get('[id^="crm-checkout-by-modal"]', { timeout: 5000 }).should("not.exist");
+        cy.get("#crm-checkout-by-modal", { timeout: 5000 }).should("not.exist");
 
         // Teardown: hidden.bs.modal destroys the TomSelect and removes the
         // body-mounted dropdown.

--- a/cypress/e2e/ui/people/standard.person.group-add.spec.js
+++ b/cypress/e2e/ui/people/standard.person.group-add.spec.js
@@ -74,7 +74,7 @@ describe("PersonView: Add to group with multiple roles", () => {
 
         // Select the multi-role group ("Angels class") via TomSelect
         cy.get("#personGroupModal .ts-control").should("be.visible").click();
-        cy.get("#personGroupModal .ts-dropdown .option")
+        cy.get("body > .ts-dropdown .option")
             .contains("Angels class")
             .click();
 
@@ -108,14 +108,14 @@ describe("PersonView: Add to group with multiple roles", () => {
 
         // Select the multi-role group
         cy.get("#personGroupModal .ts-control").should("be.visible").click();
-        cy.get("#personGroupModal .ts-dropdown .option")
+        cy.get("body > .ts-dropdown .option")
             .contains("Angels class")
             .click();
 
         // Role picker visible — select "Teacher" explicitly
         cy.get("#pgm-role-wrapper").should("be.visible");
         cy.get("#pgm-role-wrapper .ts-control").click();
-        cy.get("#pgm-role-wrapper .ts-dropdown .option")
+        cy.get("body > .ts-dropdown .option")
             .contains("Teacher")
             .click();
 

--- a/src/skin/js/CRMJSOM.js
+++ b/src/skin/js/CRMJSOM.js
@@ -270,13 +270,6 @@ window.CRM.groups = {
 
     wrapper.addEventListener("hidden.bs.modal", cleanup, { once: true });
 
-    // Fallback timeout: ensure cleanup happens if hidden.bs.modal doesn't fire
-    setTimeout(() => {
-      if (wrapper.parentNode) {
-        cleanup();
-      }
-    }, 2000);
-
     const confirmBtn = wrapper.querySelector("#crm-gs-confirm");
     const roleWrapper = wrapper.querySelector("#crm-gs-role-wrapper");
 

--- a/src/skin/js/GroupView.js
+++ b/src/skin/js/GroupView.js
@@ -93,11 +93,23 @@ function _showRoleModal(title, callback) {
   result.el.addEventListener(
     "shown.bs.modal",
     () => {
-      new window.TomSelect(roleEl, {
+      var ts = new window.TomSelect(roleEl, {
+        dropdownParent: "body",
         onChange: (value) => {
           selectedRoleId = value || null;
         },
       });
+      // Destroy the TomSelect to remove body > .ts-dropdown when the modal closes.
+      // Must use a closure reference because wrapper.remove() leaves ts.dropdown in <body>.
+      result.el.addEventListener(
+        "hidden.bs.modal",
+        () => {
+          try {
+            ts.destroy();
+          } catch (e) {}
+        },
+        { once: true },
+      );
     },
     { once: true },
   );
@@ -146,10 +158,13 @@ function _showGroupAndRoleModal(title, callback) {
       () => {
         var roleWrapper = document.getElementById("gv-role-wrapper");
         var roleEl = document.getElementById("gv-role-select");
+        var tsGroup = null;
+        var tsRole = null;
 
-        new window.TomSelect(groupEl, {
+        tsGroup = new window.TomSelect(groupEl, {
           placeholder: i18next.t("Search groups..."),
           items: [],
+          dropdownParent: "body",
           onChange: (value) => {
             selectedGroupId = value || null;
             if (!value) {
@@ -158,7 +173,12 @@ function _showGroupAndRoleModal(title, callback) {
               return;
             }
             // Load roles for selected group
-            if (roleEl.tomselect) roleEl.tomselect.destroy();
+            if (tsRole) {
+              try {
+                tsRole.destroy();
+              } catch (e) {}
+              tsRole = null;
+            }
             roleEl.innerHTML = "";
             roleWrapper.classList.add("d-none");
 
@@ -179,7 +199,8 @@ function _showGroupAndRoleModal(title, callback) {
               );
               roleWrapper.classList.remove("d-none");
               result.confirm.disabled = false;
-              new window.TomSelect(roleEl, {
+              tsRole = new window.TomSelect(roleEl, {
+                dropdownParent: "body",
                 onChange: (v) => {
                   selectedRoleId = v || null;
                 },
@@ -188,6 +209,19 @@ function _showGroupAndRoleModal(title, callback) {
             });
           },
         });
+        // Destroy TomSelect instances on close so body > .ts-dropdown is removed.
+        result.el.addEventListener(
+          "hidden.bs.modal",
+          () => {
+            try {
+              if (tsGroup) tsGroup.destroy();
+            } catch (e) {}
+            try {
+              if (tsRole) tsRole.destroy();
+            } catch (e) {}
+          },
+          { once: true },
+        );
       },
       { once: true },
     );
@@ -446,6 +480,7 @@ function initializeGroupView() {
       valueField: "objid",
       labelField: "text",
       searchField: "text",
+      dropdownParent: "body",
       load: (query, callback) => {
         if (query.length < 2) return callback();
         fetch(window.CRM.root + "/api/persons/search/" + encodeURIComponent(query))

--- a/src/skin/js/GroupView.js
+++ b/src/skin/js/GroupView.js
@@ -6,6 +6,9 @@ var GV_MODAL_ID = "groupViewModal";
 function _createModal(title, bodyHtml) {
   var existing = document.getElementById(GV_MODAL_ID);
   if (existing) {
+    existing.querySelectorAll("select").forEach(function (sel) {
+      if (sel.tomselect) sel.tomselect.destroy();
+    });
     var old = window.bootstrap.Modal.getInstance(existing);
     if (old) old.dispose();
     existing.remove();

--- a/src/skin/js/GroupView.js
+++ b/src/skin/js/GroupView.js
@@ -7,7 +7,9 @@ function _createModal(title, bodyHtml) {
   var existing = document.getElementById(GV_MODAL_ID);
   if (existing) {
     existing.querySelectorAll("select").forEach(function (sel) {
-      if (sel.tomselect) sel.tomselect.destroy();
+      try {
+        if (sel.tomselect) sel.tomselect.destroy();
+      } catch (e) {}
     });
     var old = window.bootstrap.Modal.getInstance(existing);
     if (old) old.dispose();
@@ -163,6 +165,10 @@ function _showGroupAndRoleModal(title, callback) {
         var roleEl = document.getElementById("gv-role-select");
         var tsGroup = null;
         var tsRole = null;
+        // Guard: if the modal closes before getRoles() AJAX resolves, bail out
+        // of the .done() callback to prevent creating a TomSelect on a detached
+        // element (which would leave orphaned body > .ts-dropdown nodes).
+        var isOpen = true;
 
         tsGroup = new window.TomSelect(groupEl, {
           placeholder: i18next.t("Search groups..."),
@@ -186,6 +192,7 @@ function _showGroupAndRoleModal(title, callback) {
             roleWrapper.classList.add("d-none");
 
             window.CRM.groups.getRoles(value).done((roles) => {
+              if (!isOpen) return; // modal closed before AJAX resolved
               if (roles.length === 0) {
                 selectedRoleId = null;
                 result.confirm.disabled = false;
@@ -216,6 +223,7 @@ function _showGroupAndRoleModal(title, callback) {
         result.el.addEventListener(
           "hidden.bs.modal",
           () => {
+            isOpen = false; // prevent in-flight getRoles() from creating orphaned TomSelect
             try {
               if (tsGroup) tsGroup.destroy();
             } catch (e) {}

--- a/src/skin/js/sundayschool-actions.js
+++ b/src/skin/js/sundayschool-actions.js
@@ -90,10 +90,13 @@
         () => {
           var roleWrapper = document.getElementById("ss-role-wrapper");
           var roleEl = document.getElementById("ss-role-select");
+          var tsGroup = null;
+          var tsRole = null;
 
-          new window.TomSelect(groupEl, {
+          tsGroup = new window.TomSelect(groupEl, {
             placeholder: i18next.t("Search groups..."),
             items: [],
+            dropdownParent: "body",
             onChange: (value) => {
               selectedGroupId = value || null;
               if (!value) {
@@ -101,7 +104,12 @@
                 result.confirm.disabled = true;
                 return;
               }
-              if (roleEl.tomselect) roleEl.tomselect.destroy();
+              if (tsRole) {
+                try {
+                  tsRole.destroy();
+                } catch (e) {}
+                tsRole = null;
+              }
               roleEl.innerHTML = "";
               roleWrapper.classList.add("d-none");
 
@@ -122,7 +130,8 @@
                 );
                 roleWrapper.classList.remove("d-none");
                 result.confirm.disabled = false;
-                new window.TomSelect(roleEl, {
+                tsRole = new window.TomSelect(roleEl, {
+                  dropdownParent: "body",
                   onChange: (v) => {
                     selectedRoleId = v || null;
                   },
@@ -131,6 +140,19 @@
               });
             },
           });
+          // Destroy TomSelect instances on close so body > .ts-dropdown is removed.
+          result.el.addEventListener(
+            "hidden.bs.modal",
+            () => {
+              try {
+                if (tsGroup) tsGroup.destroy();
+              } catch (e) {}
+              try {
+                if (tsRole) tsRole.destroy();
+              } catch (e) {}
+            },
+            { once: true },
+          );
         },
         { once: true },
       );

--- a/src/skin/js/sundayschool-actions.js
+++ b/src/skin/js/sundayschool-actions.js
@@ -11,7 +11,9 @@
     var existing = document.getElementById(SS_MODAL_ID);
     if (existing) {
       existing.querySelectorAll("select").forEach(function (sel) {
-        if (sel.tomselect) sel.tomselect.destroy();
+        try {
+          if (sel.tomselect) sel.tomselect.destroy();
+        } catch (e) {}
       });
       var old = window.bootstrap.Modal.getInstance(existing);
       if (old) old.dispose();
@@ -95,6 +97,10 @@
           var roleEl = document.getElementById("ss-role-select");
           var tsGroup = null;
           var tsRole = null;
+          // Guard: if the modal closes before getRoles() AJAX resolves, bail out
+          // of the .done() callback to prevent creating a TomSelect on a detached
+          // element (which would leave orphaned body > .ts-dropdown nodes).
+          var isOpen = true;
 
           tsGroup = new window.TomSelect(groupEl, {
             placeholder: i18next.t("Search groups..."),
@@ -117,6 +123,7 @@
               roleWrapper.classList.add("d-none");
 
               window.CRM.groups.getRoles(value).done((roles) => {
+                if (!isOpen) return; // modal closed before AJAX resolved
                 if (roles.length === 0) {
                   selectedRoleId = null;
                   result.confirm.disabled = false;
@@ -147,6 +154,7 @@
           result.el.addEventListener(
             "hidden.bs.modal",
             () => {
+              isOpen = false; // prevent in-flight getRoles() from creating orphaned TomSelect
               try {
                 if (tsGroup) tsGroup.destroy();
               } catch (e) {}

--- a/src/skin/js/sundayschool-actions.js
+++ b/src/skin/js/sundayschool-actions.js
@@ -10,6 +10,9 @@
   function createModal(title, bodyHtml) {
     var existing = document.getElementById(SS_MODAL_ID);
     if (existing) {
+      existing.querySelectorAll("select").forEach(function (sel) {
+        if (sel.tomselect) sel.tomselect.destroy();
+      });
       var old = window.bootstrap.Modal.getInstance(existing);
       if (old) old.dispose();
       existing.remove();

--- a/webpack/event-checkin.js
+++ b/webpack/event-checkin.js
@@ -485,10 +485,11 @@ $(() => {
   function openCheckoutByDialog(personId, personName, checkinId, checkinName) {
     const safeName = window.CRM.escapeHtml(String(personName));
 
-    // Build a unique modal ID so concurrent calls don't conflict.
-    // Uses a native BS5 modal (not bootbox) so TomSelect's dropdownParent: "body"
-    // works correctly — bootbox v6 has incompatibilities with that option.
-    const modalId = `crm-checkout-by-modal-${Date.now()}`;
+    // Use a fixed modal ID so concurrent calls can find and properly dispose
+    // any already-open instance before creating a new one. A Date.now()-based
+    // ID is always unique, making the getElementById dedup guard below
+    // unreachable dead code.
+    const modalId = "crm-checkout-by-modal";
 
     const bodyHtml =
       '<p class="mb-2">' +
@@ -509,7 +510,12 @@ $(() => {
       "</small>";
 
     const existing = document.getElementById(modalId);
-    if (existing) existing.remove();
+    if (existing) {
+      // Dispose the BS5 Modal instance before removing the element to avoid
+      // event-listener and backdrop leaks.
+      window.bootstrap.Modal.getInstance(existing)?.dispose();
+      existing.remove();
+    }
 
     const wrapper = document.createElement("div");
     wrapper.id = modalId;

--- a/webpack/event-checkin.js
+++ b/webpack/event-checkin.js
@@ -484,83 +484,158 @@ $(() => {
 
   function openCheckoutByDialog(personId, personName, checkinId, checkinName) {
     const safeName = window.CRM.escapeHtml(String(personName));
-    const dialog = bootbox.dialog({
-      title: `${i18next.t("Check out")}: ${safeName}`,
-      message:
-        '<p class="mb-2">' +
-        i18next.t("Optional — record who is checking this person out (e.g. a parent picking up a child).") +
-        "</p>" +
-        '<div class="input-group">' +
-        '<select class="form-select" id="checkoutBySelect" placeholder="' +
-        i18next.t("Search for supervisor...") +
-        '"></select>' +
-        '<button type="button" class="btn btn-outline-secondary" id="assignMeCheckout" title="' +
-        i18next.t("Assign to me") +
-        '">' +
-        '<i class="fa-solid fa-user-check"></i>' +
-        "</button>" +
-        "</div>" +
-        '<small class="text-muted mt-2 d-block">' +
-        i18next.t("Leave blank to check out without recording the supervisor.") +
-        "</small>",
-      buttons: {
-        cancel: {
-          label: `<i class="ti ti-x"></i> ${i18next.t("Cancel")}`,
-          className: "btn-link",
-        },
-        skip: {
-          label: `<i class="ti ti-check"></i> ${i18next.t("Skip & Check Out")}`,
-          className: "btn-outline-warning",
-          callback: () => {
-            performCheckout(personId, null);
-          },
-        },
-        confirm: {
-          label: `<i class="fa-solid fa-user-check"></i> ${i18next.t("Confirm Check Out")}`,
-          className: "btn-primary",
-          callback: () => {
-            const val = $("#checkoutBySelect").val();
-            const supervisorId = val ? parseInt(val, 10) : null;
-            performCheckout(personId, supervisorId);
-          },
-        },
-      },
-    });
 
-    // Initialize TomSelect on the supervisor search field once the modal is shown
-    dialog.on("shown.bs.modal", () => {
-      const el = document.getElementById("checkoutBySelect");
-      if (!el || el.tomselect) return;
-      const ts = new TomSelect(el, {
-        valueField: "objid",
-        labelField: "text",
-        searchField: "text",
-        placeholder: i18next.t("Search for supervisor..."),
-        load: (query, callback) => {
-          if (query.length < 2) return callback();
-          fetch(`${window.CRM.root}/api/persons/search/${encodeURIComponent(query)}`)
-            .then((res) => res.json())
-            .then((data) => callback(data.map((p) => ({ objid: p.objid, text: p.text }))))
-            .catch(() => callback());
-        },
-      });
+    // Build a unique modal ID so concurrent calls don't conflict.
+    // Uses a native BS5 modal (not bootbox) so TomSelect's dropdownParent: "body"
+    // works correctly — bootbox v6 has incompatibilities with that option.
+    const modalId = `crm-checkout-by-modal-${Date.now()}`;
 
-      // Pre-populate with the person who checked them in (if available)
-      if (checkinId && checkinName) {
-        ts.addOption({ objid: checkinId, text: checkinName });
-        ts.setValue(checkinId);
-      }
+    const bodyHtml =
+      '<p class="mb-2">' +
+      i18next.t("Optional — record who is checking this person out (e.g. a parent picking up a child).") +
+      "</p>" +
+      '<div class="input-group">' +
+      '<select class="form-select" id="checkoutBySelect" placeholder="' +
+      i18next.t("Search for supervisor...") +
+      '"></select>' +
+      '<button type="button" class="btn btn-outline-secondary" id="assignMeCheckout" title="' +
+      i18next.t("Assign to me") +
+      '">' +
+      '<i class="fa-solid fa-user-check"></i>' +
+      "</button>" +
+      "</div>" +
+      '<small class="text-muted mt-2 d-block">' +
+      i18next.t("Leave blank to check out without recording the supervisor.") +
+      "</small>";
 
-      // "Assign to me" button in checkout dialog
-      $("#assignMeCheckout").on("click", () => {
-        const userId = window.CRM.userId;
-        const userName = window.CRM.userName;
-        if (userId && userName) {
-          ts.addOption({ objid: userId, text: userName });
-          ts.setValue(userId);
+    const existing = document.getElementById(modalId);
+    if (existing) existing.remove();
+
+    const wrapper = document.createElement("div");
+    wrapper.id = modalId;
+    wrapper.className = "modal fade";
+    wrapper.setAttribute("tabindex", "-1");
+    wrapper.setAttribute("aria-modal", "true");
+    wrapper.setAttribute("role", "dialog");
+    wrapper.setAttribute("aria-labelledby", `${modalId}-title`);
+    wrapper.innerHTML =
+      '<div class="modal-dialog modal-dialog-centered">' +
+      '<div class="modal-content">' +
+      '<div class="modal-header">' +
+      `<h5 class="modal-title" id="${modalId}-title">` +
+      i18next.t("Check out") +
+      ": " +
+      safeName +
+      "</h5>" +
+      '<button type="button" class="btn-close" data-bs-dismiss="modal"></button>' +
+      "</div>" +
+      '<div class="modal-body">' +
+      bodyHtml +
+      "</div>" +
+      '<div class="modal-footer">' +
+      '<button type="button" class="btn btn-link" id="checkoutCancelBtn" data-bs-dismiss="modal">' +
+      '<i class="ti ti-x"></i> ' +
+      i18next.t("Cancel") +
+      "</button>" +
+      '<button type="button" class="btn btn-outline-warning" id="checkoutSkipBtn">' +
+      '<i class="ti ti-check"></i> ' +
+      i18next.t("Skip & Check Out") +
+      "</button>" +
+      '<button type="button" class="btn btn-primary" id="checkoutConfirmBtn">' +
+      '<i class="fa-solid fa-user-check"></i> ' +
+      i18next.t("Confirm Check Out") +
+      "</button>" +
+      "</div></div></div>";
+
+    document.body.appendChild(wrapper);
+    const bsModal = new window.bootstrap.Modal(wrapper, { backdrop: "static" });
+
+    let tomSelectInstance = null;
+
+    // Destroy TomSelect and remove modal element once hidden
+    wrapper.addEventListener(
+      "hidden.bs.modal",
+      () => {
+        if (tomSelectInstance) {
+          try {
+            tomSelectInstance.destroy();
+          } catch (_e) {
+            // ignore
+          }
+          tomSelectInstance = null;
         }
-      });
+        try {
+          bsModal.dispose();
+        } catch (_e) {
+          // ignore
+        }
+        if (wrapper.parentNode) wrapper.remove();
+      },
+      { once: true },
+    );
+
+    // Initialize TomSelect once the modal is fully visible (needs layout dimensions).
+    // shown.bs.modal fires after the CSS transition, so elements are measured correctly.
+    wrapper.addEventListener(
+      "shown.bs.modal",
+      () => {
+        const el = wrapper.querySelector("#checkoutBySelect");
+        if (!el || el.tomselect) return;
+        tomSelectInstance = new TomSelect(el, {
+          valueField: "objid",
+          labelField: "text",
+          searchField: "text",
+          placeholder: i18next.t("Search for supervisor..."),
+          dropdownParent: "body",
+          load: (query, callback) => {
+            if (query.length < 2) return callback();
+            fetch(`${window.CRM.root}/api/persons/search/${encodeURIComponent(query)}`)
+              .then((res) => res.json())
+              .then((data) => callback(data.map((p) => ({ objid: p.objid, text: p.text }))))
+              .catch(() => callback());
+          },
+        });
+
+        // Pre-populate with the person who checked them in (if available)
+        if (checkinId && checkinName) {
+          tomSelectInstance.addOption({ objid: checkinId, text: checkinName });
+          tomSelectInstance.setValue(checkinId);
+        }
+
+        // "Assign to me" button: set the current logged-in user as supervisor
+        const assignMeBtn = wrapper.querySelector("#assignMeCheckout");
+        if (assignMeBtn) {
+          assignMeBtn.addEventListener("click", () => {
+            const userId = window.CRM.userId;
+            const userName = window.CRM.userName;
+            if (userId && userName) {
+              tomSelectInstance.addOption({ objid: userId, text: userName });
+              tomSelectInstance.setValue(userId);
+            }
+          });
+        }
+      },
+      { once: true },
+    );
+
+    // Skip: check out without recording a supervisor
+    const skipBtn = wrapper.querySelector("#checkoutSkipBtn");
+    skipBtn.addEventListener("click", () => {
+      bsModal.hide();
+      performCheckout(personId, null);
     });
+
+    // Confirm: check out with the selected supervisor (read via TomSelect API)
+    const confirmBtn = wrapper.querySelector("#checkoutConfirmBtn");
+    confirmBtn.addEventListener("click", () => {
+      const el = wrapper.querySelector("#checkoutBySelect");
+      const val = el?.tomselect ? el.tomselect.getValue() : null;
+      const supervisorId = val ? parseInt(val, 10) : null;
+      bsModal.hide();
+      performCheckout(personId, supervisorId);
+    });
+
+    bsModal.show();
   }
 
   function performCheckout(personId, checkedOutById) {

--- a/webpack/people/person-group-manager.js
+++ b/webpack/people/person-group-manager.js
@@ -123,9 +123,10 @@ function handleAddToGroup(personId) {
         const roleWrapper = document.getElementById("pgm-role-wrapper");
         const roleEl = document.getElementById("pgm-role-select");
 
-        new window.TomSelect(groupEl, {
+        const tsGroup = new window.TomSelect(groupEl, {
           placeholder: i18next.t("Search groups..."),
           items: [],
+          dropdownParent: "body",
           onChange: (value) => {
             selectedGroupId = value || null;
             if (!value) {
@@ -138,6 +139,21 @@ function handleAddToGroup(personId) {
             });
           },
         });
+        // Destroy TomSelect instances on close so body > .ts-dropdown is removed.
+        el.addEventListener(
+          "hidden.bs.modal",
+          () => {
+            try {
+              tsGroup.destroy();
+            } catch (_e) {}
+            if (roleEl.tomselect) {
+              try {
+                roleEl.tomselect.destroy();
+              } catch (_e) {}
+            }
+          },
+          { once: true },
+        );
       },
       { once: true },
     );
@@ -188,6 +204,7 @@ function loadRoles(groupId, roleEl, roleWrapper, confirmBtn, onRoleSelected) {
     confirmBtn.disabled = false;
 
     new window.TomSelect(roleEl, {
+      dropdownParent: "body",
       onChange: (value) => {
         onRoleSelected(value || null);
       },
@@ -233,6 +250,7 @@ function handleChangeRole(personId, groupId, currentRoleId) {
       "shown.bs.modal",
       () => {
         const ts = new window.TomSelect(roleEl, {
+          dropdownParent: "body",
           onChange: (value) => {
             selectedRoleId = value || null;
           },
@@ -241,6 +259,16 @@ function handleChangeRole(personId, groupId, currentRoleId) {
         if (currentRoleId) {
           ts.setValue(String(currentRoleId), true);
         }
+        // Destroy TomSelect on close to remove body > .ts-dropdown.
+        el.addEventListener(
+          "hidden.bs.modal",
+          () => {
+            try {
+              ts.destroy();
+            } catch (_e) {}
+          },
+          { once: true },
+        );
       },
       { once: true },
     );

--- a/webpack/people/person-group-manager.js
+++ b/webpack/people/person-group-manager.js
@@ -20,7 +20,9 @@ function createModal(title, bodyHtml) {
   const existing = document.getElementById(MODAL_ID);
   if (existing) {
     existing.querySelectorAll("select").forEach((sel) => {
-      if (sel.tomselect) sel.tomselect.destroy();
+      try {
+        if (sel.tomselect) sel.tomselect.destroy();
+      } catch (_e) {}
     });
     const bsModal = window.bootstrap.Modal.getInstance(existing);
     if (bsModal) bsModal.dispose();
@@ -125,6 +127,10 @@ function handleAddToGroup(personId) {
       () => {
         const roleWrapper = document.getElementById("pgm-role-wrapper");
         const roleEl = document.getElementById("pgm-role-select");
+        // Guard: if the modal closes before getRoles() AJAX resolves, bail out
+        // of the .done() callback to prevent creating a TomSelect on a detached
+        // element (which would leave orphaned body > .ts-dropdown nodes).
+        let isOpen = true;
 
         const tsGroup = new window.TomSelect(groupEl, {
           placeholder: i18next.t("Search groups..."),
@@ -137,15 +143,23 @@ function handleAddToGroup(personId) {
               confirm.disabled = true;
               return;
             }
-            loadRoles(value, roleEl, roleWrapper, confirm, (roleId) => {
-              selectedRoleId = roleId;
-            });
+            loadRoles(
+              value,
+              roleEl,
+              roleWrapper,
+              confirm,
+              (roleId) => {
+                selectedRoleId = roleId;
+              },
+              () => isOpen,
+            );
           },
         });
         // Destroy TomSelect instances on close so body > .ts-dropdown is removed.
         el.addEventListener(
           "hidden.bs.modal",
           () => {
+            isOpen = false; // prevent in-flight getRoles() from creating orphaned TomSelect
             try {
               tsGroup.destroy();
             } catch (_e) {}
@@ -178,13 +192,19 @@ function handleAddToGroup(personId) {
 /**
  * Load roles for a group into a select element. If only 1 role, auto-select it
  * and hide the wrapper. If >1, show TomSelect.
+ *
+ * @param {Function} getIsOpen - Returns true while the parent modal is open.
+ *   When the modal closes before this AJAX call resolves, `getIsOpen()` returns
+ *   false and the callback bails out to avoid creating a TomSelect on a detached
+ *   element (which would leave orphaned body > .ts-dropdown nodes).
  */
-function loadRoles(groupId, roleEl, roleWrapper, confirmBtn, onRoleSelected) {
+function loadRoles(groupId, roleEl, roleWrapper, confirmBtn, onRoleSelected, getIsOpen) {
   if (roleEl.tomselect) roleEl.tomselect.destroy();
   roleEl.innerHTML = "";
   roleWrapper.classList.add("d-none");
 
   window.CRM.groups.getRoles(groupId).done((roles) => {
+    if (!getIsOpen()) return; // modal closed before AJAX resolved
     if (roles.length === 0) {
       onRoleSelected(null);
       confirmBtn.disabled = false;

--- a/webpack/people/person-group-manager.js
+++ b/webpack/people/person-group-manager.js
@@ -19,6 +19,9 @@ const MODAL_ID = "personGroupModal";
 function createModal(title, bodyHtml) {
   const existing = document.getElementById(MODAL_ID);
   if (existing) {
+    existing.querySelectorAll("select").forEach((sel) => {
+      if (sel.tomselect) sel.tomselect.destroy();
+    });
     const bsModal = window.bootstrap.Modal.getInstance(existing);
     if (bsModal) bsModal.dispose();
     existing.remove();


### PR DESCRIPTION
Fixes #9488. Supersedes #9595 and #9596 (combines the best of both).

## Summary

All remaining TomSelect pickers inside Bootstrap 5 modals (or cards with `overflow: hidden`) were clipping their dropdowns because `dropdownParent` was not set. This applies the `dropdownParent: "body"` fix from #9483 to every remaining call site, **and** adds the `hidden.bs.modal → ts.destroy()` teardown that a body-mounted dropdown requires so orphaned `.ts-dropdown` nodes don't accumulate on each open/close.

## Changes

- **GroupView.js** — `dropdownParent: "body"` on `_showRoleModal`, `_showGroupAndRoleModal` (group + role), and the `.personSearch` "Add Member" page-level picker; `hidden.bs.modal` teardown for the two modals.
- **person-group-manager.js** — `dropdownParent: "body"` on `handleAddToGroup` (group), `loadRoles` (role), `handleChangeRole` (role); `hidden.bs.modal` teardown per modal.
- **sundayschool-actions.js** — `dropdownParent: "body"` + teardown on `showGroupAndRoleModal` (group + role).
- **event-checkin.js** — `openCheckoutByDialog()` migrated from `bootbox.dialog` to a hand-built native Bootstrap 5 modal (matching the `CRMJSOM.js` `promptSelection` pattern from #9483 — bootbox v6 is incompatible with `.init()` / `dropdownParent`). TomSelect initialised in `shown.bs.modal` with `dropdownParent: "body"`; `hidden.bs.modal` destroys TomSelect, disposes the modal, and removes the element.
- **CRMJSOM.js** — removed an always-firing `setTimeout(cleanup, 2000)` "fallback" in `promptSelection()`. Its `if (wrapper.parentNode)` guard is always true while the modal is open, so it tore the modal down ~2 s after it appeared regardless of interaction — this is why the **"Empty Cart to Group" popup disappeared after a few seconds**. `hidden.bs.modal` remains the sole (and reliable) teardown path.
- **cypress/e2e/ui/groups/standard.tomselect-dropdownparent.spec.js** — new regression spec: asserts `body > .ts-dropdown` is a direct child of `<body>` when each picker opens (GroupView personSearch, person-group-manager Add-to-Group modal, event-checkin checkout modal), and that it is removed again when the modal closes.

## Why

- Fixes the clipped/invisible dropdowns in #9488.
- The teardown work prevents `body > .ts-dropdown` node accumulation that `dropdownParent: "body"` alone would leave behind.
- Fixes the vanishing "Empty Cart to Group" modal (same modal family, surfaced during review).

## Testing

- `npm run lint` — 0 errors
- `npm run build:webpack` — compiled successfully
- `npm run build:php` — no changed PHP files
- New Cypress spec (3 tests): open + teardown assertions for all three affected pickers.

## Relationship to #9595 / #9596

Both were competing single-commit fixes for #9488 by the implementer bot. This PR takes #9596's comprehensive per-site teardown + #9595's native-modal checkout rewrite + the CRMJSOM timeout fix, with stronger tests. #9595 and #9596 should be closed in favour of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)