### PR TITLE
docs: Add comprehensive SEO & URL normalization skills for agents

### DIFF
--- a/.agents/skills/churchcrm/canonical-consolidation.md
+++ b/.agents/skills/churchcrm/canonical-consolidation.md
@@ -1,0 +1,264 @@
+# Skill: Canonical Consolidation Strategy
+
+## Context
+
+This skill documents how to implement canonical URL consolidation—using `<link rel="canonical">` tags to tell search engines which URL is the "true" version when multiple URLs serve identical content. Use this when dealing with URL duplicates, preventing duplicate content penalties, or consolidating traffic to canonical forms.
+
+<!-- learned: 2026-09-04 -->
+
+---
+
+## Core Principle
+
+**Canonical tags consolidate search equity** without requiring redirects. Search engines recognize the canonical tag and:
+1. Index only the canonical URL (not the duplicate)
+2. Credit the canonical URL with all ranking signals from duplicates
+3. Prevent duplicate content penalties
+
+**When to use canonical instead of redirects**:
+- URL duplicates are **intentional** (index.html on static hosting, language variants)
+- You **cannot** implement HTTP redirects (static hosting like GitHub Pages)
+- You need to preserve **both URLs** for technical reasons
+- Search engines **already index** the canonical URL and can consolidate via tag recognition
+
+---
+
+## Implementation: 4-Step Pattern
+
+### Step 1: Identify the Canonical URL
+
+**Definition**: The "true" or "primary" URL for a page.
+
+**Characteristics**:
+- Matches your site's **URL strategy** (trailing slash preference, language structure)
+- Has **no unnecessary parameters** (no `?ref=old` or `?source=migration`)
+- Is **user-facing** (what you put in navigation, sitemap, marketing)
+- Is **indexable** (not blocked by robots.txt or noindex)
+
+**Examples**:
+```
+Page: "Church Management Software"
+├─ Canonical: /church-management-software/      ← trailing slash, clean
+├─ Duplicate: /church-management-software.html   ← .html suffix (legacy)
+├─ Duplicate: /church-management-software/index.html ← explicit index.html
+└─ Variant: /es/church-management-software/     ← language variant (own canonical)
+```
+
+**For multilingual sites**:
+- Each language has its **own canonical**
+- `x-default` canonical points to English (or site default)
+- Do NOT make all language variants point to English canonical (breaks hreflang!)
+
+---
+
+### Step 2: Output Canonical in Template
+
+**All pages must emit a canonical tag** (no exceptions).
+
+**Template pattern** (works for Hugo, Next.js, any framework):
+
+```go
+{{- $canonicalURL := .Permalink -}}
+{{- if hasSuffix $canonicalURL "index.html" -}}
+    {{- $canonicalURL = strings.TrimSuffix "index.html" $canonicalURL -}}
+{{- end -}}
+<link rel="canonical" href="{{ $canonicalURL }}">
+```
+
+**What this does**:
+1. Take the page's **full URL** (`.Permalink`, `req.url`, etc.)
+2. **Strip `index.html` suffix** if present (GitHub Pages native URLs)
+3. **Output canonical tag** pointing to the stripped URL
+
+**Why strip `index.html`**?
+- `/page/` and `/page/index.html` are **identical content**
+- Canonical should point to `/page/` (cleaner, no suffix)
+- Search engines will consolidate both to `/page/`
+
+**Placement in HTML**:
+```html
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width">
+  <!-- ... other meta tags ... -->
+  <link rel="canonical" href="https://example.com/page/">  ← After meta tags
+  <!-- ... rest of head ... -->
+</head>
+```
+
+**Required attributes**:
+- `rel="canonical"` — Tells engines this is the canonical link
+- `href="https://example.com/path/"` — **Absolute URL** (domain included, no relative paths)
+- Placed in `<head>` section (not `<body>`)
+
+---
+
+### Step 3: Duplicate URL Configuration (Aliases)
+
+**For intentional duplicates**, declare them in front matter so the framework generates pages at old paths.
+
+**Hugo pattern** (front matter):
+
+```yaml
+---
+title: "Page Title"
+url: "/canonical/path/"          # Canonical form
+aliases:
+  - "/old/legacy/path.html"       # Old URL (page will be generated here)
+  - "/another-old-variant/"       # Can have multiple aliases
+---
+```
+
+**Result**:
+- Page built at `/canonical/path/index.html` with canonical tag pointing to `/canonical/path/`
+- Alias page built at `/old/legacy/path.html` OR `/old/legacy/path/index.html`
+  - Contains same canonical tag (pointing to `/canonical/path/`)
+  - Contains `<meta http-equiv="refresh" content="0; url=/canonical/path/">` for browser redirect
+
+**Next.js pattern** (in `next.config.js` or API routes):
+
+```javascript
+const redirects = async () => {
+  return [
+    {
+      source: '/old/legacy/:path*',
+      destination: '/canonical/:path*',
+      permanent: false,  // false = 302 (temporary redirect)
+    },
+  ];
+};
+```
+
+**With canonical in every page**:
+```jsx
+// pages/any-page.jsx
+export default function Page() {
+  return (
+    <Head>
+      <link rel="canonical" href="https://example.com/canonical/path/" />
+    </Head>
+  );
+}
+```
+
+---
+
+### Step 4: Validation & Monitoring
+
+**Before deployment**:
+1. **Build and audit**: Generate the site, check that canonical tags exist on all pages
+   ```bash
+   npm run build
+   grep -r 'rel="canonical"' public/ | wc -l  # Should be > 0
+   grep -r 'canonical.*index.html' public/    # Should be 0 (no index.html suffixes)
+   ```
+
+2. **Verify aliases point to canonical**:
+   ```bash
+   # Old URL should contain canonical tag pointing to new URL
+   cat public/old/legacy/path/index.html | grep -o 'href="[^"]*"' | head -1
+   # Output: href="https://example.com/canonical/path/"
+   ```
+
+**After deployment**:
+1. **Search Console URL Inspection**: Test both old and new URLs
+   - Old URL should show canonical pointing to new URL
+   - New URL should show as canonical
+
+2. **Monitor consolidation**:
+   - Week 1-2: Old URL indexed separately (still indexing both)
+   - Week 2-4: Impressions/clicks consolidate to new URL
+   - Week 4+: Old URL disappears from search results (consolidated)
+
+3. **Check for indexing issues**:
+   - If old URL continues to appear as separate in search results after 4 weeks, escalate to HTTP redirects or noindex
+
+---
+
+## Common Pitfalls & Fixes
+
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| **Canonical tag missing** | Pages have no canonical | Add to all templates, verify in built site |
+| **Canonical with `index.html`** | `/page/index.html` in canonical tag | Use `TrimSuffix` to strip `index.html` |
+| **Relative canonical URL** | `href="/page/"` instead of `href="https://..."` | Always use absolute URLs with domain |
+| **Multiple canonicals** | Page outputs 2+ canonical tags | Ensure only one canonical tag per page |
+| **Canonical points to wrong page** | Canonical points to duplicate, not canonical | Debug: is alias front matter correct? Is template logic correct? |
+| **Canonical for duplicate language** | Both `/en/page/` and `/es/page/` point to `/en/page/` | Each language variant must have its own canonical; use hreflang for variants |
+| **Canonical ignored by search engines** | Old URL still appears in search results | Canonicals require 2-4 weeks to consolidate; check Search Console for errors |
+
+---
+
+## Escalation: When Canonical Alone Is Not Enough
+
+**When to add HTTP redirects** (in addition to or instead of canonical):
+
+1. **Marketing links still point to old URLs**
+   - Old links in social media, email, external sites traffic to old URL
+   - Users see URL change in browser (confusing without redirect)
+   - Redirect reduces bounce rate
+
+2. **Old URL indexed with different content**
+   - Old URL has been ranking for different keywords
+   - Canonical tag won't merge the ranking signals (separate entities)
+   - HTTP redirect consolidates ranking signals + equity
+
+3. **Canonical not recognized after 4+ weeks**
+   - Search Console shows old URL still indexed as separate
+   - Canonical tag present but not working
+   - Implement HTTP 301/302 redirect to force consolidation
+
+4. **Static hosting (GitHub Pages) limitation**
+   - GitHub Pages serves `index.html` natively at both `/page/` and `/page/index.html`
+   - Canonical consolidates one direction, but both URLs remain live
+   - If strict URL consolidation needed, server-side redirects required (outside repo scope)
+
+---
+
+## Canonical + Hreflang for Multilingual
+
+**Critical**: When using canonical with language variants, **coordinate with hreflang**.
+
+**Correct pattern**:
+```html
+<!-- English page -->
+<link rel="canonical" href="https://example.com/en/page/">
+<link rel="alternate" hreflang="en" href="https://example.com/en/page/">
+<link rel="alternate" hreflang="es" href="https://example.com/es/page/">
+<link rel="alternate" hreflang="x-default" href="https://example.com/en/page/">
+
+<!-- Spanish page -->
+<link rel="canonical" href="https://example.com/es/page/">
+<link rel="alternate" hreflang="en" href="https://example.com/en/page/">
+<link rel="alternate" hreflang="es" href="https://example.com/es/page/">
+<link rel="alternate" hreflang="x-default" href="https://example.com/en/page/">
+```
+
+**Each language variant**:
+- Has its **own canonical** (pointing to itself)
+- Lists **itself in hreflang** (`hreflang="es"` on Spanish page)
+- Lists **siblings in hreflang** (Spanish page links to English)
+- **x-default** points to default language (usually English)
+
+---
+
+## Reference Implementation (ChurchCRM)
+
+See `.agents/skills/churchcrm/url-normalization.md` for the live implementation pattern used across churchcrm.io:
+- 8 language variants of `church-management-software.md` each with own canonical
+- Hugo template stripping `index.html` from canonicals
+- Aliases for legacy `.html` paths redirecting via canonical consolidation
+- Validation script confirming no `index.html` in any canonical tag
+
+---
+
+## Related Skills
+
+- `url-normalization.md` — Hugo-specific patterns
+- `seo-audit-methodology.md` — How to audit canonicals
+- `redirect-strategy.md` — When to use redirects vs. canonicals
+- `multilingual-content.md` — Hreflang coordination
+
+---
+
+**Last updated**: 2026-09-04 <!-- learned: 2026-09-04 -->

