### PR TITLE
locale: translate all locales (7.7.0)

### DIFF
--- a/locale/terms/missing/af/af-1.json
+++ b/locale/terms/missing/af/af-1.json
@@ -1,50 +1,50 @@
 {
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "A geocoding error occurred — try again later": "'n Geokoderingsfout het voorgekom — probeer asseblief later weer",
+  "Address is incomplete (missing city, state, and ZIP)": "Adres is onvolledig (stad, provinsie en poskode ontbreek)",
+  "All families already have coordinates.": "Alle gesinne het reeds koördinate.",
+  "Failed to update coordinates": "Kon nie koördinate opdateer nie",
+  "Failed to update family coordinates": "Kon nie gesin se koördinate opdateer nie",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Alle {{geocoded}} gesinne is geokodeer. Die kaart is nou op datum.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "{{geocoded}} gesinne is geokodeer. {{failed}} kon nie opgelos word nie — sien besonderhede hieronder.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "{{geocoded}} van {{total}} gesinne is geokodeer. {{overflow}} is nog nie verwerk nie — hardloop weer om voort te gaan.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Gesinne word geokodeer… dit kan tot 'n minuut neem. U kan hierdie bladsy oop hou.",
+  "Geocoding…": "Besig om te geokodeer…",
+  "No address on file": "Geen adres aangeteken nie",
+  "No match found — check the street address, city, and ZIP": "Geen ooreenstemming gevind nie — kontroleer straatadres, stad en poskode",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Aantal dae wat gebruikers het om vir tweefaktor-verifikasie (2FA) in te skryf nadat dit verpligtend geword het. Stel op 0 om dit onmiddellik af te dwing (voormalige gedrag). Om 'n aktiewe genadetydperk te verkort kan gebruikers onmiddellik uitsluit.",
+  "Open a family to fix its address, then run this again.": "Open 'n gesin om die adres reg te stel, en hardloop dit dan weer.",
+  "Set up now": "Stel nou op",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Dit vind kaartkoördinate vir elke gesin wat dit kortkom, met behulp van OpenStreetMap. Dit verwerk tot 50 gesinne per uitvoering; 'n volle bondel neem sowat 'n minuut. U kan hierdie bladsy oop hou terwyl dit loop. Gaan voort?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "Tweefaktor-verifikasie word vereis. U het %d dag om in te skryf.",
+    "other": "Tweefaktor-verifikasie word vereis. U het %d dae om in te skryf."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Onbekende gesin",
+  "Update All Coordinates": "Werk Alle Koördinate By",
+  "Update All Family Coordinates": "Werk Alle Gesinskoördinate By",
+  "Update Coordinates": "Werk Koördinate By",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} lid gekopieer",
+    "other": "{{count}} lede gekopieer"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Hierdie lys het {{count}} ontvanger — te veel vir 'n mailto:-skakel. Gebruik eerder Kopieer Adresse.",
+    "other": "Hierdie lys het {{count}} ontvangers — te veel vir 'n mailto:-skakel. Gebruik eerder Kopieer Adresse."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Te veel ontvangers vir die e-posprogram ({{count}} > {{max}}). Gebruik eerder Kopieer Adresse.",
+    "other": "Te veel ontvangers vir die e-posprogram ({{count}} > {{max}}). Gebruik eerder Kopieer Adresse."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} minuut oor",
+    "other": "{{count}} minute oor"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} gesin kon nie geokodeer word nie",
+    "other": "{{count}} gesinne kon nie geokodeer word nie"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…en {{count}} meer. Hardloop weer om die res te sien.",
+    "other": "…en {{count}} meer. Hardloop weer om die res te sien."
   }
 }

--- a/locale/terms/missing/am/am-1.json
+++ b/locale/terms/missing/am/am-1.json
@@ -1,52 +1,52 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "የጂኦኮዲንግ ስህተት ተከስቷል — እባክዎ ቆይተው እንደገና ይሞክሩ",
+  "Address is incomplete (missing city, state, and ZIP)": "አድራሻው ያልተሟላ ነው (ከተማ፣ ክልል እና ፖስታ ኮድ ይጎድላል)",
+  "All families already have coordinates.": "ሁሉም ቤተሰቦች አስቀድሞ መጋጠሚያዎች አሏቸው።",
+  "Failed to update coordinates": "መጋጠሚያዎችን ማዘመን አልተሳካም",
+  "Failed to update family coordinates": "የቤተሰብ መጋጠሚያዎችን ማዘመን አልተሳካም",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "ሁሉም {{geocoded}} ቤተሰቦች ጂኦኮድ ተደርገዋል። ካርታው አሁን ወቅታዊ ነው።",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "{{geocoded}} ቤተሰቦች ጂኦኮድ ተደርገዋል። {{failed}} ሊፈቱ አልቻሉም — ከታች ያለውን ዝርዝር ይመልከቱ።",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "ከ{{total}} ቤተሰቦች ውስጥ {{geocoded}} ጂኦኮድ ተደርገዋል። {{overflow}} እስካሁን አልተካሄዱም — ለመቀጠል እንደገና ያሂዱ።",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "ቤተሰቦችን ጂኦኮድ በማድረግ ላይ… ይህ እስከ አንድ ደቂቃ ሊወስድ ይችላል። ይህን ገጽ ክፍት አድርገው ማቆየት ይችላሉ።",
+  "Geocoding…": "ጂኦኮድ በማድረግ ላይ…",
+  "No address on file": "የተመዘገበ አድራሻ የለም",
+  "No match found — check the street address, city, and ZIP": "ምንም ተመሳሳይ ነገር አልተገኘም — የመንገድ አድራሻ፣ ከተማ እና ፖስታ ኮድ ያረጋግጡ",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "ባለሁለት-ደረጃ ማረጋገጫ (2FA) ግዴታ ከሆነ በኋላ ተጠቃሚዎች ለመመዝገብ የሚኖራቸው የቀናት ብዛት። ወዲያውኑ ለማስፈጸም ወደ 0 ያዘጋጁ (የቀድሞ ባህሪ)። ንቁ የሆነ የችሮታ ጊዜን ማሳጠር ተጠቃሚዎችን ወዲያውኑ ሊዘጋባቸው ይችላል።",
+  "Open a family to fix its address, then run this again.": "አድራሻውን ለማስተካከል ቤተሰብ ይክፈቱ፣ ከዚያ ይህን እንደገና ያሂዱ።",
+  "Set up now": "አሁን ያዋቅሩ",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "ይህ OpenStreetMapን በመጠቀም መጋጠሚያ ለሌላቸው ለእያንዳንዱ ቤተሰብ የካርታ መጋጠሚያዎችን ያገኛል። በአንድ ሩጫ እስከ 50 ቤተሰቦችን ያካሂዳል፤ ሙሉ ስብስብ ወደ አንድ ደቂቃ ይወስዳል። እየሮጠ ሳለ ይህን ገጽ ክፍት አድርገው ማቆየት ይችላሉ። ይቀጥሉ?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "ባለሁለት-ደረጃ ማረጋገጫ ያስፈልጋል። ለመመዝገብ %d ቀን አለዎት።",
+    "other": "ባለሁለት-ደረጃ ማረጋገጫ ያስፈልጋል። ለመመዝገብ %d ቀናት አሉዎት።"
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "ያልታወቀ ቤተሰብ",
+  "Update All Coordinates": "ሁሉንም መጋጠሚያዎች ያዘምኑ",
+  "Update All Family Coordinates": "ሁሉንም የቤተሰብ መጋጠሚያዎች ያዘምኑ",
+  "Update Coordinates": "መጋጠሚያዎችን ያዘምኑ",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} አባል ተቀድቷል",
+    "other": "{{count}} አባላት ተቀድተዋል"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "ይህ ዝርዝር {{count}} ተቀባይ አለው — ለ mailto: አገናኝ በጣም ብዙ ናቸው። በምትኩ አድራሻዎችን ቅዳ የሚለውን ይጠቀሙ።",
+    "other": "ይህ ዝርዝር {{count}} ተቀባዮች አሉት — ለ mailto: አገናኝ በጣም ብዙ ናቸው። በምትኩ አድራሻዎችን ቅዳ የሚለውን ይጠቀሙ።"
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "ለኢሜይል ደንበኛ በጣም ብዙ ተቀባዮች አሉ ({{count}} > {{max}})። በምትኩ አድራሻዎችን ቅዳ የሚለውን ይጠቀሙ።",
+    "other": "ለኢሜይል ደንበኛ በጣም ብዙ ተቀባዮች አሉ ({{count}} > {{max}})። በምትኩ አድራሻዎችን ቅዳ የሚለውን ይጠቀሙ።"
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} ደቂቃ ቀርቷል",
+    "other": "{{count}} ደቂቃዎች ቀርተዋል"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} ቤተሰብ ጂኦኮድ ሊደረግ አልቻለም",
+    "other": "{{count}} ቤተሰቦች ጂኦኮድ ሊደረጉ አልቻሉም"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…እና {{count}} ተጨማሪ። የቀረውን ለማየት እንደገና ያሂዱ።",
+    "other": "…እና {{count}} ተጨማሪ። የቀረውን ለማየት እንደገና ያሂዱ።"
   }
 }

--- a/locale/terms/missing/ar/ar-1.json
+++ b/locale/terms/missing/ar/ar-1.json
@@ -1,56 +1,56 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "حدث خطأ في تحديد الموقع الجغرافي — حاول مرة أخرى لاحقًا",
+  "Address is incomplete (missing city, state, and ZIP)": "العنوان غير مكتمل (المدينة والمحافظة والرمز البريدي مفقودة)",
+  "All families already have coordinates.": "جميع العائلات لديها إحداثيات بالفعل.",
+  "Failed to update coordinates": "فشل تحديث الإحداثيات",
+  "Failed to update family coordinates": "فشل تحديث إحداثيات العائلة",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "تم تحديد الموقع الجغرافي لجميع العائلات البالغ عددها {{geocoded}}. الخريطة الآن محدّثة.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "تم تحديد الموقع الجغرافي لـ {{geocoded}} عائلة. تعذّر حل {{failed}} — راجع التفاصيل أدناه.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "تم تحديد الموقع الجغرافي لـ {{geocoded}} من أصل {{total}} عائلة. لم تتم معالجة {{overflow}} بعد — شغّل العملية مرة أخرى للمتابعة.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "جارٍ تحديد الموقع الجغرافي للعائلات… قد يستغرق هذا حتى دقيقة واحدة. يمكنك إبقاء هذه الصفحة مفتوحة.",
+  "Geocoding…": "جارٍ تحديد الموقع الجغرافي…",
+  "No address on file": "لا يوجد عنوان مسجل",
+  "No match found — check the street address, city, and ZIP": "لم يتم العثور على تطابق — تحقق من عنوان الشارع والمدينة والرمز البريدي",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "عدد الأيام المتاحة للمستخدمين للتسجيل في المصادقة الثنائية (2FA) بعد أن تصبح إلزامية. اضبط القيمة على 0 لفرضها فورًا (السلوك القديم). قد يؤدي تقصير فترة سماح نشطة إلى إغلاق الوصول عن المستخدمين فورًا.",
+  "Open a family to fix its address, then run this again.": "افتح ملف عائلة لتصحيح عنوانها، ثم شغّل هذا مرة أخرى.",
+  "Set up now": "الإعداد الآن",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "يبحث هذا عن إحداثيات الخريطة لكل عائلة تفتقر إليها، باستخدام OpenStreetMap. يعالج ما يصل إلى 50 عائلة في كل تشغيل؛ وتستغرق الدفعة الكاملة نحو دقيقة واحدة. يمكنك إبقاء هذه الصفحة مفتوحة أثناء التشغيل. هل تريد المتابعة؟",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "zero": "",
-    "one": "",
-    "two": "",
-    "few": "",
-    "many": "",
-    "other": ""
+    "zero": "المصادقة الثنائية مطلوبة. لا يوجد لديك أيام للتسجيل.",
+    "one": "المصادقة الثنائية مطلوبة. لديك يوم واحد للتسجيل.",
+    "two": "المصادقة الثنائية مطلوبة. لديك يومان للتسجيل.",
+    "few": "المصادقة الثنائية مطلوبة. لديك %d أيام للتسجيل.",
+    "many": "المصادقة الثنائية مطلوبة. لديك %d يومًا للتسجيل.",
+    "other": "المصادقة الثنائية مطلوبة. لديك %d يوم للتسجيل."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "عائلة غير معروفة",
+  "Update All Coordinates": "تحديث جميع الإحداثيات",
+  "Update All Family Coordinates": "تحديث إحداثيات جميع العائلات",
+  "Update Coordinates": "تحديث الإحداثيات",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "تم نسخ عضو واحد",
+    "other": "تم نسخ {{count}} من الأعضاء"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "تحتوي هذه القائمة على مستلم واحد — عدد كبير جدًا لرابط mailto:. استخدم نسخ العناوين بدلاً من ذلك.",
+    "other": "تحتوي هذه القائمة على {{count}} من المستلمين — عدد كبير جدًا لرابط mailto:. استخدم نسخ العناوين بدلاً من ذلك."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "عدد كبير جدًا من المستلمين لعميل البريد الإلكتروني ({{count}} > {{max}}). استخدم نسخ العناوين بدلاً من ذلك.",
+    "other": "عدد كبير جدًا من المستلمين لعميل البريد الإلكتروني ({{count}} > {{max}}). استخدم نسخ العناوين بدلاً من ذلك."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "بقيت دقيقة واحدة",
+    "other": "بقي {{count}} من الدقائق"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "تعذّر تحديد الموقع الجغرافي لعائلة واحدة",
+    "other": "تعذّر تحديد الموقع الجغرافي لـ {{count}} من العائلات"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…وواحد آخر. شغّل العملية مرة أخرى لرؤية الباقي.",
+    "other": "…و{{count}} أخرى. شغّل العملية مرة أخرى لرؤية الباقي."
   }
 }

--- a/locale/terms/missing/cs/cs-1.json
+++ b/locale/terms/missing/cs/cs-1.json
@@ -1,56 +1,56 @@
 {
-  "Fundraising": "",
-  "Data": "",
-  "CSV": "",
-  "N/A": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "Fundraising": "Fundraising",
+  "Data": "Data",
+  "CSV": "CSV",
+  "N/A": "N/A",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "Došlo k chybě geokódování — zkuste to znovu později",
+  "Address is incomplete (missing city, state, and ZIP)": "Adresa je neúplná (chybí město, kraj a PSČ)",
+  "All families already have coordinates.": "Všechny rodiny už mají souřadnice.",
+  "Failed to update coordinates": "Nepodařilo se aktualizovat souřadnice",
+  "Failed to update family coordinates": "Nepodařilo se aktualizovat souřadnice rodiny",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Geokódováno všech {{geocoded}} rodin. Mapa je nyní aktuální.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Geokódováno {{geocoded}} rodin. {{failed}} se nepodařilo vyřešit — podrobnosti viz níže.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Geokódováno {{geocoded}} z {{total}} rodin. {{overflow}} zatím nezpracováno — spusťte znovu pro pokračování.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Geokódování rodin… může to trvat až minutu. Tuto stránku můžete nechat otevřenou.",
+  "Geocoding…": "Geokódování…",
+  "No address on file": "Adresa není evidována",
+  "No match found — check the street address, city, and ZIP": "Nebyla nalezena žádná shoda — zkontrolujte ulici, město a PSČ",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Počet dní, které mají uživatelé na zapojení dvoufaktorového ověřování poté, co se stane povinným. Nastavením na 0 jej vynutíte okamžitě (dřívější chování). Zkrácení aktivní ochranné lhůty může uživatelům okamžitě zablokovat přístup.",
+  "Open a family to fix its address, then run this again.": "Otevřete rodinu a opravte její adresu, poté to spusťte znovu.",
+  "Set up now": "Nastavit nyní",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Tato funkce najde souřadnice na mapě pro každou rodinu, které chybí, pomocí OpenStreetMap. Za jedno spuštění zpracuje až 50 rodin; celá dávka trvá zhruba minutu. Tuto stránku můžete nechat otevřenou během zpracování. Pokračovat?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "few": "",
-    "other": ""
+    "one": "Je vyžadováno dvoufaktorové ověřování. Máte %d den na zapojení.",
+    "few": "Je vyžadováno dvoufaktorové ověřování. Máte %d dny na zapojení.",
+    "other": "Je vyžadováno dvoufaktorové ověřování. Máte %d dní na zapojení."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Neznámá rodina",
+  "Update All Coordinates": "Aktualizovat všechny souřadnice",
+  "Update All Family Coordinates": "Aktualizovat souřadnice všech rodin",
+  "Update Coordinates": "Aktualizovat souřadnice",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Zkopírován {{count}} člen",
+    "other": "Zkopírováno {{count}} členů"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Tento seznam má {{count}} příjemce — příliš mnoho pro odkaz mailto:. Použijte místo toho Kopírovat adresy.",
+    "other": "Tento seznam má {{count}} příjemců — příliš mnoho pro odkaz mailto:. Použijte místo toho Kopírovat adresy."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Příliš mnoho příjemců pro e-mailového klienta ({{count}} > {{max}}). Použijte místo toho Kopírovat adresy.",
+    "other": "Příliš mnoho příjemců pro e-mailového klienta ({{count}} > {{max}}). Použijte místo toho Kopírovat adresy."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "Zbývá {{count}} minuta",
+    "other": "Zbývá {{count}} minut"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} rodinu se nepodařilo geokódovat",
+    "other": "{{count}} rodin se nepodařilo geokódovat"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…a ještě {{count}}. Spusťte znovu, abyste viděli zbytek.",
+    "other": "…a ještě {{count}}. Spusťte znovu, abyste viděli zbytek."
   }
 }

--- a/locale/terms/missing/de/de-1.json
+++ b/locale/terms/missing/de/de-1.json
@@ -1,53 +1,53 @@
 {
-  "Code": "",
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "Code": "Code",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "Bei der Geokodierung ist ein Fehler aufgetreten — bitte versuchen Sie es später erneut",
+  "Address is incomplete (missing city, state, and ZIP)": "Die Adresse ist unvollständig (Stadt, Bundesland und Postleitzahl fehlen)",
+  "All families already have coordinates.": "Alle Familien haben bereits Koordinaten.",
+  "Failed to update coordinates": "Die Koordinaten konnten nicht aktualisiert werden",
+  "Failed to update family coordinates": "Die Koordinaten der Familie konnten nicht aktualisiert werden",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Alle {{geocoded}} Familien wurden geokodiert. Die Karte ist jetzt aktuell.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "{{geocoded}} Familien wurden geokodiert. {{failed}} konnten nicht aufgelöst werden — siehe Details unten.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "{{geocoded}} von {{total}} Familien wurden geokodiert. {{overflow}} sind noch nicht verarbeitet — führen Sie den Vorgang erneut aus, um fortzufahren.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Familien werden geokodiert… dies kann bis zu einer Minute dauern. Sie können diese Seite geöffnet lassen.",
+  "Geocoding…": "Geokodierung läuft…",
+  "No address on file": "Keine Adresse hinterlegt",
+  "No match found — check the street address, city, and ZIP": "Keine Übereinstimmung gefunden — überprüfen Sie Straße, Stadt und Postleitzahl",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Anzahl der Tage, die Benutzern zur Verfügung stehen, um die Zwei-Faktor-Authentifizierung (2FA) einzurichten, nachdem sie verpflichtend geworden ist. Setzen Sie den Wert auf 0, um sie sofort durchzusetzen (bisheriges Verhalten). Das Verkürzen einer aktiven Übergangsfrist kann Benutzer sofort aussperren.",
+  "Open a family to fix its address, then run this again.": "Öffnen Sie eine Familie, um die Adresse zu korrigieren, und führen Sie dies dann erneut aus.",
+  "Set up now": "Jetzt einrichten",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Dies ermittelt mithilfe von OpenStreetMap Kartenkoordinaten für alle Familien, denen sie fehlen. Pro Durchlauf werden bis zu 50 Familien verarbeitet; ein vollständiger Durchlauf dauert etwa eine Minute. Sie können diese Seite während der Ausführung geöffnet lassen. Fortfahren?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "Die Zwei-Faktor-Authentifizierung ist erforderlich. Sie haben noch %d Tag, um sie einzurichten.",
+    "other": "Die Zwei-Faktor-Authentifizierung ist erforderlich. Sie haben noch %d Tage, um sie einzurichten."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Unbekannte Familie",
+  "Update All Coordinates": "Alle Koordinaten aktualisieren",
+  "Update All Family Coordinates": "Alle Familienkoordinaten aktualisieren",
+  "Update Coordinates": "Koordinaten aktualisieren",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} Mitglied kopiert",
+    "other": "{{count}} Mitglieder kopiert"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Diese Liste hat {{count}} Empfänger — zu viele für einen mailto:-Link. Verwenden Sie stattdessen „Adressen kopieren“.",
+    "other": "Diese Liste hat {{count}} Empfänger — zu viele für einen mailto:-Link. Verwenden Sie stattdessen „Adressen kopieren“."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Zu viele Empfänger für das E-Mail-Programm ({{count}} > {{max}}). Verwenden Sie stattdessen „Adressen kopieren“.",
+    "other": "Zu viele Empfänger für das E-Mail-Programm ({{count}} > {{max}}). Verwenden Sie stattdessen „Adressen kopieren“."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "noch {{count}} Minute",
+    "other": "noch {{count}} Minuten"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} Familie konnte nicht geokodiert werden",
+    "other": "{{count}} Familien konnten nicht geokodiert werden"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…und {{count}} weitere. Führen Sie den Vorgang erneut aus, um den Rest zu sehen.",
+    "other": "…und {{count}} weitere. Führen Sie den Vorgang erneut aus, um den Rest zu sehen."
   }
 }

