### PR TITLE
Rename 'videos' Playwright project to 'recordings'

### DIFF
--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -111,7 +111,11 @@ export default defineConfig({
       // flow. Same high-quality video treatment as 'setup', kept as its
       // own project instead of appended to bootstrap.setup.ts so that
       // file stays scoped to system bootstrap only.
-      name: 'videos',
+      // Named 'recordings', not 'videos' — capture.ts writes each
+      // video-only project's output to artifacts/videos/<project-name>/,
+      // and a project literally named 'videos' collided with that parent
+      // folder (artifacts/videos/videos/...).
+      name: 'recordings',
       testMatch: /videos\/.*\.video\.ts/,
       dependencies: ['setup'],
       use: {

--- a/playwright/support/capture.ts
+++ b/playwright/support/capture.ts
@@ -54,7 +54,7 @@ const VIEWPORTS: ViewportConfig[] = [
 // Playwright project names (see playwright.config.ts) that record video at
 // a single fixed viewport instead of the desktop/tablet/mobile screenshot
 // sweep — used as both the capture-mode switch and the artifact device dir.
-const VIDEO_ONLY_PROJECTS = new Set(['setup', 'videos']);
+const VIDEO_ONLY_PROJECTS = new Set(['setup', 'recordings']);
 
 export async function captureScreen(page: Page, testInfo: TestInfo, opts: CaptureOptions): Promise<void> {
   if (testInfo.title !== opts.name) {

--- a/playwright/videos/family-register.video.ts
+++ b/playwright/videos/family-register.video.ts
@@ -5,7 +5,7 @@ import { humanClick, humanPause, humanSelect, humanType } from '../support/human
 
 /**
  * A visitor self-registering their family — no login, no staff involvement.
- * Runs unauthenticated (this 'videos' project has no storageState), against
+ * Runs unauthenticated (this 'recordings' project has no storageState), against
  * the public /external/register/ wizard (src/external/routes/register.php,
  * gated behind bEnableSelfRegistration — enabled in the demo config).
  * "Whitfield", matching people-family.spec.ts's people-family-new-family,


### PR DESCRIPTION
## Summary
Fixes a self-collision in the marketing pipeline's video output path.

## Why
\`capture.ts\` writes video-only projects' output to \`artifacts/videos/<project-name>/\` — a project literally named \`'videos'\` collided with that parent folder, producing \`artifacts/videos/videos/family-self-register.webm\` instead of \`artifacts/videos/family-self-register.webm\`. The \`'setup'\` project never had this problem since its name doesn't collide.

Found while cleaning up \`ChurchCRM/marketing\`'s already-committed pipeline output, which had inherited the same bad nesting.

## Testing
\`npx playwright test --list\` confirms the renamed \`[recordings]\` project registers correctly; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015tNJNTTky2rGhdiPi6GHFQ