### PR TITLE
Fix issue #9694: Populate the label font selector

### DIFF
--- a/cypress/e2e/ui/reports/labels-font-select.spec.js
+++ b/cypress/e2e/ui/reports/labels-font-select.spec.js
@@ -1,0 +1,71 @@
+/// <reference types="cypress" />
+
+/**
+ * Regression tests for the empty label font selector — issue #9694.
+ *
+ * FontSelect() built its list by scanning FPDF's font directory for *.php
+ * files. setasign/fpdf 1.9.0 ships its 14 core font metrics as *.json, so the
+ * filter matched nothing and <select name="labelfont"> rendered with zero
+ * options. An empty select submits nothing, the report received an empty font
+ * name, and FPDF::SetFont('','') silently no-opped — the failure only surfaced
+ * at the first FPDF::MultiCell() as:
+ *
+ *   FPDF error: No font has been set
+ *      #1 ChurchCRM/Reports/PdfLabel.php(172): FPDF->MultiCell()
+ *      #2 Reports/ConfirmLabels.php(51): PdfLabel->addPdfLabel()
+ *
+ * The option COUNT is the assertion that matters — zero is the signature of
+ * the bug. The named-option assertion additionally pins the sort order: the
+ * family-detection loop needs SCANDIR_SORT_ASCENDING, and with the previous
+ * descending order it emits "Helveticab" rather than "Helvetica Bold".
+ */
+describe("Label font selector is populated (#9694)", () => {
+    function freshAdminLogin() {
+        cy.clearCookies();
+        cy.visit("/session/begin");
+        cy.get("input[name=User]").type(Cypress.env("admin.username"));
+        cy.get("input[name=Password]").type(Cypress.env("admin.password") + "{enter}");
+        cy.url().should("not.include", "/session/begin");
+    }
+
+    beforeEach(() => {
+        freshAdminLogin();
+        cy.visit("/LettersAndLabels.php");
+    });
+
+    it("offers the FPDF core fonts rather than an empty dropdown", () => {
+        cy.get("select[name=labelfont]").should("exist");
+
+        // Zero options is the bug. FPDF ships 14 core font metric files.
+        cy.get("select[name=labelfont] option").should("have.length.greaterThan", 0);
+
+        // Style variants must be labelled, not raw filenames — this fails if the
+        // scandir order regresses to descending.
+        cy.get("select[name=labelfont]").should("contain.text", "Helvetica");
+        cy.get("select[name=labelfont] option")
+            .then(($opts) => [...$opts].map((o) => o.textContent.trim()))
+            .should((names) => {
+                expect(names, "no raw filenames leaked as labels").to.not.include("Helveticab");
+                expect(names).to.include("Helvetica Bold");
+            });
+    });
+
+    it("generates confirm data labels as a PDF instead of a 500", () => {
+        cy.intercept("GET", "**/Reports/ConfirmLabels.php*").as("confirmLabels");
+
+        cy.get("input[name=SubmitConfirmLabels]").click();
+
+        cy.wait("@confirmLabels", { timeout: 20000 }).then((interception) => {
+            expect(interception.response.statusCode, "no 500").to.equal(200);
+
+            const contentType = interception.response.headers["content-type"] || "";
+            expect(contentType).to.include("application/pdf");
+
+            const body = interception.response.body;
+            if (typeof body === "string") {
+                expect(body).to.not.include("No font has been set");
+                expect(body).to.not.include("Fatal error");
+            }
+        });
+    });
+});

