### PR TITLE
Fix issue #9578: Replace relative AJAX URLs with absolute paths

### DIFF
--- a/webpack/setup.js
+++ b/webpack/setup.js
@@ -368,7 +368,7 @@ window.Stepper = Stepper;
     updateGroupStatus(groupKey);
 
     $.ajax({
-      url: "./SystemIntegrityCheck",
+      url: `${rootPath}/setup/SystemIntegrityCheck`,
       method: "GET",
     })
       .done((data) => {
@@ -433,7 +433,7 @@ window.Stepper = Stepper;
     });
 
     $.ajax({
-      url: "./SystemPrerequisiteCheck",
+      url: `${rootPath}/setup/SystemPrerequisiteCheck`,
       method: "GET",
       contentType: "application/json",
     })
@@ -457,7 +457,7 @@ window.Stepper = Stepper;
 
   function checkFilesystem() {
     $.ajax({
-      url: "./SystemFilesystemCheck",
+      url: `${rootPath}/setup/SystemFilesystemCheck`,
       method: "GET",
       contentType: "application/json",
     })
@@ -481,7 +481,7 @@ window.Stepper = Stepper;
 
   function checkLocales() {
     $.ajax({
-      url: "./SystemLocaleCheck",
+      url: `${rootPath}/setup/SystemLocaleCheck`,
       method: "GET",
       contentType: "application/json",
     })


### PR DESCRIPTION
## Summary

Fixes setup page getting stuck in infinite loading loop on hosting environments where `.htaccess` rewrites are disabled or nginx lacks proper `try_files` routing.

## Root Cause

The setup page's system check functions used relative AJAX URLs (`./SystemPrerequisiteCheck`, etc.) which fail when web server rewrites aren't available. This causes:

1. Request to relative URL → 302 redirect (no route found)
2. Setup page receives HTML instead of JSON
3. JavaScript throws `Cannot use 'in' operator to search for 'length'`
4. Infinite loading loop — setup never completes, Config.php never created

## Changes

- `webpack/setup.js`: Replace 4 relative AJAX URLs with absolute paths using detected `rootPath`
  - `checkPrerequisites()`: `./SystemPrerequisiteCheck` → `${rootPath}/setup/SystemPrerequisiteCheck`
  - `checkFilesystem()`: `./SystemFilesystemCheck` → `${rootPath}/setup/SystemFilesystemCheck`
  - `checkLocales()`: `./SystemLocaleCheck` → `${rootPath}/setup/SystemLocaleCheck`
  - `checkIntegrity()`: `./SystemIntegrityCheck` → `${rootPath}/setup/SystemIntegrityCheck`

## Why This Works

- `rootPath` is correctly detected server-side for both root and subdirectory installs (already in `src/setup/index.php` lines 11-46)
- Injected into `window.CRM.root` before setup.js loads (verified in `src/setup/templates/header.php` line 30)
- Absolute paths don't depend on web server rewrites
- Matches pattern already used successfully by `submitSetupData()` (line 731)
- Works on all hosting configurations (shared hosting with `.htaccess` disabled, Nginx, LiteSpeed, etc.)

## Testing Verification

- ✅ Verified `rootPath` detection handles root installs (`/setup/` → `root: ""`)
- ✅ Verified `rootPath` detection handles subdirectory installs (`/churchcrm/setup/` → `root: "/churchcrm"`)
- ✅ Confirmed `rootPath` is properly injected into `window.CRM.root` in HTML
- ✅ Pattern already working in `submitSetupData()` (form submission uses same approach successfully)

## Impact

- **Fixes:** Setup page stuck in infinite loop on hosts without `.htaccess` support or with improper nginx configuration
- **Scope:** First-time installation only (setup is inaccessible after Config.php exists)
- **Breaking changes:** None
- **Affected users:** Only those attempting new installations on hosts with routing issues
- **Already-installed systems:** Not affected

## Related Issues

Fixes #9578

---
_Generated with [Claude Code](https://claude.ai/code)_