--- a/locale/terms/missing/el/el-1.json
+++ b/locale/terms/missing/el/el-1.json
@@ -1,52 +1,52 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "Παρουσιάστηκε σφάλμα γεωκωδικοποίησης — δοκιμάστε ξανά αργότερα",
+  "Address is incomplete (missing city, state, and ZIP)": "Η διεύθυνση είναι ελλιπής (λείπουν η πόλη, ο νομός και ο ταχυδρομικός κώδικας)",
+  "All families already have coordinates.": "Όλες οι οικογένειες διαθέτουν ήδη συντεταγμένες.",
+  "Failed to update coordinates": "Αποτυχία ενημέρωσης συντεταγμένων",
+  "Failed to update family coordinates": "Αποτυχία ενημέρωσης συντεταγμένων οικογένειας",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Έγινε γεωκωδικοποίηση σε όλες τις {{geocoded}} οικογένειες. Ο χάρτης είναι πλέον ενημερωμένος.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Έγινε γεωκωδικοποίηση σε {{geocoded}} οικογένειες. {{failed}} δεν ήταν δυνατόν να επιλυθούν — δείτε τις λεπτομέρειες παρακάτω.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Έγινε γεωκωδικοποίηση σε {{geocoded}} από {{total}} οικογένειες. {{overflow}} δεν έχουν ακόμη επεξεργαστεί — εκτελέστε ξανά για να συνεχίσετε.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Γίνεται γεωκωδικοποίηση οικογενειών… αυτό μπορεί να διαρκέσει έως ένα λεπτό. Μπορείτε να αφήσετε αυτή τη σελίδα ανοιχτή.",
+  "Geocoding…": "Γίνεται γεωκωδικοποίηση…",
+  "No address on file": "Δεν υπάρχει καταχωρημένη διεύθυνση",
+  "No match found — check the street address, city, and ZIP": "Δεν βρέθηκε αντιστοιχία — ελέγξτε τη διεύθυνση, την πόλη και τον ταχυδρομικό κώδικα",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Ο αριθμός ημερών που έχουν οι χρήστες για να εγγραφούν στον έλεγχο ταυτότητας δύο παραγόντων (2FA) αφότου καταστεί υποχρεωτικός. Ορίστε την τιμή σε 0 για άμεση επιβολή (παλαιότερη συμπεριφορά). Η μείωση μιας ενεργής περιόδου χάριτος ενδέχεται να αποκλείσει αμέσως τους χρήστες.",
+  "Open a family to fix its address, then run this again.": "Ανοίξτε μια οικογένεια για να διορθώσετε τη διεύθυνσή της και, στη συνέχεια, εκτελέστε ξανά αυτήν την ενέργεια.",
+  "Set up now": "Ρύθμιση τώρα",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Αυτό βρίσκει συντεταγμένες χάρτη για κάθε οικογένεια που δεν τις διαθέτει, χρησιμοποιώντας το OpenStreetMap. Επεξεργάζεται έως 50 οικογένειες ανά εκτέλεση· μια πλήρης παρτίδα διαρκεί περίπου ένα λεπτό. Μπορείτε να αφήσετε αυτή τη σελίδα ανοιχτή όσο εκτελείται. Συνέχεια;",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "Απαιτείται έλεγχος ταυτότητας δύο παραγόντων. Έχετε %d ημέρα για να εγγραφείτε.",
+    "other": "Απαιτείται έλεγχος ταυτότητας δύο παραγόντων. Έχετε %d ημέρες για να εγγραφείτε."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Άγνωστη οικογένεια",
+  "Update All Coordinates": "Ενημέρωση όλων των συντεταγμένων",
+  "Update All Family Coordinates": "Ενημέρωση συντεταγμένων όλων των οικογενειών",
+  "Update Coordinates": "Ενημέρωση συντεταγμένων",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Αντιγράφηκε {{count}} μέλος",
+    "other": "Αντιγράφηκαν {{count}} μέλη"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Αυτή η λίστα έχει {{count}} παραλήπτη — πάρα πολλοί για έναν σύνδεσμο mailto:. Χρησιμοποιήστε αντ' αυτού την Αντιγραφή διευθύνσεων.",
+    "other": "Αυτή η λίστα έχει {{count}} παραλήπτες — πάρα πολλοί για έναν σύνδεσμο mailto:. Χρησιμοποιήστε αντ' αυτού την Αντιγραφή διευθύνσεων."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Πάρα πολλοί παραλήπτες για τον πελάτη email ({{count}} > {{max}}). Χρησιμοποιήστε αντ' αυτού την Αντιγραφή διευθύνσεων.",
+    "other": "Πάρα πολλοί παραλήπτες για τον πελάτη email ({{count}} > {{max}}). Χρησιμοποιήστε αντ' αυτού την Αντιγραφή διευθύνσεων."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "απομένει {{count}} λεπτό",
+    "other": "απομένουν {{count}} λεπτά"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "Δεν ήταν δυνατή η γεωκωδικοποίηση {{count}} οικογένειας",
+    "other": "Δεν ήταν δυνατή η γεωκωδικοποίηση {{count}} οικογενειών"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…και {{count}} ακόμη. Εκτελέστε ξανά για να δείτε τα υπόλοιπα.",
+    "other": "…και {{count}} ακόμη. Εκτελέστε ξανά για να δείτε τα υπόλοιπα."
   }
 }

--- a/locale/terms/missing/es-AR/es-AR-1.json
+++ b/locale/terms/missing/es-AR/es-AR-1.json
@@ -1,52 +1,52 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "Ocurrió un error de geocodificación — intentá de nuevo más tarde",
+  "Address is incomplete (missing city, state, and ZIP)": "La dirección está incompleta (faltan ciudad, provincia y código postal)",
+  "All families already have coordinates.": "Todas las familias ya tienen coordenadas.",
+  "Failed to update coordinates": "No se pudieron actualizar las coordenadas",
+  "Failed to update family coordinates": "No se pudieron actualizar las coordenadas de la familia",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Se geocodificaron las {{geocoded}} familias. El mapa está actualizado.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Se geocodificaron {{geocoded}} familias. {{failed}} no se pudieron resolver — ver detalles abajo.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Se geocodificaron {{geocoded}} de {{total}} familias. {{overflow}} aún no se procesaron — ejecutalo de nuevo para continuar.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Geocodificando familias… esto puede tardar hasta un minuto. Podés dejar esta página abierta.",
+  "Geocoding…": "Geocodificando…",
+  "No address on file": "No hay dirección registrada",
+  "No match found — check the street address, city, and ZIP": "No se encontraron coincidencias — verificá la calle, la ciudad y el código postal",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Cantidad de días que tienen los usuarios para habilitar la autenticación de dos factores (2FA) después de que se vuelve obligatoria. Poné 0 para exigirla de inmediato (comportamiento anterior). Acortar un período de gracia activo puede bloquear el acceso de los usuarios de inmediato.",
+  "Open a family to fix its address, then run this again.": "Abrí una familia para corregir su dirección y luego ejecutá esto de nuevo.",
+  "Set up now": "Configurar ahora",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Esto busca las coordenadas en el mapa de cada familia a la que le faltan, usando OpenStreetMap. Procesa hasta 50 familias por ejecución; un lote completo tarda alrededor de un minuto. Podés dejar esta página abierta mientras se ejecuta. ¿Continuar?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "Se requiere autenticación de dos factores. Tenés %d día para habilitarla.",
+    "other": "Se requiere autenticación de dos factores. Tenés %d días para habilitarla."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Familia desconocida",
+  "Update All Coordinates": "Actualizar todas las coordenadas",
+  "Update All Family Coordinates": "Actualizar todas las coordenadas de las familias",
+  "Update Coordinates": "Actualizar coordenadas",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Se copió {{count}} miembro",
+    "other": "Se copiaron {{count}} miembros"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Esta lista tiene {{count}} destinatario — son demasiados para un enlace mailto:. Usá Copiar direcciones en su lugar.",
+    "other": "Esta lista tiene {{count}} destinatarios — son demasiados para un enlace mailto:. Usá Copiar direcciones en su lugar."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Usá Copiar direcciones en su lugar.",
+    "other": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Usá Copiar direcciones en su lugar."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "Queda {{count}} minuto",
+    "other": "Quedan {{count}} minutos"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "No se pudo geocodificar {{count}} familia",
+    "other": "No se pudieron geocodificar {{count}} familias"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…y {{count}} más. Ejecutalo de nuevo para ver el resto.",
+    "other": "…y {{count}} más. Ejecutalo de nuevo para ver el resto."
   }
 }

--- a/locale/terms/missing/es-CO/es-CO-1.json
+++ b/locale/terms/missing/es-CO/es-CO-1.json
@@ -1,53 +1,53 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "Ocurrió un error de geocodificación — inténtelo de nuevo más tarde",
+  "Address is incomplete (missing city, state, and ZIP)": "La dirección está incompleta (faltan ciudad, departamento y código postal)",
+  "All families already have coordinates.": "Todas las familias ya tienen coordenadas.",
+  "Failed to update coordinates": "Error al actualizar las coordenadas",
+  "Failed to update family coordinates": "Error al actualizar las coordenadas de la familia",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Se geocodificaron las {{geocoded}} familias. El mapa ahora está actualizado.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Se geocodificaron {{geocoded}} familias. {{failed}} no se pudieron resolver — vea los detalles a continuación.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Se geocodificaron {{geocoded}} de {{total}} familias. {{overflow}} aún no se han procesado — ejecute de nuevo para continuar.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Geocodificando familias… esto puede tardar hasta un minuto. Puede mantener esta página abierta.",
+  "Geocoding…": "Geocodificando…",
+  "No address on file": "No hay dirección registrada",
+  "No match found — check the street address, city, and ZIP": "No se encontró ninguna coincidencia — verifique la dirección, la ciudad y el código postal",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Número de días que tienen los usuarios para inscribirse en la autenticación de dos factores (2FA) después de que sea obligatoria. Establezca 0 para aplicarla de inmediato (comportamiento heredado). Acortar un período de gracia activo puede bloquear a los usuarios de inmediato.",
+  "Open a family to fix its address, then run this again.": "Abra una familia para corregir su dirección y luego ejecute esto de nuevo.",
+  "Set up now": "Configurar ahora",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Esto busca las coordenadas del mapa para cada familia a la que le falten, usando OpenStreetMap. Procesa hasta 50 familias por ejecución; un lote completo tarda aproximadamente un minuto. Puede mantener esta página abierta mientras se ejecuta. ¿Desea continuar?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "many": "",
-    "other": ""
+    "one": "Se requiere autenticación de dos factores. Tiene %d día para inscribirse.",
+    "many": "Se requiere autenticación de dos factores. Tiene %d días para inscribirse.",
+    "other": "Se requiere autenticación de dos factores. Tiene %d días para inscribirse."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Familia desconocida",
+  "Update All Coordinates": "Actualizar todas las coordenadas",
+  "Update All Family Coordinates": "Actualizar todas las coordenadas de las familias",
+  "Update Coordinates": "Actualizar coordenadas",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Se copió {{count}} miembro",
+    "other": "Se copiaron {{count}} miembros"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Esta lista tiene {{count}} destinatario — son demasiados para un enlace mailto:. Use Copiar direcciones en su lugar.",
+    "other": "Esta lista tiene {{count}} destinatarios — son demasiados para un enlace mailto:. Use Copiar direcciones en su lugar."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Use Copiar direcciones en su lugar.",
+    "other": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Use Copiar direcciones en su lugar."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "queda {{count}} minuto",
+    "other": "quedan {{count}} minutos"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} familia no se pudo geocodificar",
+    "other": "{{count}} familias no se pudieron geocodificar"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…y {{count}} más. Ejecute de nuevo para ver el resto.",
+    "other": "…y {{count}} más. Ejecute de nuevo para ver el resto."
   }
 }

--- a/locale/terms/missing/es-MX/es-MX-1.json
+++ b/locale/terms/missing/es-MX/es-MX-1.json
@@ -1,52 +1,52 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "Ocurrió un error de geocodificación — intenta de nuevo más tarde",
+  "Address is incomplete (missing city, state, and ZIP)": "La dirección está incompleta (falta la ciudad, el estado y el código postal)",
+  "All families already have coordinates.": "Todas las familias ya tienen coordenadas.",
+  "Failed to update coordinates": "No se pudieron actualizar las coordenadas",
+  "Failed to update family coordinates": "No se pudieron actualizar las coordenadas de la familia",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Se geocodificaron las {{geocoded}} familias. El mapa está actualizado.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Se geocodificaron {{geocoded}} familias. {{failed}} no se pudieron resolver — consulta los detalles a continuación.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Se geocodificaron {{geocoded}} de {{total}} familias. {{overflow}} aún no se han procesado — ejecútalo de nuevo para continuar.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Geocodificando familias… esto puede tardar hasta un minuto. Puedes dejar esta página abierta.",
+  "Geocoding…": "Geocodificando…",
+  "No address on file": "No hay dirección registrada",
+  "No match found — check the street address, city, and ZIP": "No se encontró ninguna coincidencia — verifica la calle, la ciudad y el código postal",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Número de días que tienen los usuarios para inscribirse en la autenticación de dos factores (2FA) después de que se vuelve obligatoria. Configúralo en 0 para exigirlo de inmediato (comportamiento heredado). Reducir un período de gracia activo puede bloquear a los usuarios de inmediato.",
+  "Open a family to fix its address, then run this again.": "Abre una familia para corregir su dirección y luego ejecuta esto de nuevo.",
+  "Set up now": "Configurar ahora",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Esto busca las coordenadas del mapa para cada familia a la que le faltan, usando OpenStreetMap. Procesa hasta 50 familias por ejecución; un lote completo tarda aproximadamente un minuto. Puedes dejar esta página abierta mientras se ejecuta. ¿Continuar?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "Se requiere la autenticación de dos factores. Tienes %d día para inscribirte.",
+    "other": "Se requiere la autenticación de dos factores. Tienes %d días para inscribirte."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Familia desconocida",
+  "Update All Coordinates": "Actualizar todas las coordenadas",
+  "Update All Family Coordinates": "Actualizar todas las coordenadas de las familias",
+  "Update Coordinates": "Actualizar coordenadas",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Se copió {{count}} miembro",
+    "other": "Se copiaron {{count}} miembros"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Esta lista tiene {{count}} destinatario — son demasiados para un enlace mailto:. Usa Copiar Direcciones en su lugar.",
+    "other": "Esta lista tiene {{count}} destinatarios — son demasiados para un enlace mailto:. Usa Copiar Direcciones en su lugar."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Usa Copiar Direcciones en su lugar.",
+    "other": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Usa Copiar Direcciones en su lugar."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "Queda {{count}} minuto",
+    "other": "Quedan {{count}} minutos"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} familia no se pudo geocodificar",
+    "other": "{{count}} familias no se pudieron geocodificar"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…y {{count}} más. Ejecútalo de nuevo para ver el resto.",
+    "other": "…y {{count}} más. Ejecútalo de nuevo para ver el resto."
   }
 }

--- a/locale/terms/missing/es-SV/es-SV-1.json
+++ b/locale/terms/missing/es-SV/es-SV-1.json
@@ -1,52 +1,52 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "Ocurrió un error de geocodificación — inténtelo de nuevo más tarde",
+  "Address is incomplete (missing city, state, and ZIP)": "La dirección está incompleta (falta ciudad, departamento y código postal)",
+  "All families already have coordinates.": "Todas las familias ya tienen coordenadas.",
+  "Failed to update coordinates": "No se pudieron actualizar las coordenadas",
+  "Failed to update family coordinates": "No se pudieron actualizar las coordenadas de la familia",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Se geocodificaron las {{geocoded}} familias. El mapa está actualizado.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Se geocodificaron {{geocoded}} familias. {{failed}} no se pudieron resolver — vea los detalles a continuación.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Se geocodificaron {{geocoded}} de {{total}} familias. {{overflow}} aún no procesadas — ejecute de nuevo para continuar.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Geocodificando familias… esto puede tardar hasta un minuto. Puede dejar esta página abierta.",
+  "Geocoding…": "Geocodificando…",
+  "No address on file": "No hay dirección registrada",
+  "No match found — check the street address, city, and ZIP": "No se encontró ninguna coincidencia — verifique la dirección, la ciudad y el código postal",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Número de días que tienen los usuarios para inscribirse en la autenticación de dos factores (2FA) después de que sea obligatoria. Establezca 0 para exigirlo de inmediato (comportamiento heredado). Acortar un período de gracia activo puede bloquear el acceso a los usuarios de inmediato.",
+  "Open a family to fix its address, then run this again.": "Abra una familia para corregir su dirección y luego ejecute esto de nuevo.",
+  "Set up now": "Configurar ahora",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Esto busca las coordenadas del mapa para cada familia a la que le falten, usando OpenStreetMap. Procesa hasta 50 familias por ejecución; un lote completo tarda aproximadamente un minuto. Puede dejar esta página abierta mientras se ejecuta. ¿Desea continuar?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "Se requiere la autenticación de dos factores. Tiene %d día para inscribirse.",
+    "other": "Se requiere la autenticación de dos factores. Tiene %d días para inscribirse."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Familia desconocida",
+  "Update All Coordinates": "Actualizar todas las coordenadas",
+  "Update All Family Coordinates": "Actualizar todas las coordenadas de familias",
+  "Update Coordinates": "Actualizar coordenadas",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Se copió {{count}} miembro",
+    "other": "Se copiaron {{count}} miembros"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Esta lista tiene {{count}} destinatario — demasiados para un enlace mailto:. Use Copiar direcciones en su lugar.",
+    "other": "Esta lista tiene {{count}} destinatarios — demasiados para un enlace mailto:. Use Copiar direcciones en su lugar."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Use Copiar direcciones en su lugar.",
+    "other": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Use Copiar direcciones en su lugar."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "Queda {{count}} minuto",
+    "other": "Quedan {{count}} minutos"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} familia no se pudo geocodificar",
+    "other": "{{count}} familias no se pudieron geocodificar"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…y {{count}} más. Ejecute de nuevo para ver el resto.",
+    "other": "…y {{count}} más. Ejecute de nuevo para ver el resto."
   }
 }

--- a/locale/terms/missing/es/es-1.json
+++ b/locale/terms/missing/es/es-1.json
@@ -1,52 +1,52 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "Se produjo un error de geocodificación — inténtelo de nuevo más tarde",
+  "Address is incomplete (missing city, state, and ZIP)": "La dirección está incompleta (falta la ciudad, el estado y el código postal)",
+  "All families already have coordinates.": "Todas las familias ya tienen coordenadas.",
+  "Failed to update coordinates": "No se pudieron actualizar las coordenadas",
+  "Failed to update family coordinates": "No se pudieron actualizar las coordenadas de la familia",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Se geocodificaron las {{geocoded}} familias. El mapa ahora está actualizado.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Se geocodificaron {{geocoded}} familias. {{failed}} no se pudieron resolver — vea los detalles a continuación.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Se geocodificaron {{geocoded}} de {{total}} familias. {{overflow}} aún no se han procesado — ejecútelo de nuevo para continuar.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Geocodificando familias… esto puede tardar hasta un minuto. Puede dejar esta página abierta.",
+  "Geocoding…": "Geocodificando…",
+  "No address on file": "No hay ninguna dirección registrada",
+  "No match found — check the street address, city, and ZIP": "No se encontró ninguna coincidencia — verifique la dirección, la ciudad y el código postal",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Número de días que los usuarios tienen para inscribirse en la autenticación de dos factores (2FA) después de que se vuelva obligatoria. Establezca en 0 para aplicarla de inmediato (comportamiento heredado). Acortar un período de gracia activo puede bloquear el acceso de los usuarios de inmediato.",
+  "Open a family to fix its address, then run this again.": "Abra una familia para corregir su dirección y luego ejecútelo de nuevo.",
+  "Set up now": "Configurar ahora",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Esto busca las coordenadas del mapa para cada familia a la que le falten, utilizando OpenStreetMap. Procesa hasta 50 familias por ejecución; un lote completo tarda aproximadamente un minuto. Puede dejar esta página abierta mientras se ejecuta. ¿Continuar?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "Se requiere la autenticación de dos factores. Tiene %d día para inscribirse.",
+    "other": "Se requiere la autenticación de dos factores. Tiene %d días para inscribirse."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Familia desconocida",
+  "Update All Coordinates": "Actualizar todas las coordenadas",
+  "Update All Family Coordinates": "Actualizar todas las coordenadas de las familias",
+  "Update Coordinates": "Actualizar coordenadas",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Se copió {{count}} miembro",
+    "other": "Se copiaron {{count}} miembros"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Esta lista tiene {{count}} destinatario — demasiados para un enlace mailto:. Use Copiar direcciones en su lugar.",
+    "other": "Esta lista tiene {{count}} destinatarios — demasiados para un enlace mailto:. Use Copiar direcciones en su lugar."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Use Copiar direcciones en su lugar.",
+    "other": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Use Copiar direcciones en su lugar."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "queda {{count}} minuto",
+    "other": "quedan {{count}} minutos"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} familia no se pudo geocodificar",
+    "other": "{{count}} familias no se pudieron geocodificar"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…y {{count}} más. Ejecútelo de nuevo para ver el resto.",
+    "other": "…y {{count}} más. Ejecútelo de nuevo para ver el resto."
   }
 }

--- a/locale/terms/missing/et/et-1.json
+++ b/locale/terms/missing/et/et-1.json
@@ -1,52 +1,52 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "Geokodeerimisel tekkis viga — proovige hiljem uuesti",
+  "Address is incomplete (missing city, state, and ZIP)": "Aadress on puudulik (linn, maakond ja sihtnumber puuduvad)",
+  "All families already have coordinates.": "Kõigil peredel on juba koordinaadid.",
+  "Failed to update coordinates": "Koordinaatide värskendamine ebaõnnestus",
+  "Failed to update family coordinates": "Pere koordinaatide värskendamine ebaõnnestus",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Geokodeeriti kõik {{geocoded}} peret. Kaart on nüüd ajakohane.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Geokodeeriti {{geocoded}} peret. {{failed}} ei õnnestunud lahendada — vt üksikasju allpool.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Geokodeeriti {{geocoded}} peret {{total}}-st. {{overflow}} on veel töötlemata — jätkamiseks käivitage uuesti.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Perede geokodeerimine… see võib võtta kuni minuti. Selle lehe võite avatuna hoida.",
+  "Geocoding…": "Geokodeerimine…",
+  "No address on file": "Aadressi ei ole registreeritud",
+  "No match found — check the street address, city, and ZIP": "Vastet ei leitud — kontrollige tänavaaadressi, linna ja sihtnumbrit",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Päevade arv, mis kasutajatel on kaheastmelise autentimise (2FA) seadistamiseks pärast selle kohustuslikuks muutumist. Määrake väärtuseks 0, et jõustada see koheselt (varasem käitumine). Aktiivse üleminekuperioodi lühendamine võib kasutajad koheselt välja lukustada.",
+  "Open a family to fix its address, then run this again.": "Avage pere, et parandada selle aadress, ja käivitage seejärel see uuesti.",
+  "Set up now": "Seadista kohe",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "See otsib kaardikoordinaate igale perele, kellel need puuduvad, kasutades OpenStreetMap'i. Ühe käivitusega töödeldakse kuni 50 peret; täielik partii võtab aega umbes minuti. Selle lehe võite hoida avatuna, kuni see töötab. Kas jätkata?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "Kaheastmeline autentimine on kohustuslik. Teil on %d päev selle seadistamiseks.",
+    "other": "Kaheastmeline autentimine on kohustuslik. Teil on %d päeva selle seadistamiseks."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Tundmatu pere",
+  "Update All Coordinates": "Värskenda kõiki koordinaate",
+  "Update All Family Coordinates": "Värskenda kõigi perede koordinaate",
+  "Update Coordinates": "Värskenda koordinaate",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Kopeeriti {{count}} liige",
+    "other": "Kopeeriti {{count}} liiget"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Selles loendis on {{count}} saaja — liiga palju mailto: lingi jaoks. Kasutage selle asemel funktsiooni Kopeeri aadressid.",
+    "other": "Selles loendis on {{count}} saajat — liiga palju mailto: lingi jaoks. Kasutage selle asemel funktsiooni Kopeeri aadressid."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Liiga palju saajaid e-posti kliendi jaoks ({{count}} > {{max}}). Kasutage selle asemel funktsiooni Kopeeri aadressid.",
+    "other": "Liiga palju saajaid e-posti kliendi jaoks ({{count}} > {{max}}). Kasutage selle asemel funktsiooni Kopeeri aadressid."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "jäänud on {{count}} minut",
+    "other": "jäänud on {{count}} minutit"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} peret ei õnnestunud geokodeerida",
+    "other": "{{count}} peret ei õnnestunud geokodeerida"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…ja veel {{count}}. Ülejäänu nägemiseks käivitage uuesti.",
+    "other": "…ja veel {{count}}. Ülejäänu nägemiseks käivitage uuesti."
   }
 }

