### PR TITLE
Fix issue #9677: Render all options in country and state dropdowns

### DIFF
--- a/cypress/e2e/ui/family/family.country-dropdown-maxoptions.spec.js
+++ b/cypress/e2e/ui/family/family.country-dropdown-maxoptions.spec.js
@@ -1,0 +1,94 @@
+/// <reference types="cypress" />
+
+/**
+ * Regression tests for the TomSelect `maxOptions` fix — issue #9677.
+ *
+ * TomSelect v2 defaults to `maxOptions: 50` and applies it to the rendered
+ * result set, so long fixed lists were silently truncated with no scrollbar
+ * and no "more results" hint:
+ *
+ *   - Country (256 entries) stopped at "China (中国)" — United States was
+ *     unreachable by scrolling.
+ *   - US State/Province (59 entries) stopped at "Tennessee" — Texas through
+ *     Wyoming were unreachable.
+ *
+ * `TomSelect.defaults` is module-private in v2, so the cap has to be lifted
+ * per call site. These tests assert the rendered option count, not just that
+ * the dropdown opens — a count of exactly 50 is the signature of the bug.
+ */
+describe("Country/State TomSelect renders the full list (#9677)", () => {
+    beforeEach(() => {
+        cy.setupStandardSession();
+        cy.on("uncaught:exception", () => false);
+    });
+
+    it("Family Editor country dropdown renders all countries, not just the first 50", () => {
+        cy.visit("/FamilyEditor.php");
+
+        cy.window().should("have.property", "CRM");
+        cy.window().its("CRM.localesLoaded").should("eq", true);
+
+        // DropdownManager populates #Country from /api/public/data/countries and
+        // then wraps it with TomSelect, which adds 'tomselected' to the <select>.
+        cy.get("select#Country", { timeout: 10000 }).should("have.class", "tomselected");
+
+        // The API is the source of truth for how many options there should be.
+        cy.request("/api/public/data/countries").then((resp) => {
+            const expected = resp.body.length;
+            expect(expected, "country list is long enough to trip the 50-option cap").to.be.greaterThan(50);
+
+            // TomSelect inserts .ts-wrapper as a NEXT SIBLING of the <select>, and
+            // (with no dropdownParent set) nests its .ts-dropdown inside that wrapper.
+            // Scope to the wrapper so the state dropdown's options are not counted too.
+            cy.get("select#Country").next(".ts-wrapper").find(".ts-control").click();
+
+            cy.get("select#Country")
+                .next(".ts-wrapper")
+                .find(".ts-dropdown .option", { timeout: 5000 })
+                .should("have.length", expected);
+
+            // The specific regression: United States must be reachable by scrolling.
+            cy.get("select#Country").next(".ts-wrapper").find(".ts-dropdown .option")
+                .last()
+                .should("contain.text", "Zimbabwe");
+            cy.get("select#Country").next(".ts-wrapper").find(".ts-dropdown")
+                .should("contain.text", "United States");
+        });
+
+        cy.get("body").type("{esc}");
+    });
+
+    it("Family Editor state dropdown renders all US states, not just the first 50", () => {
+        cy.visit("/FamilyEditor.php");
+
+        cy.window().should("have.property", "CRM");
+        cy.window().its("CRM.localesLoaded").should("eq", true);
+
+        cy.get("select#Country", { timeout: 10000 }).should("have.class", "tomselected");
+
+        // Selecting the US cascades DropdownManager.initializeState() into #State.
+        cy.get("select#Country").then(($sel) => {
+            $sel[0].tomselect.setValue("US");
+        });
+
+        cy.get("select#State", { timeout: 10000 }).should("have.class", "tomselected");
+
+        cy.request("/api/public/data/countries/us/states").then((resp) => {
+            const expected = Object.keys(resp.body).length;
+            expect(expected, "US state list is long enough to trip the 50-option cap").to.be.greaterThan(50);
+
+            cy.get("select#State").next(".ts-wrapper").find(".ts-control").click();
+
+            cy.get("select#State")
+                .next(".ts-wrapper")
+                .find(".ts-dropdown .option", { timeout: 5000 })
+                .should("have.length", expected);
+
+            // Texas through Wyoming were the casualties of the 50-option cap.
+            cy.get("select#State").next(".ts-wrapper").find(".ts-dropdown")
+                .should("contain.text", "Wyoming");
+        });
+
+        cy.get("body").type("{esc}");
+    });
+});

