### PR TITLE
revert: revert webpack 5.110.1 and biome 2.5.11 bump (restores CI green)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
                 "tom-select": "^2.6.2"
             },
             "devDependencies": {
-                "@biomejs/biome": "^2.5.11",
+                "@biomejs/biome": "^2.5.9",
                 "@types/jquery": "^3.5.33",
                 "archiver": "^7.0.1",
                 "css-loader": "^7.1.4",
@@ -73,7 +73,7 @@
                 "style-loader": "^4.0.0",
                 "ts-loader": "^9.6.2",
                 "typescript": "^6.0.3",
-                "webpack": "^5.110.1",
+                "webpack": "^5.109.0",
                 "webpack-cli": "^7.2.1"
             },
             "engines": {
@@ -195,9 +195,9 @@
             }
         },
         "node_modules/@biomejs/biome": {
-            "version": "2.5.11",
-            "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.11.tgz",
-            "integrity": "sha512-Tj0dnkLPdW0ASjHfj2D/ZkkvPU2wrFmnE1jWTD2xzV1ycapV1DutbYXk4NDnR3rYTi1ZCbNFD4G2gRMEY65WaA==",
+            "version": "2.5.9",
+            "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.9.tgz",
+            "integrity": "sha512-KkgCvdHB4IhtpHpF564plA9jo6fDOwWGQ/3jvreLzgOtRLEDoPqr7QO9qejNA8jKwDsSkAKr77hqBHnyUbIw4g==",
             "dev": true,
             "license": "MIT OR Apache-2.0",
             "bin": {
@@ -211,20 +211,20 @@
                 "url": "https://opencollective.com/biome"
             },
             "optionalDependencies": {
-                "@biomejs/cli-darwin-arm64": "2.5.11",
-                "@biomejs/cli-darwin-x64": "2.5.11",
-                "@biomejs/cli-linux-arm64": "2.5.11",
-                "@biomejs/cli-linux-arm64-musl": "2.5.11",
-                "@biomejs/cli-linux-x64": "2.5.11",
-                "@biomejs/cli-linux-x64-musl": "2.5.11",
-                "@biomejs/cli-win32-arm64": "2.5.11",
-                "@biomejs/cli-win32-x64": "2.5.11"
+                "@biomejs/cli-darwin-arm64": "2.5.9",
+                "@biomejs/cli-darwin-x64": "2.5.9",
+                "@biomejs/cli-linux-arm64": "2.5.9",
+                "@biomejs/cli-linux-arm64-musl": "2.5.9",
+                "@biomejs/cli-linux-x64": "2.5.9",
+                "@biomejs/cli-linux-x64-musl": "2.5.9",
+                "@biomejs/cli-win32-arm64": "2.5.9",
+                "@biomejs/cli-win32-x64": "2.5.9"
             }
         },
         "node_modules/@biomejs/cli-darwin-arm64": {
-            "version": "2.5.11",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.11.tgz",
-            "integrity": "sha512-6SGZxoKbXvUjMn1t6A98HqWISPnGNbYs0R/Rt2JarmXBSev+lva4QxUMWEBX9lX1Wo1XTJ78uk5xVDtG58SRZg==",
+            "version": "2.5.9",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.9.tgz",
+            "integrity": "sha512-am22pX2aBqznqq1eMyIj/bZ++riF3Lk6ct7cbv+gQK0csFhr+d8O0RkOi2FF2qSgFgANbqNkIZ0/PxlnW2pLFg==",
             "cpu": [
                 "arm64"
             ],
@@ -239,9 +239,9 @@
             }
         },
         "node_modules/@biomejs/cli-darwin-x64": {
-            "version": "2.5.11",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.11.tgz",
-            "integrity": "sha512-nYkXY7tLBEgnGbYapDKAyKzgt44ZEyG+AKalvTXtCWKYgepI9dw327q+cVgedxm+Udi1ZzHKUyZrIusHi/KQbw==",
+            "version": "2.5.9",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.9.tgz",
+            "integrity": "sha512-l44KWDHLDvEnD0N/XcrVs7VXb3A18xL7QS3WB0eL93wbmk529ffIG55vleGCqaunpRUjLrdnjK05Qki1dsjylg==",
             "cpu": [
                 "x64"
             ],
@@ -256,9 +256,9 @@
             }
         },
         "node_modules/@biomejs/cli-linux-arm64": {
-            "version": "2.5.11",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.11.tgz",
-            "integrity": "sha512-3PVLSTD9RR73rvVPt5G3T1gc+ycggWEGfTD7RvzzbtcDPD27NxgxBbAFfpm7DXJKW6VLHWE1lLMGvFt2Qxjcow==",
+            "version": "2.5.9",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.9.tgz",
+            "integrity": "sha512-ICaK+IYaVZvKbBxX2rwrPT0DdUDMnE9Vm3nQGe+mltQPmUg19pONzkPWGdY4FCsoreDETWDynvdt4ysCbF5gNQ==",
             "cpu": [
                 "arm64"
             ],
@@ -276,9 +276,9 @@
             }
         },
         "node_modules/@biomejs/cli-linux-arm64-musl": {
-            "version": "2.5.11",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.11.tgz",
-            "integrity": "sha512-qhyZUMyCbWYFV2bAwRNVvfMVZ+hv7WYl6mossGrxC+uiQQXhvsuWWU8zz6jYX0mChZd9MgQZbm4vozTmG/5iGw==",
+            "version": "2.5.9",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.9.tgz",
+            "integrity": "sha512-7ImVPwBLCtkmpR5esd8RHhTqW94f0JLJQum6AneYcy94jRm18TaPPm7slaigGzFhfgt3QiD1Vj52LKmBAnKizA==",
             "cpu": [
                 "arm64"
             ],
@@ -296,9 +296,9 @@
             }
         },
         "node_modules/@biomejs/cli-linux-x64": {
-            "version": "2.5.11",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.11.tgz",
-            "integrity": "sha512-JOytptlsgM33B2MMFUg8iBrb4IKpbD5JnJrSeYiaFEeAj4vuXx0iQSQZ4qK7sqyMtfjZxxPdNdMZZVL4y/mFyA==",
+            "version": "2.5.9",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.9.tgz",
+            "integrity": "sha512-z22Q/zFYSvbIJfW1CbfZPu4X8PddS6Qd2ORbc6h+aT6EcwAxUF3m6fA4HjNvA3TU4X0dTJRwNPB165ES3PJXzg==",
             "cpu": [
                 "x64"
             ],
@@ -316,9 +316,9 @@
             }
         },
         "node_modules/@biomejs/cli-linux-x64-musl": {
-            "version": "2.5.11",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.11.tgz",
-            "integrity": "sha512-oRRlrchG5EfrEL/EmtT1qUjSNHk3/5LGeZhQqADBBAJF1b1ET6964xEKe7aGlGARzDfza8H/seEsFJl7S6Ql9w==",
+            "version": "2.5.9",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.9.tgz",
+            "integrity": "sha512-RXGaD0o1/pTTguYw1aeDJh9ad6Lfrui0fI7mBderTyGr7WuUJkBIttgLkR3XJyoxOkkgfBDspaUT8wXArTqLZw==",
             "cpu": [
                 "x64"
             ],
@@ -336,9 +336,9 @@
             }
         },
         "node_modules/@biomejs/cli-win32-arm64": {
-            "version": "2.5.11",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.11.tgz",
-            "integrity": "sha512-e49E6K9hzH/ohJNx8Y26mY8HaV4I4ZViIeoqhKsmoXLKHhQnMeBAVqCgsGf2Wa3lXlS7RkporDXMHHWkzvZzFw==",
+            "version": "2.5.9",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.9.tgz",
+            "integrity": "sha512-nHK+/HHC+D0ogAHUxomgoSTdjImb6fmNNVTKmf0tyu4eDL1DqPKIHc+i+UL8+b0RnAu8224qo8F2tCVnaT0A3w==",
             "cpu": [
                 "arm64"
             ],
@@ -353,9 +353,9 @@
             }
         },
         "node_modules/@biomejs/cli-win32-x64": {
-            "version": "2.5.11",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.11.tgz",
-            "integrity": "sha512-QSQr/KjOgXA7OzXJUWS+oguKyAZ3Q0l/lnlDGbu397eKo83atuWUjBPJrsqbKNF6CARGw8XXJLGzpHC8Ryhd4Q==",
+            "version": "2.5.9",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.9.tgz",
+            "integrity": "sha512-Yiq0H56LjXSSw/hd9YkXgSLQfzyDJzbzU2TezozxyNw+uKWAqOtqGVvBfzKRRDiaFF5avGAhHdWKx7LtDOShUw==",
             "cpu": [
                 "x64"
             ],
@@ -1315,7 +1315,6 @@
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
             "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.0",
                 "@jridgewell/trace-mapping": "^0.3.24"
@@ -1326,7 +1325,6 @@
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
             "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
             }
