### PR TITLE
fix: suppress DataTables AJAX error popups on dashboard (#9566, #9570)

### DIFF
--- a/locale/messages.po
+++ b/locale/messages.po
@@ -13558,3 +13558,9 @@ msgid ""
 "• User demographics (if enabled in GA4)\n"
 "• Device and browser information"
 msgstr ""
+
+msgid "Could not load data"
+msgstr ""
+
+msgid "Please refresh the page or try again later."
+msgstr ""

--- a/src/skin/js/MainDashboard.js
+++ b/src/skin/js/MainDashboard.js
@@ -18,6 +18,64 @@ export function initializeMainDashboard() {
     setTimeout(() => initializeMainDashboard(), 500);
     return;
   }
+
+  // Suppress DataTables' default obtrusive alert() popup on AJAX errors (#9566/#9570).
+  // Without this, every failing dashboard widget fires a modal that must be dismissed
+  // individually. We replace it with a per-widget inline error state via the
+  // 'error.dt' event bound below.
+  if ($.fn.dataTable) {
+    $.fn.dataTable.ext.errMode = "none";
+  }
+
+  /**
+   * Render an inline Tabler empty-state error message inside the widget's card body.
+   * Called by the 'error.dt' handler when a dashboard DataTable AJAX request fails.
+   * @param {string} selector - CSS selector for the DataTable element (e.g. "#latestFamiliesDashboardItem")
+   */
+  function showWidgetLoadError(selector) {
+    const $table = $(selector);
+    if (!$table.length) return;
+    // Destroy the DataTable instance before removing the DOM node so the
+    // settings registry does not retain a stale reference to a detached element.
+    if ($.fn.dataTable && $.fn.dataTable.isDataTable($table[0])) {
+      $table.DataTable().destroy();
+    }
+    $table
+      .closest(".card-body")
+      .html(
+        '<div class="empty py-4">' +
+          '<div class="empty-icon"><i class="fa-solid fa-triangle-exclamation fa-2x text-muted"></i></div>' +
+          '<p class="empty-title">' +
+          i18next.t("Could not load data") +
+          "</p>" +
+          '<p class="empty-subtitle text-muted">' +
+          i18next.t("Please refresh the page or try again later.") +
+          "</p>" +
+          "</div>",
+      );
+  }
+
+  // Listen for DataTables AJAX errors on all dashboard tables and render an
+  // inline error state instead of the suppressed alert popup.
+  // Note: 'error.dt' fires even when errMode is 'none' — settings.nTable is the
+  // failing <table> element, so we can map it back to its CSS id.
+  // Use a namespaced event ('error.dt.dashboard') and guard with .off() so
+  // that calling initializeMainDashboard() more than once does not stack up
+  // duplicate handlers.
+  $(document)
+    .off("error.dt.dashboard")
+    .on("error.dt.dashboard", (_e, settings, techNote, message) => {
+      const tableId = settings?.nTable?.id;
+      console.error(
+        `[Dashboard] DataTables AJAX error${tableId ? ` (${tableId})` : ""}:`,
+        message,
+        `(tech note #${techNote})`,
+      );
+      if (tableId) {
+        showWidgetLoadError(`#${tableId}`);
+      }
+    });
+
   // Helper to generate Tabler simple avatar with initials (not clickable)
   function generateTablerAvatar(name, id, type = "person") {
     const parts = name.trim().split(/\s+/);


### PR DESCRIPTION
## Summary
Split out of #9613 — this covers only the DataTables popup-storm bug (#9566/#9570), unrelated to the Fundraiser badge fix (which is #9613, tracking #9569).

## Changes
- **`src/skin/js/MainDashboard.js`**:
  - Sets `$.fn.dataTable.ext.errMode = 'none'` at dashboard init (guarded by `if ($.fn.dataTable)`) to suppress DataTables' default `alert()` modals.
  - Adds `showWidgetLoadError(selector)` — renders an inline Tabler empty-state (⚠ icon + "Could not load data") inside the failing widget's card body, destroying the DataTable instance first to avoid a zombie reference to a detached DOM node.
  - Binds a delegated, namespaced `error.dt.dashboard` handler on `document` that `console.error`s the failure details and calls `showWidgetLoadError` for the affected widget. Namespaced + `.off()`-guarded so re-running `initializeMainDashboard()` doesn't stack duplicate handlers.
- **`locale/messages.po`** — adds the two new UI strings ("Could not load data", "Please refresh the page or try again later.").

## Why
The affected widgets (`latestFamiliesDashboardItem`, `latestPersonDashboardItem`, `todayEventsDashboardItem`, `updatedPersonDashboardItem`, `PersonBirthdayDashboardItem`, `FamiliesWithAnniversariesDashboardItem`) call `/api/families/*`, `/api/persons/*`, `/api/events/today` — none of them gated behind a feature flag. So this is a genuinely separate bug from the Fundraiser badge issue: any transient/unexpected AJAX failure on these widgets threw a blocking DataTables `alert()` modal (~7 in a row on every dashboard load/refresh). This PR replaces that with a non-blocking inline error state per widget.

## Testing
- ✅ `npm run lint` (Biome)
- ✅ `npm run build:webpack`
- Pre-commit locale-check and PHP validation hooks passed

Fixes #9566
Fixes #9570