--- a/locale/terms/missing/fi/fi-1.json
+++ b/locale/terms/missing/fi/fi-1.json
@@ -1,52 +1,52 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "Geokoodauksessa tapahtui virhe — yritä myöhemmin uudelleen",
+  "Address is incomplete (missing city, state, and ZIP)": "Osoite on puutteellinen (kaupunki, alue ja postinumero puuttuvat)",
+  "All families already have coordinates.": "Kaikilla perheillä on jo koordinaatit.",
+  "Failed to update coordinates": "Koordinaattien päivitys epäonnistui",
+  "Failed to update family coordinates": "Perheen koordinaattien päivitys epäonnistui",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Kaikki {{geocoded}} perhettä geokoodattiin. Kartta on nyt ajan tasalla.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "{{geocoded}} perhettä geokoodattiin. {{failed}} ei voitu ratkaista — katso tiedot alta.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "{{geocoded}}/{{total}} perhettä geokoodattiin. {{overflow}} on vielä käsittelemättä — suorita uudelleen jatkaaksesi.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Geokoodataan perheitä… tämä voi kestää jopa minuutin. Voit pitää tämän sivun auki.",
+  "Geocoding…": "Geokoodataan…",
+  "No address on file": "Osoitetta ei ole tallennettu",
+  "No match found — check the street address, city, and ZIP": "Osumaa ei löytynyt — tarkista katuosoite, kaupunki ja postinumero",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Päivien määrä, jonka käyttäjillä on aikaa ottaa kaksivaiheinen tunnistautuminen (2FA) käyttöön sen tultua pakolliseksi. Aseta arvoksi 0, jotta se otetaan käyttöön välittömästi (aiempi toimintatapa). Aktiivisen siirtymäajan lyhentäminen voi lukita käyttäjät ulos välittömästi.",
+  "Open a family to fix its address, then run this again.": "Avaa perhe korjataksesi sen osoitteen ja suorita tämä sitten uudelleen.",
+  "Set up now": "Ota käyttöön nyt",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Tämä etsii karttakoordinaatit jokaiselle perheelle, joilta ne puuttuvat, käyttäen OpenStreetMapia. Se käsittelee enintään 50 perhettä ajokerralla; koko erä kestää noin minuutin. Voit pitää tämän sivun auki suorituksen ajan. Jatketaanko?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "Kaksivaiheinen tunnistautuminen on pakollinen. Sinulla on %d päivä aikaa ottaa se käyttöön.",
+    "other": "Kaksivaiheinen tunnistautuminen on pakollinen. Sinulla on %d päivää aikaa ottaa se käyttöön."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Tuntematon perhe",
+  "Update All Coordinates": "Päivitä kaikki koordinaatit",
+  "Update All Family Coordinates": "Päivitä kaikkien perheiden koordinaatit",
+  "Update Coordinates": "Päivitä koordinaatit",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Kopioitiin {{count}} jäsen",
+    "other": "Kopioitiin {{count}} jäsentä"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Tässä listassa on {{count}} vastaanottaja — liikaa mailto:-linkille. Käytä sen sijaan Kopioi osoitteet -toimintoa.",
+    "other": "Tässä listassa on {{count}} vastaanottajaa — liikaa mailto:-linkille. Käytä sen sijaan Kopioi osoitteet -toimintoa."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Liikaa vastaanottajia sähköpostiohjelmalle ({{count}} > {{max}}). Käytä sen sijaan Kopioi osoitteet -toimintoa.",
+    "other": "Liikaa vastaanottajia sähköpostiohjelmalle ({{count}} > {{max}}). Käytä sen sijaan Kopioi osoitteet -toimintoa."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} minuutti jäljellä",
+    "other": "{{count}} minuuttia jäljellä"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} perhettä ei voitu geokoodata",
+    "other": "{{count}} perhettä ei voitu geokoodata"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…ja {{count}} muuta. Suorita uudelleen nähdäksesi loput.",
+    "other": "…ja {{count}} muuta. Suorita uudelleen nähdäksesi loput."
   }
 }

--- a/locale/terms/missing/fil/fil-1.json
+++ b/locale/terms/missing/fil/fil-1.json
@@ -1,64 +1,64 @@
 {
-  "Access": "",
-  "Self-service": "",
-  "Feature": "",
-  "Check-out": "",
-  "Code": "",
-  "Live Preview": "",
-  "Sell-through": "",
-  "BCC Mode": "",
-  "Data": "",
-  "CSV": "",
-  "N/A": "",
-  "OFX": "",
-  "Preview": "",
-  "Teller": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "Access": "Access",
+  "Self-service": "Self-service",
+  "Feature": "Feature",
+  "Check-out": "Check-out",
+  "Code": "Code",
+  "Live Preview": "Live Preview",
+  "Sell-through": "Sell-through",
+  "BCC Mode": "BCC Mode",
+  "Data": "Data",
+  "CSV": "CSV",
+  "N/A": "N/A",
+  "OFX": "OFX",
+  "Preview": "Preview",
+  "Teller": "Teller",
+  "A geocoding error occurred — try again later": "Nagkaroon ng error sa pag-geocode — subukan muli mamaya",
+  "Address is incomplete (missing city, state, and ZIP)": "Hindi kumpleto ang address (kulang ang lungsod, probinsya, at ZIP code)",
+  "All families already have coordinates.": "Lahat ng mga pamilya ay mayroon nang mga coordinate.",
+  "Failed to update coordinates": "Nabigong i-update ang mga coordinate",
+  "Failed to update family coordinates": "Nabigong i-update ang mga coordinate ng pamilya",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Na-geocode na ang lahat ng {{geocoded}} na pamilya. Napapanahon na ngayon ang mapa.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Na-geocode ang {{geocoded}} na pamilya. Hindi na-resolve ang {{failed}} — tingnan ang mga detalye sa ibaba.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Na-geocode ang {{geocoded}} sa {{total}} na pamilya. Hindi pa naproseso ang {{overflow}} — patakbuhin muli para magpatuloy.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Ginageocode ang mga pamilya… maaari itong tumagal ng hanggang isang minuto. Maaari mong iwanang bukas ang pahinang ito.",
+  "Geocoding…": "Ginageocode…",
+  "No address on file": "Walang naka-file na address",
+  "No match found — check the street address, city, and ZIP": "Walang nahanap na tugma — suriin ang address, lungsod, at ZIP code",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Bilang ng mga araw na mayroon ang mga user para mag-enroll sa two-factor authentication (2FA) matapos itong maging mandatory. Itakda sa 0 para agad itong ipatupad (dating gawi). Ang pagpapaikli sa isang aktibong grace period ay maaaring agad na mag-lock out sa mga user.",
+  "Open a family to fix its address, then run this again.": "Buksan ang isang pamilya para ayusin ang address nito, pagkatapos ay patakbuhin ito muli.",
+  "Set up now": "I-set up na ngayon",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Hinahanap nito ang mga koordinate sa mapa para sa bawat pamilyang kulang nito, gamit ang OpenStreetMap. Nagpoproseso ito ng hanggang 50 pamilya kada takbo; humigit-kumulang isang minuto ang tagal ng isang buong batch. Maaari mong iwanang bukas ang pahinang ito habang tumatakbo ito. Magpatuloy?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "Kinakailangan ang two-factor authentication. Mayroon kang %d araw para mag-enroll.",
+    "other": "Kinakailangan ang two-factor authentication. Mayroon kang %d na araw para mag-enroll."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Hindi kilalang pamilya",
+  "Update All Coordinates": "I-update ang Lahat ng Coordinate",
+  "Update All Family Coordinates": "I-update ang Lahat ng Coordinate ng Pamilya",
+  "Update Coordinates": "I-update ang mga Coordinate",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Nakopya ang {{count}} miyembro",
+    "other": "Nakopya ang {{count}} na miyembro"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Ang listahang ito ay may {{count}} tatanggap — masyadong marami para sa isang mailto: link. Gamitin na lang ang Kopyahin ang mga Address.",
+    "other": "Ang listahang ito ay may {{count}} na tatanggap — masyadong marami para sa isang mailto: link. Gamitin na lang ang Kopyahin ang mga Address."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Masyadong maraming tatanggap para sa email client ({{count}} > {{max}}). Gamitin na lang ang Kopyahin ang mga Address.",
+    "other": "Masyadong maraming tatanggap para sa email client ({{count}} > {{max}}). Gamitin na lang ang Kopyahin ang mga Address."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} minuto na lang ang natitira",
+    "other": "{{count}} na minuto na lang ang natitira"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "Hindi na-geocode ang {{count}} pamilya",
+    "other": "Hindi na-geocode ang {{count}} na pamilya"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…at {{count}} pa. Patakbuhin muli para makita ang natitira.",
+    "other": "…at {{count}} pa. Patakbuhin muli para makita ang natitira."
   }
 }

--- a/locale/terms/missing/fr/fr-1.json
+++ b/locale/terms/missing/fr/fr-1.json
@@ -1,56 +1,56 @@
 {
-  "Code": "",
-  "Signature": "",
-  "Auto": "",
-  "CSV": "",
-  "OFX": "",
-  "Classifications": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "Code": "Code",
+  "Signature": "Signature",
+  "Auto": "Auto",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "Classifications": "Classifications",
+  "A geocoding error occurred — try again later": "Une erreur de géocodage s'est produite — veuillez réessayer plus tard",
+  "Address is incomplete (missing city, state, and ZIP)": "L'adresse est incomplète (ville, région et code postal manquants)",
+  "All families already have coordinates.": "Toutes les familles ont déjà des coordonnées.",
+  "Failed to update coordinates": "Échec de la mise à jour des coordonnées",
+  "Failed to update family coordinates": "Échec de la mise à jour des coordonnées de la famille",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Géocodage effectué pour les {{geocoded}} familles. La carte est maintenant à jour.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Géocodage effectué pour {{geocoded}} familles. {{failed}} n'ont pas pu être résolues — voir les détails ci-dessous.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Géocodage effectué pour {{geocoded}} familles sur {{total}}. {{overflow}} pas encore traitées — relancez pour continuer.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Géocodage des familles en cours… cela peut prendre jusqu'à une minute. Vous pouvez garder cette page ouverte.",
+  "Geocoding…": "Géocodage…",
+  "No address on file": "Aucune adresse enregistrée",
+  "No match found — check the street address, city, and ZIP": "Aucune correspondance trouvée — vérifiez l'adresse, la ville et le code postal",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Nombre de jours dont disposent les utilisateurs pour s'inscrire à l'authentification à deux facteurs après qu'elle devient obligatoire. Réglez sur 0 pour l'appliquer immédiatement (comportement hérité). Raccourcir une période de grâce active peut verrouiller immédiatement l'accès des utilisateurs.",
+  "Open a family to fix its address, then run this again.": "Ouvrez une famille pour corriger son adresse, puis relancez cette opération.",
+  "Set up now": "Configurer maintenant",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Cette action recherche les coordonnées cartographiques de chaque famille qui n'en possède pas, à l'aide d'OpenStreetMap. Elle traite jusqu'à 50 familles par exécution ; un lot complet prend environ une minute. Vous pouvez garder cette page ouverte pendant le traitement. Continuer ?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "L'authentification à deux facteurs est requise. Vous avez %d jour pour vous inscrire.",
+    "other": "L'authentification à deux facteurs est requise. Vous avez %d jours pour vous inscrire."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Famille inconnue",
+  "Update All Coordinates": "Mettre à jour toutes les coordonnées",
+  "Update All Family Coordinates": "Mettre à jour les coordonnées de toutes les familles",
+  "Update Coordinates": "Mettre à jour les coordonnées",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} membre copié",
+    "other": "{{count}} membres copiés"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Cette liste contient {{count}} destinataire — trop pour un lien mailto:. Utilisez plutôt Copier les adresses.",
+    "other": "Cette liste contient {{count}} destinataires — trop pour un lien mailto:. Utilisez plutôt Copier les adresses."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Trop de destinataires pour le client de messagerie ({{count}} > {{max}}). Utilisez plutôt Copier les adresses.",
+    "other": "Trop de destinataires pour le client de messagerie ({{count}} > {{max}}). Utilisez plutôt Copier les adresses."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} minute restante",
+    "other": "{{count}} minutes restantes"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} famille n'a pas pu être géocodée",
+    "other": "{{count}} familles n'ont pas pu être géocodées"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…et {{count}} de plus. Relancez pour voir le reste.",
+    "other": "…et {{count}} de plus. Relancez pour voir le reste."
   }
 }

--- a/locale/terms/missing/he/he-1.json
+++ b/locale/terms/missing/he/he-1.json
@@ -1,52 +1,52 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "אירעה שגיאת מיקום גיאוגרפי — נסה שוב מאוחר יותר",
+  "Address is incomplete (missing city, state, and ZIP)": "הכתובת אינה שלמה (חסרים עיר, מחוז ומיקוד)",
+  "All families already have coordinates.": "לכל המשפחות כבר יש קואורדינטות.",
+  "Failed to update coordinates": "עדכון הקואורדינטות נכשל",
+  "Failed to update family coordinates": "עדכון קואורדינטות המשפחה נכשל",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "בוצע מיקום גיאוגרפי לכל {{geocoded}} המשפחות. המפה מעודכנת כעת.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "בוצע מיקום גיאוגרפי ל-{{geocoded}} משפחות. לא ניתן היה לפתור {{failed}} — ראה פרטים למטה.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "בוצע מיקום גיאוגרפי ל-{{geocoded}} מתוך {{total}} משפחות. {{overflow}} עדיין לא עובדו — הפעל שוב כדי להמשיך.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "מבצע מיקום גיאוגרפי למשפחות… זה עשוי לקחת עד דקה. ניתן להשאיר דף זה פתוח.",
+  "Geocoding…": "מבצע מיקום גיאוגרפי…",
+  "No address on file": "אין כתובת רשומה",
+  "No match found — check the street address, city, and ZIP": "לא נמצאה התאמה — בדוק את כתובת הרחוב, העיר והמיקוד",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "מספר הימים שיש למשתמשים כדי להירשם לאימות דו-שלבי (2FA) לאחר שהוא הופך לחובה. הגדר ל-0 כדי לאכוף באופן מיידי (התנהגות קודמת). קיצור תקופת חסד פעילה עלול לנעול משתמשים החוצה באופן מיידי.",
+  "Open a family to fix its address, then run this again.": "פתח משפחה כדי לתקן את כתובתה, ולאחר מכן הפעל זאת שוב.",
+  "Set up now": "הגדר כעת",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "פעולה זו מוצאת קואורדינטות מפה עבור כל משפחה שחסרות לה, באמצעות OpenStreetMap. היא מעבדת עד 50 משפחות בכל הרצה; אצווה מלאה אורכת כדקה. ניתן להשאיר דף זה פתוח בזמן הריצה. להמשיך?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "נדרש אימות דו-שלבי. נותר לך יום %d להירשם.",
+    "other": "נדרש אימות דו-שלבי. נותרו לך %d ימים להירשם."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "משפחה לא ידועה",
+  "Update All Coordinates": "עדכן את כל הקואורדינטות",
+  "Update All Family Coordinates": "עדכן את קואורדינטות כל המשפחות",
+  "Update Coordinates": "עדכן קואורדינטות",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "הועתק חבר {{count}}",
+    "other": "הועתקו {{count}} חברים"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "לרשימה זו יש {{count}} נמען — יותר מדי עבור קישור mailto:. השתמש בהעתקת כתובות במקום זאת.",
+    "other": "לרשימה זו יש {{count}} נמענים — יותר מדי עבור קישור mailto:. השתמש בהעתקת כתובות במקום זאת."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "יותר מדי נמענים עבור לקוח הדוא\"ל ({{count}} > {{max}}). השתמש בהעתקת כתובות במקום זאת.",
+    "other": "יותר מדי נמענים עבור לקוח הדוא\"ל ({{count}} > {{max}}). השתמש בהעתקת כתובות במקום זאת."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "נותרה {{count}} דקה",
+    "other": "נותרו {{count}} דקות"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "לא ניתן היה למקם גיאוגרפית משפחה {{count}}",
+    "other": "לא ניתן היה למקם גיאוגרפית {{count}} משפחות"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…ועוד {{count}}. הפעל שוב כדי לראות את השאר.",
+    "other": "…ועוד {{count}}. הפעל שוב כדי לראות את השאר."
   }
 }

--- a/locale/terms/missing/hi/hi-1.json
+++ b/locale/terms/missing/hi/hi-1.json
@@ -1,52 +1,52 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "जियोकोडिंग में त्रुटि हुई — कृपया बाद में पुनः प्रयास करें",
+  "Address is incomplete (missing city, state, and ZIP)": "पता अधूरा है (शहर, राज्य और पिन कोड गायब हैं)",
+  "All families already have coordinates.": "सभी परिवारों के पास पहले से ही निर्देशांक मौजूद हैं।",
+  "Failed to update coordinates": "निर्देशांक अपडेट करने में विफल",
+  "Failed to update family coordinates": "परिवार के निर्देशांक अपडेट करने में विफल",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "सभी {{geocoded}} परिवारों की जियोकोडिंग पूरी हुई। मानचित्र अब अद्यतित है।",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "{{geocoded}} परिवारों की जियोकोडिंग की गई। {{failed}} को हल नहीं किया जा सका — नीचे विवरण देखें।",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "{{total}} में से {{geocoded}} परिवारों की जियोकोडिंग की गई। {{overflow}} अभी तक संसाधित नहीं हुए हैं — जारी रखने के लिए दोबारा चलाएं।",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "परिवारों की जियोकोडिंग की जा रही है… इसमें एक मिनट तक लग सकता है। आप इस पृष्ठ को खुला रख सकते हैं।",
+  "Geocoding…": "जियोकोडिंग हो रही है…",
+  "No address on file": "कोई पता दर्ज नहीं है",
+  "No match found — check the street address, city, and ZIP": "कोई मिलान नहीं मिला — सड़क का पता, शहर और पिन कोड जांचें",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "टू-फैक्टर ऑथेंटिकेशन (2FA) अनिवार्य होने के बाद उपयोगकर्ताओं के पास नामांकन के लिए कितने दिन हैं। इसे तुरंत लागू करने के लिए 0 पर सेट करें (पुराना व्यवहार)। सक्रिय छूट अवधि को छोटा करने से उपयोगकर्ता तुरंत लॉक हो सकते हैं।",
+  "Open a family to fix its address, then run this again.": "पता ठीक करने के लिए किसी परिवार को खोलें, फिर इसे दोबारा चलाएं।",
+  "Set up now": "अभी सेट अप करें",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "यह OpenStreetMap का उपयोग करके हर उस परिवार के लिए मानचित्र निर्देशांक खोजता है जिनके पास ये नहीं हैं। यह प्रति रन अधिकतम 50 परिवारों को संसाधित करता है; एक पूरे बैच में लगभग एक मिनट लगता है। चलने के दौरान आप इस पृष्ठ को खुला रख सकते हैं। जारी रखें?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "टू-फैक्टर ऑथेंटिकेशन आवश्यक है। नामांकन के लिए आपके पास %d दिन है।",
+    "other": "टू-फैक्टर ऑथेंटिकेशन आवश्यक है। नामांकन के लिए आपके पास %d दिन हैं।"
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "अज्ञात परिवार",
+  "Update All Coordinates": "सभी निर्देशांक अपडेट करें",
+  "Update All Family Coordinates": "सभी परिवारों के निर्देशांक अपडेट करें",
+  "Update Coordinates": "निर्देशांक अपडेट करें",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} सदस्य कॉपी किया गया",
+    "other": "{{count}} सदस्य कॉपी किए गए"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "इस सूची में {{count}} प्राप्तकर्ता है — mailto: लिंक के लिए बहुत अधिक। इसके बजाय पते कॉपी करें का उपयोग करें।",
+    "other": "इस सूची में {{count}} प्राप्तकर्ता हैं — mailto: लिंक के लिए बहुत अधिक। इसके बजाय पते कॉपी करें का उपयोग करें।"
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "ईमेल क्लाइंट के लिए बहुत अधिक प्राप्तकर्ता ({{count}} > {{max}})। इसके बजाय पते कॉपी करें का उपयोग करें।",
+    "other": "ईमेल क्लाइंट के लिए बहुत अधिक प्राप्तकर्ता ({{count}} > {{max}})। इसके बजाय पते कॉपी करें का उपयोग करें।"
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} मिनट शेष",
+    "other": "{{count}} मिनट शेष"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} परिवार की जियोकोडिंग नहीं की जा सकी",
+    "other": "{{count}} परिवारों की जियोकोडिंग नहीं की जा सकी"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…और {{count}} और। बाकी देखने के लिए दोबारा चलाएं।",
+    "other": "…और {{count}} और। बाकी देखने के लिए दोबारा चलाएं।"
   }
 }

