### PR TITLE
feat(events): add month filter to Event Dashboard

### DIFF
--- a/cypress/e2e/ui-admin/admin.events.dashboard.spec.js
+++ b/cypress/e2e/ui-admin/admin.events.dashboard.spec.js
@@ -56,17 +56,28 @@ describe("Events Dashboard (MVC)", () => {
             .and("match", /\/event\/repeat-editor$/);
     });
 
-    it("should have event type and year filters", () => {
+    it("should have event type, month, and year filters", () => {
         cy.visit("event/dashboard");
         cy.get("#type").should("exist");
+        cy.get("#month").should("exist");
         cy.get("#year").should("exist");
         cy.get("#type option").should("have.length.at.least", 1);
+        // Month dropdown has 13 options: 1 for "All Months" + 12 calendar months
+        cy.get("#month option").should("have.length", 13);
     });
 
     it("should filter dashboard by URL params", () => {
         cy.visit("event/dashboard?year=2024");
         cy.contains("Events Dashboard").should("exist");
         cy.url().should("include", "year=2024");
+    });
+
+    it("should filter dashboard by month URL param", () => {
+        cy.visit("event/dashboard?month=1");
+        cy.contains("Events Dashboard").should("exist");
+        cy.url().should("include", "month=1");
+        // Month select should reflect the param
+        cy.get("#month").should("have.value", "1");
     });
 
     it("should have Manage Event Types button in header", () => {

--- a/src/event/routes/list-events.php
+++ b/src/event/routes/list-events.php
@@ -29,6 +29,16 @@ $app->get('/dashboard', function (Request $request, Response $response) {
         ? (int) $params['year']
         : (int) DateTimeUtils::getCurrentYear();
 
+    // Month filter — null means "all months" (full-year view, default behaviour).
+    // Clamp to 1-12; ignore out-of-range values.
+    $EventMonth = null;
+    if (!empty($params['month']) && $params['month'] !== 'All') {
+        $m = (int) $params['month'];
+        if ($m >= 1 && $m <= 12) {
+            $EventMonth = $m;
+        }
+    }
+
     // --- Dashboard Stats (Propel ORM) ---
     $yearMin = $EventYear . '-01-01 00:00:00';
     $yearMax = $EventYear . '-12-31 23:59:59';
@@ -81,8 +91,10 @@ $app->get('/dashboard', function (Request $request, Response $response) {
     $monthlyData = [];
     // $now is defined once outside the foreach loop to avoid re-instantiation
     // and to use the church-configured timezone via DateTimeUtils::getToday().
+    // When a month filter is active only that month is processed; otherwise all.
+    $monthsToShow = $EventMonth !== null ? [$EventMonth] : $allMonths;
 
-    foreach ($allMonths as $mVal) {
+    foreach ($monthsToShow as $mVal) {
         $daysInMonth = DateTimeUtils::getDaysInMonth($mVal, $EventYear);
         $monthMin = sprintf('%04d-%02d-01 00:00:00', $EventYear, $mVal);
         $monthMax = sprintf('%04d-%02d-%02d 23:59:59', $EventYear, $mVal, $daysInMonth);
@@ -223,6 +235,7 @@ $app->get('/dashboard', function (Request $request, Response $response) {
         'canEditEvents'          => $canEditEvents,
         'eType'                  => $eType,
         'EventYear'              => $EventYear,
+        'EventMonth'             => $EventMonth,
         'totalEventsThisYear'    => $totalEventsThisYear,
         'totalCheckInsThisYear'  => $totalCheckInsThisYear,
         'totalCurrentEvents'     => $totalCurrentEvents,
@@ -262,6 +275,9 @@ $app->post('/dashboard', function (Request $request, Response $response) {
     }
     if (!empty($body['year'])) {
         $query['year'] = $body['year'];
+    }
+    if (!empty($body['month']) && (int) $body['month'] >= 1 && (int) $body['month'] <= 12) {
+        $query['month'] = (int) $body['month'];
     }
     $target = SystemURLs::getRootPath() . '/event/dashboard';
     if (!empty($query)) {

--- a/src/event/views/list-events.php
+++ b/src/event/views/list-events.php
@@ -116,8 +116,8 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
 <div class="card mb-3">
   <div class="card-body py-2">
     <form id="eventFilterForm" name="EventFilterForm" method="GET" action="<?= $sRootPath ?>/event/dashboard">
-      <div class="row align-items-end">
-        <div class="col-md-5">
+      <div class="row g-2 align-items-end">
+        <div class="col-12 col-md-4">
           <label for="type" class="form-label mb-1"><?= gettext('Event Type') ?></label>
           <select name="type" id="type" class="form-select form-select-sm">
             <option value="All"><?= gettext('All Types') ?></option>
@@ -128,7 +128,18 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
             <?php endforeach; ?>
           </select>
         </div>
-        <div class="col-md-5">
+        <div class="col-12 col-md-3">
+          <label for="month" class="form-label mb-1"><?= gettext('Month') ?></label>
+          <select name="month" id="month" class="form-select form-select-sm">
+            <option value="All" <?= ($EventMonth === null) ? 'selected' : '' ?>><?= gettext('All Months') ?></option>
+            <?php for ($m = 1; $m <= 12; $m++): ?>
+              <option value="<?= (int) $m ?>" <?= ($EventMonth === $m) ? 'selected' : '' ?>>
+                <?= InputUtils::escapeHTML(gettext(date('F', mktime(0, 0, 0, $m, 1)))) ?>
+              </option>
+            <?php endfor; ?>
+          </select>
+        </div>
+        <div class="col-12 col-md-3">
           <label for="year" class="form-label mb-1"><?= gettext('Year') ?></label>
           <select name="year" id="year" class="form-select form-select-sm">
             <?php foreach ($availableYears as $year): ?>
@@ -138,8 +149,8 @@ require SystemURLs::getDocumentRoot() . '/Include/Header.php';
             <?php endforeach; ?>
           </select>
         </div>
-        <div class="col-md-2 text-end">
-          <?php if ($eType !== 'All'): ?>
+        <div class="col-12 col-md-2 text-md-end">
+          <?php if ($eType !== 'All' || $EventMonth !== null): ?>
             <a href="<?= $sRootPath ?>/event/dashboard" class="btn btn-sm btn-ghost-secondary">
               <i class="fa-solid fa-xmark me-1"></i><?= gettext('Clear Filter') ?>
             </a>
@@ -288,7 +299,7 @@ foreach ($monthlyData as $monthData):
 </div>
 <?php endforeach; ?>
 
-<?php if ($hasEvents && $EventYear === (int) date('Y')): ?>
+<?php if ($hasEvents && $EventMonth === null && $EventYear === (int) date('Y')): ?>
 <script nonce="<?= SystemURLs::getCSPNonce() ?>">
   document.addEventListener('DOMContentLoaded', function () {
     var m = document.getElementById('month-<?= (int) date('n') ?>');
@@ -305,9 +316,13 @@ foreach ($monthlyData as $monthData):
     </div>
     <h3 class="text-body-secondary"><?= gettext('No Events Found') ?></h3>
     <p class="text-body-secondary mb-3">
-      <?= sprintf(gettext('No events found for %s.'), (int) $EventYear) ?>
-      <?php if ($eType !== 'All'): ?>
-        <?= gettext('Try selecting a different event type or year.') ?>
+      <?php if ($EventMonth !== null): ?>
+        <?= sprintf(gettext('No events found for %s %d.'), InputUtils::escapeHTML(gettext(date('F', mktime(0, 0, 0, $EventMonth, 1)))), (int) $EventYear) ?>
+      <?php else: ?>
+        <?= sprintf(gettext('No events found for %s.'), (int) $EventYear) ?>
+      <?php endif; ?>
+      <?php if ($eType !== 'All' || $EventMonth !== null): ?>
+        <?= gettext('Try selecting a different event type, month, or year.') ?>
       <?php endif; ?>
     </p>
     <?php if ($canEditEvents): ?>


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Add a **Month filter** dropdown to the Event Dashboard at `/crm/event/dashboard`, alongside the existing Type and Year filters.

**What changed:**
- New `?month=N` (1–12) query param on `GET /event/dashboard`; limits the monthly-card loop to the selected month. Absent / `All` preserves the full-year view with no behaviour change.
- `POST /event/dashboard` now preserves `month` in the redirect query (validated: int cast + 1-12 range check).
- Month `<select id="month">` added to the filter form between Type and Year — 13 options ("All Months" + Jan–Dec), i18n via `gettext()`, output escaped with `InputUtils::escapeHTML()`, values cast to `(int)`.
- Bootstrap columns rebalanced (4/3/3/2) with `g-2` gutter for mobile stacking.
- Clear Filter link appears whenever type **or** month filter is active.
- Auto-scroll to current month is suppressed when a month filter is set.
- Empty-state message names the filtered month.
- Cypress filter test updated + new `?month=1` URL param test added.

**Design decision — "All Months" default:**
The dropdown defaults to "All Months" (no filter), preserving the current full-year view. A future UX iteration could default to the current month.

**Known test gap:**
The Cypress month-filter test verifies the URL param is reflected in the select but cannot assert that events from other months are excluded — the `quick-create` API does not accept a start-date, so a controlled cross-month fixture isn't feasible without a dedicated fixture endpoint.

Docs: #9627
Closes #9558