--- a/src/SystemSettings.php
+++ b/src/SystemSettings.php
@@ -292,16 +292,21 @@ function categoryId(string $category): string {
 
 <script nonce="<?= SystemURLs::getCSPNonce() ?>">
   $(document).ready(function() {
+    // TomSelect renders at most `maxOptions` entries (default 50). Choice settings
+    // include sDefaultCountry / sChurchCountry (256 options) and sTimeZone (419),
+    // which were silently truncated. Render the full list. See issue #9677.
+    var choiceSelectOptions = { dropdownParent: 'body', maxOptions: null };
+
     // Initialise TomSelect for the active tab immediately
     $('.tab-pane.active .choiceSelectBox').each(function () {
-      if (!this.tomselect) new TomSelect(this, { dropdownParent: 'body' });
+      if (!this.tomselect) new TomSelect(this, choiceSelectOptions);
     });
 
     // Initialise TomSelect when switching tabs
     $('a[data-bs-toggle="pill"]').on('shown.bs.tab', function(e) {
       var target = $(e.target).attr('href');
       $(target + ' .choiceSelectBox').each(function () {
-        if (!this.tomselect) new TomSelect(this, { dropdownParent: 'body' });
+        if (!this.tomselect) new TomSelect(this, choiceSelectOptions);
       });
     });
 

--- a/src/skin/js/DropdownManager.js
+++ b/src/skin/js/DropdownManager.js
@@ -3,6 +3,14 @@
  * Used across PersonEditor, CartToFamilyForm, CSVImport, FamilyEditor, and FamilyRegister
  */
 
+/**
+ * TomSelect renders at most `maxOptions` entries (default 50), so the 256-country
+ * list stopped at China and the 59-entry US state list stopped at Tennessee.
+ * These are fixed enumerations the user picks from by scrolling, not searchable
+ * datasets, so every option has to be rendered. See issue #9677.
+ */
+const FULL_LIST_TOM_SELECT_OPTIONS = { maxOptions: null };
+
 class DropdownManager {
   /**
    * Initialize a country dropdown with API data
@@ -54,7 +62,7 @@ class DropdownManager {
       if (config.initTomSelect) {
         const el = countrySelect[0];
         if (el && !el.tomselect) {
-          new TomSelect(el);
+          new TomSelect(el, FULL_LIST_TOM_SELECT_OPTIONS);
         }
       }
     });
@@ -138,7 +146,7 @@ class DropdownManager {
           if (config.initTomSelect) {
             const stateEl = stateSelect[0];
             if (stateEl && !stateEl.tomselect) {
-              new TomSelect(stateEl);
+              new TomSelect(stateEl, FULL_LIST_TOM_SELECT_OPTIONS);
             }
           }
 
@@ -237,7 +245,7 @@ class DropdownManager {
       countrySelect.change();
       const el = countrySelect[0];
       if (el && !el.tomselect) {
-        new TomSelect(el);
+        new TomSelect(el, FULL_LIST_TOM_SELECT_OPTIONS);
       }
     });
 
@@ -264,7 +272,7 @@ class DropdownManager {
           });
 
           stateContainer.html($select);
-          new TomSelect($select[0]);
+          new TomSelect($select[0], FULL_LIST_TOM_SELECT_OPTIONS);
         } else {
           // Country has no states - show text input
           const $input = $(

--- a/webpack/church-info.js
+++ b/webpack/church-info.js
@@ -86,6 +86,10 @@ document.addEventListener("DOMContentLoaded", () => {
     }
     new TomSelect(el, {
       allowEmptyOption: true,
+      // TomSelect renders at most `maxOptions` entries (default 50), which cut the
+      // country list off at China and the timezone list off inside America/*.
+      // These are fixed enumerations, so render all of them. See issue #9677.
+      maxOptions: null,
       placeholder: window.i18next ? i18next.t("Search or select...") : "Search or select...",
     });
   }


### PR DESCRIPTION
## Summary

Lift TomSelect's default 50-option cap on the fixed-enumeration dropdowns, so the country, state/province and System Settings choice lists render in full. Adds a regression spec that asserts the rendered option count against the API's own totals.

## Changes

- Set `maxOptions: null` on the country and state selects in `DropdownManager.js` (4 call sites — Family Editor, Person Editor, Cart-to-Family, Family Register), via a named `FULL_LIST_TOM_SELECT_OPTIONS` constant so the intent is documented once
- Set `maxOptions: null` in the shared `initTomSelect()` helper on the Church Info page (church + default country/state, language, timezone)
- Set `maxOptions: null` on the `.choiceSelectBox` initializer in `SystemSettings.php`, hoisted into a `choiceSelectOptions` variable shared by the initial-tab and tab-switch initializers
- New Cypress regression spec covering the country and state dropdowns

## Why

Fixes #9677. TomSelect v2 defaults to [`maxOptions: 50`](https://tom-select.js.org/docs/#max-options) and applies the cap to the rendered result set:

```js
n = results.items.length;
if (typeof self.settings.maxOptions === 'number') {
  n = Math.min(n, self.settings.maxOptions);
}
```

No call site passed `maxOptions`, so long lists were truncated with no scrollbar and no "more results" hint:

| Dropdown | Options | Stopped at | Unreachable |
|---|---|---|---|
| Country | 256 | China | everything after — including **United States** |
| State (US) | 59 | Tennessee | **Texas → Wyoming** |
| Time Zone | 419 | inside `America/*` | ~370 zones |

A US church could not select its own country, or nine of its own states, by scrolling. `TomSelect.defaults` is module-private in v2, so the cap has to be lifted per call site.

Scoped deliberately to fixed enumerations the user picks from by scrolling. The type-to-search person/family/group pickers keep the default, where a 50-result cap is reasonable — noted in the issue as worth a separate look.

## Files Changed

- `src/skin/js/DropdownManager.js` — 12 insertions, 4 deletions
- `src/SystemSettings.php` — 7 insertions, 2 deletions
- `webpack/church-info.js` — 4 insertions
- `cypress/e2e/ui/family/family.country-dropdown-maxoptions.spec.js` — new, 94 lines

## Testing

- ✅ New regression spec passes (2/2), and **fails without the fix** — both dropdowns render exactly 50, against expected 256 and 59
- ✅ `groups/standard.tomselect-dropdownparent.spec.js`, `guest/guest.family.reg.spec.js`, `people/standard.person.new.spec.js` — 9/9
- ✅ `admin.church-info.spec.js`, `admin.localization.spec.js` — 48/48
- ✅ `npm run build:php`, `npm run lint` (no new warnings), `npm run build`
- ✅ PHP log clean after each run

```bash
npx cypress run --config-file cypress/configs/docker.config.ts \
  --spec "cypress/e2e/ui/family/family.country-dropdown-maxoptions.spec.js"
```

The assertions derive their expected counts from `/api/public/data/countries` and `/api/public/data/countries/us/states` rather than hardcoding 256/59, so they won't go stale if the country data changes.

## Related Issues

Fixes #9677

🤖 Generated with [Claude Code](https://claude.com/claude-code)