--- a/locale/terms/missing/hr/hr-1.json
+++ b/locale/terms/missing/hr/hr-1.json
@@ -1,53 +1,53 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "Došlo je do pogreške geokodiranja — pokušajte ponovno kasnije",
+  "Address is incomplete (missing city, state, and ZIP)": "Adresa je nepotpuna (nedostaju grad, županija i poštanski broj)",
+  "All families already have coordinates.": "Sve obitelji već imaju koordinate.",
+  "Failed to update coordinates": "Ažuriranje koordinata nije uspjelo",
+  "Failed to update family coordinates": "Ažuriranje koordinata obitelji nije uspjelo",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Geokodirano je svih {{geocoded}} obitelji. Karta je sada ažurirana.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Geokodirano je {{geocoded}} obitelji. {{failed}} nije bilo moguće razriješiti — pogledajte pojedinosti u nastavku.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Geokodirano je {{geocoded}} od {{total}} obitelji. {{overflow}} još nije obrađeno — pokrenite ponovno za nastavak.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Geokodiranje obitelji… ovo može potrajati do minute. Ovu stranicu možete ostaviti otvorenom.",
+  "Geocoding…": "Geokodiranje…",
+  "No address on file": "Nema zabilježene adrese",
+  "No match found — check the street address, city, and ZIP": "Nije pronađeno podudaranje — provjerite adresu, grad i poštanski broj",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Broj dana koje korisnici imaju za prijavu na dvofaktorsku autentifikaciju (2FA) nakon što postane obavezna. Postavite na 0 za trenutnu primjenu (prijašnje ponašanje). Skraćivanje aktivnog razdoblja odgode može odmah zaključati korisnike.",
+  "Open a family to fix its address, then run this again.": "Otvorite obitelj kako biste ispravili njezinu adresu, a zatim ponovno pokrenite ovo.",
+  "Set up now": "Postavi sada",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Ovo pronalazi koordinate na karti za svaku obitelj kojoj nedostaju, koristeći OpenStreetMap. Obrađuje do 50 obitelji po pokretanju; potpuna serija traje otprilike minutu. Ovu stranicu možete ostaviti otvorenom dok se izvodi. Nastaviti?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "few": "",
-    "other": ""
+    "one": "Potrebna je dvofaktorska autentifikacija. Imate %d dan za prijavu.",
+    "few": "Potrebna je dvofaktorska autentifikacija. Imate %d dana za prijavu.",
+    "other": "Potrebna je dvofaktorska autentifikacija. Imate %d dana za prijavu."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Nepoznata obitelj",
+  "Update All Coordinates": "Ažuriraj sve koordinate",
+  "Update All Family Coordinates": "Ažuriraj koordinate svih obitelji",
+  "Update Coordinates": "Ažuriraj koordinate",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Kopiran je {{count}} član",
+    "other": "Kopirano je {{count}} članova"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Ovaj popis ima {{count}} primatelja — previše za mailto: poveznicu. Umjesto toga upotrijebite Kopiraj adrese.",
+    "other": "Ovaj popis ima {{count}} primatelja — previše za mailto: poveznicu. Umjesto toga upotrijebite Kopiraj adrese."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Previše primatelja za klijenta e-pošte ({{count}} > {{max}}). Umjesto toga upotrijebite Kopiraj adrese.",
+    "other": "Previše primatelja za klijenta e-pošte ({{count}} > {{max}}). Umjesto toga upotrijebite Kopiraj adrese."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "preostala je {{count}} minuta",
+    "other": "preostalo je {{count}} minuta"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} obitelj nije bilo moguće geokodirati",
+    "other": "{{count}} obitelji nije bilo moguće geokodirati"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…i još {{count}}. Pokrenite ponovno da vidite ostatak.",
+    "other": "…i još {{count}}. Pokrenite ponovno da vidite ostatak."
   }
 }

--- a/locale/terms/missing/hu/hu-1.json
+++ b/locale/terms/missing/hu/hu-1.json
@@ -1,53 +1,53 @@
 {
-  "CSV": "",
-  "N/A": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "N/A": "N/A",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "Geokódolási hiba történt — próbálja újra később",
+  "Address is incomplete (missing city, state, and ZIP)": "A cím hiányos (hiányzik a város, a megye és az irányítószám)",
+  "All families already have coordinates.": "Minden családnak már vannak koordinátái.",
+  "Failed to update coordinates": "A koordináták frissítése sikertelen",
+  "Failed to update family coordinates": "A család koordinátáinak frissítése sikertelen",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Mind a(z) {{geocoded}} család geokódolva lett. A térkép mostantól naprakész.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "{{geocoded}} család geokódolva lett. {{failed}} nem volt feloldható — lásd az alábbi részleteket.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "{{geocoded}} család geokódolva lett a(z) {{total}} közül. {{overflow}} még nincs feldolgozva — futtassa újra a folytatáshoz.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Családok geokódolása… ez akár egy percig is eltarthat. Nyugodtan hagyja nyitva ezt az oldalt.",
+  "Geocoding…": "Geokódolás…",
+  "No address on file": "Nincs rögzített cím",
+  "No match found — check the street address, city, and ZIP": "Nem található egyezés — ellenőrizze a címet, a várost és az irányítószámot",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Azon napok száma, amennyi idő alatt a felhasználóknak be kell állítaniuk a kétfaktoros hitelesítést (2FA), miután az kötelezővé válik. Állítsa 0-ra az azonnali érvényesítéshez (korábbi viselkedés). Az aktív türelmi időszak lerövidítése azonnal kizárhatja a felhasználókat.",
+  "Open a family to fix its address, then run this again.": "Nyisson meg egy családot a cím javításához, majd futtassa ezt újra.",
+  "Set up now": "Beállítás most",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Ez megkeresi a térképkoordinátákat minden olyan családhoz, amelynél hiányoznak, az OpenStreetMap segítségével. Futtatásonként legfeljebb 50 családot dolgoz fel; egy teljes kötegnyi feldolgozás körülbelül egy percet vesz igénybe. Nyugodtan hagyja nyitva ezt az oldalt a futás alatt. Folytatja?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "Kétfaktoros hitelesítés szükséges. %d napja van a beállításra.",
+    "other": "Kétfaktoros hitelesítés szükséges. %d napja van a beállításra."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Ismeretlen család",
+  "Update All Coordinates": "Összes koordináta frissítése",
+  "Update All Family Coordinates": "Összes családi koordináta frissítése",
+  "Update Coordinates": "Koordináták frissítése",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} tag másolva",
+    "other": "{{count}} tag másolva"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Ez a lista {{count}} címzettet tartalmaz — ez túl sok egy mailto: hivatkozáshoz. Használja inkább a Címek másolása funkciót.",
+    "other": "Ez a lista {{count}} címzettet tartalmaz — ez túl sok egy mailto: hivatkozáshoz. Használja inkább a Címek másolása funkciót."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Túl sok címzett az e-mail-kliens számára ({{count}} > {{max}}). Használja inkább a Címek másolása funkciót.",
+    "other": "Túl sok címzett az e-mail-kliens számára ({{count}} > {{max}}). Használja inkább a Címek másolása funkciót."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} perc van hátra",
+    "other": "{{count}} perc van hátra"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} családot nem sikerült geokódolni",
+    "other": "{{count}} családot nem sikerült geokódolni"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…és még {{count}}. Futtassa újra a többi megtekintéséhez.",
+    "other": "…és még {{count}}. Futtassa újra a többi megtekintéséhez."
   }
 }

--- a/locale/terms/missing/id/id-1.json
+++ b/locale/terms/missing/id/id-1.json
@@ -1,52 +1,52 @@
 {
-  "Data": "",
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "Data": "Data",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "Terjadi kesalahan geocoding — coba lagi nanti",
+  "Address is incomplete (missing city, state, and ZIP)": "Alamat tidak lengkap (kota, provinsi, dan kode pos belum diisi)",
+  "All families already have coordinates.": "Semua keluarga sudah memiliki koordinat.",
+  "Failed to update coordinates": "Gagal memperbarui koordinat",
+  "Failed to update family coordinates": "Gagal memperbarui koordinat keluarga",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Berhasil melakukan geocode pada semua {{geocoded}} keluarga. Peta sekarang sudah diperbarui.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Berhasil melakukan geocode pada {{geocoded}} keluarga. {{failed}} tidak dapat diselesaikan — lihat detail di bawah.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Berhasil melakukan geocode pada {{geocoded}} dari {{total}} keluarga. {{overflow}} belum diproses — jalankan lagi untuk melanjutkan.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Melakukan geocoding pada keluarga… ini bisa memakan waktu hingga satu menit. Anda dapat membiarkan halaman ini tetap terbuka.",
+  "Geocoding…": "Melakukan geocoding…",
+  "No address on file": "Tidak ada alamat yang tercatat",
+  "No match found — check the street address, city, and ZIP": "Tidak ditemukan kecocokan — periksa alamat jalan, kota, dan kode pos",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Jumlah hari yang dimiliki pengguna untuk mendaftar autentikasi dua faktor (2FA) setelah menjadi wajib. Atur ke 0 untuk menerapkannya segera (perilaku lama). Memperpendek masa tenggang yang sedang berjalan dapat langsung mengunci akses pengguna.",
+  "Open a family to fix its address, then run this again.": "Buka data keluarga untuk memperbaiki alamatnya, lalu jalankan ini lagi.",
+  "Set up now": "Siapkan sekarang",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Fitur ini mencari koordinat peta untuk setiap keluarga yang belum memilikinya, menggunakan OpenStreetMap. Fitur ini memproses hingga 50 keluarga per proses; satu batch penuh memerlukan waktu sekitar satu menit. Anda dapat membiarkan halaman ini tetap terbuka selama proses berjalan. Lanjutkan?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "other": ""
+    "other": "Autentikasi dua faktor diwajibkan. Anda memiliki %d hari untuk mendaftar."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Keluarga tidak dikenal",
+  "Update All Coordinates": "Perbarui Semua Koordinat",
+  "Update All Family Coordinates": "Perbarui Semua Koordinat Keluarga",
+  "Update Coordinates": "Perbarui Koordinat",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} anggota disalin",
+    "other": "{{count}} anggota disalin"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Daftar ini memiliki {{count}} penerima — terlalu banyak untuk tautan mailto:. Gunakan Salin Alamat sebagai gantinya.",
+    "other": "Daftar ini memiliki {{count}} penerima — terlalu banyak untuk tautan mailto:. Gunakan Salin Alamat sebagai gantinya."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Terlalu banyak penerima untuk klien email ({{count}} > {{max}}). Gunakan Salin Alamat sebagai gantinya.",
+    "other": "Terlalu banyak penerima untuk klien email ({{count}} > {{max}}). Gunakan Salin Alamat sebagai gantinya."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} menit tersisa",
+    "other": "{{count}} menit tersisa"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} keluarga tidak dapat di-geocode",
+    "other": "{{count}} keluarga tidak dapat di-geocode"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…dan {{count}} lainnya. Jalankan lagi untuk melihat sisanya.",
+    "other": "…dan {{count}} lainnya. Jalankan lagi untuk melihat sisanya."
   }
 }

--- a/locale/terms/missing/it/it-1.json
+++ b/locale/terms/missing/it/it-1.json
@@ -1,54 +1,54 @@
 {
-  "Check-out": "",
-  "Auto": "",
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "Check-out": "Check-out",
+  "Auto": "Automatico",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "Si è verificato un errore di geocodifica — riprova più tardi",
+  "Address is incomplete (missing city, state, and ZIP)": "L'indirizzo è incompleto (mancano città, provincia e CAP)",
+  "All families already have coordinates.": "Tutte le famiglie hanno già le coordinate.",
+  "Failed to update coordinates": "Impossibile aggiornare le coordinate",
+  "Failed to update family coordinates": "Impossibile aggiornare le coordinate della famiglia",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Geocodificate tutte le {{geocoded}} famiglie. La mappa è ora aggiornata.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Geocodificate {{geocoded}} famiglie. {{failed}} non è stato possibile risolverle — vedi i dettagli qui sotto.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Geocodificate {{geocoded}} di {{total}} famiglie. {{overflow}} non ancora elaborate — esegui di nuovo per continuare.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Geocodifica delle famiglie in corso… può richiedere fino a un minuto. Puoi lasciare questa pagina aperta.",
+  "Geocoding…": "Geocodifica in corso…",
+  "No address on file": "Nessun indirizzo registrato",
+  "No match found — check the street address, city, and ZIP": "Nessuna corrispondenza trovata — controlla via, città e CAP",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Numero di giorni a disposizione degli utenti per attivare l'autenticazione a due fattori dopo che è stata resa obbligatoria. Imposta 0 per applicarla immediatamente (comportamento precedente). Ridurre un periodo di grazia attivo potrebbe bloccare immediatamente l'accesso agli utenti.",
+  "Open a family to fix its address, then run this again.": "Apri una famiglia per correggere il suo indirizzo, poi esegui di nuovo questa operazione.",
+  "Set up now": "Configura ora",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Questa funzione trova le coordinate mappa per ogni famiglia che ne è priva, utilizzando OpenStreetMap. Elabora fino a 50 famiglie per esecuzione; un batch completo richiede circa un minuto. Puoi lasciare questa pagina aperta durante l'elaborazione. Continuare?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "L'autenticazione a due fattori è obbligatoria. Hai %d giorno per attivarla.",
+    "other": "L'autenticazione a due fattori è obbligatoria. Hai %d giorni per attivarla."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Famiglia sconosciuta",
+  "Update All Coordinates": "Aggiorna tutte le coordinate",
+  "Update All Family Coordinates": "Aggiorna tutte le coordinate delle famiglie",
+  "Update Coordinates": "Aggiorna coordinate",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Copiato {{count}} membro",
+    "other": "Copiati {{count}} membri"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Questo elenco ha {{count}} destinatario — troppi per un link mailto:. Usa invece Copia indirizzi.",
+    "other": "Questo elenco ha {{count}} destinatari — troppi per un link mailto:. Usa invece Copia indirizzi."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Troppi destinatari per il client di posta ({{count}} > {{max}}). Usa invece Copia indirizzi.",
+    "other": "Troppi destinatari per il client di posta ({{count}} > {{max}}). Usa invece Copia indirizzi."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} minuto rimanente",
+    "other": "{{count}} minuti rimanenti"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} famiglia non può essere geocodificata",
+    "other": "{{count}} famiglie non possono essere geocodificate"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…e {{count}} altro. Esegui di nuovo per vedere il resto.",
+    "other": "…e altri {{count}}. Esegui di nuovo per vedere il resto."
   }
 }

--- a/locale/terms/missing/ja/ja-1.json
+++ b/locale/terms/missing/ja/ja-1.json
@@ -1,51 +1,45 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "ジオコーディングエラーが発生しました — 後でもう一度お試しください",
+  "Address is incomplete (missing city, state, and ZIP)": "住所が不完全です（市区町村、都道府県、郵便番号が不足しています）",
+  "All families already have coordinates.": "すべての家族にはすでに座標が設定されています。",
+  "Failed to update coordinates": "座標の更新に失敗しました",
+  "Failed to update family coordinates": "家族の座標の更新に失敗しました",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "{{geocoded}} 件すべての家族のジオコーディングが完了しました。地図は最新の状態です。",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "{{geocoded}} 件の家族のジオコーディングが完了しました。{{failed}} 件は解決できませんでした — 詳細は以下をご覧ください。",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "{{total}} 件中 {{geocoded}} 件の家族のジオコーディングが完了しました。{{overflow}} 件はまだ処理されていません — 続行するには再度実行してください。",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "家族のジオコーディングを実行中です… 最大で1分ほどかかる場合があります。このページは開いたままにしておいて構いません。",
+  "Geocoding…": "ジオコーディング中…",
+  "No address on file": "登録された住所がありません",
+  "No match found — check the street address, city, and ZIP": "一致する結果が見つかりませんでした — 番地、市区町村、郵便番号を確認してください",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "二要素認証（2FA）が必須になった後、ユーザーが登録するまでに猶予される日数です。即時に強制するには0に設定してください（従来の動作）。有効な猶予期間を短縮すると、ユーザーが直ちにロックアウトされる可能性があります。",
+  "Open a family to fix its address, then run this again.": "家族を開いて住所を修正し、その後もう一度実行してください。",
+  "Set up now": "今すぐ設定",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "この機能は、OpenStreetMap を使用して座標が設定されていないすべての家族の地図座標を検索します。1回の実行で最大50件の家族を処理し、フルバッチには約1分かかります。実行中はこのページを開いたままにしておくことができます。続行しますか？",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "other": ""
+    "other": "二要素認証が必要です。登録までにあと %d 日あります。"
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "不明な家族",
+  "Update All Coordinates": "すべての座標を更新",
+  "Update All Family Coordinates": "すべての家族の座標を更新",
+  "Update Coordinates": "座標を更新",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "other": "{{count}} 人のメンバーをコピーしました"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "other": "このリストには {{count}} 人の宛先があります — mailto: リンクには多すぎます。代わりに「アドレスをコピー」をご利用ください。"
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "other": "メールクライアントに対して宛先が多すぎます（{{count}} > {{max}}）。代わりに「アドレスをコピー」をご利用ください。"
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "other": "残り {{count}} 分"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "other": "{{count}} 件の家族はジオコーディングできませんでした"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "other": "…他 {{count}} 件。残りを表示するには再度実行してください。"
   }
 }

--- a/locale/terms/missing/ko/ko-1.json
+++ b/locale/terms/missing/ko/ko-1.json
@@ -1,51 +1,51 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "지오코딩 오류가 발생했습니다 — 나중에 다시 시도하세요",
+  "Address is incomplete (missing city, state, and ZIP)": "주소가 불완전합니다(시/도, 시/군/구, 우편번호 누락)",
+  "All families already have coordinates.": "모든 가족에 이미 좌표가 있습니다.",
+  "Failed to update coordinates": "좌표를 업데이트하지 못했습니다",
+  "Failed to update family coordinates": "가족 좌표를 업데이트하지 못했습니다",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "{{geocoded}}개 가족 모두 지오코딩되었습니다. 지도가 이제 최신 상태입니다.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "{{geocoded}}개 가족이 지오코딩되었습니다. {{failed}}개는 확인할 수 없었습니다 — 아래 세부 정보를 참조하세요.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "{{total}}개 가족 중 {{geocoded}}개가 지오코딩되었습니다. {{overflow}}개는 아직 처리되지 않았습니다 — 계속하려면 다시 실행하세요.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "가족 정보를 지오코딩하는 중… 최대 1분 정도 걸릴 수 있습니다. 이 페이지를 열어 두어도 됩니다.",
+  "Geocoding…": "지오코딩 중…",
+  "No address on file": "등록된 주소 없음",
+  "No match found — check the street address, city, and ZIP": "일치하는 항목을 찾을 수 없습니다 — 도로명 주소, 시/도, 우편번호를 확인하세요",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "2단계 인증(2FA)이 의무화된 후 사용자가 등록할 수 있는 유예 일수입니다. 즉시 적용하려면 0으로 설정하세요(이전 동작 방식). 활성화된 유예 기간을 단축하면 사용자가 즉시 차단될 수 있습니다.",
+  "Open a family to fix its address, then run this again.": "가족 정보를 열어 주소를 수정한 다음 다시 실행하세요.",
+  "Set up now": "지금 설정",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "OpenStreetMap을 사용하여 좌표가 없는 모든 가족의 지도 좌표를 찾습니다. 실행당 최대 50개 가족을 처리하며, 전체 배치는 약 1분이 걸립니다. 실행되는 동안 이 페이지를 열어 두어도 됩니다. 계속하시겠습니까?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "other": ""
+    "other": "2단계 인증이 필요합니다. 등록까지 %d일 남았습니다."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "알 수 없는 가족",
+  "Update All Coordinates": "모든 좌표 업데이트",
+  "Update All Family Coordinates": "모든 가족 좌표 업데이트",
+  "Update Coordinates": "좌표 업데이트",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}}명의 회원을 복사했습니다",
+    "other": "{{count}}명의 회원을 복사했습니다"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "이 목록에는 {{count}}명의 수신자가 있습니다 — mailto: 링크로 처리하기에는 너무 많습니다. 대신 주소 복사를 사용하세요.",
+    "other": "이 목록에는 {{count}}명의 수신자가 있습니다 — mailto: 링크로 처리하기에는 너무 많습니다. 대신 주소 복사를 사용하세요."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "이메일 클라이언트에 비해 수신자가 너무 많습니다({{count}} > {{max}}). 대신 주소 복사를 사용하세요.",
+    "other": "이메일 클라이언트에 비해 수신자가 너무 많습니다({{count}} > {{max}}). 대신 주소 복사를 사용하세요."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}}분 남음",
+    "other": "{{count}}분 남음"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}}개 가족을 지오코딩할 수 없었습니다",
+    "other": "{{count}}개 가족을 지오코딩할 수 없었습니다"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…외 {{count}}개 더. 나머지를 보려면 다시 실행하세요.",
+    "other": "…외 {{count}}개 더. 나머지를 보려면 다시 실행하세요."
   }
 }

