### PR TITLE
docs: no new keys on the System Settings page — use dashboard panels

### DIFF
--- a/.agents/skills/churchcrm/configuration-management.md
+++ b/.agents/skills/churchcrm/configuration-management.md
@@ -21,6 +21,43 @@ ChurchCRM uses a centralized `SystemConfig` class for:
 
 ---
 
+## HARD RULE — no new keys on the System Settings page <!-- learned: 2026-09-10 -->
+
+**Do not add a new key to `SystemConfig::buildCategories()`.** The big
+`/SystemSettings.php` list is frozen — it is already an overwhelming wall of
+toggles, and every addition makes it worse. New admin-editable settings go on
+the **dashboard `settingsPanel`** for the area they belong to, next to the
+data they affect:
+
+| Area | Dashboard | Settings container |
+|------|-----------|--------------------|
+| People / directory / self-registration | `/people/dashboard` | `#peopleSettings` |
+| Groups | `/groups/dashboard` | `#groupsSettings` |
+| Finance | `/finance/dashboard` | (add a panel if none) |
+| System-wide only (SSL, session timeout, updates) | `/admin` | still the System Settings page |
+
+**How to add a dashboard setting:**
+
+1. Define the `ConfigItem` in `SystemConfig::getConfigItems()` as usual — this
+   is what makes the value persist. **Do NOT** list its key in
+   `buildCategories()`.
+2. Add an entry to that dashboard view's `window.CRM.settingsPanel.init({ settings: [...] })`
+   array (`{ name, type: 'boolean'|'text'|'number'|'choice', label, tooltip }`).
+   The panel saves through `POST /admin/api/system/config/{key}` automatically.
+3. `label`/`tooltip` live in the JS config (wrapped in `gettext()` via
+   `InputUtils::jsonEncodeForScript()`), not in the `ConfigItem`.
+
+`bEnableSelfRegistration` and `bHideDeceasedFromDirectory` are the reference
+examples — both are `ConfigItem`s absent from `buildCategories()`, surfaced on
+`#peopleSettings`.
+
+**Moving an existing key off the System Settings page:** delete it from its
+`buildCategories()` array and add it to the relevant dashboard panel. The
+`ConfigItem` and every `getBooleanValue()` / `getValue()` call site stay
+untouched.
+
+---
+
 ## SystemConfig Basics
 
 ### Location


### PR DESCRIPTION
## Summary

Adds one hard rule to `configuration-management.md`: the `/SystemSettings.php` list is frozen. New admin-editable settings go on the relevant dashboard `settingsPanel` — the `ConfigItem` is still defined in `SystemConfig`, but its key is **omitted from `buildCategories()`** so it never renders on the big System Settings page.

## Why

The System Settings list is already an overwhelming wall of toggles, and every addition makes it worse. Dashboard panels (`#peopleSettings` on `/people/dashboard`, `#groupsSettings` on `/groups/dashboard`, etc.) put each setting next to the data it affects, where an admin actually looks for it.

## Changes

- New "HARD RULE — no new keys on the System Settings page" section in `.agents/skills/churchcrm/configuration-management.md`, containing:
  - area → dashboard → settings-container table
  - the add-a-dashboard-setting recipe (define `ConfigItem`, skip `buildCategories()`, add a `settingsPanel` entry)
  - the move-an-existing-key recipe
  - `bEnableSelfRegistration` and `bHideDeceasedFromDirectory` cited as the reference examples

## Files Changed

- `.agents/skills/churchcrm/configuration-management.md` — +37 lines

## Testing

Docs only — no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsdtLJwMvp5KRiL1qijCwL