### PR TITLE
chore(deps): bump @biomejs/biome from 2.5.9 to 2.5.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
                 "tom-select": "^2.6.2"
             },
             "devDependencies": {
-                "@biomejs/biome": "^2.5.9",
+                "@biomejs/biome": "^2.5.12",
                 "@playwright/test": "^1.63.0",
                 "@types/jquery": "^3.5.33",
                 "archiver": "^7.0.1",
@@ -196,11 +196,10 @@
             }
         },
         "node_modules/@biomejs/biome": {
-            "version": "2.5.9",
-            "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.9.tgz",
-            "integrity": "sha512-KkgCvdHB4IhtpHpF564plA9jo6fDOwWGQ/3jvreLzgOtRLEDoPqr7QO9qejNA8jKwDsSkAKr77hqBHnyUbIw4g==",
+            "version": "2.5.12",
+            "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.12.tgz",
+            "integrity": "sha512-Lw4VHZRebrReBBnlHa12JQjnIBm3JJAA55PDB9LbBVBF0q4RYphm6KfmIjqtPhf61MxZ5Q9KoK8R8x+7per5Aw==",
             "dev": true,
-            "license": "MIT OR Apache-2.0",
             "bin": {
                 "biome": "bin/biome"
             },
@@ -212,25 +211,24 @@
                 "url": "https://opencollective.com/biome"
             },
             "optionalDependencies": {
-                "@biomejs/cli-darwin-arm64": "2.5.9",
-                "@biomejs/cli-darwin-x64": "2.5.9",
-                "@biomejs/cli-linux-arm64": "2.5.9",
-                "@biomejs/cli-linux-arm64-musl": "2.5.9",
-                "@biomejs/cli-linux-x64": "2.5.9",
-                "@biomejs/cli-linux-x64-musl": "2.5.9",
-                "@biomejs/cli-win32-arm64": "2.5.9",
-                "@biomejs/cli-win32-x64": "2.5.9"
+                "@biomejs/cli-darwin-arm64": "2.5.12",
+                "@biomejs/cli-darwin-x64": "2.5.12",
+                "@biomejs/cli-linux-arm64": "2.5.12",
+                "@biomejs/cli-linux-arm64-musl": "2.5.12",
+                "@biomejs/cli-linux-x64": "2.5.12",
+                "@biomejs/cli-linux-x64-musl": "2.5.12",
+                "@biomejs/cli-win32-arm64": "2.5.12",
+                "@biomejs/cli-win32-x64": "2.5.12"
             }
         },
         "node_modules/@biomejs/cli-darwin-arm64": {
-            "version": "2.5.9",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.9.tgz",
-            "integrity": "sha512-am22pX2aBqznqq1eMyIj/bZ++riF3Lk6ct7cbv+gQK0csFhr+d8O0RkOi2FF2qSgFgANbqNkIZ0/PxlnW2pLFg==",
+            "version": "2.5.12",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.12.tgz",
+            "integrity": "sha512-lCRY1rwgNeWNgTr4DI/u6ZwXTRwRLHAvbaio1YLLGS+4r1nhvB2ssyPqIpfUSmRveNfv0fn/N58C7CAdK2XVrg==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
-            "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
                 "darwin"
@@ -240,14 +238,13 @@
             }
         },
         "node_modules/@biomejs/cli-darwin-x64": {
-            "version": "2.5.9",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.9.tgz",
-            "integrity": "sha512-l44KWDHLDvEnD0N/XcrVs7VXb3A18xL7QS3WB0eL93wbmk529ffIG55vleGCqaunpRUjLrdnjK05Qki1dsjylg==",
+            "version": "2.5.12",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.12.tgz",
+            "integrity": "sha512-vhPgwnh+6tN3ArdAXuET99xaNbFt7CG82Bqn+omHVLC5xdVx45JsYjGPmUIGNzjDek5XdNCP1HKksK7fn8+3bQ==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
-            "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
                 "darwin"
@@ -257,14 +254,13 @@
             }
         },
         "node_modules/@biomejs/cli-linux-arm64": {
-            "version": "2.5.9",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.9.tgz",
-            "integrity": "sha512-ICaK+IYaVZvKbBxX2rwrPT0DdUDMnE9Vm3nQGe+mltQPmUg19pONzkPWGdY4FCsoreDETWDynvdt4ysCbF5gNQ==",
+            "version": "2.5.12",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.12.tgz",
+            "integrity": "sha512-2gp8aVwXYKdAtmBfRFCUuyDMcfN1ahHqUkGfLYrZlNRFmryMATLVvJgWKvyA8wu4Rwn5OSxM1UcUmOuOFNGeBQ==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
-            "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
                 "linux"
@@ -274,14 +270,13 @@
             }
         },
         "node_modules/@biomejs/cli-linux-arm64-musl": {
-            "version": "2.5.9",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.9.tgz",
-            "integrity": "sha512-7ImVPwBLCtkmpR5esd8RHhTqW94f0JLJQum6AneYcy94jRm18TaPPm7slaigGzFhfgt3QiD1Vj52LKmBAnKizA==",
+            "version": "2.5.12",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.12.tgz",
+            "integrity": "sha512-couHYjFLL5uuI8ne6zhT7KwEsXo5YP7ry/2xmEqah7qanu0YmfDi3mwJg47YXSuv/NpZj22CZzcRH/5c4gjPSQ==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
-            "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
                 "linux"
@@ -291,14 +286,13 @@
             }
         },
         "node_modules/@biomejs/cli-linux-x64": {
-            "version": "2.5.9",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.9.tgz",
-            "integrity": "sha512-z22Q/zFYSvbIJfW1CbfZPu4X8PddS6Qd2ORbc6h+aT6EcwAxUF3m6fA4HjNvA3TU4X0dTJRwNPB165ES3PJXzg==",
+            "version": "2.5.12",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.12.tgz",
+            "integrity": "sha512-SnvOs3TSTiuia4SQOUNe1aWC9RT4+YkjcKnOhL/nsKOV0k5ycgBkDzF0lUxKn1V7Q8CLTRq6iV23ZAivHomRoA==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
-            "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
                 "linux"
@@ -308,14 +302,13 @@
             }
         },
         "node_modules/@biomejs/cli-linux-x64-musl": {
-            "version": "2.5.9",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.9.tgz",
-            "integrity": "sha512-RXGaD0o1/pTTguYw1aeDJh9ad6Lfrui0fI7mBderTyGr7WuUJkBIttgLkR3XJyoxOkkgfBDspaUT8wXArTqLZw==",
+            "version": "2.5.12",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.12.tgz",
+            "integrity": "sha512-8A0oDW58/w9f/PQNYuq0sGUZtGtGrkNF4Z6n0PUoXpLCshi85vtKTv1XSznQawhdE4MXJ8ufpzHXyLFe87M/+w==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
-            "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
                 "linux"
@@ -325,14 +318,13 @@
             }
         },
         "node_modules/@biomejs/cli-win32-arm64": {
-            "version": "2.5.9",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.9.tgz",
-            "integrity": "sha512-nHK+/HHC+D0ogAHUxomgoSTdjImb6fmNNVTKmf0tyu4eDL1DqPKIHc+i+UL8+b0RnAu8224qo8F2tCVnaT0A3w==",
+            "version": "2.5.12",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.12.tgz",
+            "integrity": "sha512-b9vtoZFsuZt1pdjNwJvXl0f+BpayRzV008uS2+JpmwIKdSE2qdu4A/l04FESwLoou5g2E/Qlec0xwJydZplH+A==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
-            "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
                 "win32"
@@ -342,14 +334,13 @@
             }
         },
         "node_modules/@biomejs/cli-win32-x64": {
-            "version": "2.5.9",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.9.tgz",
-            "integrity": "sha512-Yiq0H56LjXSSw/hd9YkXgSLQfzyDJzbzU2TezozxyNw+uKWAqOtqGVvBfzKRRDiaFF5avGAhHdWKx7LtDOShUw==",
+            "version": "2.5.12",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.12.tgz",
+            "integrity": "sha512-B1R/l+CwEpKFSuqiwePzPNRk1EiJN8kc0UhdafNz6MZN9v5OFP9HYP1irptvWzHrwVI4blVNGMbxc5zt70m3IA==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
-            "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
                 "win32"

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
         "tom-select": "^2.6.2"
     },
     "devDependencies": {
-        "@biomejs/biome": "^2.5.9",
+        "@biomejs/biome": "^2.5.12",
         "@playwright/test": "^1.63.0",
         "@types/jquery": "^3.5.33",
         "archiver": "^7.0.1",


### PR DESCRIPTION
## Summary
- Bump `@biomejs/biome` dev dependency from `^2.5.9` to `^2.5.12` (latest release)

## Changes
- Updated `package.json` devDependency version constraint
- Updated `package-lock.json` for `@biomejs/biome` and its platform-specific `@biomejs/cli-*` optional dependencies

## Why
- Pick up the latest Biome patch releases (bug fixes / improvements since 2.5.9)

## Testing
- ✅ `npm run lint` — passes (0 errors, 10 pre-existing CSS specificity warnings unrelated to this change)
- ✅ `npm run build:webpack` — compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)