### PR TITLE
Fix issue #9696: Stop promising a password that is never shown

### DIFF
--- a/cypress/e2e/ui-admin/admin.user-editor-email-disabled.spec.js
+++ b/cypress/e2e/ui-admin/admin.user-editor-email-disabled.spec.js
@@ -1,0 +1,52 @@
+/// <reference types="cypress" />
+
+/**
+ * Regression test for the misleading create-user banner — issue #9696.
+ *
+ * With email disabled, UserService::createUser() generates a random password,
+ * hashes it, and only reveals the plaintext inside the
+ * `if (SystemConfig::isEmailEnabled())` branch. That branch never runs, so the
+ * plaintext goes out of scope with no path back to it — yet the banner told the
+ * admin to "Share the password with them manually", which is impossible. Every
+ * account created while email was off was therefore unreachable, with the
+ * banner pointing away from the one recovery path that exists
+ * (System Users -> Change Password).
+ *
+ * The banner must not promise a password the software never surfaces.
+ */
+describe("Create-user banner with email disabled (#9696)", () => {
+    before(() => {
+        cy.makePrivateAdminAPICall("POST", "/admin/api/system/config/bEnabledEmail", { value: "0" }, 200);
+    });
+
+    after(() => {
+        cy.makePrivateAdminAPICall("POST", "/admin/api/system/config/bEnabledEmail", { value: "1" }, 200);
+    });
+
+    beforeEach(() => {
+        cy.setupAdminSession();
+        cy.visit("/admin/system/users/new");
+    });
+
+    it("warns that email is disabled", () => {
+        cy.contains("Email is disabled").should("exist");
+    });
+
+    it("does not tell the admin to share a password that is never shown", () => {
+        cy.get("body")
+            .invoke("text")
+            .should("not.include", "Share the password with them manually");
+    });
+
+    it("points at Change Password, the path that actually works", () => {
+        cy.get(".alert-warning")
+            .invoke("text")
+            .should("include", "Change Password");
+    });
+
+    it("still offers no password field on the create form", () => {
+        // Nothing here should imply the admin can set a password inline; the
+        // account is created first, then a password is set from System Users.
+        cy.get("input[type=password], input[name*=assword]").should("have.length", 0);
+    });
+});

--- a/src/admin/views/user-editor.php
+++ b/src/admin/views/user-editor.php
@@ -26,7 +26,7 @@ $accessMode = $perms['admin'] ? 'admin' : ($perms['editSelf'] ? 'self' : 'custom
     <i class="fa-solid fa-triangle-exclamation me-2 fs-3"></i>
     <div class="flex-grow-1">
         <strong><?= gettext('Email is disabled') ?></strong>
-        <div class="text-secondary"><?= gettext('New users will not receive a welcome email with their credentials. Share the password with them manually, or configure email first.') ?></div>
+        <div class="text-secondary"><?= gettext('New users will not receive a welcome email, and the generated password is never displayed. After creating the account, set one from System Users using Change Password — or configure email first.') ?></div>
     </div>
     <a href="<?= SystemURLs::getRootPath() ?>/v2/email/dashboard?settings=open" class="btn btn-warning ms-3">
         <i class="fa-solid fa-envelope me-1"></i><?= gettext('Set up Email') ?>


### PR DESCRIPTION
## Summary

Rewords the create-user banner so it stops telling admins to share a password the software never surfaces, and points at the recovery path that actually works. Opened at @churchcrm-hazel's invitation on #9696.

## Changes

- `src/admin/views/user-editor.php` — banner text when email is disabled
- New regression spec `cypress/e2e/ui-admin/admin.user-editor-email-disabled.spec.js`

Before:

> New users will not receive a welcome email with their credentials. **Share the password with them manually**, or configure email first.

After:

> New users will not receive a welcome email, and **the generated password is never displayed**. After creating the account, set one from System Users using **Change Password** — or configure email first.

## Why

Fixes #9696.

`UserService::createUser()` generates a random password, hashes it, and reveals the plaintext only inside the `if (SystemConfig::isEmailEnabled())` branch. With email off that branch never runs and `$rawPassword` goes out of scope — never displayed, returned, or logged. The banner asked the admin to do something the code makes impossible.

The consequence is worse than a confusing string: **every account created while email is disabled is immediately unusable**, and the banner points away from the one recovery path that exists (`/admin/system/user/{id}/changePassword`).

The codebase already gives the right guidance in two other places — the reset API refuses with *"Email is disabled. Configure email before resetting passwords, or use Change Password"*, and the banner in `users.php` describes the situation accurately without over-promising. Only the create-user banner was out of step.

Per the discussion on the issue, this deliberately does **not** add a one-time password display. That has its own tradeoffs — shoulder-surfing, browser history, screenshots — and is a separate design conversation.

## Files Changed

- `src/admin/views/user-editor.php` — 1 insertion, 1 deletion
- `cypress/e2e/ui-admin/admin.user-editor-email-disabled.spec.js` — new, 4 tests

## Testing

Reproduced in the browser on `master` @ db9e046ac against a rebuilt dev instance before changing anything: with `bEnabledEmail = 0`, creating a user succeeds, lands on `/admin/system/users`, and scanning the page for "password" returns only the nav item and unrelated settings help text. The account carries a valid bcrypt hash and `usr_NeedPasswordChange = 1`, confirming a password was set but is unknowable.

- ✅ New spec 4/4; **2 of 4 fail on master** (the two asserting the wording; the "email is disabled" and no-password-field assertions hold either way, by design)
- ✅ Spec toggles `bEnabledEmail` via `/admin/api/system/config/bEnabledEmail` in `before`/`after`, so it restores the prior state
- ✅ `npm run lint` clean; pre-commit locale-check, PHP validation and YAML checks passed
- ✅ No new translatable-string issues (`locale-check --staged` clean)

```bash
npx cypress run --config-file cypress/configs/docker-admin.config.ts \
  --spec "cypress/e2e/ui-admin/admin.user-editor-email-disabled.spec.js"
```

## Related Issues

Fixes #9696.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
