### PR TITLE
Fix #9611: Remove stale email/role-based contact guidance from SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -62,11 +62,11 @@ The following activities are within the scope of our responsible disclosure proc
 - Providing steps to reproduce and validate the vulnerability
 - Sharing proof-of-concept code or test cases (privately, through the advisory)
 
-**Out of scope** (please use [GitHub Issues](https://github.com/ChurchCRM/CRM/issues) instead):
+**Out of scope:**
 
-- General bugs with no security impact
-- Feature requests or usability concerns
-- Vulnerabilities in self-hosted infrastructure outside of the ChurchCRM application code
+- General bugs with no security impact — please use [GitHub Issues](https://github.com/ChurchCRM/CRM/issues) instead
+- Feature requests or usability concerns — please use [GitHub Issues](https://github.com/ChurchCRM/CRM/issues) instead
+- Vulnerabilities in self-hosted infrastructure outside of the ChurchCRM application and its bundled dependencies — please contact the affected site's administrator directly
 
 ## Security Best Practices
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,6 +8,7 @@ Security patch announcements, CVE disclosures, and dependency update notices are
 
 **Please do not:**
 - DM maintainers directly about security issues
+- Email individual maintainers or any role-specific address about security issues (no such contacts exist — use GitHub Security Advisories)
 - Post vulnerability details in any other Discord channel
 - Ask about undisclosed vulnerabilities in public channels
 
@@ -55,10 +56,17 @@ If you're unsure whether an issue is security-related, err on the side of cautio
 
 ## Scope
 
-Please note that the following activities are considered within the scope of our responsible disclosure process:
+The following activities are within the scope of our responsible disclosure process:
 
-- Reporting security vulnerabilities directly to us via GitHub Security Advisory
-- Providing details necessary for us to reproduce and validate the vulnerability
+- Reporting security vulnerabilities directly to us via [GitHub Security Advisory](https://github.com/ChurchCRM/CRM/security/advisories)
+- Providing steps to reproduce and validate the vulnerability
+- Sharing proof-of-concept code or test cases (privately, through the advisory)
+
+**Out of scope** (please use [GitHub Issues](https://github.com/ChurchCRM/CRM/issues) instead):
+
+- General bugs with no security impact
+- Feature requests or usability concerns
+- Vulnerabilities in self-hosted infrastructure outside of the ChurchCRM application code
 
 ## Security Best Practices
 


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

## Summary
Closes #9611. The stale mailto-based permissions/role table noted in the issue no longer exists in `SECURITY.md` (it was removed in a prior update). This PR adds the complementary \*explicit\* guidance confirming there are no email contacts, and expands the thin Scope section.

## Changes
- Add "no email / no role-specific contacts" bullet to the **Please do not** list — directly addresses the issue's concern about outdated mailto-based role/contact routing
- Expand the Scope section: tighten prose, hyperlink the Security Advisory reference, add PoC sharing as an explicit in-scope item, add an **Out of scope** list to reduce ambiguous reports

## Why
The issue reporter saw (or expected) a mailto-based permissions table mapping roles to individual maintainer emails. That table has already been removed; this PR makes the absence explicit and improves surrounding documentation for clarity.

## Files Changed
- `SECURITY.md` — 11 insertions, 3 deletions (doc-only)

## Testing
No code changed. `npm run lint` (Biome) exits 0. Pre-push hook passed.

## Related Issues
Fixes #9611