--- a/.agents/skills/churchcrm/multilingual-content.md
+++ b/.agents/skills/churchcrm/multilingual-content.md
@@ -1,0 +1,381 @@
+# Skill: Multilingual Content & Hreflang Patterns
+
+## Context
+
+This skill documents strategies for managing content across multiple languages and locales. Focus areas include canonical URL structure for language variants, hreflang implementation for SEO, and language-specific routing patterns.
+
+<!-- learned: 2026-09-04 -->
+
+---
+
+## Multilingual URL Structure Patterns
+
+### Pattern 1: Language Prefix (Recommended for ChurchCRM)
+
+**Structure**: `/[lang]/path/`
+
+**Examples**:
+- `/en/church-management-software/` (English at root, no prefix)
+- `/es/church-management-software/` (Spanish)
+- `/pt/church-management-software/` (Portuguese)
+- `/zh/church-management-software/` (Chinese)
+
+**Advantages**:
+- Clear language separation in URL
+- Easy to redirect language-specific traffic
+- SEO-friendly (canonical per language)
+- Works well with hreflang
+
+**Disadvantages**:
+- Longer URLs
+- English often special-cased (at root vs. `/en/`)
+
+**Hugo Configuration**:
+```toml
+# hugo.toml
+[languages]
+  [languages.en]
+    contentDir = "content/en"
+    languageCode = "en"
+    title = "ChurchCRM"
+    weight = 1
+  [languages.es]
+    contentDir = "content/es"
+    languageCode = "es"
+    title = "ChurchCRM"
+    weight = 2
+  # ... more languages ...
+
+defaultContentLanguage = "en"
+defaultContentLanguageInSubdir = false  # English at /, not /en/
+disableDefaultLanguageRedirect = true   # Don't auto-redirect /en/ to /
+```
+
+**Content structure**:
+```
+content/
+  en/
+    church-management-software.md
+    _index.md (homepage)
+  es/
+    church-management-software.md
+    _index.md (Spanish homepage)
+  pt/
+    church-management-software.md
+    _index.md
+  # ... more languages ...
+```
+
+**Front matter (multilingual pages)**:
+```yaml
+---
+title: "Page Title"
+url: "/church-management-software/"     # English at root
+---
+```
+
+```yaml
+---
+title: "Título en Español"
+url: "/es/church-management-software/"  # Spanish with prefix
+---
+```
+
+---
+
+### Pattern 2: Domain-Based (Alternative)
+
+**Structure**: `en.example.com`, `es.example.com`, etc.
+
+**Advantages**:
+- Each language can have independent server/CDN
+- SEO treats them as separate properties
+- Can have different content strategy per domain
+
+**Disadvantages**:
+- Multiple domains to manage (SSL, DNS, backups)
+- Hreflang still required to signal relationships
+- More complex infrastructure
+
+**When to use**: Large-scale, language-specific teams or regions
+
+---
+
+### Pattern 3: Subdirectory (Least Recommended)
+
+**Structure**: `example.com/en/`, `example.com/es/`
+
+**Note**: This is problematic when English is at root (`/`) but other languages have prefixes. Better to use Pattern 1 consistently.
+
+---
+
+## Hreflang Implementation (Critical for SEO)
+
+**What is hreflang?** A tag that tells search engines: *"This page has versions in other languages; here are the links."*
+
+**Why is it important?**
+- Prevents duplicate content penalties (each language is a variant, not duplicate)
+- Directs users to their language version
+- Consolidates ranking signals within language (not across)
+- Signals x-default for unknown locales
+
+**Template Implementation** (Hugo):
+
+```go
+<!-- Place in <head> section -->
+{{ range .AllTranslations -}}
+{{- $hrefLangURL := .Permalink -}}
+{{- if hasSuffix $hrefLangURL "index.html" -}}
+    {{- $hrefLangURL = strings.TrimSuffix "index.html" $hrefLangURL -}}
+{{- end -}}
+<link rel="alternate" hreflang="{{ .Language.LanguageCode }}" href="{{ $hrefLangURL }}" />
+{{- end }}
+<link rel="alternate" hreflang="x-default" href="{{ (index .Sites 0).BaseURL }}" />
+```
+
+**What each line does**:
+1. Loop through `.AllTranslations` (all language versions of this page)
+2. Get the page's permalink
+3. Strip `index.html` if present (canonical consolidation)
+4. Output hreflang tag with language code (e.g., `hreflang="es"`)
+5. After all languages, output `x-default` pointing to English/default
+
+**Example output (Spanish page)**:
+```html
+<link rel="alternate" hreflang="en" href="https://churchcrm.io/church-management-software/">
+<link rel="alternate" hreflang="es" href="https://churchcrm.io/es/church-management-software/">
+<link rel="alternate" hreflang="pt" href="https://churchcrm.io/pt/church-management-software/">
+<link rel="alternate" hreflang="x-default" href="https://churchcrm.io/">
+```
+
+**Critical rules**:
+1. ✅ Each language page lists **itself** in hreflang (self-reference)
+2. ✅ English page lists `hreflang="en"` pointing to itself
+3. ✅ Spanish page lists `hreflang="es"` pointing to itself
+4. ✅ ALL language variants linked (don't leave any out)
+5. ✅ x-default points to English/primary language
+6. ❌ Do NOT make all languages point to English canonical (breaks hreflang!)
+7. ❌ Do NOT skip x-default (helps search engines pick default for unknown locales)
+
+---
+
+## Canonical + Hreflang Coordination
+
+**Critical**: Canonical and hreflang must work together, not conflict.
+
+**Correct pattern**:
+
+**English page (`/church-management-software/`)**:
+```html
+<link rel="canonical" href="https://churchcrm.io/church-management-software/">
+<link rel="alternate" hreflang="en" href="https://churchcrm.io/church-management-software/">
+<link rel="alternate" hreflang="es" href="https://churchcrm.io/es/church-management-software/">
+<link rel="alternate" hreflang="pt" href="https://churchcrm.io/pt/church-management-software/">
+<link rel="alternate" hreflang="x-default" href="https://churchcrm.io/">
+```
+
+**Spanish page (`/es/church-management-software/`)**:
+```html
+<link rel="canonical" href="https://churchcrm.io/es/church-management-software/">
+<link rel="alternate" hreflang="en" href="https://churchcrm.io/church-management-software/">
+<link rel="alternate" hreflang="es" href="https://churchcrm.io/es/church-management-software/">
+<link rel="alternate" hreflang="pt" href="https://churchcrm.io/pt/church-management-software/">
+<link rel="alternate" hreflang="x-default" href="https://churchcrm.io/">
+```
+
+**Key observations**:
+- Each language's **canonical points to itself** (not to English)
+- **Hreflang is identical** on all language pages (each lists all variants)
+- **x-default always points to the default language** (English)
+
+**❌ Common mistake** (all languages pointing to English canonical):
+```html
+<!-- WRONG on Spanish page -->
+<link rel="canonical" href="https://churchcrm.io/church-management-software/">
+<!-- This tells search engines Spanish page is duplicate of English, breaks language variants -->
+```
+
+---
+
+## Language Detection & Routing
+
+### Server-Side Language Detection (Recommended)
+
+**Middleware detects browser language, redirects to appropriate version**:
+
+```javascript
+// Express.js middleware
+app.use((req, res, next) => {
+  const browserLang = req.acceptsLanguages(['en', 'es', 'pt', 'zh', 'fr', 'ru', 'de', 'ar']);
+  if (browserLang && req.url === '/' && !req.cookies.language) {
+    return res.redirect(`/${browserLang}/`);
+  }
+  next();
+});
+```
+
+**Advantages**:
+- User sees correct language automatically
+- Respects browser language preferences
+- No extra clicks needed
+
+**Disadvantages**:
+- Requires dynamic server (not available on GitHub Pages)
+- Must store language preference (cookie) to avoid re-redirecting
+
+---
+
+### Client-Side Language Detection (Static Hosting)
+
+**JavaScript detects browser language, redirects**:
+
+```html
+<script>
+  // Check if language preference is set
+  if (!localStorage.getItem('language')) {
+    const browserLang = navigator.language.split('-')[0]; // 'es' from 'es-MX'
+    const supported = ['en', 'es', 'pt', 'zh', 'fr', 'ru', 'de', 'ar'];
+    if (supported.includes(browserLang) && browserLang !== 'en') {
+      localStorage.setItem('language', browserLang);
+      window.location.href = `/${browserLang}/`;
+    }
+  }
+</script>
+```
+
+**Advantages**:
+- Works on GitHub Pages (client-side only)
+- Respects browser preferences
+
+**Disadvantages**:
+- Delay (JavaScript must run)
+- Requires JavaScript enabled
+- Doesn't work for crawlers/SEO
+
+---
+
+## Sitemap for Multilingual
+
+**Sitemap must list all language variants with hreflang**.
+
+**Format** (sitemap.xml):
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>https://churchcrm.io/church-management-software/</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://churchcrm.io/church-management-software/" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://churchcrm.io/es/church-management-software/" />
+    <xhtml:link rel="alternate" hreflang="pt" href="https://churchcrm.io/pt/church-management-software/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://churchcrm.io/" />
+  </url>
+  <!-- ... more URLs ... -->
+</urlset>
+```
+
+**Hugo template pattern**:
+```go
+{{- $loc := $page.Permalink | strings.TrimSuffix "index.html" }}
+<url>
+  <loc>{{ $loc }}</loc>
+  {{- if $page.IsTranslated }}
+    {{- range $page.Translations }}
+    <xhtml:link rel="alternate" hreflang="{{ .Language.LanguageCode }}"
+                href="{{ .Permalink | strings.TrimSuffix "index.html" }}" />
+    {{- end }}
+    <xhtml:link rel="alternate" hreflang="{{ $page.Language.LanguageCode }}"
+                href="{{ $loc }}" />
+  {{- end }}
+</url>
+```
+
+---
+
+## Language Fallback Strategy
+
+**What happens if a page doesn't exist in a language?**
+
+**Option 1: Fallback to English**
+```yaml
+# content/es/missing-page.md doesn't exist
+# Request to /es/missing-page/ falls back to English /missing-page/
+```
+
+**Option 2: 404 (Recommended for SEO)**
+```yaml
+# content/es/missing-page.md doesn't exist
+# Request to /es/missing-page/ returns 404
+# User can navigate to English version from 404 page
+```
+
+**Implementation** (Hugo):
+```toml
+[languages.es]
+  disabled = false
+  weight = 2
+  # If set to true, untranslated pages fall back to default language
+  # Better to NOT fall back (return 404) so users know content isn't translated
+```
+
+---
+
+## Language Switcher (UX)
+
+**Always provide a language switcher for user convenience**.
+
+**Pattern**:
+```html
+<div class="language-switcher">
+  <a href="/church-management-software/">English</a>
+  <a href="/es/church-management-software/">Español</a>
+  <a href="/pt/church-management-software/">Português</a>
+  <a href="/zh/church-management-software/">中文</a>
+  <!-- ... more languages ... -->
+</div>
+```
+
+**Best practices**:
+- Show current language as highlighted/bold
+- Place in consistent location (header, footer)
+- Use language names in the native language (Español not Spanish)
+- Include flag emojis cautiously (politics/representation sensitive)
+
+---
+
+## Validation Checklist
+
+- [ ] Each language has its own content directory (`content/en/`, `content/es/`, etc.)
+- [ ] Canonical URL is set per language (each language points to itself)
+- [ ] Hreflang tags list all language variants
+- [ ] x-default hreflang points to primary language (usually English)
+- [ ] Sitemap includes all language variants with xhtml:link hreflang
+- [ ] No `index.html` in canonical or hreflang URLs (use TrimSuffix)
+- [ ] Language switcher works on every page
+- [ ] Browser language detection works (if implemented)
+- [ ] Search Console shows correct hreflang relationships
+- [ ] No missing translations cause broken links (404 or fallback?)
+
+---
+
+## Reference Implementation (ChurchCRM)
+
+See `.agents/skills/churchcrm/url-normalization.md` for the live implementation:
+- 8 languages: en, es, pt, zh, fr, ru, de, ar
+- English at root (`/`), others with prefix (`/es/`, `/pt/`, etc.)
+- Hreflang template in `layouts/partials/head.html`
+- Sitemap with xhtml:link variants in `layouts/sitemap.xml`
+- Language switcher in navigation
+
+---
+
+## Related Skills
+
+- `url-normalization.md` — Hugo-specific patterns
+- `canonical-consolidation.md` — Canonical strategy for languages
+- `seo-audit-methodology.md` — Auditing language variants
+- `redirect-strategy.md` — Redirecting between language versions
+
+---
+
+**Last updated**: 2026-09-04 <!-- learned: 2026-09-04 -->

--- a/.agents/skills/churchcrm/redirect-strategy.md
+++ b/.agents/skills/churchcrm/redirect-strategy.md
@@ -1,0 +1,312 @@
+# Skill: Redirect Strategy & Implementation
+
+## Context
+
+This skill documents when and how to implement redirects for URL migrations, consolidations, and legacy path handling. Different hosting platforms have different redirect mechanisms; this covers decision-making and implementation patterns.
+
+<!-- learned: 2026-09-04 -->
+
+---
+
+## Redirect Decision Tree
+
+**START**: You have a URL migration (old URL → new URL)
+
+```
+Is the old URL still indexed or trafficked?
+├─ NO → No redirect needed, use canonical consolidation only
+└─ YES → Continue...
+
+Can you implement HTTP-level redirects?
+├─ YES (dynamic server, Node.js, etc.)
+│  └─ Use HTTP 301 (permanent) or 302 (temporary) redirect
+│     ├─ HTTP 301: "This URL moved permanently" (preserves ranking, can be cached by browsers)
+│     └─ HTTP 302: "This URL moved temporarily" (re-indexes old URL, loses ranking)
+│     └─ BEST: HTTP 301 for permanent migrations
+│
+└─ NO (static hosting: GitHub Pages, Netlify, S3)
+   ├─ Can you use meta-refresh + canonical? → YES (GitHub Pages, Netlify)
+   │  └─ Generate static HTML at old path with:
+   │     ├─ <meta http-equiv="refresh" content="0; url=NEW_URL">
+   │     └─ <link rel="canonical" href="NEW_URL">
+   │     └─ HTTP 200 (not 301) because GitHub Pages serves only static files
+   │
+   └─ Can you use redirect rules/config file? → YES (Netlify, Vercel)
+      └─ Use _redirects or netlify.toml or vercel.json
+         ├─ These are server-side (platform handles redirect)
+         └─ Closest to HTTP 301 without server code
+```
+
+---
+
+## Redirect Types & Mechanisms
+
+### HTTP-Level Redirects (Best)
+
+**Best for**: Dynamic servers (Node.js, Django, PHP), platforms with middleware support
+
+**HTTP Status Codes**:
+- **301 (Moved Permanently)**: "This URL will never come back." Browsers/engines cache. Recommended for migrations.
+- **302 (Found)**: "This URL moved temporarily." Engines re-index old URL. Only use if reverting.
+- **307/308**: HTTP/1.1+ variants (similar semantics to 301/302, preserve request method)
+
+**Search engine behavior**:
+- **301**: Consolidates ranking signals. Old URL disappears from index within weeks.
+- **302**: Keeps old URL indexed. Both URLs compete for rankings.
+
+**Implementation patterns**:
+
+**Next.js** (vercel.json or next.config.js):
+```javascript
+// next.config.js
+const redirects = async () => [
+  {
+    source: '/old/path.html',
+    destination: '/new/path/',
+    permanent: true,  // 301 redirect
+  },
+  {
+    source: '/es/old-page.html',
+    destination: '/es/new-page/',
+    permanent: true,
+  },
+];
+```
+
+**Express.js / Node.js**:
+```javascript
+app.get('/old/path.html', (req, res) => {
+  res.redirect(301, '/new/path/');  // 301 Moved Permanently
+});
+```
+
+**Django**:
+```python
+# urls.py
+from django.views.generic.base import RedirectView
+
+urlpatterns = [
+    path('old/path.html', RedirectView.as_view(url='/new/path/', permanent=True)),
+]
+```
+
+---
+
+### Meta-Refresh + Canonical (Static Hosting)
+
+**Best for**: GitHub Pages, static site hosting, Hugo/Jekyll with aliases
+
+**Mechanism**:
+1. Generate a static HTML file at the old path
+2. File contains `<meta http-equiv="refresh">` for browser redirect (instant, user-facing)
+3. File contains `<link rel="canonical">` for search engine consolidation
+4. Server returns **HTTP 200** (file exists and is delivered)
+
+**Limitations**:
+- HTTP 200 (not 301), so search engines may take longer to consolidate
+- Browser redirect happens client-side after page load
+- Not all crawlers honor meta-refresh
+
+**Implementation (Hugo)**:
+```yaml
+# content/page.md
+---
+title: "Page Title"
+url: "/new/path/"
+aliases:
+  - "/old/path.html"
+---
+```
+
+**Result**: Hugo generates:
+- `/new/path/index.html` — actual content page with canonical pointing to `/new/path/`
+- `/old/path.html` OR `/old/path/index.html` — alias page with:
+  ```html
+  <link rel="canonical" href="https://domain.com/new/path/">
+  <meta http-equiv="refresh" content="0; url=https://domain.com/new/path/">
+  ```
+
+**Advantages**:
+- Works on static hosting (no server-side code)
+- User sees redirect (meta-refresh handles it)
+- Search engines see canonical tag + redirect
+
+**Disadvantages**:
+- Not a true HTTP redirect (engines may not treat it as permanence signal)
+- Slower consolidation (2-4 weeks typical, vs. immediate with 301)
+- Some crawlers don't follow meta-refresh
+
+---
+
+### Platform-Specific Redirects (Netlify, Vercel, etc.)
+
+**Best for**: Platforms with built-in redirect support (closest to HTTP redirects without server code)
+
+**Netlify (_redirects file)**:
+```
+/old/path.html              /new/path/          301
+/es/old-page.html           /es/new-page/       301
+/blog/:year/:month/:slug    /blog/:slug         301
+```
+
+**Vercel (vercel.json)**:
+```json
+{
+  "redirects": [
+    {
+      "source": "/old/path.html",
+      "destination": "/new/path/",
+      "permanent": true
+    }
+  ]
+}
+```
+
+**Advantages**:
+- Closest to true HTTP redirects (platform handles it server-side)
+- Works like 301 redirects for search engines
+- No static file overhead
+
+---
+
+## Redirect Mapping & Documentation
+
+**Always document redirects** in a CSV file or configuration file.
+
+**Format**:
+```
+old_url,new_url,status_code,reason,date_implemented
+https://domain.com/old/path.html,https://domain.com/new/path/,301,URL normalization,2026-01-15
+https://domain.com/page.php,https://domain.com/page/,301,Legacy PHP migration,2026-02-01
+```
+
+**Columns**:
+- `old_url`: Full URL including domain and scheme
+- `new_url`: Canonical destination
+- `status_code`: 301 (permanent), 302 (temporary), or 200 (meta-refresh)
+- `reason`: Why the redirect exists
+- `date_implemented`: When it went live
+
+**Example from ChurchCRM** (content/redirect-mapping.csv):
+```
+https://churchcrm.io/es/church-management-software.html,https://churchcrm.io/es/church-management-software/,200,Hugo alias redirect (meta-refresh + canonical),2026-09-04
+```
+
+---
+
+## Validation & Monitoring
+
+**Before deployment**:
+1. **Test redirect chain**:
+   ```bash
+   curl -I https://domain.com/old/path.html
+   # Should show:
+   # HTTP/1.1 301 Moved Permanently
+   # Location: https://domain.com/new/path/
+   
+   # NOT a chain: old → temporary → new
+   ```
+
+2. **Verify final destination**:
+   ```bash
+   curl -L https://domain.com/old/path.html | head -5
+   # Should show new page content (after following redirect)
+   ```
+
+3. **Check canonical in new page**:
+   ```bash
+   curl https://domain.com/new/path/ | grep canonical
+   # Should show: <link rel="canonical" href="https://domain.com/new/path/">
+   ```
+
+**After deployment**:
+1. **Monitor Search Console**:
+   - Old URL should show as redirected (if 301)
+   - Ranking signals should consolidate to new URL
+   - Typical consolidation time: 1-4 weeks
+
+2. **Check for redirect loops**:
+   - Search Console will report errors if old URL redirects to itself
+   - URL Inspection tool will show redirect chain
+
+3. **Verify no 404s on old paths**:
+   - If redirect is broken, old path returns 404
+   - Search Console will report these as crawl errors
+
+---
+
+## GitHub Pages Constraint (ChurchCRM Context)
+
+**GitHub Pages cannot serve HTTP 301/308 redirects from repository files.**
+
+Why? GitHub Pages is **static hosting**:
+- Only delivers files as-is (HTTP 200)
+- No dynamic code to generate HTTP headers
+- Cannot distinguish between "redirect" and "regular file"
+
+**Workaround**: Use meta-refresh + canonical (HTTP 200)
+- Hugo generates static HTML at old path
+- Page contains `<meta http-equiv="refresh">` + `<link rel="canonical">`
+- Browser redirects user, search engines see canonical
+
+**Limitation**: Consolidation is slower than HTTP 301 (typically 2-4 weeks)
+
+**Escalation**: If strict/immediate URL consolidation is needed, GitHub Pages is a constraint. Escalate to:
+- Server-side redirects (requires moving off GitHub Pages)
+- Proxy layer (Cloudflare Workers, etc.) to inject HTTP redirects
+- Configuration outside the repository scope
+
+---
+
+## Decision Examples
+
+### Example 1: Church Website URL Normalization
+
+**Scenario**: Migrating from `.html` URLs to trailing-slash URLs
+
+**Old URLs**: `/church-management-software.html` (8 language variants)
+**New URLs**: `/church-management-software/` (8 language variants)
+**Platform**: GitHub Pages (static hosting)
+**Status**: Some old URLs already indexed
+
+**Decision**:
+1. ❌ Cannot use HTTP 301 (static hosting limitation)
+2. ✅ Use Hugo aliases + canonical + meta-refresh
+3. ✅ Document in redirect-mapping.csv
+4. ✅ Monitor Search Console for consolidation (2-4 weeks)
+5. ⏳ If separation persists, escalate for server-level config
+
+**Result**: HTTP 200 + canonical consolidation strategy selected
+
+---
+
+### Example 2: Blog URL Restructure
+
+**Scenario**: Changing blog URLs from `/blog/YYYY-MM-DD-slug.html` to `/blog/slug/`
+
+**Old URLs**: 100+ blog posts with date-based slugs
+**New URLs**: Shorter, date-less paths
+**Platform**: Netlify (platform redirects support)
+**Status**: High traffic to old URLs (SEO, email links)
+
+**Decision**:
+1. ✅ Can use Netlify _redirects (HTTP 301 support)
+2. ✅ Generate bulk redirects with regex: `/blog/:year/:month/:day/:slug.html /blog/:slug/ 301`
+3. ✅ Document in Netlify config + external CSV
+4. ✅ Monitor for redirect loops, broken chains
+5. ✅ Expect consolidation within 2 weeks (HTTP 301)
+
+**Result**: HTTP 301 permanent redirects selected
+
+---
+
+## Related Skills
+
+- `url-normalization.md` — Hugo-specific implementation
+- `canonical-consolidation.md` — Canonical tag strategy
+- `seo-audit-methodology.md` — Audit redirects
+- `multilingual-content.md` — Multilingual redirect patterns
+
+---
+
+**Last updated**: 2026-09-04 <!-- learned: 2026-09-04 -->

--- a/.agents/skills/churchcrm/seo-audit-methodology.md
+++ b/.agents/skills/churchcrm/seo-audit-methodology.md
@@ -1,0 +1,233 @@
+# Skill: SEO Audit Methodology
+
+## Context
+
+This skill documents systematic approaches to conducting SEO audits on web properties, using URL normalization and canonicalization audits as the reference pattern. Use this when investigating site structure, identifying duplicate content, validating configuration, or planning technical SEO improvements.
+
+---
+
+## Audit Framework: 4-Phase Approach
+
+### Phase 1: Inventory & Discovery
+
+**Objective**: Map all URL patterns, identify duplicates, understand routing strategy.
+
+**Steps**:
+1. List all URL patterns currently served:
+   - Homepage variants (`/`, `/index.html`, `/index.php`)
+   - Language/locale variants (`/en/`, `/es/`, etc.)
+   - Content paths (pages, blog posts, archives)
+   - Taxonomy URLs (tags, categories)
+   - Legacy formats (`.html`, `.php`, trailing slash vs. non-trailing)
+
+2. Document the generation mechanism:
+   - Server framework (Hugo, Next.js, Django, etc.)
+   - URL generation rules (`uglyURLs: true`, route definitions, trailing slashes)
+   - Redirect/alias mechanisms (server-side, client-side, static files)
+   - Multi-domain vs. subdomain strategy
+
+3. Identify URL variations:
+   - What URLs serve identical content?
+   - What's intentional (language variants) vs. accidental (index.html duplication)?
+   - Are there legacy paths that should redirect to new canonical forms?
+
+**Deliverable**: URL inventory table with columns:
+- URL pattern
+- Content served
+- Canonical form (if multiple variants)
+- Generation mechanism
+- Status (working, broken, indexed)
+
+**Example**:
+```
+| URL Pattern | Content | Canonical | Mechanism | Status |
+|---|---|---|---|---|
+| `/page/` | Page content | `/page/` | Hugo trailing-slash | Indexed |
+| `/page/index.html` | Page content | `/page/` | GitHub Pages native | Indexed |
+| `/page.html` | Page content | `/page/` | Hugo alias redirect | Indexed, consolidated |
+```
+
+---
+
+### Phase 2: Configuration Analysis
+
+**Objective**: Verify that templates, sitemap, and metadata are configured to consolidate duplicates.
+
+**Steps**:
+
+1. **Canonical tag implementation**:
+   - Audit all templates that output `<link rel="canonical">`
+   - Verify canonical URL matches the "true" form (e.g., no `index.html`, consistent trailing slash)
+   - Check that all pages emit a canonical tag (not just some sections)
+   - Test against built site: `grep -r 'rel="canonical"' public/ | head -20`
+
+2. **Hreflang for multilingual**:
+   - If site has multiple languages, verify hreflang tags are present
+   - Check that each language variant links to itself and siblings
+   - Verify `x-default` points to the primary language/region
+   - Validate hreflang URLs match canonical forms (no `index.html`)
+
+3. **Sitemap correctness**:
+   - Verify sitemap lists only canonical URLs (no duplicates, no `index.html`)
+   - Check that all indexable pages are included
+   - Verify lastmod timestamps are accurate
+   - For multilingual, confirm hreflang `<xhtml:link>` elements in sitemap entries
+
+4. **robots.txt & meta robots**:
+   - Verify `robots.txt` allows crawling of canonical URLs
+   - Check that duplicate/legacy URLs are either redirected or have `noindex` meta tag
+   - Confirm taxonomy/archive pages use appropriate directives (`index` for main, `noindex` for paginated duplicates)
+
+**Deliverable**: Configuration audit checklist with pass/fail for each check.
+
+**Template check example** (canonical tags):
+```bash
+# Build site (Hugo, Next.js, etc.)
+npm run build
+
+# Extract all canonical hrefs
+grep -oh 'href="[^"]*"' public/**/*.html | grep canonical | sort | uniq -c
+
+# Check for index.html in canonical URLs (should be 0)
+grep -r 'href=".*index.html"' public/ | grep canonical | wc -l
+```
+
+---
+
+### Phase 3: Mechanism Validation
+
+**Objective**: Verify that redirects/aliases actually work and preserve search equity.
+
+**Steps**:
+
+1. **Test redirect chains**:
+   - For each old URL → new URL mapping, verify the redirect works
+   - Check HTTP status code (301/308 for server-side redirects, 200 for meta-refresh with canonical)
+   - Verify no redirect chains (A→B→C is bad; should be A→C, B→C)
+
+2. **Validate alias pages** (for static hosting like GitHub Pages):
+   - Old URL should resolve to a page containing:
+     - `<meta http-equiv="refresh" content="0; url=CANONICAL_URL">`
+     - `<link rel="canonical" href="CANONICAL_URL">`
+   - Both should point to the same new URL
+
+3. **Search engine consolidation**:
+   - Verify canonical tags are recognized by testing in Search Console's URL Inspection tool
+   - Check that old URLs have consolidated to new URLs (if already indexed)
+   - Monitor for 404s on old paths (should not occur if aliases work)
+
+**Deliverable**: Redirect validation report.
+
+**Test script pattern** (Node.js):
+```javascript
+// For each old_url in redirect mapping:
+// 1. Fetch old_url, check HTTP status
+// 2. Parse HTML, look for canonical or meta-refresh
+// 3. Verify canonical points to new_url
+// 4. Confirm new_url exists in built site
+const redirects = [
+  { old: '/old/path.html', new: '/new/path/' },
+  // ...
+];
+for (const r of redirects) {
+  const html = fs.readFileSync(`public${r.old.replace(/\.html$/, '')}/index.html`, 'utf8');
+  if (!html.includes(r.new)) throw new Error(`${r.old} doesn't point to ${r.new}`);
+}
+```
+
+---
+
+### Phase 4: Evidence-Based Decisions
+
+**Objective**: Determine what actually needs to be fixed, with justification.
+
+**Decision Framework**:
+
+1. **Evidence of ranking harm**:
+   - Search Console: Are there duplicate URLs indexed separately with split impressions/clicks?
+   - PageSpeed Insights: Are there warnings about duplicate content?
+   - Crawl reports: Are crawlers hitting the duplicates?
+   - If NO evidence of harm, consolidation via canonical may be sufficient (no redirect needed)
+
+2. **User impact**:
+   - Do users encounter the duplicate URLs? (broken links, outdated bookmarks)
+   - Would a redirect improve UX? (e.g., old marketing links pointing to new paths)
+   - Can the duplicate be eliminated entirely? (remove from sitemap, robots.txt noindex)
+
+3. **Technical constraints**:
+   - Can you implement HTTP redirects? (requires server-side config, not available on static hosting)
+   - Can you use aliases/meta-refresh? (works on static hosting, loses some redirect juice)
+   - Can you rely on canonical consolidation? (sufficient if search engines recognize canonical tags)
+
+**Decision tree**:
+```
+Do we have evidence of ranking harm from this duplicate?
+├─ YES → Fix it (redirect or noindex)
+│  ├─ Can we do HTTP 301/308? → Best option
+│  ├─ Can we use meta-refresh + canonical? → Good option
+│  └─ Can we use noindex tag? → Last resort (if redirect is impossible)
+└─ NO → Leave as-is, monitor Search Console
+   └─ If harm emerges later (2-4 weeks), escalate to redirect
+```
+
+**Example decision**: *"/ vs /index.html duplication detected, but canonical consolidation is configured and no Search Console evidence of harm. Decision: monitor for 2-4 weeks, escalate if continued separate indexing occurs."*
+
+---
+
+## Audit Outputs & Recommendations
+
+### Audit Report Structure
+
+1. **Executive summary**: Key findings + conservative decisions
+2. **URL inventory table**: All patterns, canonical forms, status
+3. **Configuration audit**: Templates, sitemap, hreflang verified
+4. **Redirect validation**: Test results for old→new mappings
+5. **Evidence & rationale**: Why each decision was made
+6. **Limitations**: What can't be fixed at repo level (e.g., GitHub Pages native behavior)
+7. **Next steps**: Post-deployment monitoring, escalation criteria
+
+### Conservative Approach Principles
+
+1. **Do NOT assume duplicates are bad**: Evidence of ranking harm or user confusion required
+2. **Do NOT make blanket changes**: Each URL pattern deserves individual assessment
+3. **Do NOT rely on search engine optimism**: Monitor Search Console for actual consolidation
+4. **Do NOT over-engineer**: Canonical + sitemap often sufficient; escalate only if evidence warrants
+
+---
+
+## Related Skills
+
+- `url-normalization.md` — Specific patterns for Hugo + GitHub Pages
+- `canonical-consolidation.md` — Implementing canonicalization strategies
+- `multilingual-content.md` — Hreflang and language variant patterns
+- `redirect-strategy.md` — Choosing redirect mechanisms
+
+---
+
+## Example Audit Workflow
+
+**Scenario**: Migrating a site from PHP (`.php` URLs) to Hugo (trailing-slash URLs)
+
+**Phase 1 - Inventory**:
+- Identify all `.php` paths still being served (legacy aliases)
+- Document new Hugo paths (`/page/` instead of `/page.php`)
+- List language variants (`/es/page/` vs. `/page.php?lang=es`)
+
+**Phase 2 - Configuration**:
+- Verify Hugo templates strip `index.html` from canonicals
+- Check that old `.php` paths have `aliases:` in front matter
+- Validate sitemap lists only `/page/`, not `/page.php` or `/page/index.html`
+
+**Phase 3 - Validation**:
+- Run validation script to confirm alias pages point to new URLs
+- Test that old `.php` paths resolve to meta-refresh pages
+- Verify new paths have canonical tags
+
+**Phase 4 - Decision**:
+- If Search Console shows old `.php` URLs indexed: canonical tags will consolidate
+- If no evidence of harm: monitor for 2-4 weeks
+- If harm emerges: consider server-level HTTP redirects (outside repo scope)
+
+---
+
+**Last updated**: 2026-09-04 <!-- learned: 2026-09-04 -->

--- a/.agents/skills/churchcrm/url-normalization.md
+++ b/.agents/skills/churchcrm/url-normalization.md
@@ -1,0 +1,290 @@
+# Skill: URL Normalization & Canonicalization
+
+## Context
+
+This skill documents URL normalization patterns, canonicalization strategies, and redirect mechanisms used across ChurchCRM's web properties (churchcrm.io, docs.churchcrm.io). Use this when adding pages, managing multilingual content, or implementing SEO-critical URL structures.
+
+## Core Principle
+
+**One canonical URL per page.** Eliminate duplicates via:
+- Canonical link tags pointing search engines to the true URL
+- Hreflang tags for language variants (with x-default)
+- Sitemap entries listing only canonical URLs
+- Redirects for legacy paths (preserving search equity)
+
+---
+
+## Hugo Configuration
+
+### URL Stripping (index.html)
+
+All canonical URLs, hreflang tags, and sitemap entries must strip `index.html` suffixes. Hugo generates `/page/index.html` for trailing-slash URLs; templates remove the suffix for canonical consolidation.
+
+**Canonical tag** (`layouts/partials/head.html`):
+```go
+{{- $canonicalURL := .Permalink -}}
+{{- if hasSuffix $canonicalURL "index.html" -}}
+    {{- $canonicalURL = strings.TrimSuffix "index.html" $canonicalURL -}}
+{{- end -}}
+<link rel="canonical" href="{{ $canonicalURL }}">
+```
+
+**Hreflang tags** (same file):
+```go
+{{ range .AllTranslations -}}
+{{- $hrefLangURL := .Permalink -}}
+{{- if hasSuffix $hrefLangURL "index.html" -}}
+    {{- $hrefLangURL = strings.TrimSuffix "index.html" $hrefLangURL -}}
+{{- end -}}
+<link rel="alternate" hreflang="{{ .Language.LanguageCode }}" href="{{ $hrefLangURL }}" />
+{{- end }}
+<link rel="alternate" hreflang="x-default" href="{{ (index .Sites 0).BaseURL }}" />
+```
+
+**Sitemap** (`layouts/sitemap.xml`):
+```go
+{{- $loc := $page.Permalink | strings.TrimSuffix "index.html" }}
+<loc>{{ $loc }}</loc>
+```
+
+---
+
+## Multilingual Pages (Language Variants)
+
+### Front Matter Configuration
+
+For multilingual content, explicitly set the canonical URL in the page's front matter to ensure correct generation:
+
+```yaml
+---
+title: "Page Title"
+url: "/en/path/to/page/"  # For English (often at root: "/path/to/page/")
+aliases:
+  - "/path/to/page.html"   # Legacy .html path for redirect
+---
+```
+
+**Pattern for non-English**:
+```yaml
+url: "/[lang]/path/to/page/"
+aliases:
+  - "/path/to/page.html"    # Old URL without language prefix
+```
+
+**All 8 languages currently using this pattern** (churchcrm.io):
+- English (en): `/church-management-software/` (root)
+- Spanish (es): `/es/church-management-software/`
+- Portuguese (pt): `/pt/church-management-software/`
+- Chinese (zh): `/zh/church-management-software/`
+- French (fr): `/fr/church-management-software/`
+- Russian (ru): `/ru/church-management-software/`
+- German (de): `/de/church-management-software/`
+- Arabic (ar): `/ar/church-management-software/`
+
+---
+
+## Redirect Mechanism (GitHub Pages + Hugo Aliases)
+
+**Limitation**: GitHub Pages cannot serve HTTP 301/308 redirects from repository files (static hosting only).
+
+**Solution**: Use Hugo aliases to generate static redirect pages:
+
+1. Hugo creates a static HTML file at the old path (e.g., `/church-management-software.html`)
+2. File contains `<meta http-equiv="refresh">` for browser redirect
+3. File contains `<link rel="canonical">` for search engine consolidation
+4. GitHub Pages serves as HTTP 200 + static HTML
+
+**Search equity preservation**: The canonical tag in the alias page tells search engines to consolidate the old URL's ranking into the canonical form.
+
+**Example alias page generated at `/es/church-management-software.html`**:
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <link rel="canonical" href="https://churchcrm.io/es/church-management-software/">
+  <meta http-equiv="refresh" content="0; url=https://churchcrm.io/es/church-management-software/">
+</head>
+<body></body>
+</html>
+```
+
+---
+
+## Validation Strategy
+
+### Automated Script
+
+The validation script `scripts/check-url-normalization.mjs` verifies:
+
+1. ✅ No canonical href ends in `index.html`
+2. ✅ No hreflang href ends in `index.html`
+3. ✅ Sitemap contains no `index.html` entries
+4. ✅ All redirect aliases point to canonical URLs
+5. ✅ Redirect mapping CSV matches built site
+
+**Run locally** (requires Hugo installed):
+```bash
+hugo --minify
+node scripts/check-url-normalization.mjs
+```
+
+**CI execution**: Runs automatically after `hugo --minify` in CI pipeline.
+
+**Expected output**:
+```
+OK:   XXX canonical hrefs checked, none end in index.html
+OK:   XXX hreflang alternate hrefs checked, none end in index.html
+OK:   XXX sitemap.xml <loc> entries checked, none end in index.html
+OK:   7 implemented redirect-mapping.csv rows checked (old_url alias + new_url target)
+
+3 check group(s) passed, 0 failure(s).
+```
+
+---
+
+## Root URL Handling (/ vs /index.html)
+
+### GitHub Pages Native Behavior
+
+GitHub Pages serves `index.html` natively at BOTH `/` and `/index.html`. This is expected static-hosting behavior, not a site bug.
+
+**Evidence**:
+```
+$ curl -sI https://churchcrm.io/ | head -5
+HTTP/2 200
+ETag: "abc123-def456"
+
+$ curl -sI https://churchcrm.io/index.html | head -5
+HTTP/2 200
+ETag: "abc123-def456"  # Identical ETags = identical content
+```
+
+### Conservative Decision: No Redirect
+
+**Why not redirect `/index.html` → `/`?**
+1. Hugo aliases cannot override GitHub Pages' native `index.html` serving
+2. Canonical consolidation already configured to point to `/`
+3. Search engines recognize canonical tags and consolidate duplicates
+4. No ranking impact detected; canonical is sufficient
+
+**Follow-up**: Monitor Search Console post-deployment for consolidation (2-4 weeks). If separate indexing persists, server-level configuration (outside repository scope) may be needed.
+
+---
+
+## Redirect Mapping Documentation
+
+Maintain a CSV file (`content/redirect-mapping.csv`) documenting all URL migrations:
+
+| old_url | new_url | mechanism | status | reason |
+|---------|---------|-----------|--------|--------|
+| `https://churchcrm.io/es/church-management-software.html` | `https://churchcrm.io/es/church-management-software/` | Hugo alias (meta-refresh + canonical) | implemented | Normalized trailing-slash form |
+
+**Columns**:
+- `old_url`: Legacy URL (with `http(s)://domain`)
+- `new_url`: Canonical URL
+- `mechanism`: How the redirect works (Hugo alias, HTTP 301, meta-refresh, etc.)
+- `status`: "implemented", "planned", or "audited but not changed"
+- `reason`: Why the redirect exists (normalization, consolidation, legacy cleanup, etc.)
+
+---
+
+## When to Add URL Normalization
+
+### Before Creating a Page
+
+✅ **Check**:
+1. Is this a new language variant? → Use `url: "/[lang]/path/"` + language-specific alias
+2. Is this replacing an old page? → Document the old URL in `aliases:` for redirect
+3. Does this need a trailing slash? → Use trailing-slash form in `url:` (canonical)
+
+✅ **Configure**:
+```yaml
+url: "/canonical/path/"
+aliases:
+  - "/old/legacy/path.html"
+  - "/another-old-variant/"
+```
+
+✅ **Verify**:
+- Hugo build generates alias pages at old paths
+- Canonical tag in new page points to `/canonical/path/`
+- Sitemap lists only `/canonical/path/` (no `index.html`, no aliases)
+
+### When Renaming Pages
+
+1. Add old URL to `aliases:` in the page's front matter
+2. Run `hugo --minify`
+3. Verify alias page generated at old path
+4. Update navigation links to point to new URL
+5. Document in `content/redirect-mapping.csv`
+
+### When Adding Language Variants
+
+For a page already published in one language, adding a variant:
+
+1. **Create content file**: `content/[lang]/page.md`
+2. **Set canonical URL**: `url: "/[lang]/path/"`
+3. **Add redirect alias** (if old URL exists): `aliases: ["/old/path/"]`
+4. **Verify hreflang**: Hugo automatically generates hreflang tags linking language variants
+5. **Test validation script**: Run `node scripts/check-url-normalization.mjs`
+
+---
+
+## Testing & Debugging
+
+### Common Issues
+
+**Issue**: Canonical tag includes `index.html`
+- **Cause**: Template not stripping suffix
+- **Fix**: Check `layouts/partials/head.html` has `strings.TrimSuffix "index.html"`
+
+**Issue**: Alias page not generated
+- **Cause**: Hugo build failed or aliases misconfigured
+- **Fix**: Check front matter `aliases:` field exists and is valid YAML
+- **Test**: Run `hugo --minify` and check `public/[old-path]/index.html` exists
+
+**Issue**: Sitemap includes `index.html` entries
+- **Cause**: Sitemap template not stripping suffix
+- **Fix**: Verify `layouts/sitemap.xml` line 7 has `strings.TrimSuffix "index.html"`
+
+**Issue**: Hreflang tags missing language variants
+- **Cause**: Content not translated or language not configured
+- **Fix**: Verify all language versions exist and `defaultContentLanguage` is set correctly in `hugo.toml`
+
+### Manual Testing
+
+```bash
+# Build and validate
+hugo --minify
+node scripts/check-url-normalization.mjs
+
+# Check specific file in built site
+cat public/path/to/page/index.html | grep '<link rel="canonical"'
+
+# Verify redirect alias
+cat public/old/legacy/path/index.html | grep 'meta.*refresh'
+```
+
+---
+
+## Reference Files
+
+- **Validation script**: `scripts/check-url-normalization.mjs`
+- **Redirect mapping**: `content/redirect-mapping.csv`
+- **Hugo config**: `hugo.toml`
+- **Canonical implementation**: `layouts/partials/head.html` (lines 27-31)
+- **Hreflang implementation**: `layouts/partials/head.html` (lines 220-227)
+- **Sitemap implementation**: `layouts/sitemap.xml` (line 7)
+- **Audit findings**: `/marketing/research/seo-audits/URL_NORMALIZATION_AUDIT.md` (marketing repo)
+
+---
+
+## Related Skills
+
+- `i18n-localization.md` — Multilingual content strategy
+- `security-best-practices.md` — Canonical tag XSS considerations
+- `seo-audits.md` — Full audit methodology
+
+---
+
+Last updated: 2026-09-04


### PR DESCRIPTION
Created 5 new agent skills documenting learnings from churchcrm.io issue #54
(URL normalization audit and implementation):

- seo-audit-methodology.md: 4-phase framework for systematic SEO audits
  (inventory, configuration, validation, evidence-based decisions)
- canonical-consolidation.md: Implementing canonical tags for URL consolidation
  (template patterns, multilingual coordination, monitoring)
- redirect-strategy.md: Redirect decision tree and implementation patterns
  (HTTP 301/302, meta-refresh, platform-specific approaches)
- multilingual-content.md: Language variants, hreflang, language detection
  (8-language ChurchCRM pattern as reference)
- url-normalization.md: Hugo-specific URL structure and validation
  (already created; now complete with others)

All skills include live implementation references from churchcrm.io where applicable.
Use these when working with URL structure, redirects, multilingual content, or SEO audits.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>