### PR TITLE
Fix issue #9722: Delegate npm build:orm to the composer orm-gen script

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "build:webpack:watch": "webpack --watch",
         "build:php": "run-s composer:install build:php:validate",
         "build:openapi": "cd src && composer install --no-interaction --prefer-dist && composer run openapi:public && composer run openapi:private",
-        "build:orm": "cd src/ && ./vendor/bin/propel build --config-dir=propel",
+        "build:orm": "cd src/ && composer run orm-gen",
         "clean": "rm -rf node_modules/ temp src/vendor/ src/skin/external src/locale/vendor ai-notes/ src/logs/*.log",
         "composer:install": "cd src/ && composer validate --no-check-publish && composer install --no-dev && find vendor -type d \\( -name 'tests' -o -name 'Tests' -o -name 'test' -o -name 'docs' -o -name 'examples' -o -name 'example' \\) -exec rm -rf {} + 2>/dev/null || true",
         "composer:update": "cd src/ && composer update",


### PR DESCRIPTION
## What Changed
`npm run build:orm` pointed at `--config-dir=propel` under `src/`, which does not exist, so it always failed. It now delegates to the composer `orm-gen` script, which is the invocation that actually works and is what the ORM validation step expects.

Fixes #9722

## Type
- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [x] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
Ran `npm run build:orm` after `composer install`: exit 0, regenerated `Base/` identical to a pre-run snapshot (95 files), `git status` shows only `package.json`. `npm run build:php:validate:orm` and `npm run lint` pass.

## Pre-Merge
- [x] Tested locally
- [x] No new warnings
- [x] Build passes
- [x] Backward compatible (or migration documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