--- a/locale/terms/missing/ml/ml-1.json
+++ b/locale/terms/missing/ml/ml-1.json
@@ -1,60 +1,60 @@
 {
-  "CSV": "",
+  "CSV": "CSV",
   "Email sent to %d family.": {
     "one": "%d കുടുംബത്തിലേക്ക് ഇമെയിൽ അയച്ചു.|%d കുടുംബങ്ങളിലേക്ക് ഇമെയിൽ അയച്ചു.|%d കുടുംബങ്ങളിലേക്ക് ഇമെയിൽ അയച്ചു.",
-    "other": ""
+    "other": "%d കുടുംബങ്ങളിലേക്ക് ഇമെയിൽ അയച്ചു."
   },
-  "OFX": "",
+  "OFX": "OFX",
   "PDF successfully emailed to %d family.": {
     "one": "%d കുടുംബത്തിലേക്ക് PDF വിജയകരമായി ഇമെയിൽ ചെയ്തു.|%d കുടുംബങ്ങളിലേക്ക് PDF വിജയകരമായി ഇമെയിൽ ചെയ്തു.|%d കുടുംബങ്ങളിലേക്ക് PDF വിജയകരമായി ഇമെയിൽ ചെയ്തു.",
-    "other": ""
+    "other": "%d കുടുംബങ്ങളിലേക്ക് PDF വിജയകരമായി ഇമെയിൽ ചെയ്തു."
   },
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "A geocoding error occurred — try again later": "ജിയോകോഡിംഗ് പിശക് സംഭവിച്ചു — ദയവായി പിന്നീട് വീണ്ടും ശ്രമിക്കുക",
+  "Address is incomplete (missing city, state, and ZIP)": "വിലാസം അപൂർണ്ണമാണ് (നഗരം, സംസ്ഥാനം, പിൻ കോഡ് എന്നിവ ഇല്ല)",
+  "All families already have coordinates.": "എല്ലാ കുടുംബങ്ങൾക്കും ഇതിനകം കോർഡിനേറ്റുകൾ ഉണ്ട്.",
+  "Failed to update coordinates": "കോർഡിനേറ്റുകൾ അപ്ഡേറ്റ് ചെയ്യുന്നതിൽ പരാജയപ്പെട്ടു",
+  "Failed to update family coordinates": "കുടുംബത്തിന്റെ കോർഡിനേറ്റുകൾ അപ്ഡേറ്റ് ചെയ്യുന്നതിൽ പരാജയപ്പെട്ടു",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "{{geocoded}} കുടുംബങ്ങൾ മുഴുവനും ജിയോകോഡ് ചെയ്തു. മാപ്പ് ഇപ്പോൾ കാലികമാണ്.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "{{geocoded}} കുടുംബങ്ങൾ ജിയോകോഡ് ചെയ്തു. {{failed}} എണ്ണം പരിഹരിക്കാൻ കഴിഞ്ഞില്ല — താഴെ വിശദാംശങ്ങൾ കാണുക.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "{{total}} കുടുംബങ്ങളിൽ {{geocoded}} എണ്ണം ജിയോകോഡ് ചെയ്തു. {{overflow}} എണ്ണം ഇതുവരെ പ്രോസസ്സ് ചെയ്തിട്ടില്ല — തുടരാൻ വീണ്ടും പ്രവർത്തിപ്പിക്കുക.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "കുടുംബങ്ങളെ ജിയോകോഡ് ചെയ്യുന്നു… ഇതിന് ഒരു മിനിറ്റ് വരെ എടുത്തേക്കാം. ഈ പേജ് തുറന്നിരിക്കാൻ അനുവദിക്കാം.",
+  "Geocoding…": "ജിയോകോഡ് ചെയ്യുന്നു…",
+  "No address on file": "രേഖപ്പെടുത്തിയ വിലാസമില്ല",
+  "No match found — check the street address, city, and ZIP": "പൊരുത്തമൊന്നും കണ്ടെത്തിയില്ല — തെരുവ് വിലാസം, നഗരം, പിൻ കോഡ് എന്നിവ പരിശോധിക്കുക",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "രണ്ട്-ഘടക പ്രാമാണീകരണം (2FA) നിർബന്ധമായതിന് ശേഷം ഉപയോക്താക്കൾക്ക് രജിസ്റ്റർ ചെയ്യാൻ ലഭിക്കുന്ന ദിവസങ്ങളുടെ എണ്ണം. ഉടൻ നടപ്പിലാക്കാൻ 0 ആയി സജ്ജമാക്കുക (പഴയ പെരുമാറ്റം). സജീവമായ ഗ്രേസ് പിരീഡ് ചുരുക്കുന്നത് ഉപയോക്താക്കളെ ഉടൻ ലോക്ക് ചെയ്യപ്പെടാൻ ഇടയാക്കാം.",
+  "Open a family to fix its address, then run this again.": "വിലാസം ശരിയാക്കാൻ ഒരു കുടുംബം തുറന്ന്, തുടർന്ന് ഇത് വീണ്ടും പ്രവർത്തിപ്പിക്കുക.",
+  "Set up now": "ഇപ്പോൾ സജ്ജമാക്കുക",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "OpenStreetMap ഉപയോഗിച്ച്, കോർഡിനേറ്റുകൾ ഇല്ലാത്ത എല്ലാ കുടുംബങ്ങൾക്കും ഇത് മാപ്പ് കോർഡിനേറ്റുകൾ കണ്ടെത്തുന്നു. ഓരോ റണ്ണിലും പരമാവധി 50 കുടുംബങ്ങൾ പ്രോസസ്സ് ചെയ്യുന്നു; ഒരു പൂർണ്ണ ബാച്ചിന് ഏകദേശം ഒരു മിനിറ്റ് എടുക്കും. ഇത് പ്രവർത്തിക്കുമ്പോൾ ഈ പേജ് തുറന്നിരിക്കാൻ അനുവദിക്കാം. തുടരണോ?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "രണ്ട്-ഘടക പ്രാമാണീകരണം ആവശ്യമാണ്. രജിസ്റ്റർ ചെയ്യാൻ നിങ്ങൾക്ക് %d ദിവസം ഉണ്ട്.",
+    "other": "രണ്ട്-ഘടക പ്രാമാണീകരണം ആവശ്യമാണ്. രജിസ്റ്റർ ചെയ്യാൻ നിങ്ങൾക്ക് %d ദിവസങ്ങൾ ഉണ്ട്."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "അജ്ഞാത കുടുംബം",
+  "Update All Coordinates": "എല്ലാ കോർഡിനേറ്റുകളും അപ്ഡേറ്റ് ചെയ്യുക",
+  "Update All Family Coordinates": "എല്ലാ കുടുംബ കോർഡിനേറ്റുകളും അപ്ഡേറ്റ് ചെയ്യുക",
+  "Update Coordinates": "കോർഡിനേറ്റുകൾ അപ്ഡേറ്റ് ചെയ്യുക",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} അംഗത്തെ പകർത്തി",
+    "other": "{{count}} അംഗങ്ങളെ പകർത്തി"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "ഈ ലിസ്റ്റിൽ {{count}} സ്വീകർത്താവ് ഉണ്ട് — mailto: ലിങ്കിന് വളരെ കൂടുതലാണ്. പകരം വിലാസങ്ങൾ പകർത്തുക ഉപയോഗിക്കുക.",
+    "other": "ഈ ലിസ്റ്റിൽ {{count}} സ്വീകർത്താക്കൾ ഉണ്ട് — mailto: ലിങ്കിന് വളരെ കൂടുതലാണ്. പകരം വിലാസങ്ങൾ പകർത്തുക ഉപയോഗിക്കുക."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "ഇമെയിൽ ക്ലയന്റിന് സ്വീകർത്താക്കൾ വളരെ കൂടുതലാണ് ({{count}} > {{max}}). പകരം വിലാസങ്ങൾ പകർത്തുക ഉപയോഗിക്കുക.",
+    "other": "ഇമെയിൽ ക്ലയന്റിന് സ്വീകർത്താക്കൾ വളരെ കൂടുതലാണ് ({{count}} > {{max}}). പകരം വിലാസങ്ങൾ പകർത്തുക ഉപയോഗിക്കുക."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} മിനിറ്റ് ബാക്കി",
+    "other": "{{count}} മിനിറ്റുകൾ ബാക്കി"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} കുടുംബത്തെ ജിയോകോഡ് ചെയ്യാൻ കഴിഞ്ഞില്ല",
+    "other": "{{count}} കുടുംബങ്ങളെ ജിയോകോഡ് ചെയ്യാൻ കഴിഞ്ഞില്ല"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…കൂടാതെ {{count}} കൂടി. ബാക്കിയുള്ളവ കാണാൻ വീണ്ടും പ്രവർത്തിപ്പിക്കുക.",
+    "other": "…കൂടാതെ {{count}} കൂടി. ബാക്കിയുള്ളവ കാണാൻ വീണ്ടും പ്രവർത്തിപ്പിക്കുക."
   }
 }

--- a/locale/terms/missing/nb/nb-1.json
+++ b/locale/terms/missing/nb/nb-1.json
@@ -1,62 +1,62 @@
 {
-  "Data": "",
-  "Auto": "",
-  "CSV": "",
+  "Data": "Data",
+  "Auto": "Auto",
+  "CSV": "CSV",
   "Email sent to %d family.": {
     "one": "E-post sendt til %d familie.|E-post sendt til %d familier.|E-post sendt til %d familier.",
-    "other": ""
+    "other": "E-post sendt til %d familier."
   },
-  "OFX": "",
+  "OFX": "OFX",
   "PDF successfully emailed to %d family.": {
     "one": "PDF ble sendt på e-post til %d familie.|PDF ble sendt på e-post til %d familier.|PDF ble sendt på e-post til %d familier.",
-    "other": ""
+    "other": "PDF ble sendt på e-post til %d familier."
   },
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "A geocoding error occurred — try again later": "Det oppstod en geokodingsfeil — prøv igjen senere",
+  "Address is incomplete (missing city, state, and ZIP)": "Adressen er ufullstendig (by, fylke og postnummer mangler)",
+  "All families already have coordinates.": "Alle familier har allerede koordinater.",
+  "Failed to update coordinates": "Kunne ikke oppdatere koordinater",
+  "Failed to update family coordinates": "Kunne ikke oppdatere familiens koordinater",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Geokodet alle {{geocoded}} familier. Kartet er nå oppdatert.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Geokodet {{geocoded}} familier. {{failed}} kunne ikke løses — se detaljer nedenfor.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Geokodet {{geocoded}} av {{total}} familier. {{overflow}} er ikke behandlet ennå — kjør på nytt for å fortsette.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Geokoder familier… dette kan ta opptil ett minutt. Du kan la denne siden være åpen.",
+  "Geocoding…": "Geokoder…",
+  "No address on file": "Ingen adresse registrert",
+  "No match found — check the street address, city, and ZIP": "Ingen treff funnet — sjekk gateadresse, by og postnummer",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Antall dager brukere har på seg til å aktivere tofaktorautentisering (2FA) etter at det er blitt obligatorisk. Sett til 0 for å håndheve det umiddelbart (tidligere virkemåte). Å forkorte en aktiv overgangsperiode kan umiddelbart låse ute brukere.",
+  "Open a family to fix its address, then run this again.": "Åpne en familie for å rette adressen, og kjør deretter dette på nytt.",
+  "Set up now": "Konfigurer nå",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Dette finner kartkoordinater for hver familie som mangler dem, ved hjelp av OpenStreetMap. Det behandler opptil 50 familier per kjøring; en full batch tar omtrent ett minutt. Du kan la denne siden være åpen mens den kjører. Fortsette?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "Tofaktorautentisering er påkrevd. Du har %d dag på deg til å aktivere den.",
+    "other": "Tofaktorautentisering er påkrevd. Du har %d dager på deg til å aktivere den."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Ukjent familie",
+  "Update All Coordinates": "Oppdater alle koordinater",
+  "Update All Family Coordinates": "Oppdater alle familiekoordinater",
+  "Update Coordinates": "Oppdater koordinater",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Kopierte {{count}} medlem",
+    "other": "Kopierte {{count}} medlemmer"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Denne listen har {{count}} mottaker — for mange for en mailto:-lenke. Bruk Kopier adresser i stedet.",
+    "other": "Denne listen har {{count}} mottakere — for mange for en mailto:-lenke. Bruk Kopier adresser i stedet."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "For mange mottakere for e-postklienten ({{count}} > {{max}}). Bruk Kopier adresser i stedet.",
+    "other": "For mange mottakere for e-postklienten ({{count}} > {{max}}). Bruk Kopier adresser i stedet."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} minutt igjen",
+    "other": "{{count}} minutter igjen"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} familie kunne ikke geokodes",
+    "other": "{{count}} familier kunne ikke geokodes"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…og {{count}} til. Kjør på nytt for å se resten.",
+    "other": "…og {{count}} til. Kjør på nytt for å se resten."
   }
 }

--- a/locale/terms/missing/nl/nl-1.json
+++ b/locale/terms/missing/nl/nl-1.json
@@ -1,63 +1,63 @@
 {
-  "Code": "",
-  "Items": "",
-  "Planning": "",
-  "CSV": "",
+  "Code": "Code",
+  "Items": "Items",
+  "Planning": "Planning",
+  "CSV": "CSV",
   "Email sent to %d family.": {
     "one": "E-mail verzonden naar %d gezin.|E-mail verzonden naar %d gezinnen.|E-mail verzonden naar %d gezinnen.",
-    "other": ""
+    "other": "E-mail verzonden naar %d gezinnen."
   },
-  "OFX": "",
+  "OFX": "OFX",
   "PDF successfully emailed to %d family.": {
     "one": "PDF succesvol gemaild naar %d gezin.|PDF succesvol gemaild naar %d gezinnen.|PDF succesvol gemaild naar %d gezinnen.",
-    "other": ""
+    "other": "PDF succesvol gemaild naar %d gezinnen."
   },
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "A geocoding error occurred — try again later": "Er is een geocoderingsfout opgetreden — probeer het later opnieuw",
+  "Address is incomplete (missing city, state, and ZIP)": "Het adres is onvolledig (plaats, provincie en postcode ontbreken)",
+  "All families already have coordinates.": "Alle gezinnen hebben al coördinaten.",
+  "Failed to update coordinates": "Bijwerken van coördinaten mislukt",
+  "Failed to update family coordinates": "Bijwerken van de coördinaten van het gezin mislukt",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Alle {{geocoded}} gezinnen zijn gegeocodeerd. De kaart is nu up-to-date.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "{{geocoded}} gezinnen zijn gegeocodeerd. {{failed}} konden niet worden herleid — zie details hieronder.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "{{geocoded}} van de {{total}} gezinnen zijn gegeocodeerd. {{overflow}} zijn nog niet verwerkt — voer opnieuw uit om door te gaan.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Gezinnen worden gegeocodeerd… dit kan tot een minuut duren. U kunt deze pagina open laten staan.",
+  "Geocoding…": "Geocoderen…",
+  "No address on file": "Geen adres bekend",
+  "No match found — check the street address, city, and ZIP": "Geen overeenkomst gevonden — controleer straat, plaats en postcode",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Aantal dagen dat gebruikers hebben om tweefactorauthenticatie (2FA) in te stellen nadat dit verplicht is geworden. Stel in op 0 om dit onmiddellijk af te dwingen (voormalig gedrag). Het verkorten van een actieve overgangsperiode kan gebruikers onmiddellijk buitensluiten.",
+  "Open a family to fix its address, then run this again.": "Open een gezin om het adres te corrigeren en voer dit daarna opnieuw uit.",
+  "Set up now": "Nu instellen",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Dit zoekt kaartcoördinaten voor elk gezin dat ze mist, met behulp van OpenStreetMap. Er worden per keer maximaal 50 gezinnen verwerkt; een volledige batch duurt ongeveer een minuut. U kunt deze pagina open laten staan terwijl dit wordt uitgevoerd. Doorgaan?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "Tweefactorauthenticatie is verplicht. U heeft nog %d dag om dit in te stellen.",
+    "other": "Tweefactorauthenticatie is verplicht. U heeft nog %d dagen om dit in te stellen."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Onbekend gezin",
+  "Update All Coordinates": "Alle coördinaten bijwerken",
+  "Update All Family Coordinates": "Alle gezinscoördinaten bijwerken",
+  "Update Coordinates": "Coördinaten bijwerken",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} lid gekopieerd",
+    "other": "{{count}} leden gekopieerd"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Deze lijst heeft {{count}} ontvanger — te veel voor een mailto:-link. Gebruik in plaats daarvan Adressen kopiëren.",
+    "other": "Deze lijst heeft {{count}} ontvangers — te veel voor een mailto:-link. Gebruik in plaats daarvan Adressen kopiëren."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Te veel ontvangers voor de e-mailclient ({{count}} > {{max}}). Gebruik in plaats daarvan Adressen kopiëren.",
+    "other": "Te veel ontvangers voor de e-mailclient ({{count}} > {{max}}). Gebruik in plaats daarvan Adressen kopiëren."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "nog {{count}} minuut",
+    "other": "nog {{count}} minuten"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} gezin kon niet worden gegeocodeerd",
+    "other": "{{count}} gezinnen konden niet worden gegeocodeerd"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…en {{count}} meer. Voer opnieuw uit om de rest te zien.",
+    "other": "…en {{count}} meer. Voer opnieuw uit om de rest te zien."
   }
 }

--- a/locale/terms/missing/pl/pl-1.json
+++ b/locale/terms/missing/pl/pl-1.json
@@ -1,64 +1,64 @@
 {
-  "Auto": "",
-  "CSV": "",
+  "Auto": "Automatyczny",
+  "CSV": "CSV",
   "Email sent to %d family.": {
     "one": "E-mail wysłany do %d rodziny.|E-mail wysłany do %d rodzin.|E-mail wysłany do %d rodzin.|E-mail wysłany do %d rodzin.|E-mail wysłany do %d rodzin.",
-    "few": "",
-    "other": ""
+    "few": "E-mail wysłany do %d rodzin.",
+    "other": "E-mail wysłany do %d rodzin."
   },
-  "OFX": "",
+  "OFX": "OFX",
   "PDF successfully emailed to %d family.": {
     "one": "PDF został pomyślnie wysłany e-mailem do %d rodziny.|PDF został pomyślnie wysłany e-mailem do %d rodzin.|PDF został pomyślnie wysłany e-mailem do %d rodzin.|PDF został pomyślnie wysłany e-mailem do %d rodzin.|PDF został pomyślnie wysłany e-mailem do %d rodzin.",
-    "few": "",
-    "other": ""
+    "few": "PDF został pomyślnie wysłany e-mailem do %d rodzin.",
+    "other": "PDF został pomyślnie wysłany e-mailem do %d rodzin."
   },
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "A geocoding error occurred — try again later": "Wystąpił błąd geokodowania — spróbuj ponownie później",
+  "Address is incomplete (missing city, state, and ZIP)": "Adres jest niekompletny (brak miasta, województwa i kodu pocztowego)",
+  "All families already have coordinates.": "Wszystkie rodziny mają już współrzędne.",
+  "Failed to update coordinates": "Nie udało się zaktualizować współrzędnych",
+  "Failed to update family coordinates": "Nie udało się zaktualizować współrzędnych rodziny",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Zgeokodowano wszystkie {{geocoded}} rodziny. Mapa jest teraz aktualna.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Zgeokodowano {{geocoded}} rodzin. {{failed}} nie udało się rozwiązać — zobacz szczegóły poniżej.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Zgeokodowano {{geocoded}} z {{total}} rodzin. {{overflow}} jeszcze nie przetworzono — uruchom ponownie, aby kontynuować.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Geokodowanie rodzin… może to potrwać do minuty. Możesz zostawić tę stronę otwartą.",
+  "Geocoding…": "Geokodowanie…",
+  "No address on file": "Brak zarejestrowanego adresu",
+  "No match found — check the street address, city, and ZIP": "Nie znaleziono dopasowania — sprawdź adres, miasto i kod pocztowy",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Liczba dni, jakie użytkownicy mają na włączenie uwierzytelniania dwuskładnikowego (2FA) po tym, jak stanie się ono obowiązkowe. Ustaw 0, aby wymusić je natychmiast (dawne zachowanie). Skrócenie aktywnego okresu karencji może natychmiast zablokować dostęp użytkownikom.",
+  "Open a family to fix its address, then run this again.": "Otwórz rodzinę, aby poprawić jej adres, a następnie uruchom to ponownie.",
+  "Set up now": "Skonfiguruj teraz",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Znajduje to współrzędne mapy dla każdej rodziny, której ich brakuje, korzystając z OpenStreetMap. Przetwarza do 50 rodzin na uruchomienie; pełna partia trwa około minuty. Możesz zostawić tę stronę otwartą podczas działania. Kontynuować?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "few": "",
-    "other": ""
+    "one": "Uwierzytelnianie dwuskładnikowe jest wymagane. Masz %d dzień na jego włączenie.",
+    "few": "Uwierzytelnianie dwuskładnikowe jest wymagane. Masz %d dni na jego włączenie.",
+    "other": "Uwierzytelnianie dwuskładnikowe jest wymagane. Masz %d dni na jego włączenie."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Nieznana rodzina",
+  "Update All Coordinates": "Zaktualizuj wszystkie współrzędne",
+  "Update All Family Coordinates": "Zaktualizuj współrzędne wszystkich rodzin",
+  "Update Coordinates": "Zaktualizuj współrzędne",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Skopiowano {{count}} członka",
+    "other": "Skopiowano {{count}} członków"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Ta lista ma {{count}} odbiorcę — zbyt wielu dla linku mailto:. Użyj zamiast tego opcji Kopiuj adresy.",
+    "other": "Ta lista ma {{count}} odbiorców — zbyt wielu dla linku mailto:. Użyj zamiast tego opcji Kopiuj adresy."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Zbyt wielu odbiorców dla klienta poczty e-mail ({{count}} > {{max}}). Użyj zamiast tego opcji Kopiuj adresy.",
+    "other": "Zbyt wielu odbiorców dla klienta poczty e-mail ({{count}} > {{max}}). Użyj zamiast tego opcji Kopiuj adresy."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "Pozostała {{count}} minuta",
+    "other": "Pozostało {{count}} minut"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "Nie udało się zgeokodować {{count}} rodziny",
+    "other": "Nie udało się zgeokodować {{count}} rodzin"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…i jeszcze {{count}}. Uruchom ponownie, aby zobaczyć resztę.",
+    "other": "…i jeszcze {{count}}. Uruchom ponownie, aby zobaczyć resztę."
   }
 }

--- a/locale/terms/missing/pt-br/pt-br-1.json
+++ b/locale/terms/missing/pt-br/pt-br-1.json
@@ -1,60 +1,60 @@
 {
-  "CSV": "",
+  "CSV": "CSV",
   "Email sent to %d family.": {
     "one": "E-mail enviado para %d família.|E-mail enviado para %d famílias.|E-mail enviado para %d famílias.",
-    "other": ""
+    "other": "E-mail enviado para %d famílias."
   },
-  "OFX": "",
+  "OFX": "OFX",
   "PDF successfully emailed to %d family.": {
     "one": "PDF enviado com sucesso por e-mail para %d família.|PDF enviado com sucesso por e-mail para %d famílias.|PDF enviado com sucesso por e-mail para %d famílias.",
-    "other": ""
+    "other": "PDF enviado com sucesso por e-mail para %d famílias."
   },
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "A geocoding error occurred — try again later": "Ocorreu um erro de geocodificação — tente novamente mais tarde",
+  "Address is incomplete (missing city, state, and ZIP)": "O endereço está incompleto (faltando cidade, estado e CEP)",
+  "All families already have coordinates.": "Todas as famílias já têm coordenadas.",
+  "Failed to update coordinates": "Falha ao atualizar as coordenadas",
+  "Failed to update family coordinates": "Falha ao atualizar as coordenadas da família",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Geocodificação concluída para todas as {{geocoded}} famílias. O mapa está atualizado.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "{{geocoded}} famílias geocodificadas. {{failed}} não puderam ser resolvidas — veja os detalhes abaixo.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "{{geocoded}} de {{total}} famílias geocodificadas. {{overflow}} ainda não foram processadas — execute novamente para continuar.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Geocodificando famílias… isso pode levar até um minuto. Você pode manter esta página aberta.",
+  "Geocoding…": "Geocodificando…",
+  "No address on file": "Nenhum endereço registrado",
+  "No match found — check the street address, city, and ZIP": "Nenhuma correspondência encontrada — verifique o endereço, a cidade e o CEP",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Número de dias que os usuários têm para se inscrever na autenticação de dois fatores (2FA) após ela se tornar obrigatória. Defina como 0 para exigir imediatamente (comportamento legado). Reduzir um período de carência ativo pode bloquear o acesso dos usuários imediatamente.",
+  "Open a family to fix its address, then run this again.": "Abra uma família para corrigir o endereço e execute isso novamente.",
+  "Set up now": "Configurar agora",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Isso encontra as coordenadas no mapa para todas as famílias que ainda não as possuem, usando o OpenStreetMap. Processa até 50 famílias por execução; um lote completo leva cerca de um minuto. Você pode manter esta página aberta enquanto o processo é executado. Continuar?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "A autenticação de dois fatores é obrigatória. Você tem %d dia para se inscrever.",
+    "other": "A autenticação de dois fatores é obrigatória. Você tem %d dias para se inscrever."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Família desconhecida",
+  "Update All Coordinates": "Atualizar Todas as Coordenadas",
+  "Update All Family Coordinates": "Atualizar Todas as Coordenadas das Famílias",
+  "Update Coordinates": "Atualizar Coordenadas",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} membro copiado",
+    "other": "{{count}} membros copiados"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Esta lista tem {{count}} destinatário — muitos para um link mailto:. Use Copiar Endereços.",
+    "other": "Esta lista tem {{count}} destinatários — muitos para um link mailto:. Use Copiar Endereços."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Muitos destinatários para o cliente de e-mail ({{count}} > {{max}}). Use Copiar Endereços.",
+    "other": "Muitos destinatários para o cliente de e-mail ({{count}} > {{max}}). Use Copiar Endereços."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} minuto restante",
+    "other": "{{count}} minutos restantes"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} família não pôde ser geocodificada",
+    "other": "{{count}} famílias não puderam ser geocodificadas"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…e mais {{count}}. Execute novamente para ver o restante.",
+    "other": "…e mais {{count}}. Execute novamente para ver o restante."
   }
 }

