### PR TITLE
Fix marketing pipeline selectors: TomSelect state field, DataTables 2.x search

### DIFF
--- a/playwright/videos/family-register.video.ts
+++ b/playwright/videos/family-register.video.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 import { captureScreen } from '../support/capture';
-import { humanClick, humanPause, humanType } from '../support/human';
+import { humanClick, humanPause, humanSelect, humanType } from '../support/human';
 
 /**
  * A visitor self-registering their family — no login, no staff involvement.
@@ -20,7 +20,11 @@ test('family-self-register', async ({ page }, testInfo) => {
   await humanType(page.locator('#familyName'), 'Whitfield');
   await humanType(page.locator('#familyAddress1'), '245 Willow Creek Rd');
   await humanType(page.locator('#familyCity'), 'Springfield');
-  await humanType(page.locator('#familyState'), 'IL');
+  // DropdownManager.initializeFamilyRegisterCountryState() (FamilyRegister.js)
+  // replaces this input with a TomSelect-enhanced <select> of state codes at
+  // runtime — humanType's click is blocked by TomSelect's overlay, same as
+  // #State/#sChurchState elsewhere in this pipeline.
+  await humanSelect(page.locator('#familyState'), 'IL');
   await humanType(page.locator('#familyZip'), '62704');
   await humanType(page.locator('#familyHomePhone'), '(555) 010-1000');
   await humanPause(page, 600);

--- a/playwright/workflows/dark-mode.spec.ts
+++ b/playwright/workflows/dark-mode.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 import { captureScreen } from '../support/capture';
-import { humanClick, humanPause } from '../support/human';
+import { humanClick, humanPause, humanType } from '../support/human';
 
 /**
  * themeMode ('ui.style': 'auto' | 'default' | 'dark') is a per-user setting
@@ -61,6 +61,12 @@ test.describe('Dark Mode', () => {
       await page.reload();
       await expect(page.locator('html[data-bs-theme="dark"]')).toBeAttached({ timeout: 10000 });
       await expect(rows.first()).toBeVisible({ timeout: 15000 });
+      await humanPause(page, 500);
+
+      // With 62 demo families, "Scott" isn't on the default first page —
+      // search for it (same DataTables 2.x `.dt-search input`, not the
+      // 1.x `#{table}_filter` wrapper, as people-family.spec.ts).
+      await humanType(page.locator('.dt-search input'), 'Scott');
       await humanPause(page, 500);
 
       const scottRow = rows.filter({ hasText: 'Scott' }).first();

--- a/playwright/workflows/people-family.spec.ts
+++ b/playwright/workflows/people-family.spec.ts
@@ -21,7 +21,9 @@ test.describe('People & Families', () => {
     // DataTables paginates (src/people/views/family-list.php) — with 62
     // demo families, "Scott" isn't on the default first page, so search
     // for it instead of filtering whatever rows happen to be rendered.
-    await humanType(page.locator('#families_filter input'), 'Scott');
+    // DataTables 2.x's search box has no #{table}_filter wrapper (that's
+    // the 1.x id) — its input lives at `.dt-search input` (id `dt-search-N`).
+    await humanType(page.locator('.dt-search input'), 'Scott');
     await humanPause(page, 500);
     const scottRow = rows.filter({ hasText: 'Scott' }).first();
     await expect(scottRow).toBeVisible({ timeout: 15000 });


### PR DESCRIPTION
## Summary
Fixes the 3 test failures surfaced by the last full `marketing:screenshots:chrome` run.

## Changes
- `family-register.video.ts`: `#familyState` is replaced with a TomSelect-enhanced `<select>` at runtime (`DropdownManager.initializeFamilyRegisterCountryState`, `FamilyRegister.js`) — switched `humanType` (click+type, blocked by TomSelect's overlay) to `humanSelect`.
- `people-family.spec.ts`: targeted `#families_filter input`, the DataTables **1.x** filter-box id. This app runs DataTables 2.x, whose search input is `.dt-search input` — confirmed live against a running instance (`#families_filter` had zero matches).
- `dark-mode.spec.ts`: `people-family-overview-dark` never actually searched for "Scott" before filtering rendered rows, so with 62 seeded families it wasn't on the visible page. Added the same DataTables search step.

## Why
All three broke the marketing screenshot/video pipeline (`npm run marketing:screenshots:chrome`), blocking screenshot regeneration.

## Testing
Fresh `docker:ci:new-system` instance, full `BROWSER_CHANNEL=chrome playwright test` run: **26/26 passing** (was 23/26 before this fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015tNJNTTky2rGhdiPi6GHFQ