### PR TITLE
Fix American spellings in code; queue en/en-au/en-ca locale overrides

### DIFF
--- a/cypress/e2e/api/private/standard/private.plainauth.read-default.spec.js
+++ b/cypress/e2e/api/private/standard/private.plainauth.read-default.spec.js
@@ -4,7 +4,7 @@
  * Tests for the explicit read-default security policy (issues #8999, #9000, #9001).
  *
  * Verifies that ALL authenticated users — even those with no edit/admin role flags —
- * can read basic people and family metadata. This formalises the implicit behaviour
+ * can read basic people and family metadata. This formalises the implicit behavior
  * that was present before PR #8964 introduced object-level authorization.
  *
  * Test user: john.plainauth (user ID 900, `plainauth.api.key`)
@@ -17,7 +17,7 @@
  * Side-effect (intentional): Notes=1 users can also POST notes to any family/person
  * because canReadFamily() (and canViewFamily()) now returns true for all authenticated
  * users, and NotesRoleAuthMiddleware checks only the Notes flag. This is correct
- * behaviour — Notes permission has always implied "can write notes"; the read-default
+ * behavior — Notes permission has always implied "can write notes"; the read-default
  * policy simply removes the accidental read-block for non-EditSelf users.
  *
  * The EditSelf-only restriction (family 20 scoping) is separately covered in
@@ -177,7 +177,7 @@ describe("Read-default policy — plain authenticated user can read any family/p
     // POST /api/family/{familyId}/note — intentional side-effect
     // Notes=1 users can write notes to any family because canViewFamily() now
     // returns true for all authenticated users (read-default policy). This is
-    // correct behaviour: the Notes flag has always meant "can write notes";
+    // correct behavior: the Notes flag has always meant "can write notes";
     // the read-default policy only removes the accidental block for users without
     // EditSelf/EditRecords. FamilyMiddleware passes, NotesRoleAuthMiddleware
     // passes (Notes=1), so POST succeeds.

--- a/cypress/e2e/ui-admin/admin.church-info.spec.js
+++ b/cypress/e2e/ui-admin/admin.church-info.spec.js
@@ -387,7 +387,7 @@ describe("Admin - Church Information Page", () => {
             // When all address fields are empty the handler returns early:
             // the geocoder is never called and the button is never disabled.
             // Using toast-visibility assertions for this case is fragile
-            // (Notyf animation timing), so we verify the observable behaviour:
+            // (Notyf animation timing), so we verify the observable behavior:
             // (a) button stays enabled — it is only disabled during a live request;
             // (b) geocoder endpoint was not contacted.
             cy.get("#generate-coordinates-btn").should("not.be.disabled");

--- a/cypress/e2e/ui/family/family.verify.spec.js
+++ b/cypress/e2e/ui/family/family.verify.spec.js
@@ -59,7 +59,7 @@ describe("Family verification — self-verify token link (no account)", () => {
         // Photos must work without a session: the page renders avatars inline
         // (base64 <img> when a photo exists, initials fallback otherwise). There
         // is deliberately no /api/*/photo sub-request here — that would 403 for a
-        // sessionless visitor. Asserting avatars exist guards that behaviour.
+        // sessionless visitor. Asserting avatars exist guards that behavior.
         cy.get(".avatar").should("have.length.greaterThan", 0);
 
         // Privacy invariant: notes are private and must NEVER appear on the

--- a/cypress/e2e/ui/finance/finance.deposits.spec.js
+++ b/cypress/e2e/ui/finance/finance.deposits.spec.js
@@ -103,7 +103,7 @@ describe("Finance Deposits", () => {
 
         // Create the deposit directly via the API to test server-side sanitization.
         // Using cy.request() here is intentional: the test targets the POST /api/deposits
-        // endpoint's sanitization behaviour, not the modal UI itself.  Typing the raw
+        // endpoint's sanitization behavior, not the modal UI itself.  Typing the raw
         // XSS payload (<script>…</script>) through a Bootstrap modal input is fragile
         // because Bootstrap's transition management can interrupt Cypress keystroke
         // delivery, causing only part of the value to be committed.

--- a/cypress/e2e/ui/groups/standard.email.spec.js
+++ b/cypress/e2e/ui/groups/standard.email.spec.js
@@ -5,7 +5,7 @@
  *
  * The old email dropdown (which lazy-loaded via ajax) has been replaced by
  * a single "Email" button that opens the in-app email composer modal via
- * /api/groups/{id}/emails. This spec verifies the new behaviour:
+ * /api/groups/{id}/emails. This spec verifies the new behavior:
  *  - The composer button is present in the group toolbar.
  *  - Clicking it opens the modal and fetches recipients.
  *  - The modal shows a recipient count badge and action buttons.

--- a/cypress/e2e/ui/people/people.dashboard.email.spec.js
+++ b/cypress/e2e/ui/people/people.dashboard.email.spec.js
@@ -5,7 +5,7 @@
  *
  * The old mailto: dropdown links have been replaced by a single
  * "Email All" button that opens the in-app email composer modal.
- * This spec verifies the new behaviour:
+ * This spec verifies the new behavior:
  *  - The composer button is rendered when email is enabled.
  *  - Clicking it opens the modal (waits for the /api/people/emails fetch).
  *  - The modal shows a recipient count and action buttons.

--- a/cypress/support/ui-commands.js
+++ b/cypress/support/ui-commands.js
@@ -14,7 +14,7 @@
  * @param {string} sessionName - Unique identifier for this session (e.g., 'admin-session')
  * @param {string} username - The username to authenticate with
  * @param {string} password - The password to authenticate with
- * @param {{ forceLogin?: boolean }} options - Additional behaviour flags
+ * @param {{ forceLogin?: boolean }} options - Additional behavior flags
  */
 Cypress.Commands.add('setupLoginSession', (sessionName, username, password, options = {}) => {
     const { forceLogin = false, validate } = options;

--- a/locale/terms/missing/en-au/en-au-1.json
+++ b/locale/terms/missing/en-au/en-au-1.json
@@ -1,0 +1,20 @@
+{
+  "Failed to cancel enrollment. Please try again.": "Failed to cancel enrolment. Please try again.",
+  "Failed to load neighbors.": "Failed to load neighbours.",
+  "Find Neighbors": "Find Neighbours",
+  "Search Neighbors": "Search Neighbours",
+  "Max neighbors": "Max neighbours",
+  "Neighborhood": "Neighbourhood",
+  "Select a family and click Find Neighbors to see results.": "Select a family and click Find Neighbours to see results.",
+  "Gravatar (Globally Recognized Avatar) displays profile photos from gravatar.com for members who don't have uploaded photos in ChurchCRM.": "Gravatar (Globally Recognised Avatar) displays profile photos from gravatar.com for members who don't have uploaded photos in ChurchCRM.",
+  "Include Sunday School classes and enrollments": "Include Sunday School classes and enrolments",
+  "Map centered on": "Map centred on",
+  "Require all users to enroll in two-factor authentication": "Require all users to enrol in two-factor authentication",
+  "Two Factor Enrollment Error": "Two Factor Enrolment Error",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Number of days users have to enrol in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behaviour). Shortening an active grace period may lock users out immediately.",
+  "The ChurchCRM maintainers have not reviewed it. You are responsible for the security and behavior of anything you install here. Prefer the Browse Approved flow whenever possible.": "The ChurchCRM maintainers have not reviewed it. You are responsible for the security and behaviour of anything you install here. Prefer the Browse Approved flow whenever possible.",
+  "Two-factor authentication is required. You have %d day to enroll.": {
+    "one": "Two-factor authentication is required. You have %d day to enrol.",
+    "other": "Two-factor authentication is required. You have %d days to enrol."
+  }
+}

--- a/locale/terms/missing/en-ca/en-ca-1.json
+++ b/locale/terms/missing/en-ca/en-ca-1.json
@@ -1,0 +1,21 @@
+{
+  "Failed to cancel enrollment. Please try again.": "Failed to cancel enrolment. Please try again.",
+  "Failed to load neighbors.": "Failed to load neighbours.",
+  "Find Neighbors": "Find Neighbours",
+  "Search Neighbors": "Search Neighbours",
+  "Max neighbors": "Max neighbours",
+  "Neighborhood": "Neighbourhood",
+  "Select a family and click Find Neighbors to see results.": "Select a family and click Find Neighbours to see results.",
+  "Include Sunday School classes and enrollments": "Include Sunday School classes and enrolments",
+  "Map centered on": "Map centred on",
+  "Require all users to enroll in two-factor authentication": "Require all users to enrol in two-factor authentication",
+  "Two Factor Enrollment Error": "Two Factor Enrolment Error",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Number of days users have to enrol in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behaviour). Shortening an active grace period may lock users out immediately.",
+  "The ChurchCRM maintainers have not reviewed it. You are responsible for the security and behavior of anything you install here. Prefer the Browse Approved flow whenever possible.": "The ChurchCRM maintainers have not reviewed it. You are responsible for the security and behaviour of anything you install here. Prefer the Browse Approved flow whenever possible.",
+  "Two-factor authentication is required. You have %d day to enroll.": {
+    "one": "Two-factor authentication is required. You have %d day to enrol.",
+    "other": "Two-factor authentication is required. You have %d days to enrol."
+  },
+  "Catalog": "Catalogue",
+  "Generate Catalog": "Generate Catalogue"
+}

--- a/locale/terms/missing/en/en-1.json
+++ b/locale/terms/missing/en/en-1.json
@@ -1,0 +1,20 @@
+{
+  "Failed to cancel enrollment. Please try again.": "Failed to cancel enrolment. Please try again.",
+  "Failed to load neighbors.": "Failed to load neighbours.",
+  "Find Neighbors": "Find Neighbours",
+  "Search Neighbors": "Search Neighbours",
+  "Max neighbors": "Max neighbours",
+  "Neighborhood": "Neighbourhood",
+  "Select a family and click Find Neighbors to see results.": "Select a family and click Find Neighbours to see results.",
+  "Gravatar (Globally Recognized Avatar) displays profile photos from gravatar.com for members who don't have uploaded photos in ChurchCRM.": "Gravatar (Globally Recognised Avatar) displays profile photos from gravatar.com for members who don't have uploaded photos in ChurchCRM.",
+  "Include Sunday School classes and enrollments": "Include Sunday School classes and enrolments",
+  "Map centered on": "Map centred on",
+  "Require all users to enroll in two-factor authentication": "Require all users to enrol in two-factor authentication",
+  "Two Factor Enrollment Error": "Two Factor Enrolment Error",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Number of days users have to enrol in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behaviour). Shortening an active grace period may lock users out immediately.",
+  "The ChurchCRM maintainers have not reviewed it. You are responsible for the security and behavior of anything you install here. Prefer the Browse Approved flow whenever possible.": "The ChurchCRM maintainers have not reviewed it. You are responsible for the security and behaviour of anything you install here. Prefer the Browse Approved flow whenever possible.",
+  "Two-factor authentication is required. You have %d day to enroll.": {
+    "one": "Two-factor authentication is required. You have %d day to enrol.",
+    "other": "Two-factor authentication is required. You have %d days to enrol."
+  }
+}

--- a/src/ChurchCRM/Utils/DateTimeUtils.php
+++ b/src/ChurchCRM/Utils/DateTimeUtils.php
@@ -338,7 +338,7 @@ class DateTimeUtils
      * the shared source of truth for CSV importers, which must handle both
      * month-day-only values (valid for Person.BirthYear) and full dates
      * (required for SQL DATE custom-field columns) with the same rules. The
-     * previous behaviour called `strtotime()` directly, which silently
+     * previous behavior called `strtotime()` directly, which silently
      * assigned the current year to "7/4" and corrupted user data. It also
      * misread a bare year like "2020" as a time (8:20 PM) and returned
      * today's date.

--- a/src/ChurchCRM/dto/SystemConfig.php
+++ b/src/ChurchCRM/dto/SystemConfig.php
@@ -270,7 +270,7 @@ class   SystemConfig
             'bSearchIncludeCalendarEvents'         => new ConfigItem('bSearchIncludeCalendarEvents', 'boolean', '1', gettext('Search Calendar Events')),
             'bSearchIncludeCalendarEventsMax'      => new ConfigItem('bSearchIncludeCalendarEventsMax', 'text', '15', gettext('Maximum number of Calendar Events')),
             'bRequire2FA'                          => new ConfigItem('bRequire2FA', 'boolean', '0', gettext('Require all users to enroll in two-factor authentication')),
-            'i2FAGracePeriodDays'                   => new ConfigItem('i2FAGracePeriodDays', 'number', '7', gettext('Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behaviour). Shortening an active grace period may lock users out immediately.')),
+            'i2FAGracePeriodDays'                   => new ConfigItem('i2FAGracePeriodDays', 'number', '7', gettext('Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.')),
             's2FAApplicationName'                  => new ConfigItem('s2FAApplicationName', 'text', 'ChurchCRM', gettext('Specify the application name to be displayed in authenticator app')),
             'sTwoFASecretKey'                      => new ConfigItem('sTwoFASecretKey', 'password', '', gettext('Encryption key for storing 2FA secret keys in the database')),
             'bSendUserDeletedEmail'                => new ConfigItem('bSendUserDeletedEmail', 'boolean', '0', gettext('Send an email notifying users when their account has been deleted')),

--- a/src/FamilyCustomFieldsRowOps.php
+++ b/src/FamilyCustomFieldsRowOps.php
@@ -90,7 +90,7 @@ switch ($sAction) {
             ListOptionQuery::create()->filterById((int)$customField->getCustomSpecial())->delete();
         }
 
-        // Drop the column from the family_custom table first (DDL-first order matches original behaviour).
+        // Drop the column from the family_custom table first (DDL-first order matches original behavior).
         // If the ORM delete ran first and ALTER TABLE failed, the master record would be gone
         // while the physical column with user data remained — an unrecoverable orphan.
         // $sField is regex-validated (^c\d+$) above; DDL identifiers cannot be parameterised.

--- a/src/PersonCustomFieldsRowOps.php
+++ b/src/PersonCustomFieldsRowOps.php
@@ -89,7 +89,7 @@ switch ($sAction) {
             ListOptionQuery::create()->filterById((int)$customField->getSpecial())->delete();
         }
 
-        // Drop the column from the person_custom table first (DDL-first order matches original behaviour).
+        // Drop the column from the person_custom table first (DDL-first order matches original behavior).
         // If the ORM delete ran first and ALTER TABLE failed, the master record would be gone
         // while the physical column with user data remained — an unrecoverable orphan.
         // $sField is regex-validated (^c\d+$) above; DDL identifiers cannot be parameterised.

--- a/src/event/routes/list-events.php
+++ b/src/event/routes/list-events.php
@@ -29,7 +29,7 @@ $app->get('/dashboard', function (Request $request, Response $response) {
         ? (int) $params['year']
         : (int) DateTimeUtils::getCurrentYear();
 
-    // Month filter — null means "all months" (full-year view, default behaviour).
+    // Month filter — null means "all months" (full-year view, default behavior).
     // Clamp to 1-12; ignore out-of-range values.
     $EventMonth = null;
     if (!empty($params['month']) && $params['month'] !== 'All') {

--- a/src/kiosk/routes/device.php
+++ b/src/kiosk/routes/device.php
@@ -81,7 +81,7 @@ function getAdultFamilyMembers(Person $person): array
         } else {
             // No complete birth date: fall back to role-based adult check
             // (Head/Spouse roles — same criterion as Family::getAdults()).
-            // Preserves existing behaviour for members with no recorded DOB.
+            // Preserves existing behavior for members with no recorded DOB.
             if (!in_array((int) $member->getId(), $roleBasedAdultIds, true)) {
                 continue;
             }

--- a/src/plugins/core/holidays/src/HolidayCalendarProvider.php
+++ b/src/plugins/core/holidays/src/HolidayCalendarProvider.php
@@ -13,7 +13,7 @@ use Yasumi\Yasumi;
  * One holiday calendar (for a specific Yasumi country), instantiated by the
  * Holidays plugin. Replaces the old hard-wired ChurchCRM\SystemCalendars\HolidayCalendar.
  *
- * Behaviour vs. the legacy implementation:
+ * Behavior vs. the legacy implementation:
  *  - Country is constructor-injected instead of read from sChurchCountry directly.
  *  - Honours the FullCalendar $start/$end range (the legacy version was hard-coded
  *    to the current year, so navigating to other years showed no holidays).

--- a/src/plugins/core/vonage/src/VonagePlugin.php
+++ b/src/plugins/core/vonage/src/VonagePlugin.php
@@ -128,7 +128,7 @@ class VonagePlugin extends AbstractPlugin
         $apiSecret  = $settings['apiSecret']  ?? '';
         $fromNumber = $settings['fromNumber'] ?? '';
 
-        // Fall back to the saved secret when the form omits it (password field behaviour)
+        // Fall back to the saved secret when the form omits it (password field behavior)
         if (empty($apiSecret)) {
             $apiSecret = $this->apiSecret ?? '';
         }

--- a/src/plugins/views/management.php
+++ b/src/plugins/views/management.php
@@ -491,7 +491,7 @@ function renderPluginCard(array $plugin, string $rootPath, string $nonce): void 
             <div class="modal-body">
                 <div class="alert alert-warning" role="alert">
                     <strong><?= gettext('This plugin will be installed as UNVERIFIED.') ?></strong><br>
-                    <?= gettext('The ChurchCRM maintainers have not reviewed it. You are responsible for the security and behaviour of anything you install here. Prefer the Browse Approved flow whenever possible.') ?>
+                    <?= gettext('The ChurchCRM maintainers have not reviewed it. You are responsible for the security and behavior of anything you install here. Prefer the Browse Approved flow whenever possible.') ?>
                 </div>
                 <form id="installFromUrlForm">
                     <div class="mb-3">

--- a/src/skin/scss/_quill.scss
+++ b/src/skin/scss/_quill.scss
@@ -4,7 +4,7 @@
  * Targets the default `snow` theme bundled via webpack/skin-core-css.js.
  * Replaces Quill's hardcoded #ccc borders with Tabler's --tblr-border-color,
  * unifies the focus ring with other form controls, standardises container
- * sizing, and adds RTL + print behaviour.
+ * sizing, and adds RTL + print behavior.
  */
 
 .quill-editor-container {

--- a/webpack/event-calendars.js
+++ b/webpack/event-calendars.js
@@ -598,7 +598,7 @@ function initializeCalendar() {
   });
 
   // FullCalendar v7 removed the windowResize option. Replicate the debounced
-  // resize behaviour with a native event listener. Clean up the old handler
+  // resize behavior with a native event listener. Clean up the old handler
   // when initializeCalendar() is called again (e.g. after locale reload).
   if (window.CRM._calendarResizeHandler) {
     window.removeEventListener("resize", window.CRM._calendarResizeHandler);


### PR DESCRIPTION
## Summary

Follow-up from the #9682 locale-string review.

1. Make source strings use consistent **US** spelling — replace `behaviour` → `behavior` everywhere in code.
2. Queue the **British / Australian / Canadian** spelling overrides through the POEditor missing-terms pipeline (not by hand-editing the generated files).

## Changes

**Code spelling (`behaviour` → `behavior`)** — 18 files
- 16 comments / docblocks (PHP, Cypress specs, webpack JS, SCSS)
- 2 user-facing `gettext()` strings: `SystemConfig.php` (2FA grace-period help), `plugins/views/management.php` (unverified-plugin warning)

**Locale variant overrides** — `locale/terms/missing/{en,en-au,en-ca}/*.json`
- Batch files for `poeditor-upload-missing.js` to push to the POEditor `en` / `en-au` / `en-ca` languages
- Covers US spellings in current UI strings: `behavior→behaviour`, `neighbor→neighbour` (×6), `enrollment/enroll→enrolment/enrol` (incl. the ngettext plural), `centered→centred`, `Recognized→Recognised`, `catalog→catalogue`
- `en` (GB) / `en-au`: 15 terms each
- `en-ca`: 16 terms — `-our`/`-re`/`neighbour`/`catalogue` subset; deliberately keeps `-ize` and `Recognized` per Canadian English

## Why

- `src/locale/i18n/*.json` and `src/locale/textdomain/*` are **regenerated by the POEditor download job** — hand edits there get overwritten on the next sync. Variant spellings belong in `locale/terms/missing/` → upload → POEditor → auto-download, same as every other translation.
- Consistent US spelling in source keeps one canonical string per concept.

## Testing

- `npm run lint` — pass (pre-existing SCSS warnings only)
- pre-commit PHP syntax + YAML validation — pass
- Batch JSON validated against `poeditor-upload-missing.js` rules (no empty values, none identical to source key)

## Next step (maintainer, has POEDITOR_TOKEN)

`npm run locale:upload:missing -- --locale en,en-au,en-ca` then let the download job open the sync PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsdtLJwMvp5KRiL1qijCwL