### PR TITLE
Fix issue #9681: Fail malformed login POSTs instead of raising a 500

### DIFF
--- a/cypress/e2e/ui/session/session.malformed-login.spec.js
+++ b/cypress/e2e/ui/session/session.malformed-login.spec.js
@@ -1,0 +1,59 @@
+/// <reference types="cypress" />
+
+/**
+ * Regression tests for the malformed-login 500 — issue #9681.
+ *
+ * src/session/index.php read $loginRequestBody['User'] and ['Password']
+ * unguarded into LocalUsernamePasswordRequest::__construct(string, string).
+ * A body missing either key — or getParsedBody() returning null for a media
+ * type with no registered parser — passed null into a strictly typed
+ * parameter and raised an uncaught TypeError:
+ *
+ *   LocalUsernamePasswordRequest::__construct(): Argument #1 ($username)
+ *   must be of type string, null given
+ *
+ * The throw happens before any credential check, so this was never an
+ * authentication bypass — it was unhandled input producing a 500, which any
+ * bot probing the login form could trigger repeatedly.
+ *
+ * cy.request with failOnStatusCode:false is used rather than the form, since
+ * the point is to send bodies a browser form cannot produce.
+ */
+describe("Malformed POST to /session/begin fails the login instead of 500ing (#9681)", () => {
+    const cases = [
+        { name: "no fields at all", options: {} },
+        { name: "Password present, User missing", options: { form: true, body: { Password: "x" } } },
+        { name: "User present, Password missing", options: { form: true, body: { User: "x" } } },
+        { name: "JSON body with no credential keys", options: { body: {} } },
+    ];
+
+    cases.forEach(({ name, options }) => {
+        it(`returns the login page for: ${name}`, () => {
+            cy.request({
+                method: "POST",
+                url: "/session/begin",
+                failOnStatusCode: false,
+                ...options,
+            }).then((resp) => {
+                // 500 is the bug. Anything non-5xx means the request was handled.
+                expect(resp.status, "must not be a server error").to.be.lessThan(500);
+                if (typeof resp.body === "string") {
+                    expect(resp.body).to.not.include("must be of type string");
+                    expect(resp.body).to.not.include("TypeError");
+                }
+            });
+        });
+    });
+
+    it("still rejects a well-formed login with bad credentials", () => {
+        cy.request({
+            method: "POST",
+            url: "/session/begin",
+            form: true,
+            failOnStatusCode: false,
+            body: { User: "nobody", Password: "wrong" },
+        }).then((resp) => {
+            expect(resp.status).to.be.lessThan(500);
+        });
+    });
+});

--- a/src/session/index.php
+++ b/src/session/index.php
@@ -91,11 +91,16 @@ function beginSession(Request $request, Response $response, array $args): Respon
     ];
 
     if ($request->getMethod() === 'POST') {
-        $loginRequestBody = $request->getParsedBody();
+        // getParsedBody() returns null when the body is absent or its media type
+        // has no registered parser, and a malformed form post can omit either
+        // field. LocalUsernamePasswordRequest is strictly typed, so passing null
+        // raised an uncaught TypeError (HTTP 500) instead of failing the login.
+        // Matches the ?? '' already used for TwoFACode above.
+        $loginRequestBody = $request->getParsedBody() ?? [];
 
         $userPassRequest = new LocalUsernamePasswordRequest(
-            $loginRequestBody['User'],
-            $loginRequestBody['Password']
+            (string) ($loginRequestBody['User'] ?? ''),
+            (string) ($loginRequestBody['Password'] ?? '')
         );
         $authenticationResult = AuthenticationManager::authenticate($userPassRequest);
         $pageArgs['sErrorText'] = $authenticationResult->message;


### PR DESCRIPTION
## Summary

Makes `POST /session/begin` treat a malformed body as a failed login rather than raising an uncaught `TypeError` (HTTP 500). Opened at @churchcrm-hazel's invitation on #9681.

## Changes

- Default the parsed body to `[]` and both credentials to `''` in `src/session/index.php`
- New regression spec `cypress/e2e/ui/session/session.malformed-login.spec.js`

## Why

Fixes #9681.

The login route read both fields unguarded into a strictly typed constructor:

```php
$loginRequestBody = $request->getParsedBody();

$userPassRequest = new LocalUsernamePasswordRequest(
    $loginRequestBody['User'],
    $loginRequestBody['Password']
);
```

`LocalUsernamePasswordRequest::__construct(string $username, string $password)` rejects `null`, so a body missing either key produced:

```
LocalUsernamePasswordRequest::__construct(): Argument #1 ($username)
must be of type string, null given
```

`?? []` on the body additionally covers `getParsedBody()` returning `null` outright when the media type has no registered parser.

This mirrors what the file already does a few lines above for the 2FA path (`$loginRequestBody['TwoFACode'] ?? ''`) — the local-login branch simply missed it.

**Not a security issue**, consistent with the read in the issue: the throw happens before any credential check and the 500 page leaks no trace. The cost is unhandled input and log noise — on a public install, bot probes of the login form fill the app log with uncaught exceptions and bury real errors.

## Files Changed

- `src/session/index.php` — 7 insertions, 2 deletions
- `cypress/e2e/ui/session/session.malformed-login.spec.js` — new

## Testing

Reproduced on `master` @ 5f201dd04 against a rebuilt dev instance before writing the fix:

| Request | Before | After |
|---|---|---|
| empty POST | 500 | 200 |
| `Password=x`, no `User` | 500 | 200 |
| `Content-Type: application/json`, `{}` | 500 | 200 |
| `User=nobody&Password=wrong` (control) | 200 | 200 |

- ✅ New spec 5/5; **4 of 5 fail on master** (the control passes both ways, by design)
- ✅ `session.login-flows.spec.js` 3/3 — 2FA challenge, forced password change, and lockout redirects all still behave
- ✅ Zero `must be of type string, null given` entries in the app log after the fix, three before
- ✅ `npm run lint` clean, pre-commit PHP validation passed

```bash
npx cypress run --config-file cypress/configs/docker.config.ts \
  --spec "cypress/e2e/ui/session/session.malformed-login.spec.js"
```

## Related Issues

Fixes #9681.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