@@ -1336,7 +1334,6 @@
             "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
             "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.25"
@@ -1353,7 +1350,6 @@
             "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
             "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -2126,11 +2122,10 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "26.4.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
-            "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
+            "version": "26.1.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+            "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "undici-types": "~8.3.0"
             }
@@ -3346,8 +3341,7 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/cachedir": {
             "version": "2.4.0",
@@ -4887,6 +4881,19 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/eslint-scope": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+            "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+            "dev": true,
+            "dependencies": {
+                "esrecurse": "^4.3.0",
+                "estraverse": "^4.1.1"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
         "node_modules/eslint-visitor-keys": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
@@ -4910,6 +4917,36 @@
             },
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/esrecurse": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+            "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+            "dev": true,
+            "dependencies": {
+                "estraverse": "^5.2.0"
+            },
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/esrecurse/node_modules/estraverse": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+            "dev": true,
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/estraverse": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+            "dev": true,
+            "engines": {
+                "node": ">=4.0"
             }
         },
         "node_modules/estree-walker": {
@@ -7459,7 +7496,6 @@
             "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
             "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/node": "*",
                 "merge-stream": "^2.0.0",
@@ -8166,16 +8202,15 @@
             }
         },
         "node_modules/minimizer-webpack-plugin": {
-            "version": "5.8.0",
-            "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.8.0.tgz",
-            "integrity": "sha512-2cT9+goJfBhtMz+gJqejSf09ClgmYhPhccRb/fb0ztVbixt0BkO8mRuI26FoPPuUNkRk6iEDryWAIouc5W8eJA==",
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.6.1.tgz",
+            "integrity": "sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@jridgewell/trace-mapping": "^0.3.31",
+                "@jridgewell/trace-mapping": "^0.3.25",
                 "jest-worker": "^27.4.5",
-                "schema-utils": "^4.3.3",
-                "terser": "^5.51.0"
+                "schema-utils": "^4.3.0",
+                "terser": "^5.31.1"
             },
             "engines": {
                 "node": ">= 10.13.0"
@@ -10588,7 +10623,6 @@
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
             "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
@@ -10599,7 +10633,6 @@
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -11133,11 +11166,10 @@
             "license": "MIT"
         },
         "node_modules/terser": {
-            "version": "5.51.2",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.51.2.tgz",
-            "integrity": "sha512-bWnjSNscmuI+GJze6ZupnHP8G/cTcsJF+bXCeQknk2SHQsgbNJnLrqiH9jZ2W4STPVXH2mDKKRX3iwPhc9Cn/Q==",
+            "version": "5.49.0",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.0.tgz",
+            "integrity": "sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==",
             "dev": true,
-            "license": "BSD-2-Clause",
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.3",
                 "acorn": "^8.15.0",
@@ -11155,8 +11187,7 @@
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/text-decoder": {
             "version": "1.2.7",
@@ -11523,8 +11554,7 @@
             "version": "8.3.0",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
             "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/unicode-properties": {
             "version": "1.4.1",
@@ -11694,11 +11724,10 @@
             "license": "Apache-2.0"
         },
         "node_modules/webpack": {
-            "version": "5.110.1",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.110.1.tgz",
-            "integrity": "sha512-gInQB+jxXxgnZyvPwuzT5NGQmECDqeu85oxcrjinrYHqPoBex0hCAN2SFTJVyPVrK0Pq9E44VFP+e89fAc10/w==",
+            "version": "5.109.2",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.109.2.tgz",
+            "integrity": "sha512-U9/cvLzxObKNEZ9+TtdqrHM5/9z3lgl2c+c4BzbqGxFQvQvBAq87yql5A8pQ+rrMbS496MZJeF5enVBndIy2hw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/estree": "^1.0.8",
                 "@types/json-schema": "^7.0.15",
@@ -11710,10 +11739,11 @@
                 "chrome-trace-event": "^1.0.2",
                 "enhanced-resolve": "^5.24.4",
                 "es-module-lexer": "^2.1.0",
+                "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
                 "graceful-fs": "^4.2.11",
                 "mime-db": "^1.54.0",
-                "minimizer-webpack-plugin": "^5.7.0",
+                "minimizer-webpack-plugin": "^5.6.1",
                 "neo-async": "^2.6.2",
                 "schema-utils": "^4.3.3",
                 "tapable": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
         "tom-select": "^2.6.2"
     },
     "devDependencies": {
-        "@biomejs/biome": "^2.5.11",
+        "@biomejs/biome": "^2.5.9",
         "@types/jquery": "^3.5.33",
         "archiver": "^7.0.1",
         "css-loader": "^7.1.4",
@@ -151,7 +151,7 @@
         "style-loader": "^4.0.0",
         "ts-loader": "^9.6.2",
         "typescript": "^6.0.3",
-        "webpack": "^5.110.1",
+        "webpack": "^5.109.0",
         "webpack-cli": "^7.2.1"
     },
     "overrides": {


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Reverts d62d745 — the Dependabot bump that upgraded webpack 5.109.0→5.110.1 and biome 2.5.9→2.5.11.

**Why**: After that commit the "Build, Test and Package" CI run started failing across all event-editor-related Cypress tests (standard.calendar, mobile.calendar, event-editor, repeat-event-editor, person profile Quill) while the immediately preceding commit (80b4ffe — a pure CI workflow bump) was green. The webpack upgrade is the only application-affecting change between the two runs.

**What changed**: Restores `package.json` constraints to `webpack: ^5.109.0` and `@biomejs/biome: ^2.5.9`; lockfile reflects webpack 5.109.2 (latest in range).

**Testing**: `npm run lint` and `npm run build:webpack` pass. CI will confirm the E2E tests recover.