### PR TITLE
Fix #9677: extend TomSelect maxOptions fix to the Localization page

### DIFF
--- a/cypress/e2e/ui-admin/admin.localization.spec.js
+++ b/cypress/e2e/ui-admin/admin.localization.spec.js
@@ -69,6 +69,31 @@ describe("Admin - Localization & Formats Page", () => {
         cy.get("#sTimeZone", { timeout: 5000 }).siblings(".ts-wrapper").should("exist");
     });
 
+    // Regression for #9677: TomSelect's default maxOptions:50 truncated the
+    // ~419-entry timezone list at "America/*". Assert the rendered option count
+    // matches the <select>'s own option count — a rendered count of exactly 50
+    // is the signature of the cap still being in place.
+    it("should render every timezone option, not just the first 50 (#9677)", () => {
+        cy.visit("/admin/system/localization");
+
+        cy.get("#sTimeZone", { timeout: 8000 }).siblings(".ts-wrapper").should("exist");
+
+        cy.get("#sTimeZone option").then(($opts) => {
+            const expected = $opts.length;
+            expect(expected, "timezone list is long enough to trip the 50-option cap").to.be.greaterThan(50);
+
+            cy.get("#sTimeZone").siblings(".ts-wrapper").find(".ts-control").click();
+            cy.get("#sTimeZone").siblings(".ts-wrapper").find(".ts-dropdown .option", { timeout: 5000 })
+                .should("have.length", expected);
+
+            // The specific casualty of the cap: Pacific/* sorts last and was unreachable.
+            cy.get("#sTimeZone").siblings(".ts-wrapper").find(".ts-dropdown")
+                .should("contain.text", "Pacific/");
+        });
+
+        cy.get("body").type("{esc}");
+    });
+
     it("should populate language dropdown grouped by region with native names", () => {
         cy.visit("/admin/system/localization");
 

--- a/cypress/e2e/ui/family/family.country-dropdown-maxoptions.spec.js
+++ b/cypress/e2e/ui/family/family.country-dropdown-maxoptions.spec.js
@@ -70,11 +70,15 @@ describe("Country/State TomSelect renders the full list (#9677)", () => {
             $sel[0].tomselect.setValue("US");
         });
 
-        cy.get("select#State", { timeout: 10000 }).should("have.class", "tomselected");
-
         cy.request("/api/public/data/countries/us/states").then((resp) => {
             const expected = Object.keys(resp.body).length;
             expect(expected, "US state list is long enough to trip the 50-option cap").to.be.greaterThan(50);
+
+            // Wait for the states cascade to fully settle before touching the widget:
+            // setValue() can fire the change event more than once, so assert on the
+            // rebuilt <select> reaching its final option count rather than racing it.
+            cy.get("select#State option", { timeout: 10000 }).should("have.length", expected);
+            cy.get("select#State").should("have.class", "tomselected");
 
             cy.get("select#State").next(".ts-wrapper").find(".ts-control").click();
 

--- a/cypress/e2e/ui/family/family.country-dropdown-maxoptions.spec.js
+++ b/cypress/e2e/ui/family/family.country-dropdown-maxoptions.spec.js
@@ -19,7 +19,6 @@
 describe("Country/State TomSelect renders the full list (#9677)", () => {
     beforeEach(() => {
         cy.setupStandardSession();
-        cy.on("uncaught:exception", () => false);
     });
 
     it("Family Editor country dropdown renders all countries, not just the first 50", () => {

--- a/src/skin/js/DropdownManager.js
+++ b/src/skin/js/DropdownManager.js
@@ -9,7 +9,7 @@
  * These are fixed enumerations the user picks from by scrolling, not searchable
  * datasets, so every option has to be rendered. See issue #9677.
  */
-const FULL_LIST_TOM_SELECT_OPTIONS = { maxOptions: null };
+const FULL_LIST_TOM_SELECT_OPTIONS = Object.freeze({ maxOptions: null });
 
 class DropdownManager {
   /**

--- a/webpack/localization.js
+++ b/webpack/localization.js
@@ -199,7 +199,10 @@ document.addEventListener("DOMContentLoaded", () => {
     window.CRM.populateLocaleDropdown(langSelect, selected)
       .then(() => {
         if (window.TomSelect && !langSelect.tomselect) {
-          new window.TomSelect(langSelect, { allowEmptyOption: false, dropdownParent: "body" });
+          // maxOptions defaults to 50; the locale list (49 today) sits right at
+          // that boundary and would truncate the moment another locale is added.
+          // See issue #9677.
+          new window.TomSelect(langSelect, { allowEmptyOption: false, dropdownParent: "body", maxOptions: null });
         }
         // Locale dropdown is now populated — render the preview for the selection.
         if (renderLocalePreview) {
@@ -216,6 +219,9 @@ document.addEventListener("DOMContentLoaded", () => {
         new window.TomSelect(el, {
           allowEmptyOption: true,
           placeholder: "Search or select...",
+          // #sTimeZone carries 419 options; without this the list truncates at 50
+          // (inside America/*), so most of the world is unreachable. See issue #9677.
+          maxOptions: null,
         });
       }
     });


### PR DESCRIPTION
## Summary

Follow-up to #9678 (now merged). Extends its TomSelect `maxOptions` fix to the one place it didn't reach: `webpack/localization.js`, the bundle behind the **Localization admin page** (`/admin/system/localization`) — where admins actually set the church timezone and language.

Rebased on master; contains only the delta over #9678.

## Changes

**`webpack/localization.js`** — `maxOptions: null` added to:
- `#sTimeZone` (`.auto-tomselect`, ~419 options) — was truncated at 50 inside `America/*`, so most of the world's timezones were unreachable by scrolling
- `#sLanguage` (49 locales) — sits exactly at the 50-cap; truncates silently the moment a 51st locale is added

**`cypress/e2e/ui-admin/admin.localization.spec.js`** — new regression test: opens the timezone dropdown, asserts the rendered `.option` count equals the `<select>`'s own option count (a rendered count of exactly 50 is the signature of the cap), and that `Pacific/*` is reachable.

**`cypress/e2e/ui/family/family.country-dropdown-maxoptions.spec.js`** — removed the blanket `cy.on("uncaught:exception", () => false)` added in #9678 (sibling `FamilyEditor.php` specs register no such handler); hardened the US-state test against the states cascade race (`setValue()` can emit `change` more than once) by waiting on the rebuilt `<select>` reaching its final option count before asserting on the widget.

**`src/skin/js/DropdownManager.js`** — `Object.freeze()` on the shared `FULL_LIST_TOM_SELECT_OPTIONS` config (from #9678's automated review).

## Why

#9678's per-call-site approach is correct — TomSelect v2 has no global-defaults hook (`defaults` is a module-private `var`; `TomSelect.define()` is plugins-only), and a blanket lift would regress the many *searchable* pickers where the 50-cap is a deliberate performance feature. But it missed the Localization page, and the timezone picker there is the single most extreme case (419 options).

## Testing

- `npm run lint` — clean
- `npm run build:webpack` — compiled successfully
- Self-registration + Localization page both load the full lists locally
- New Cypress regression covers the Localization-page timezone dropdown

## Related Issues

Fixes #9677 (together with the merged #9678). Companion doc PR: #9679 — its skill text should add `webpack/localization.js` to the fix-site list and correct "Issue #9677 fixed..." (means PR #9678).

Milestone: 7.7.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015tNJNTTky2rGhdiPi6GHFQ
