### PR TITLE
Fix stale Discord invite link in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 Security patch announcements, CVE disclosures, and dependency update notices are posted in the **#security** channel on our Discord server.
 
-> 👉 **Join Discord:** [https://discord.gg/w4mmYPSnE](https://discord.gg/w4mmYPSnE) — then follow **#security** for announcements.
+> 👉 **Join Discord:** [https://discord.gg/tuWyFzj3Nj](https://discord.gg/tuWyFzj3Nj) — then follow **#security** for announcements.
 
 **Please do not:**
 - DM maintainers directly about security issues


### PR DESCRIPTION
## Summary

`SECURITY.md` links to `discord.gg/w4mmYPSnE` — found while cross-checking [ChurchCRM.io#67](https://github.com/ChurchCRM/ChurchCRM.io/pull/82) (`content/en/security.md` on the marketing site uses `discord.gg/tuWyFzj3Nj` instead, and I couldn't tell from the marketing site alone which invite was actually current).

Checked this repo directly: `tuWyFzj3Nj` is the only invite code used everywhere else —

- `README.md` (3 places: two badges, one inline link)
- `CONTRIBUTING.md`
- `src/plugins/README.md`
- All GitHub issue templates (`bug_report.yml`, `question.yml`, `feature_request.yml`, `config.yml`)
- All issue-comment templates (`generic.md`, `bug.md`, `question.md`, `system-info.md`)

`w4mmYPSnE` appears in exactly one place: this line in `SECURITY.md`. That's conclusive enough to fix directly rather than just flag.

## Changes

- `SECURITY.md`: Discord invite link updated to `discord.gg/tuWyFzj3Nj`, matching every other reference in the repo.

## Testing

Documentation-only, single-line link change. No build/test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmVz7nypD3wTNJ3N5Yf5jo

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmVz7nypD3wTNJ3N5Yf5jo)_