--- a/locale/terms/missing/pt/pt-1.json
+++ b/locale/terms/missing/pt/pt-1.json
@@ -1,60 +1,60 @@
 {
-  "CSV": "",
+  "CSV": "CSV",
   "Email sent to %d family.": {
     "one": "E-mail enviado para %d família.|E-mail enviado para %d famílias.|E-mail enviado para %d famílias.",
-    "other": ""
+    "other": "E-mail enviado para %d famílias."
   },
-  "OFX": "",
+  "OFX": "OFX",
   "PDF successfully emailed to %d family.": {
     "one": "PDF enviado com sucesso por e-mail para %d família.|PDF enviado com sucesso por e-mail para %d famílias.|PDF enviado com sucesso por e-mail para %d famílias.",
-    "other": ""
+    "other": "PDF enviado com sucesso por e-mail para %d famílias."
   },
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "A geocoding error occurred — try again later": "Ocorreu um erro de geocodificação — tente novamente mais tarde",
+  "Address is incomplete (missing city, state, and ZIP)": "O endereço está incompleto (falta cidade, estado e código postal)",
+  "All families already have coordinates.": "Todas as famílias já têm coordenadas.",
+  "Failed to update coordinates": "Falha ao atualizar as coordenadas",
+  "Failed to update family coordinates": "Falha ao atualizar as coordenadas da família",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Geocodificação concluída para todas as {{geocoded}} famílias. O mapa está agora atualizado.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "{{geocoded}} famílias geocodificadas. {{failed}} não puderam ser resolvidas — veja os detalhes abaixo.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "{{geocoded}} de {{total}} famílias geocodificadas. {{overflow}} ainda não processadas — execute novamente para continuar.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "A geocodificar famílias… isto pode demorar até um minuto. Pode manter esta página aberta.",
+  "Geocoding…": "A geocodificar…",
+  "No address on file": "Nenhum endereço registado",
+  "No match found — check the street address, city, and ZIP": "Nenhuma correspondência encontrada — verifique o endereço, a cidade e o código postal",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Número de dias que os utilizadores têm para se inscrever na autenticação de dois fatores (2FA) depois de esta se tornar obrigatória. Defina como 0 para aplicar imediatamente (comportamento legado). Reduzir um período de tolerância ativo pode bloquear imediatamente o acesso dos utilizadores.",
+  "Open a family to fix its address, then run this again.": "Abra uma família para corrigir o endereço e execute isto novamente.",
+  "Set up now": "Configurar agora",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Isto encontra as coordenadas do mapa para todas as famílias que não as têm, utilizando o OpenStreetMap. Processa até 50 famílias por execução; um lote completo demora cerca de um minuto. Pode manter esta página aberta enquanto é executado. Continuar?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "A autenticação de dois fatores é obrigatória. Tem %d dia para se inscrever.",
+    "other": "A autenticação de dois fatores é obrigatória. Tem %d dias para se inscrever."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Família desconhecida",
+  "Update All Coordinates": "Atualizar Todas as Coordenadas",
+  "Update All Family Coordinates": "Atualizar Todas as Coordenadas das Famílias",
+  "Update Coordinates": "Atualizar Coordenadas",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Copiado {{count}} membro",
+    "other": "Copiados {{count}} membros"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Esta lista tem {{count}} destinatário — demasiado para um link mailto:. Utilize Copiar Endereços em alternativa.",
+    "other": "Esta lista tem {{count}} destinatários — demasiados para um link mailto:. Utilize Copiar Endereços em alternativa."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Demasiados destinatários para o cliente de e-mail ({{count}} > {{max}}). Utilize Copiar Endereços em alternativa.",
+    "other": "Demasiados destinatários para o cliente de e-mail ({{count}} > {{max}}). Utilize Copiar Endereços em alternativa."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} min restante",
+    "other": "{{count}} min restantes"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} família não pôde ser geocodificada",
+    "other": "{{count}} famílias não puderam ser geocodificadas"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…e mais {{count}}. Execute novamente para ver o resto.",
+    "other": "…e mais {{count}}. Execute novamente para ver o resto."
   }
 }

--- a/locale/terms/missing/ro/ro-1.json
+++ b/locale/terms/missing/ro/ro-1.json
@@ -1,68 +1,68 @@
 {
-  "Important": "",
-  "Major": "",
-  "Catalog": "",
-  "Auto": "",
-  "CSV": "",
+  "Important": "Important",
+  "Major": "Major",
+  "Catalog": "Catalog",
+  "Auto": "Automat",
+  "CSV": "CSV",
   "Email sent to %d family.": {
-    "one": "E-mail trimis către %d familie.|E-mail trimis către %d familii.|E-mail trimis către %d de familii.|E-mail trimis către %d familii.|E-mail trimis către %d de familii.",
-    "few": "",
-    "other": ""
+    "one": "E-mail trimis către %d familie.",
+    "few": "E-mail trimis către %d familii.",
+    "other": "E-mail trimis către %d de familii."
   },
-  "N/A": "",
-  "OFX": "",
+  "N/A": "N/A",
+  "OFX": "OFX",
   "PDF successfully emailed to %d family.": {
-    "one": "PDF trimis cu succes prin e-mail către %d familie.|PDF trimis cu succes prin e-mail către %d familii.|PDF trimis cu succes prin e-mail către %d de familii.|PDF trimis cu succes prin e-mail către %d familii.|PDF trimis cu succes prin e-mail către %d de familii.",
-    "few": "",
-    "other": ""
+    "one": "PDF trimis cu succes prin e-mail către %d familie.",
+    "few": "PDF trimis cu succes prin e-mail către %d familii.",
+    "other": "PDF trimis cu succes prin e-mail către %d de familii."
   },
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "A geocoding error occurred — try again later": "A apărut o eroare de geocodificare — încercați din nou mai târziu",
+  "Address is incomplete (missing city, state, and ZIP)": "Adresa este incompletă (lipsesc orașul, județul și codul poștal)",
+  "All families already have coordinates.": "Toate familiile au deja coordonate.",
+  "Failed to update coordinates": "Actualizarea coordonatelor a eșuat",
+  "Failed to update family coordinates": "Actualizarea coordonatelor familiei a eșuat",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "S-au geocodificat toate cele {{geocoded}} familii. Harta este acum actualizată.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "S-au geocodificat {{geocoded}} familii. {{failed}} nu au putut fi rezolvate — vedeți detaliile de mai jos.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "S-au geocodificat {{geocoded}} din {{total}} familii. {{overflow}} nu au fost încă procesate — rulați din nou pentru a continua.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Se geocodifică familiile… acest lucru poate dura până la un minut. Puteți lăsa această pagină deschisă.",
+  "Geocoding…": "Se geocodifică…",
+  "No address on file": "Nicio adresă înregistrată",
+  "No match found — check the street address, city, and ZIP": "Nu s-a găsit nicio potrivire — verificați adresa, orașul și codul poștal",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Numărul de zile pe care utilizatorii le au pentru a se înscrie la autentificarea în doi factori după ce aceasta devine obligatorie. Setați la 0 pentru a o impune imediat (comportament vechi). Scurtarea unei perioade de grație active poate bloca imediat accesul utilizatorilor.",
+  "Open a family to fix its address, then run this again.": "Deschideți o familie pentru a-i corecta adresa, apoi rulați din nou această acțiune.",
+  "Set up now": "Configurați acum",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Aceasta găsește coordonatele pe hartă pentru fiecare familie căreia îi lipsesc, folosind OpenStreetMap. Procesează până la 50 de familii pe rulare; un lot complet durează aproximativ un minut. Puteți lăsa această pagină deschisă în timp ce rulează. Continuați?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "few": "",
-    "other": ""
+    "one": "Autentificarea în doi factori este necesară. Aveți %d zi pentru a vă înscrie.",
+    "few": "Autentificarea în doi factori este necesară. Aveți %d zile pentru a vă înscrie.",
+    "other": "Autentificarea în doi factori este necesară. Aveți %d de zile pentru a vă înscrie."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Familie necunoscută",
+  "Update All Coordinates": "Actualizați toate coordonatele",
+  "Update All Family Coordinates": "Actualizați toate coordonatele familiilor",
+  "Update Coordinates": "Actualizați coordonatele",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "S-a copiat {{count}} membru",
+    "other": "S-au copiat {{count}} membri"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Această listă are {{count}} destinatar — prea mulți pentru un link mailto. Folosiți în schimb Copiere adrese.",
+    "other": "Această listă are {{count}} destinatari — prea mulți pentru un link mailto. Folosiți în schimb Copiere adrese."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Prea mulți destinatari pentru clientul de e-mail ({{count}} > {{max}}). Folosiți în schimb Copiere adrese.",
+    "other": "Prea mulți destinatari pentru clientul de e-mail ({{count}} > {{max}}). Folosiți în schimb Copiere adrese."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} minut rămas",
+    "other": "{{count}} minute rămase"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} familie nu a putut fi geocodificată",
+    "other": "{{count}} familii nu au putut fi geocodificate"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…și încă {{count}}. Rulați din nou pentru a vedea restul.",
+    "other": "…și încă {{count}}. Rulați din nou pentru a vedea restul."
   }
 }

--- a/locale/terms/missing/ru/ru-1.json
+++ b/locale/terms/missing/ru/ru-1.json
@@ -1,66 +1,66 @@
 {
-  "CSV": "",
+  "CSV": "CSV",
   "Email sent to %d family.": {
     "one": "Письмо отправлено %d семье.|Письмо отправлено %d семьям.|Письмо отправлено %d семьям.|Письмо отправлено %d семьи.|Письмо отправлено %d семьям.|Письмо отправлено %d семьям.|Письмо отправлено %d семьи.",
-    "few": "",
-    "many": "",
-    "other": ""
+    "few": "Письмо отправлено %d семьям.",
+    "many": "Письмо отправлено %d семьям.",
+    "other": "Письмо отправлено %d семьям."
   },
-  "OFX": "",
+  "OFX": "OFX",
   "PDF successfully emailed to %d family.": {
     "one": "PDF успешно отправлен %d семье.|PDF успешно отправлен %d семьям.|PDF успешно отправлен %d семьям.|PDF успешно отправлен %d семьи.|PDF успешно отправлен %d семьям.|PDF успешно отправлен %d семьям.|PDF успешно отправлен %d семьи.",
-    "few": "",
-    "many": "",
-    "other": ""
+    "few": "PDF успешно отправлен %d семьям.",
+    "many": "PDF успешно отправлен %d семьям.",
+    "other": "PDF успешно отправлен %d семьям."
   },
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "A geocoding error occurred — try again later": "Произошла ошибка геокодирования — повторите попытку позже",
+  "Address is incomplete (missing city, state, and ZIP)": "Адрес неполный (не указаны город, область и почтовый индекс)",
+  "All families already have coordinates.": "У всех семей уже есть координаты.",
+  "Failed to update coordinates": "Не удалось обновить координаты",
+  "Failed to update family coordinates": "Не удалось обновить координаты семьи",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Геокодированы все {{geocoded}} семей. Карта обновлена.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Геокодировано {{geocoded}} семей. {{failed}} не удалось определить — см. подробности ниже.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Геокодировано {{geocoded}} из {{total}} семей. {{overflow}} ещё не обработаны — запустите ещё раз, чтобы продолжить.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Геокодирование семей… это может занять до минуты. Вы можете оставить эту страницу открытой.",
+  "Geocoding…": "Геокодирование…",
+  "No address on file": "Адрес не указан",
+  "No match found — check the street address, city, and ZIP": "Совпадений не найдено — проверьте улицу, город и почтовый индекс",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Количество дней, в течение которых пользователи должны подключить двухфакторную аутентификацию после того, как она станет обязательной. Установите 0, чтобы применить её немедленно (прежнее поведение). Сокращение действующего льготного периода может немедленно заблокировать доступ пользователям.",
+  "Open a family to fix its address, then run this again.": "Откройте карточку семьи, чтобы исправить адрес, а затем запустите это снова.",
+  "Set up now": "Настроить сейчас",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Эта функция находит координаты на карте для всех семей, у которых их нет, используя OpenStreetMap. За один запуск обрабатывается до 50 семей; полный пакет занимает около минуты. Вы можете оставить эту страницу открытой во время выполнения. Продолжить?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "few": "",
-    "many": "",
-    "other": ""
+    "one": "Требуется двухфакторная аутентификация. У вас есть %d день, чтобы подключить её.",
+    "few": "Требуется двухфакторная аутентификация. У вас есть %d дня, чтобы подключить её.",
+    "many": "Требуется двухфакторная аутентификация. У вас есть %d дней, чтобы подключить её.",
+    "other": "Требуется двухфакторная аутентификация. У вас есть %d дней, чтобы подключить её."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Неизвестная семья",
+  "Update All Coordinates": "Обновить все координаты",
+  "Update All Family Coordinates": "Обновить координаты всех семей",
+  "Update Coordinates": "Обновить координаты",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Скопирован {{count}} участник",
+    "other": "Скопировано {{count}} участников"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "В этом списке {{count}} получатель — слишком много для ссылки mailto:. Используйте вместо этого «Копировать адреса».",
+    "other": "В этом списке {{count}} получателей — слишком много для ссылки mailto:. Используйте вместо этого «Копировать адреса»."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Слишком много получателей для почтового клиента ({{count}} > {{max}}). Используйте вместо этого «Копировать адреса».",
+    "other": "Слишком много получателей для почтового клиента ({{count}} > {{max}}). Используйте вместо этого «Копировать адреса»."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "Осталась {{count}} минута",
+    "other": "Осталось {{count}} минут"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} семью не удалось геокодировать",
+    "other": "{{count}} семей не удалось геокодировать"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…и ещё {{count}}. Запустите снова, чтобы увидеть остальное.",
+    "other": "…и ещё {{count}}. Запустите снова, чтобы увидеть остальное."
   }
 }

--- a/locale/terms/missing/sk/sk-1.json
+++ b/locale/terms/missing/sk/sk-1.json
@@ -1,66 +1,66 @@
 {
-  "CSV": "",
+  "CSV": "CSV",
   "Email sent to %d family.": {
-    "one": "E-mail odoslaný %d rodine.|E-mail odoslaný %d rodinám.|E-mail odoslaný %d rodinám.|E-mail odoslaný %d rodinám.|E-mail odoslaný %d rodinám.|E-mail odoslaný %d rodinám.|E-mail odoslaný %d rodinám.",
-    "few": "",
-    "many": "",
-    "other": ""
+    "one": "E-mail odoslaný %d rodine.",
+    "few": "E-mail odoslaný %d rodinám.",
+    "many": "E-mail odoslaný %d rodinám.",
+    "other": "E-mail odoslaný %d rodinám."
   },
-  "OFX": "",
+  "OFX": "OFX",
   "PDF successfully emailed to %d family.": {
-    "one": "PDF úspešne odoslané %d rodine.|PDF úspešne odoslané %d rodinám.|PDF úspešne odoslané %d rodinám.|PDF úspešne odoslané %d rodinám.|PDF úspešne odoslané %d rodinám.|PDF úspešne odoslané %d rodinám.|PDF úspešne odoslané %d rodinám.",
-    "few": "",
-    "many": "",
-    "other": ""
+    "one": "PDF úspešne odoslané %d rodine.",
+    "few": "PDF úspešne odoslané %d rodinám.",
+    "many": "PDF úspešne odoslané %d rodinám.",
+    "other": "PDF úspešne odoslané %d rodinám."
   },
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "A geocoding error occurred — try again later": "Vyskytla sa chyba geokódovania — skúste to znova neskôr",
+  "Address is incomplete (missing city, state, and ZIP)": "Adresa je neúplná (chýba mesto, kraj a PSČ)",
+  "All families already have coordinates.": "Všetky rodiny už majú súradnice.",
+  "Failed to update coordinates": "Nepodarilo sa aktualizovať súradnice",
+  "Failed to update family coordinates": "Nepodarilo sa aktualizovať súradnice rodiny",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Geokódovaných bolo všetkých {{geocoded}} rodín. Mapa je teraz aktuálna.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Geokódovaných bolo {{geocoded}} rodín. {{failed}} sa nepodarilo vyriešiť — podrobnosti nájdete nižšie.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Geokódovaných bolo {{geocoded}} z {{total}} rodín. {{overflow}} zatiaľ nebolo spracovaných — spustite znova pre pokračovanie.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Geokódovanie rodín… môže to trvať až minútu. Túto stránku môžete nechať otvorenú.",
+  "Geocoding…": "Geokódovanie…",
+  "No address on file": "Adresa nie je zaznamenaná",
+  "No match found — check the street address, city, and ZIP": "Nebola nájdená žiadna zhoda — skontrolujte ulicu, mesto a PSČ",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Počet dní, ktoré majú používatelia na zapojenie dvojfaktorového overovania po tom, čo sa stane povinným. Nastavením na 0 ho vynútite okamžite (predchádzajúce správanie). Skrátenie aktívnej ochrannej lehoty môže používateľov okamžite zablokovať.",
+  "Open a family to fix its address, then run this again.": "Otvorte rodinu a opravte jej adresu, potom to spustite znova.",
+  "Set up now": "Nastaviť teraz",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Táto funkcia nájde súradnice na mape pre každú rodinu, ktorej chýbajú, pomocou OpenStreetMap. Za jedno spustenie spracuje až 50 rodín; celá dávka trvá približne minútu. Túto stránku môžete nechať otvorenú počas spracovania. Pokračovať?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "few": "",
-    "many": "",
-    "other": ""
+    "one": "Vyžaduje sa dvojfaktorové overovanie. Máte %d deň na zapojenie.",
+    "few": "Vyžaduje sa dvojfaktorové overovanie. Máte %d dni na zapojenie.",
+    "many": "Vyžaduje sa dvojfaktorové overovanie. Máte %d dňa na zapojenie.",
+    "other": "Vyžaduje sa dvojfaktorové overovanie. Máte %d dní na zapojenie."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Neznáma rodina",
+  "Update All Coordinates": "Aktualizovať všetky súradnice",
+  "Update All Family Coordinates": "Aktualizovať súradnice všetkých rodín",
+  "Update Coordinates": "Aktualizovať súradnice",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Skopírovaný {{count}} člen",
+    "other": "Skopírovaných {{count}} členov"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Tento zoznam má {{count}} príjemcu — príliš veľa pre odkaz mailto:. Použite namiesto toho Kopírovať adresy.",
+    "other": "Tento zoznam má {{count}} príjemcov — príliš veľa pre odkaz mailto:. Použite namiesto toho Kopírovať adresy."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Príliš veľa príjemcov pre e-mailového klienta ({{count}} > {{max}}). Použite namiesto toho Kopírovať adresy.",
+    "other": "Príliš veľa príjemcov pre e-mailového klienta ({{count}} > {{max}}). Použite namiesto toho Kopírovať adresy."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "Zostáva {{count}} minúta",
+    "other": "Zostáva {{count}} minút"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} rodinu sa nepodarilo geokódovať",
+    "other": "{{count}} rodín sa nepodarilo geokódovať"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…a ešte {{count}}. Spustite znova, aby ste videli zvyšok.",
+    "other": "…a ešte {{count}}. Spustite znova, aby ste videli zvyšok."
   }
 }

--- a/locale/terms/missing/sq/sq-1.json
+++ b/locale/terms/missing/sq/sq-1.json
@@ -1,61 +1,61 @@
 {
-  "CSV": "",
+  "CSV": "CSV",
   "Email sent to %d family.": {
     "one": "Email-i u dërgua tek %d familje.|Email-i u dërgua tek %d familje.|Email-i u dërgua tek %d familje.",
-    "other": ""
+    "other": "Email-i u dërgua tek %d familje."
   },
-  "N/A": "",
-  "OFX": "",
+  "N/A": "N/A",
+  "OFX": "OFX",
   "PDF successfully emailed to %d family.": {
     "one": "PDF-i u dërgua me sukses me email tek %d familje.|PDF-i u dërgua me sukses me email tek %d familje.|PDF-i u dërgua me sukses me email tek %d familje.",
-    "other": ""
+    "other": "PDF-i u dërgua me sukses me email tek %d familje."
   },
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "A geocoding error occurred — try again later": "Ndodhi një gabim gjeokodimi — provoni përsëri më vonë",
+  "Address is incomplete (missing city, state, and ZIP)": "Adresa është e paplotë (mungojnë qyteti, qarku dhe kodi postar)",
+  "All families already have coordinates.": "Të gjitha familjet kanë tashmë koordinata.",
+  "Failed to update coordinates": "Përditësimi i koordinatave dështoi",
+  "Failed to update family coordinates": "Përditësimi i koordinatave të familjes dështoi",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "U gjeokoduan të gjitha {{geocoded}} familjet. Harta tani është e përditësuar.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "U gjeokoduan {{geocoded}} familje. {{failed}} nuk u zgjidhën dot — shihni detajet më poshtë.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "U gjeokoduan {{geocoded}} nga {{total}} familje. {{overflow}} ende nuk janë përpunuar — ekzekutojeni përsëri për të vazhduar.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Duke gjeokoduar familjet… kjo mund të zgjasë deri në një minutë. Mund ta lini këtë faqe të hapur.",
+  "Geocoding…": "Duke gjeokoduar…",
+  "No address on file": "Nuk ka adresë të regjistruar",
+  "No match found — check the street address, city, and ZIP": "Nuk u gjet asnjë përputhje — kontrolloni adresën, qytetin dhe kodin postar",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Numri i ditëve që kanë përdoruesit për t'u regjistruar në vërtetimin me dy faktorë (2FA) pasi ai bëhet i detyrueshëm. Vendoseni në 0 për ta zbatuar menjëherë (sjellja e mëparshme). Shkurtimi i një periudhe hiri aktive mund t'i bllokojë përdoruesit menjëherë.",
+  "Open a family to fix its address, then run this again.": "Hapni një familje për të korrigjuar adresën e saj, pastaj ekzekutojeni këtë përsëri.",
+  "Set up now": "Konfiguro tani",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Kjo gjen koordinatat e hartës për çdo familje që nuk i ka, duke përdorur OpenStreetMap. Përpunon deri në 50 familje për ekzekutim; një grup i plotë zgjat rreth një minutë. Mund ta lini këtë faqe të hapur ndërsa ekzekutohet. Të vazhdohet?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "Kërkohet vërtetimi me dy faktorë. Keni %d ditë për t'u regjistruar.",
+    "other": "Kërkohet vërtetimi me dy faktorë. Keni %d ditë për t'u regjistruar."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Familje e panjohur",
+  "Update All Coordinates": "Përditëso të gjitha koordinatat",
+  "Update All Family Coordinates": "Përditëso koordinatat e të gjitha familjeve",
+  "Update Coordinates": "Përditëso koordinatat",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "U kopjua {{count}} anëtar",
+    "other": "U kopjuan {{count}} anëtarë"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Kjo listë ka {{count}} marrës — shumë për një lidhje mailto:. Përdorni Kopjo Adresat në vend të kësaj.",
+    "other": "Kjo listë ka {{count}} marrës — shumë për një lidhje mailto:. Përdorni Kopjo Adresat në vend të kësaj."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Shumë marrës për klientin e email-it ({{count}} > {{max}}). Përdorni Kopjo Adresat në vend të kësaj.",
+    "other": "Shumë marrës për klientin e email-it ({{count}} > {{max}}). Përdorni Kopjo Adresat në vend të kësaj."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} minutë e mbetur",
+    "other": "{{count}} minuta të mbetura"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} familje nuk u gjeokodua dot",
+    "other": "{{count}} familje nuk u gjeokoduan dot"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…dhe {{count}} më shumë. Ekzekutojeni përsëri për të parë pjesën tjetër.",
+    "other": "…dhe {{count}} më shumë. Ekzekutojeni përsëri për të parë pjesën tjetër."
   }
 }