--- a/src/Include/LabelFunctions.php
+++ b/src/Include/LabelFunctions.php
@@ -6,24 +6,41 @@ use ChurchCRM\Utils\MiscUtils;
 
 function FontSelect($fieldname): void
 {
-    $sFPDF_PATH = 'vendor/setasign/fpdf';
+    // Absolute path: the previous relative 'vendor/setasign/fpdf' only resolved
+    // when the CWD happened to be the web root, and scandir() failing left the
+    // font list silently empty.
+    $sFPDF_PATH = __DIR__ . '/../vendor/setasign/fpdf';
 
-    $d = scandir($sFPDF_PATH . '/font/', SCANDIR_SORT_DESCENDING);
-    $fontnames = [];
-    $family = ' ';
-    foreach ($d as $entry) {
-        $len = strlen($entry);
-        if ($len > 3) {
-            if (strtoupper(mb_substr($entry, $len - 3)) === 'PHP') { // php files only
-                $filename = mb_substr($entry, 0, $len - 4);
-                if (mb_substr($filename, 0, strlen($family)) != $family) {
-                    $family = $filename;
-                }
-                $fontnames[] = MiscUtils::filenameToFontname($filename, $family);
-            }
+    // FPDF shipped core font metrics as .php up to 1.8.x and as .json from
+    // 1.9.0. Accept both so the list is not empty on either version, and use
+    // pathinfo() rather than a hardcoded length to strip the extension (the
+    // old code hardcoded $len - 4, which is wrong for ".json").
+    $basenames = [];
+    foreach (scandir($sFPDF_PATH . '/font/') ?: [] as $entry) {
+        if (preg_match('/\.(php|json)$/i', $entry)) {
+            $basenames[] = pathinfo($entry, PATHINFO_FILENAME);
         }
     }
 
+    // Sort explicitly rather than trusting scandir's ordering. The $family
+    // tracking below only works if a family's base name ("helvetica") is seen
+    // before its variants ("helveticab"), and scandir's sort argument is not
+    // dependable across filesystems -- on a Docker bind mount it was observed
+    // returning "courierbi, courierb, courieri, courier" even with
+    // SCANDIR_SORT_ASCENDING, which yields "Helveticab" instead of
+    // "Helvetica Bold".
+    sort($basenames, SORT_STRING);
+
+    $fontnames = [];
+    $family = ' ';
+    foreach ($basenames as $filename) {
+        if (mb_substr($filename, 0, strlen($family)) != $family) {
+            $family = $filename;
+        }
+        $fontnames[] = MiscUtils::filenameToFontname($filename, $family);
+    }
+
+    $fontnames = array_values(array_unique($fontnames));
     sort($fontnames);
 
     echo '<tr>';


### PR DESCRIPTION
## Summary

Repairs the label font selector, which rendered with zero options and caused label generation to fail with `FPDF error: No font has been set`. Adds a regression spec covering both the dropdown and PDF generation.

## Changes

- Accept `.json` as well as `.php` when scanning FPDF's font directory, and strip the extension with `pathinfo()` instead of a hardcoded `$len - 4`
- Resolve the font directory absolutely (`__DIR__`-relative) rather than depending on the working directory
- Collect basenames and `sort()` them explicitly rather than relying on `scandir()`'s ordering
- New Cypress spec: `cypress/e2e/ui/reports/labels-font-select.spec.js`

## Why

Fixes #9694.

`FontSelect()` filtered FPDF's font directory for `*.php`. The bundled `setasign/fpdf` **1.9.0** ships its 14 core font metrics as `*.json`, so nothing matched and `<select name="labelfont">` was emitted with no options. The Font *Size* dropdown still worked (hardcoded list), which made the empty font list read as a layout quirk rather than a failure.

An empty `<select>` submits nothing, so the report received `''`. `FPDF::SetFont('', '')` does **not** throw — it falls back to `$this->FontFamily`, also empty — so the failure surfaced later at the first render:

```
PHP Fatal error:  Uncaught Exception: FPDF error: No font has been set
  #1 ChurchCRM/Reports/PdfLabel.php(172): FPDF->MultiCell()
  #2 Reports/ConfirmLabels.php(51): ChurchCRM\Reports\PdfLabel->addPdfLabel()
```

Newsletter Labels fails identically wherever a family has `fam_SendNewsLetter = 'TRUE'`; on installs where none do, `addPdfLabel()` is never reached and the user gets an empty PDF instead of a 500.

Two further defects in the same function are fixed here because each independently reproduces the empty list:

- **CWD-relative path.** `'vendor/setasign/fpdf'` resolved only when the working directory was the web root; elsewhere `scandir()` failed and the list was silently empty.
- **Unreliable ordering.** The `$family` tracking assumes a family's base name arrives before its variants. Fixing only the extension yields `Courierb`, `Helveticab`, `Timesi`. Switching to `SCANDIR_SORT_ASCENDING` is **not** sufficient: on a Docker bind mount `scandir()` returned entries unsorted even when passed that flag (`courierbi, courierb, courieri, courier`), while CLI on the same container sorted correctly. Sorting explicitly removes the dependency.

## Files Changed

- `src/Include/LabelFunctions.php` — 25 insertions, 12 deletions
- `cypress/e2e/ui/reports/labels-font-select.spec.js` — new

## Testing

- ✅ New spec passes (2/2) and **both tests fail on master** — the dropdown assertion times out with no `option` elements, and the PDF assertion produces `FPDF error: No font has been set` in the PHP log
- ✅ `confirm-reports.spec.js` 21/21, `standard.reports.spec.js` 2/2, `pdf-report-iconv-issue.spec.js` 3/3
- ✅ Verified in the browser, not only via CLI — the ordering defect reproduces only in the web request
- ✅ All 14 resulting names round-trip through `MiscUtils::fontFromName()` to a valid `[family, style]` pair and render through `FPDF::MultiCell()`
- ✅ PHP log clean after each run

```bash
npx cypress run --config-file cypress/configs/docker.config.ts \
  --spec "cypress/e2e/ui/reports/labels-font-select.spec.js"
```

## Related Issues

Fixes #9694. Overlaps #8152 / #8153, which propose migrating these reports to mPDF — that would remove FPDF from these paths entirely, so this may serve as a stopgap. Happy to defer if those are imminent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
