### PR TITLE
docs: never hand-edit generated en-GB/AU/CA locale files

### DIFF
--- a/.agents/skills/churchcrm/i18n-localization.md
+++ b/.agents/skills/churchcrm/i18n-localization.md
@@ -396,6 +396,44 @@ grep -rn "gettext('State')\|gettext('State / Province')" src webpack
 ```
 Not every `"X / Y"` label is a duplicate — some legitimately combine two distinct data concepts into one compound column header or checkbox (e.g. `"Class / Group"` in `kiosk/views/manager.php` covers rows that are either a class or a group; `"Role / Gender"` in `people/views/dashboard.php` covers two separate stat columns; `"Age / Years Married"` in `CSVExport.php` is a CSV column that means Age for a person row and Years Married for a couple row). Only merge when both sides genuinely label the *same single field*.
 
+### Regional English Spelling Overrides (en-GB / en-AU / en-CA) — Never Hand-Edit the Generated Files <!-- learned: 2026-09-10 -->
+
+Source strings use **US** spelling (`behavior`, `color`, `neighbor`, `enroll`, `catalog`, `centered`, `-ize`). British/Australian/Canadian spellings are delivered as *translations* of the `en` POEditor language and its `en-au` / `en-ca` variants.
+
+The files the app actually reads —
+
+```
+src/locale/i18n/en_GB.json          src/locale/textdomain/en_GB/LC_MESSAGES/messages.{po,mo}
+src/locale/i18n/en_AU.json           src/locale/textdomain/en_AU/LC_MESSAGES/messages.{po,mo}
+src/locale/i18n/en_CA.json           src/locale/textdomain/en_CA/LC_MESSAGES/messages.{po,mo}
+```
+
+— are **regenerated wholesale by `poeditor-downloader.js`** on every POEditor sync (commits titled `locale: update translations from POEditor`). Hand edits there are silently overwritten on the next sync. `msgfmt`-ing the `.mo` by hand is likewise pointless.
+
+**Correct workflow** — same async pipeline as every other translation:
+
+1. Fix the source string to US spelling (one canonical string per concept).
+2. Add the regional spelling to the missing-terms batch files, keyed by the **exact** US source string:
+   ```
+   locale/terms/missing/en/en-1.json        # poEditor code "en"  = English - Great Britain
+   locale/terms/missing/en-au/en-au-1.json   # poEditor code "en-au"
+   locale/terms/missing/en-ca/en-ca-1.json   # poEditor code "en-ca"
+   ```
+   (poEditor codes come from `src/locale/locales.json`; these three English variants are `skip_audit: true`, so the downloader never auto-creates the folders — create them by hand.)
+   ```jsonc
+   {
+     "Map centered on": "Map centred on",
+     "Two Factor Enrollment Error": "Two Factor Enrolment Error",
+     "Two-factor authentication is required. You have %d day to enroll.": {
+       "one":   "Two-factor authentication is required. You have %d day to enrol.",
+       "other": "Two-factor authentication is required. You have %d days to enrol."
+     }
+   }
+   ```
+3. A maintainer with `POEDITOR_TOKEN` runs `npm run locale:upload:missing -- --locale en,en-au,en-ca`; the download job then opens the sync PR that updates the generated files.
+
+**Canadian English is not British** — `en-ca` keeps `-ize` endings and `Recognized`/`organized`/`synchronized`, but takes `-our` (`colour`, `behaviour`, `neighbour`, `honour`), `-re` (`centre`, `centred`), `cheque`, `catalogue`, and `enrolment`. Only include the terms that actually differ for that variant.
+
 ### Pattern: Status Messages
 
 ```php

--- a/.agents/skills/churchcrm/locale-translation-workflow.md
+++ b/.agents/skills/churchcrm/locale-translation-workflow.md
@@ -525,3 +525,25 @@ for locale, terms in sorted(d.items()):
     print(f'  {locale}: {len(terms)} terms — {terms[:3]}...' if len(terms) > 3 else f'  {locale}: {terms}')
 "
 ```
+
+---
+
+## Regional English Spelling Overrides (en-GB / en-AU / en-CA) <!-- learned: 2026-09-10 -->
+
+Source strings stay **US-spelled**. British/Australian/Canadian spellings (`behaviour`, `colour`, `neighbour`, `enrolment`, `centre`, `catalogue`, …) are ordinary translations of the `en` / `en-au` / `en-ca` POEditor languages.
+
+**Never hand-edit** `src/locale/i18n/en_{GB,AU,CA}.json` or `src/locale/textdomain/en_{GB,AU,CA}/LC_MESSAGES/messages.{po,mo}` — `poeditor-downloader.js` overwrites them on every sync.
+
+Put the overrides in the missing-terms batches instead, then upload:
+
+```
+locale/terms/missing/en/en-1.json          # "en"    = English - Great Britain
+locale/terms/missing/en-au/en-au-1.json     # "en-au"
+locale/terms/missing/en-ca/en-ca-1.json     # "en-ca"
+```
+
+Keyed by the exact US source string; plurals as `{ "one": "...", "other": "..." }`. These three variants are `skip_audit: true` in `src/locale/locales.json`, so the folders aren't auto-created — make them by hand. Then `npm run locale:upload:missing -- --locale en,en-au,en-ca` and let the download job open the sync PR.
+
+`en-ca` ≠ British: keeps `-ize` / `Recognized`, takes `-our` / `-re` / `cheque` / `catalogue` / `enrolment`.
+
+Full detail: [[i18n-localization]] → "Regional English Spelling Overrides".


### PR DESCRIPTION
## Summary

Adds a skill rule (raised while doing #9684): regional English spelling overrides go through the POEditor missing-terms pipeline, not by editing the generated files.

## Changes

- `i18n-localization.md` — new section "Regional English Spelling Overrides (en-GB / en-AU / en-CA)": which files are generated, the `locale/terms/missing/{en,en-au,en-ca}/` workflow, plural syntax, and that Canadian English keeps `-ize`.
- `locale-translation-workflow.md` — short companion section + cross-link.

## Why

`src/locale/i18n/en_*.json` and `src/locale/textdomain/en_*/` are regenerated wholesale by `poeditor-downloader.js` on every sync — hand edits are silently lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsdtLJwMvp5KRiL1qijCwL