--- a/locale/terms/missing/sv/sv-1.json
+++ b/locale/terms/missing/sv/sv-1.json
@@ -1,62 +1,62 @@
 {
-  "Data": "",
-  "Auto": "",
-  "CSV": "",
+  "Data": "Data",
+  "Auto": "Auto",
+  "CSV": "CSV",
   "Email sent to %d family.": {
     "one": "E-post skickad till %d familj.|E-post skickad till %d familjer.|E-post skickad till %d familjer.",
-    "other": ""
+    "other": "E-post skickad till %d familjer."
   },
-  "OFX": "",
+  "OFX": "OFX",
   "PDF successfully emailed to %d family.": {
     "one": "PDF har skickats via e-post till %d familj.|PDF har skickats via e-post till %d familjer.|PDF har skickats via e-post till %d familjer.",
-    "other": ""
+    "other": "PDF har skickats via e-post till %d familjer."
   },
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "A geocoding error occurred — try again later": "Ett geokodningsfel inträffade — försök igen senare",
+  "Address is incomplete (missing city, state, and ZIP)": "Adressen är ofullständig (ort, län och postnummer saknas)",
+  "All families already have coordinates.": "Alla familjer har redan koordinater.",
+  "Failed to update coordinates": "Det gick inte att uppdatera koordinaterna",
+  "Failed to update family coordinates": "Det gick inte att uppdatera familjens koordinater",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Geokodade alla {{geocoded}} familjer. Kartan är nu uppdaterad.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Geokodade {{geocoded}} familjer. {{failed}} kunde inte matchas — se detaljer nedan.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Geokodade {{geocoded}} av {{total}} familjer. {{overflow}} har ännu inte bearbetats — kör igen för att fortsätta.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Geokodar familjer… detta kan ta upp till en minut. Du kan låta den här sidan vara öppen.",
+  "Geocoding…": "Geokodar…",
+  "No address on file": "Ingen adress registrerad",
+  "No match found — check the street address, city, and ZIP": "Ingen matchning hittades — kontrollera adress, ort och postnummer",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Antal dagar användare har på sig att aktivera tvåfaktorsautentisering (2FA) efter att det blivit obligatoriskt. Ange 0 för att kräva det omedelbart (tidigare beteende). Att förkorta en aktiv övergångsperiod kan omedelbart låsa ute användare.",
+  "Open a family to fix its address, then run this again.": "Öppna en familj för att rätta adressen och kör sedan detta igen.",
+  "Set up now": "Konfigurera nu",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Detta hittar kartkoordinater för varje familj som saknar dem, med hjälp av OpenStreetMap. Upp till 50 familjer bearbetas per körning; en full omgång tar ungefär en minut. Du kan låta den här sidan vara öppen medan den körs. Fortsätta?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "Tvåfaktorsautentisering krävs. Du har %d dag på dig att aktivera den.",
+    "other": "Tvåfaktorsautentisering krävs. Du har %d dagar på dig att aktivera den."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Okänd familj",
+  "Update All Coordinates": "Uppdatera alla koordinater",
+  "Update All Family Coordinates": "Uppdatera alla familjekoordinater",
+  "Update Coordinates": "Uppdatera koordinater",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Kopierade {{count}} medlem",
+    "other": "Kopierade {{count}} medlemmar"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Den här listan har {{count}} mottagare — för många för en mailto:-länk. Använd Kopiera adresser istället.",
+    "other": "Den här listan har {{count}} mottagare — för många för en mailto:-länk. Använd Kopiera adresser istället."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "För många mottagare för e-postklienten ({{count}} > {{max}}). Använd Kopiera adresser istället.",
+    "other": "För många mottagare för e-postklienten ({{count}} > {{max}}). Använd Kopiera adresser istället."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} minut kvar",
+    "other": "{{count}} minuter kvar"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} familj kunde inte geokodas",
+    "other": "{{count}} familjer kunde inte geokodas"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…och {{count}} till. Kör igen för att se resten.",
+    "other": "…och {{count}} till. Kör igen för att se resten."
   }
 }

--- a/locale/terms/missing/sw/sw-1.json
+++ b/locale/terms/missing/sw/sw-1.json
@@ -1,61 +1,61 @@
 {
-  "Data": "",
-  "CSV": "",
+  "Data": "Data",
+  "CSV": "CSV",
   "Email sent to %d family.": {
     "one": "Barua pepe imetumwa kwa familia %d.|Barua pepe zimetumwa kwa familia %d.|Barua pepe zimetumwa kwa familia %d.",
-    "other": ""
+    "other": "Barua pepe zimetumwa kwa familia %d."
   },
-  "OFX": "",
+  "OFX": "OFX",
   "PDF successfully emailed to %d family.": {
     "one": "PDF imetumwa kwa mafanikio kwa familia %d.|PDF zimetumwa kwa mafanikio kwa familia %d.|PDF zimetumwa kwa mafanikio kwa familia %d.",
-    "other": ""
+    "other": "PDF zimetumwa kwa mafanikio kwa familia %d."
   },
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "A geocoding error occurred — try again later": "Hitilafu ya kuweka eneo la kijiografia imetokea — jaribu tena baadaye",
+  "Address is incomplete (missing city, state, and ZIP)": "Anwani haijakamilika (jiji, mkoa, na msimbo wa posta havipo)",
+  "All families already have coordinates.": "Familia zote tayari zina viwianishi.",
+  "Failed to update coordinates": "Imeshindwa kusasisha viwianishi",
+  "Failed to update family coordinates": "Imeshindwa kusasisha viwianishi vya familia",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Familia zote {{geocoded}} zimewekewa eneo la kijiografia. Ramani sasa imesasishwa.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Familia {{geocoded}} zimewekewa eneo la kijiografia. Familia {{failed}} hazikuweza kutatuliwa — angalia maelezo hapa chini.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Familia {{geocoded}} kati ya {{total}} zimewekewa eneo la kijiografia. {{overflow}} bado hazijashughulikiwa — endesha tena ili kuendelea.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Inaweka eneo la kijiografia la familia… hii inaweza kuchukua hadi dakika moja. Unaweza kuacha ukurasa huu wazi.",
+  "Geocoding…": "Inaweka eneo la kijiografia…",
+  "No address on file": "Hakuna anwani iliyohifadhiwa",
+  "No match found — check the street address, city, and ZIP": "Hakuna kinacholingana kilichopatikana — angalia anwani ya mtaa, jiji, na msimbo wa posta",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Idadi ya siku watumiaji wanazopaswa kujiandikisha kwa uthibitishaji wa hatua mbili (2FA) baada ya kuwa lazima. Weka 0 ili kulazimisha mara moja (tabia ya awali). Kupunguza muda wa neema unaoendelea kunaweza kuwafungia watumiaji nje mara moja.",
+  "Open a family to fix its address, then run this again.": "Fungua familia ili kurekebisha anwani yake, kisha endesha hii tena.",
+  "Set up now": "Weka sasa",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Hii hutafuta viwianishi vya ramani kwa kila familia isiyo na viwianishi, kwa kutumia OpenStreetMap. Huchakata hadi familia 50 kwa kila mzunguko; kundi kamili huchukua takriban dakika moja. Unaweza kuacha ukurasa huu wazi wakati unaendesha. Endelea?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "Uthibitishaji wa hatua mbili unahitajika. Una siku %d ya kujiandikisha.",
+    "other": "Uthibitishaji wa hatua mbili unahitajika. Una siku %d za kujiandikisha."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Familia isiyojulikana",
+  "Update All Coordinates": "Sasisha Viwianishi Vyote",
+  "Update All Family Coordinates": "Sasisha Viwianishi Vyote vya Familia",
+  "Update Coordinates": "Sasisha Viwianishi",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Mwanachama {{count}} amenakiliwa",
+    "other": "Wanachama {{count}} wamenakiliwa"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Orodha hii ina mpokeaji {{count}} — ni wengi mno kwa kiungo cha mailto:. Tumia Nakili Anwani badala yake.",
+    "other": "Orodha hii ina wapokeaji {{count}} — ni wengi mno kwa kiungo cha mailto:. Tumia Nakili Anwani badala yake."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Wapokeaji ni wengi mno kwa programu ya barua pepe ({{count}} > {{max}}). Tumia Nakili Anwani badala yake.",
+    "other": "Wapokeaji ni wengi mno kwa programu ya barua pepe ({{count}} > {{max}}). Tumia Nakili Anwani badala yake."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "dakika {{count}} imesalia",
+    "other": "dakika {{count}} zimesalia"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "Familia {{count}} haikuweza kuwekewa eneo la kijiografia",
+    "other": "Familia {{count}} hazikuweza kuwekewa eneo la kijiografia"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…na {{count}} zaidi. Endesha tena ili kuona zilizobaki.",
+    "other": "…na {{count}} zaidi. Endesha tena ili kuona zilizobaki."
   }
 }

--- a/locale/terms/missing/ta/ta-1.json
+++ b/locale/terms/missing/ta/ta-1.json
@@ -1,36 +1,36 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "புவிக்குறியீட்டு பிழை ஏற்பட்டது — பிறகு மீண்டும் முயற்சிக்கவும்",
+  "Address is incomplete (missing city, state, and ZIP)": "முகவரி முழுமையடையவில்லை (நகரம், மாநிலம் மற்றும் அஞ்சல் குறியீடு இல்லை)",
+  "All families already have coordinates.": "அனைத்து குடும்பங்களுக்கும் ஏற்கனவே ஆயத்தொலைவுகள் உள்ளன.",
+  "Failed to update coordinates": "ஆயத்தொலைவுகளை புதுப்பிக்க முடியவில்லை",
+  "Failed to update family coordinates": "குடும்பத்தின் ஆயத்தொலைவுகளை புதுப்பிக்க முடியவில்லை",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "{{geocoded}} குடும்பங்கள் அனைத்தும் புவிக்குறியிடப்பட்டன. வரைபடம் இப்போது புதுப்பிக்கப்பட்டது.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "{{geocoded}} குடும்பங்கள் புவிக்குறியிடப்பட்டன. {{failed}} தீர்க்க முடியவில்லை — கீழே உள்ள விவரங்களைப் பார்க்கவும்.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "{{total}} குடும்பங்களில் {{geocoded}} புவிக்குறியிடப்பட்டன. {{overflow}} இன்னும் செயலாக்கப்படவில்லை — தொடர மீண்டும் இயக்கவும்.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "குடும்பங்களை புவிக்குறியிடுகிறது… இதற்கு ஒரு நிமிடம் வரை ஆகலாம். இந்தப் பக்கத்தை திறந்தே வைத்திருக்கலாம்.",
+  "Geocoding…": "புவிக்குறியிடுகிறது…",
+  "No address on file": "பதிவு செய்யப்பட்ட முகவரி இல்லை",
+  "No match found — check the street address, city, and ZIP": "பொருத்தம் எதுவும் கிடைக்கவில்லை — தெரு முகவரி, நகரம் மற்றும் அஞ்சல் குறியீட்டைச் சரிபார்க்கவும்",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "இரு-கூறு அங்கீகாரம் (2FA) கட்டாயமாக்கப்பட்ட பிறகு பயனர்கள் பதிவு செய்ய வேண்டிய நாட்களின் எண்ணிக்கை. உடனடியாக அமல்படுத்த 0 எனக் குறிக்கவும் (முந்தைய நடத்தை). செயலில் உள்ள சலுகைக் காலத்தை குறைப்பது பயனர்களை உடனடியாக பூட்டக்கூடும்.",
+  "Open a family to fix its address, then run this again.": "முகவரியைச் சரிசெய்ய ஒரு குடும்பத்தைத் திறந்து, பின்னர் இதை மீண்டும் இயக்கவும்.",
+  "Set up now": "இப்போது அமைக்கவும்",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "இது OpenStreetMap ஐப் பயன்படுத்தி, ஆயத்தொலைவுகள் இல்லாத ஒவ்வொரு குடும்பத்திற்கும் வரைபட ஆயத்தொலைவுகளைக் கண்டறியும். ஒரு இயக்கத்திற்கு அதிகபட்சம் 50 குடும்பங்கள் செயலாக்கப்படும்; ஒரு முழு தொகுதிக்கு சுமார் ஒரு நிமிடம் ஆகும். இயங்கும் போது இந்தப் பக்கத்தை திறந்தே வைத்திருக்கலாம். தொடரவா?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "இரு-கூறு அங்கீகாரம் தேவை. பதிவு செய்ய உங்களுக்கு %d நாள் உள்ளது.",
+    "other": "இரு-கூறு அங்கீகாரம் தேவை. பதிவு செய்ய உங்களுக்கு %d நாட்கள் உள்ளன."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "தெரியாத குடும்பம்",
+  "Update All Coordinates": "அனைத்து ஆயத்தொலைவுகளையும் புதுப்பிக்கவும்",
+  "Update All Family Coordinates": "அனைத்து குடும்ப ஆயத்தொலைவுகளையும் புதுப்பிக்கவும்",
+  "Update Coordinates": "ஆயத்தொலைவுகளை புதுப்பிக்கவும்",
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} குடும்பத்தை புவிக்குறியிட முடியவில்லை",
+    "other": "{{count}} குடும்பங்களை புவிக்குறியிட முடியவில்லை"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…மேலும் {{count}}. மீதமுள்ளவற்றைப் பார்க்க மீண்டும் இயக்கவும்.",
+    "other": "…மேலும் {{count}}. மீதமுள்ளவற்றைப் பார்க்க மீண்டும் இயக்கவும்."
   }
 }

--- a/locale/terms/missing/te/te-1.json
+++ b/locale/terms/missing/te/te-1.json
@@ -1,60 +1,60 @@
 {
-  "CSV": "",
+  "CSV": "CSV",
   "Email sent to %d family.": {
     "one": "%d కుటుంబానికి ఇమెయిల్ పంపబడింది.|%d కుటుంబాలకు ఇమెయిల్ పంపబడింది.|%d కుటుంబాలకు ఇమెయిల్ పంపబడింది.",
-    "other": ""
+    "other": "%d కుటుంబాలకు ఇమెయిల్ పంపబడింది."
   },
-  "OFX": "",
+  "OFX": "OFX",
   "PDF successfully emailed to %d family.": {
     "one": "%d కుటుంబానికి PDF విజయవంతంగా ఇమెయిల్ చేయబడింది.|%d కుటుంబాలకు PDF విజయవంతంగా ఇమెయిల్ చేయబడింది.|%d కుటుంబాలకు PDF విజయవంతంగా ఇమెయిల్ చేయబడింది.",
-    "other": ""
+    "other": "%d కుటుంబాలకు PDF విజయవంతంగా ఇమెయిల్ చేయబడింది."
   },
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "A geocoding error occurred — try again later": "జియోకోడింగ్ లోపం సంభవించింది — దయచేసి తర్వాత మళ్ళీ ప్రయత్నించండి",
+  "Address is incomplete (missing city, state, and ZIP)": "చిరునామా అసంపూర్ణంగా ఉంది (నగరం, రాష్ట్రం మరియు పిన్ కోడ్ లేవు)",
+  "All families already have coordinates.": "అన్ని కుటుంబాలకు ఇప్పటికే కోఆర్డినేట్‌లు ఉన్నాయి.",
+  "Failed to update coordinates": "కోఆర్డినేట్‌లను నవీకరించడంలో విఫలమైంది",
+  "Failed to update family coordinates": "కుటుంబ కోఆర్డినేట్‌లను నవీకరించడంలో విఫలమైంది",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "మొత్తం {{geocoded}} కుటుంబాలకు జియోకోడింగ్ పూర్తయింది. మ్యాప్ ఇప్పుడు తాజాగా ఉంది.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "{{geocoded}} కుటుంబాలకు జియోకోడింగ్ చేయబడింది. {{failed}} పరిష్కరించబడలేదు — దిగువ వివరాలను చూడండి.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "{{total}} కుటుంబాలలో {{geocoded}} కుటుంబాలకు జియోకోడింగ్ చేయబడింది. {{overflow}} ఇంకా ప్రాసెస్ చేయబడలేదు — కొనసాగించడానికి మళ్ళీ అమలు చేయండి.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "కుటుంబాలను జియోకోడ్ చేస్తోంది… దీనికి ఒక నిమిషం వరకు పట్టవచ్చు. మీరు ఈ పేజీని తెరిచి ఉంచవచ్చు.",
+  "Geocoding…": "జియోకోడింగ్ జరుగుతోంది…",
+  "No address on file": "నమోదైన చిరునామా లేదు",
+  "No match found — check the street address, city, and ZIP": "సరిపోలిక కనుగొనబడలేదు — వీధి చిరునామా, నగరం మరియు పిన్ కోడ్‌ను తనిఖీ చేయండి",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "టూ-ఫ్యాక్టర్ అథెంటికేషన్ (2FA) తప్పనిసరి అయిన తర్వాత నమోదు చేసుకోవడానికి వినియోగదారులకు ఉన్న రోజుల సంఖ్య. వెంటనే అమలు చేయడానికి దీన్ని 0కి సెట్ చేయండి (పాత ప్రవర్తన). యాక్టివ్‌గా ఉన్న గ్రేస్ పీరియడ్‌ను తగ్గించడం వలన వినియోగదారులు వెంటనే లాక్ అవ్వవచ్చు.",
+  "Open a family to fix its address, then run this again.": "చిరునామాను సరిచేయడానికి ఒక కుటుంబాన్ని తెరిచి, తర్వాత దీన్ని మళ్ళీ అమలు చేయండి.",
+  "Set up now": "ఇప్పుడే సెటప్ చేయండి",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "OpenStreetMapని ఉపయోగించి, కోఆర్డినేట్‌లు లేని ప్రతి కుటుంబానికి మ్యాప్ కోఆర్డినేట్‌లను ఇది కనుగొంటుంది. ఒక్కో రన్‌కు గరిష్టంగా 50 కుటుంబాలను ప్రాసెస్ చేస్తుంది; పూర్తి బ్యాచ్‌కు సుమారు ఒక నిమిషం పడుతుంది. ఇది నడుస్తున్నప్పుడు మీరు ఈ పేజీని తెరిచి ఉంచవచ్చు. కొనసాగించాలా?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "టూ-ఫ్యాక్టర్ అథెంటికేషన్ అవసరం. నమోదు చేసుకోవడానికి మీకు %d రోజు ఉంది.",
+    "other": "టూ-ఫ్యాక్టర్ అథెంటికేషన్ అవసరం. నమోదు చేసుకోవడానికి మీకు %d రోజులు ఉన్నాయి."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "తెలియని కుటుంబం",
+  "Update All Coordinates": "అన్ని కోఆర్డినేట్‌లను నవీకరించండి",
+  "Update All Family Coordinates": "అన్ని కుటుంబ కోఆర్డినేట్‌లను నవీకరించండి",
+  "Update Coordinates": "కోఆర్డినేట్‌లను నవీకరించండి",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} సభ్యుడు కాపీ చేయబడ్డారు",
+    "other": "{{count}} సభ్యులు కాపీ చేయబడ్డారు"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "ఈ జాబితాలో {{count}} గ్రహీత ఉన్నారు — mailto: లింక్‌కు చాలా ఎక్కువ. బదులుగా చిరునామాలను కాపీ చేయండి ఉపయోగించండి.",
+    "other": "ఈ జాబితాలో {{count}} గ్రహీతలు ఉన్నారు — mailto: లింక్‌కు చాలా ఎక్కువ. బదులుగా చిరునామాలను కాపీ చేయండి ఉపయోగించండి."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "ఇమెయిల్ క్లయింట్‌కు చాలా మంది గ్రహీతలు ఉన్నారు ({{count}} > {{max}}). బదులుగా చిరునామాలను కాపీ చేయండి ఉపయోగించండి.",
+    "other": "ఇమెయిల్ క్లయింట్‌కు చాలా మంది గ్రహీతలు ఉన్నారు ({{count}} > {{max}}). బదులుగా చిరునామాలను కాపీ చేయండి ఉపయోగించండి."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} నిమిషం మిగిలి ఉంది",
+    "other": "{{count}} నిమిషాలు మిగిలి ఉన్నాయి"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} కుటుంబాన్ని జియోకోడ్ చేయలేకపోయింది",
+    "other": "{{count}} కుటుంబాలను జియోకోడ్ చేయలేకపోయింది"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…మరియు {{count}} మరిన్ని. మిగిలినవి చూడటానికి మళ్ళీ అమలు చేయండి.",
+    "other": "…మరియు {{count}} మరిన్ని. మిగిలినవి చూడటానికి మళ్ళీ అమలు చేయండి."
   }
 }

--- a/locale/terms/missing/th/th-1.json
+++ b/locale/terms/missing/th/th-1.json
@@ -1,51 +1,51 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "เกิดข้อผิดพลาดในการระบุพิกัดทางภูมิศาสตร์ — โปรดลองอีกครั้งในภายหลัง",
+  "Address is incomplete (missing city, state, and ZIP)": "ที่อยู่ไม่สมบูรณ์ (ไม่มีเมือง จังหวัด และรหัสไปรษณีย์)",
+  "All families already have coordinates.": "ทุกครอบครัวมีพิกัดอยู่แล้ว",
+  "Failed to update coordinates": "อัปเดตพิกัดไม่สำเร็จ",
+  "Failed to update family coordinates": "อัปเดตพิกัดของครอบครัวไม่สำเร็จ",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "ระบุพิกัดทางภูมิศาสตร์ให้ครอบครัวทั้งหมด {{geocoded}} ครอบครัวแล้ว แผนที่อัปเดตล่าสุดแล้ว",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "ระบุพิกัดทางภูมิศาสตร์ให้ {{geocoded}} ครอบครัวแล้ว {{failed}} ครอบครัวไม่สามารถระบุได้ — ดูรายละเอียดด้านล่าง",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "ระบุพิกัดทางภูมิศาสตร์ให้ {{geocoded}} จาก {{total}} ครอบครัวแล้ว {{overflow}} ครอบครัวยังไม่ได้ประมวลผล — เรียกใช้อีกครั้งเพื่อดำเนินการต่อ",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "กำลังระบุพิกัดทางภูมิศาสตร์ของครอบครัว… อาจใช้เวลาถึงหนึ่งนาที คุณสามารถเปิดหน้านี้ทิ้งไว้ได้",
+  "Geocoding…": "กำลังระบุพิกัดทางภูมิศาสตร์…",
+  "No address on file": "ไม่มีที่อยู่ที่บันทึกไว้",
+  "No match found — check the street address, city, and ZIP": "ไม่พบรายการที่ตรงกัน — โปรดตรวจสอบที่อยู่ ถนน เมือง และรหัสไปรษณีย์",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "จำนวนวันที่ผู้ใช้มีเพื่อลงทะเบียนการยืนยันตัวตนแบบสองปัจจัย (2FA) หลังจากที่กลายเป็นข้อบังคับ ตั้งค่าเป็น 0 เพื่อบังคับใช้ทันที (พฤติกรรมแบบเดิม) การลดระยะเวลาผ่อนผันที่ใช้งานอยู่อาจทำให้ผู้ใช้ถูกล็อกออกทันที",
+  "Open a family to fix its address, then run this again.": "เปิดครอบครัวเพื่อแก้ไขที่อยู่ จากนั้นเรียกใช้สิ่งนี้อีกครั้ง",
+  "Set up now": "ตั้งค่าตอนนี้",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "ฟีเจอร์นี้จะค้นหาพิกัดแผนที่สำหรับทุกครอบครัวที่ยังไม่มี โดยใช้ OpenStreetMap โดยประมวลผลได้สูงสุด 50 ครอบครัวต่อการเรียกใช้แต่ละครั้ง การประมวลผลแบบเต็มชุดใช้เวลาประมาณหนึ่งนาที คุณสามารถเปิดหน้านี้ทิ้งไว้ระหว่างการทำงานได้ ต้องการดำเนินการต่อหรือไม่",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "other": ""
+    "other": "จำเป็นต้องมีการยืนยันตัวตนแบบสองปัจจัย คุณมีเวลา %d วันในการลงทะเบียน"
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "ครอบครัวที่ไม่รู้จัก",
+  "Update All Coordinates": "อัปเดตพิกัดทั้งหมด",
+  "Update All Family Coordinates": "อัปเดตพิกัดของครอบครัวทั้งหมด",
+  "Update Coordinates": "อัปเดตพิกัด",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "คัดลอกสมาชิก {{count}} คนแล้ว",
+    "other": "คัดลอกสมาชิก {{count}} คนแล้ว"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "รายการนี้มีผู้รับ {{count}} ราย — มากเกินไปสำหรับลิงก์ mailto: โปรดใช้คัดลอกที่อยู่แทน",
+    "other": "รายการนี้มีผู้รับ {{count}} ราย — มากเกินไปสำหรับลิงก์ mailto: โปรดใช้คัดลอกที่อยู่แทน"
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "มีผู้รับมากเกินไปสำหรับโปรแกรมอีเมล ({{count}} > {{max}}) โปรดใช้คัดลอกที่อยู่แทน",
+    "other": "มีผู้รับมากเกินไปสำหรับโปรแกรมอีเมล ({{count}} > {{max}}) โปรดใช้คัดลอกที่อยู่แทน"
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "เหลืออีก {{count}} นาที",
+    "other": "เหลืออีก {{count}} นาที"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "ไม่สามารถระบุพิกัดทางภูมิศาสตร์ให้ {{count}} ครอบครัวได้",
+    "other": "ไม่สามารถระบุพิกัดทางภูมิศาสตร์ให้ {{count}} ครอบครัวได้"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…และอีก {{count}} รายการ เรียกใช้อีกครั้งเพื่อดูส่วนที่เหลือ",
+    "other": "…และอีก {{count}} รายการ เรียกใช้อีกครั้งเพื่อดูส่วนที่เหลือ"
   }
 }

--- a/locale/terms/missing/tr/tr-1.json
+++ b/locale/terms/missing/tr/tr-1.json
@@ -1,60 +1,60 @@
 {
-  "CSV": "",
+  "CSV": "CSV",
   "Email sent to %d family.": {
-    "one": "%d aileye e-posta gönderildi.|%d aileye e-posta gönderildi.|%d aileye e-posta gönderildi.",
-    "other": ""
+    "one": "%d aileye e-posta gönderildi.",
+    "other": "%d aileye e-posta gönderildi."
   },
-  "OFX": "",
+  "OFX": "OFX",
   "PDF successfully emailed to %d family.": {
-    "one": "PDF başarıyla %d aileye e-posta ile gönderildi.|PDF başarıyla %d aileye e-posta ile gönderildi.|PDF başarıyla %d aileye e-posta ile gönderildi.",
-    "other": ""
+    "one": "PDF başarıyla %d aileye e-posta ile gönderildi.",
+    "other": "PDF başarıyla %d aileye e-posta ile gönderildi."
   },
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "A geocoding error occurred — try again later": "Coğrafi kodlama hatası oluştu — lütfen daha sonra tekrar deneyin",
+  "Address is incomplete (missing city, state, and ZIP)": "Adres eksik (şehir, il ve posta kodu eksik)",
+  "All families already have coordinates.": "Tüm ailelerin zaten koordinatları var.",
+  "Failed to update coordinates": "Koordinatlar güncellenemedi",
+  "Failed to update family coordinates": "Aile koordinatları güncellenemedi",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "{{geocoded}} ailenin tamamı coğrafi olarak kodlandı. Harita artık güncel.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "{{geocoded}} aile coğrafi olarak kodlandı. {{failed}} çözümlenemedi — ayrıntılar için aşağıya bakın.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "{{total}} aileden {{geocoded}} tanesi coğrafi olarak kodlandı. {{overflow}} henüz işlenmedi — devam etmek için tekrar çalıştırın.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Aileler coğrafi olarak kodlanıyor… bu işlem bir dakikaya kadar sürebilir. Bu sayfayı açık bırakabilirsiniz.",
+  "Geocoding…": "Coğrafi kodlama yapılıyor…",
+  "No address on file": "Kayıtlı adres yok",
+  "No match found — check the street address, city, and ZIP": "Eşleşme bulunamadı — sokak adresini, şehri ve posta kodunu kontrol edin",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "İki faktörlü kimlik doğrulama (2FA) zorunlu hale geldikten sonra kullanıcıların kaydolması için sahip olduğu gün sayısı. Hemen uygulamak için 0 olarak ayarlayın (eski davranış). Etkin bir tolerans süresini kısaltmak, kullanıcıların hemen erişiminin kilitlenmesine neden olabilir.",
+  "Open a family to fix its address, then run this again.": "Adresini düzeltmek için bir aileyi açın, ardından bunu tekrar çalıştırın.",
+  "Set up now": "Şimdi ayarla",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Bu işlem, OpenStreetMap kullanarak koordinatları eksik olan her aile için harita koordinatlarını bulur. Her çalıştırmada en fazla 50 aile işlenir; tam bir grup işlemi yaklaşık bir dakika sürer. Çalışırken bu sayfayı açık bırakabilirsiniz. Devam edilsin mi?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "İki faktörlü kimlik doğrulama gereklidir. Kaydolmak için %d gününüz var.",
+    "other": "İki faktörlü kimlik doğrulama gereklidir. Kaydolmak için %d gününüz var."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Bilinmeyen aile",
+  "Update All Coordinates": "Tüm Koordinatları Güncelle",
+  "Update All Family Coordinates": "Tüm Aile Koordinatlarını Güncelle",
+  "Update Coordinates": "Koordinatları Güncelle",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} üye kopyalandı",
+    "other": "{{count}} üye kopyalandı"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Bu listede {{count}} alıcı var — bir mailto: bağlantısı için çok fazla. Bunun yerine Adresleri Kopyala seçeneğini kullanın.",
+    "other": "Bu listede {{count}} alıcı var — bir mailto: bağlantısı için çok fazla. Bunun yerine Adresleri Kopyala seçeneğini kullanın."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "E-posta istemcisi için çok fazla alıcı var ({{count}} > {{max}}). Bunun yerine Adresleri Kopyala seçeneğini kullanın.",
+    "other": "E-posta istemcisi için çok fazla alıcı var ({{count}} > {{max}}). Bunun yerine Adresleri Kopyala seçeneğini kullanın."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} dakika kaldı",
+    "other": "{{count}} dakika kaldı"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} aile coğrafi olarak kodlanamadı",
+    "other": "{{count}} aile coğrafi olarak kodlanamadı"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…ve {{count}} tane daha. Kalanını görmek için tekrar çalıştırın.",
+    "other": "…ve {{count}} tane daha. Kalanını görmek için tekrar çalıştırın."
   }
 }

--- a/locale/terms/missing/uk/uk-1.json
+++ b/locale/terms/missing/uk/uk-1.json
@@ -1,66 +1,66 @@
 {
-  "CSV": "",
+  "CSV": "CSV",
   "Email sent to %d family.": {
     "one": "Електронний лист надіслано %d родині.|Електронний лист надіслано %d родинам.|Електронний лист надіслано %d родинам.|Електронний лист надіслано %d родини.|Електронний лист надіслано %d родинам.|Електронний лист надіслано %d родинам.|Електронний лист надіслано %d родини.",
-    "few": "",
-    "many": "",
-    "other": ""
+    "few": "Електронний лист надіслано %d родинам.",
+    "many": "Електронний лист надіслано %d родинам.",
+    "other": "Електронний лист надіслано %d родинам."
   },
-  "OFX": "",
+  "OFX": "OFX",
   "PDF successfully emailed to %d family.": {
     "one": "PDF успішно надіслано %d родині.|PDF успішно надіслано %d родинам.|PDF успішно надіслано %d родинам.|PDF успішно надіслано %d родини.|PDF успішно надіслано %d родинам.|PDF успішно надіслано %d родинам.|PDF успішно надіслано %d родини.",
-    "few": "",
-    "many": "",
-    "other": ""
+    "few": "PDF успішно надіслано %d родинам.",
+    "many": "PDF успішно надіслано %d родинам.",
+    "other": "PDF успішно надіслано %d родинам."
   },
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "A geocoding error occurred — try again later": "Сталася помилка геокодування — спробуйте ще раз пізніше",
+  "Address is incomplete (missing city, state, and ZIP)": "Адреса неповна (не вказано місто, область і поштовий індекс)",
+  "All families already have coordinates.": "Усі родини вже мають координати.",
+  "Failed to update coordinates": "Не вдалося оновити координати",
+  "Failed to update family coordinates": "Не вдалося оновити координати родини",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Геокодовано всі {{geocoded}} родини. Карта тепер оновлена.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Геокодовано {{geocoded}} родин. {{failed}} не вдалося визначити — див. деталі нижче.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Геокодовано {{geocoded}} з {{total}} родин. {{overflow}} ще не оброблено — запустіть знову, щоб продовжити.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Геокодування родин… це може зайняти до хвилини. Ви можете залишити цю сторінку відкритою.",
+  "Geocoding…": "Геокодування…",
+  "No address on file": "Адресу не вказано",
+  "No match found — check the street address, city, and ZIP": "Збігів не знайдено — перевірте вулицю, місто та поштовий індекс",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Кількість днів, протягом яких користувачі мають підключити двофакторну автентифікацію після того, як вона стане обов'язковою. Встановіть 0, щоб застосувати негайно (попередня поведінка). Скорочення активного пільгового періоду може одразу заблокувати доступ користувачам.",
+  "Open a family to fix its address, then run this again.": "Відкрийте родину, щоб виправити адресу, а потім запустіть це знову.",
+  "Set up now": "Налаштувати зараз",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Це знаходить координати на карті для всіх родин, яким їх бракує, використовуючи OpenStreetMap. За один запуск обробляється до 50 родин; повний пакет займає близько хвилини. Ви можете залишити цю сторінку відкритою під час виконання. Продовжити?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "few": "",
-    "many": "",
-    "other": ""
+    "one": "Потрібна двофакторна автентифікація. У вас є %d день, щоб підключити її.",
+    "few": "Потрібна двофакторна автентифікація. У вас є %d дні, щоб підключити її.",
+    "many": "Потрібна двофакторна автентифікація. У вас є %d днів, щоб підключити її.",
+    "other": "Потрібна двофакторна автентифікація. У вас є %d днів, щоб підключити її."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Невідома родина",
+  "Update All Coordinates": "Оновити всі координати",
+  "Update All Family Coordinates": "Оновити координати всіх родин",
+  "Update Coordinates": "Оновити координати",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Скопійовано {{count}} учасника",
+    "other": "Скопійовано {{count}} учасників"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "У цьому списку {{count}} отримувач — забагато для посилання mailto:. Скористайтеся замість цього «Копіювати адреси».",
+    "other": "У цьому списку {{count}} отримувачів — забагато для посилання mailto:. Скористайтеся замість цього «Копіювати адреси»."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Забагато отримувачів для поштового клієнта ({{count}} > {{max}}). Скористайтеся замість цього «Копіювати адреси».",
+    "other": "Забагато отримувачів для поштового клієнта ({{count}} > {{max}}). Скористайтеся замість цього «Копіювати адреси»."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "Залишилася {{count}} хвилина",
+    "other": "Залишилося {{count}} хвилин"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} родину не вдалося геокодувати",
+    "other": "{{count}} родин не вдалося геокодувати"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…і ще {{count}}. Запустіть знову, щоб побачити решту.",
+    "other": "…і ще {{count}}. Запустіть знову, щоб побачити решту."
   }
 }

--- a/locale/terms/missing/vi/vi-1.json
+++ b/locale/terms/missing/vi/vi-1.json
@@ -1,51 +1,51 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "Đã xảy ra lỗi định vị địa lý — vui lòng thử lại sau",
+  "Address is incomplete (missing city, state, and ZIP)": "Địa chỉ chưa đầy đủ (thiếu thành phố, tỉnh/bang và mã bưu điện)",
+  "All families already have coordinates.": "Tất cả các gia đình đã có tọa độ.",
+  "Failed to update coordinates": "Không thể cập nhật tọa độ",
+  "Failed to update family coordinates": "Không thể cập nhật tọa độ gia đình",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Đã định vị địa lý cho tất cả {{geocoded}} gia đình. Bản đồ hiện đã được cập nhật.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Đã định vị địa lý cho {{geocoded}} gia đình. {{failed}} không thể xác định được — xem chi tiết bên dưới.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Đã định vị địa lý cho {{geocoded}} trong số {{total}} gia đình. {{overflow}} chưa được xử lý — chạy lại để tiếp tục.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Đang định vị địa lý cho các gia đình… quá trình này có thể mất đến một phút. Bạn có thể để trang này mở.",
+  "Geocoding…": "Đang định vị địa lý…",
+  "No address on file": "Không có địa chỉ được lưu",
+  "No match found — check the street address, city, and ZIP": "Không tìm thấy kết quả phù hợp — kiểm tra địa chỉ đường, thành phố và mã bưu điện",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Số ngày người dùng có để đăng ký xác thực hai yếu tố (2FA) sau khi nó trở thành bắt buộc. Đặt thành 0 để áp dụng ngay lập tức (hành vi trước đây). Rút ngắn thời gian ân hạn đang hoạt động có thể khiến người dùng bị khóa ngay lập tức.",
+  "Open a family to fix its address, then run this again.": "Mở một gia đình để sửa địa chỉ, sau đó chạy lại thao tác này.",
+  "Set up now": "Thiết lập ngay",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Chức năng này tìm tọa độ bản đồ cho mọi gia đình chưa có tọa độ, sử dụng OpenStreetMap. Mỗi lần chạy xử lý tối đa 50 gia đình; một đợt đầy đủ mất khoảng một phút. Bạn có thể để trang này mở trong khi chạy. Tiếp tục?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "other": ""
+    "other": "Yêu cầu xác thực hai yếu tố. Bạn còn %d ngày để đăng ký."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Gia đình không xác định",
+  "Update All Coordinates": "Cập nhật tất cả tọa độ",
+  "Update All Family Coordinates": "Cập nhật tọa độ của tất cả gia đình",
+  "Update Coordinates": "Cập nhật tọa độ",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Đã sao chép {{count}} thành viên",
+    "other": "Đã sao chép {{count}} thành viên"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Danh sách này có {{count}} người nhận — quá nhiều cho một liên kết mailto:. Hãy sử dụng Sao chép địa chỉ thay thế.",
+    "other": "Danh sách này có {{count}} người nhận — quá nhiều cho một liên kết mailto:. Hãy sử dụng Sao chép địa chỉ thay thế."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Quá nhiều người nhận cho ứng dụng email ({{count}} > {{max}}). Hãy sử dụng Sao chép địa chỉ thay thế.",
+    "other": "Quá nhiều người nhận cho ứng dụng email ({{count}} > {{max}}). Hãy sử dụng Sao chép địa chỉ thay thế."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "Còn lại {{count}} phút",
+    "other": "Còn lại {{count}} phút"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "Không thể định vị địa lý cho {{count}} gia đình",
+    "other": "Không thể định vị địa lý cho {{count}} gia đình"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…và {{count}} gia đình khác. Chạy lại để xem phần còn lại.",
+    "other": "…và {{count}} gia đình khác. Chạy lại để xem phần còn lại."
   }
 }

--- a/locale/terms/missing/zh-CN/zh-CN-1.json
+++ b/locale/terms/missing/zh-CN/zh-CN-1.json
@@ -1,51 +1,45 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "发生地理编码错误 — 请稍后重试",
+  "Address is incomplete (missing city, state, and ZIP)": "地址不完整（缺少城市、省份和邮政编码）",
+  "All families already have coordinates.": "所有家庭均已拥有坐标。",
+  "Failed to update coordinates": "更新坐标失败",
+  "Failed to update family coordinates": "更新家庭坐标失败",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "已对全部 {{geocoded}} 个家庭完成地理编码。地图现已是最新状态。",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "已对 {{geocoded}} 个家庭完成地理编码。{{failed}} 个未能解析 — 详情见下文。",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "已对 {{total}} 个家庭中的 {{geocoded}} 个完成地理编码。{{overflow}} 个尚未处理 — 请再次运行以继续。",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "正在对家庭进行地理编码……最多可能需要一分钟。您可以让此页面保持打开状态。",
+  "Geocoding…": "正在进行地理编码……",
+  "No address on file": "没有存档地址",
+  "No match found — check the street address, city, and ZIP": "未找到匹配项 — 请检查街道地址、城市和邮政编码",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "双因素身份验证 (2FA) 成为强制要求后，用户需要在多少天内完成注册。设置为 0 可立即强制执行（旧版行为）。缩短当前生效的宽限期可能会立即使用户被锁定。",
+  "Open a family to fix its address, then run this again.": "打开某个家庭以修正其地址，然后再次运行此操作。",
+  "Set up now": "立即设置",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "此功能会使用 OpenStreetMap 为每个缺少坐标的家庭查找地图坐标。每次运行最多处理 50 个家庭；完整处理一批大约需要一分钟。运行期间您可以让此页面保持打开状态。是否继续？",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "other": ""
+    "other": "需要进行双因素身份验证。您还有 %d 天可以完成注册。"
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "未知家庭",
+  "Update All Coordinates": "更新所有坐标",
+  "Update All Family Coordinates": "更新所有家庭坐标",
+  "Update Coordinates": "更新坐标",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "other": "已复制 {{count}} 名成员"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "other": "此列表有 {{count}} 个收件人 — 对于 mailto: 链接而言数量过多。请改用“复制地址”。"
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "other": "邮件客户端的收件人过多（{{count}} > {{max}}）。请改用“复制地址”。"
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "other": "剩余 {{count}} 分钟"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "other": "有 {{count}} 个家庭无法完成地理编码"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "other": "……以及另外 {{count}} 个。再次运行以查看其余内容。"
   }
 }

--- a/locale/terms/missing/zh-TW/zh-TW-1.json
+++ b/locale/terms/missing/zh-TW/zh-TW-1.json
@@ -1,51 +1,51 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "發生地理編碼錯誤 — 請稍後再試",
+  "Address is incomplete (missing city, state, and ZIP)": "地址不完整（缺少城市、縣市和郵遞區號）",
+  "All families already have coordinates.": "所有家庭都已擁有座標。",
+  "Failed to update coordinates": "更新座標失敗",
+  "Failed to update family coordinates": "更新家庭座標失敗",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "已為全部 {{geocoded}} 個家庭完成地理編碼。地圖現已是最新狀態。",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "已為 {{geocoded}} 個家庭完成地理編碼。{{failed}} 個無法解析 — 詳情請見下方。",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "已為 {{total}} 個家庭中的 {{geocoded}} 個完成地理編碼。{{overflow}} 個尚未處理 — 請再次執行以繼續。",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "正在為家庭進行地理編碼……最多可能需要一分鐘。您可以讓此頁面保持開啟。",
+  "Geocoding…": "正在進行地理編碼……",
+  "No address on file": "沒有存檔地址",
+  "No match found — check the street address, city, and ZIP": "找不到相符項目 — 請檢查街道地址、城市和郵遞區號",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "雙重要素驗證 (2FA) 成為強制要求後，使用者可用來完成註冊的天數。設為 0 可立即強制執行（舊版行為）。縮短正在生效的寬限期可能會立即鎖定使用者。",
+  "Open a family to fix its address, then run this again.": "開啟某個家庭以修正其地址，然後再次執行此操作。",
+  "Set up now": "立即設定",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "此功能會使用 OpenStreetMap，為每個缺少座標的家庭尋找地圖座標。每次執行最多處理 50 個家庭；完整處理一批大約需要一分鐘。執行期間您可以讓此頁面保持開啟。是否繼續？",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "other": ""
+    "other": "需要進行雙重要素驗證。您還有 %d 天可以完成註冊。"
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "未知家庭",
+  "Update All Coordinates": "更新所有座標",
+  "Update All Family Coordinates": "更新所有家庭座標",
+  "Update Coordinates": "更新座標",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "已複製 {{count}} 位成員",
+    "other": "已複製 {{count}} 位成員"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "此清單有 {{count}} 位收件人 — 對於 mailto: 連結而言數量過多。請改用「複製地址」。",
+    "other": "此清單有 {{count}} 位收件人 — 對於 mailto: 連結而言數量過多。請改用「複製地址」。"
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "郵件用戶端的收件人過多（{{count}} > {{max}}）。請改用「複製地址」。",
+    "other": "郵件用戶端的收件人過多（{{count}} > {{max}}）。請改用「複製地址」。"
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "剩餘 {{count}} 分鐘",
+    "other": "剩餘 {{count}} 分鐘"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "有 {{count}} 個家庭無法完成地理編碼",
+    "other": "有 {{count}} 個家庭無法完成地理編碼"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "……以及另外 {{count}} 個。請再次執行以查看其餘內容。",
+    "other": "……以及另外 {{count}} 個。請再次執行以查看其餘內容。"
   }
 }


### PR DESCRIPTION
Automated locale translation for ChurchCRM 7.7.0.

## Translation Summary
- Group A (Latin America & Iberia): es, es-MX, pt-br, pt, es-AR ✅
- Group B (Romance & Europe): es-CO, es-SV, fr, it, ro ✅
- Group C (Eastern Europe): ru, uk, pl, cs, hu ✅
- Group D (Northern Europe): de, nl, sv, nb, fi, et ✅
- Group E (Asia Pacific): fil, ko, id, vi, zh-CN ✅
- Group F (More Asia): zh-TW, hi, ja, ta, te ✅
- Group G (Africa & Other): sw, am, af, sq, ml ✅
- Group H (Completion): ar, el, he, th, sk, tr ✅
- Bonus: hr (Croatian) — found outstanding during verification, translated for full completion ✅

43 locales, ~1,339 terms translated in total.

## Next Steps
1. Review and merge
2. Run: `npm run locale:upload:missing -- --yes`