### PR TITLE
Fix issue #9732: Remove the unused User::getAllPermissions() map

### DIFF
--- a/src/ChurchCRM/model/ChurchCRM/User.php
+++ b/src/ChurchCRM/model/ChurchCRM/User.php
@@ -231,38 +231,6 @@ class User extends BaseUser
         return SystemConfig::getBooleanValue('bEnabledEvents');
     }
 
-    // -- Consolidated permission map for API/UI consumption --
-
-    /**
-     * Return a structured map of all permissions for this user.
-     * Useful for the user editor UI (/admin/system/users/{personId}/edit) and the user settings API.
-     * Every value reflects the effective permission (with admin bypass applied).
-     *
-     * @return array<string, bool>
-     */
-    public function getAllPermissions(): array
-    {
-        return [
-            // Core record permissions (user_usr columns)
-            'isAdmin'             => $this->isAdmin(),
-            'addRecords'          => $this->isAddRecordsEnabled(),
-            'editRecords'         => $this->isEditRecordsEnabled(),
-            'deleteRecords'       => $this->isDeleteRecordsEnabled(),
-            'menuOptions'         => $this->isMenuOptionsEnabled(),
-            'manageGroups'        => $this->isManageGroupsEnabled(),
-            'finance'             => $this->isFinanceEnabled(),
-            'manageFundraisers'   => $this->isManageFundraisersEnabled(),
-            'notes'               => $this->isNotesEnabled(),
-            'editSelf'            => $this->isEditSelfEnabled(),
-            // Module permissions (userconfig_ucfg rows)
-            'addEvent'            => $this->isAddEventEnabled(),
-            'emailMailto'         => $this->isEmailEnabled(),
-            // Computed module-level gates
-            'canViewEvents'       => $this->canViewEvents(),
-            'canManageEvents'     => $this->canManageEvents(),
-        ];
-    }
-
     /**
      * Returns true if the current user may read basic metadata for any family.
      * All authenticated users have this capability by default (read-default policy).


### PR DESCRIPTION
## What Changed
`User::getAllPermissions()` had no callers. Its docblock claimed the user editor and the user permissions API consume it, but the editor builds its checkboxes from the stored column getters (it must show saved values, not effective ones with the admin bypass), and the API returns only `addEvent`. Wiring it up would not be behaviour-preserving, so the dead method is removed.

Fixes #9732

## Type
- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
`grep -rn getAllPermissions` is empty after the change; every helper it called still has other callers; `npm run build:php` and `npm run lint` pass.

## Pre-Merge
- [x] Tested locally
- [x] No new warnings
- [x] Build passes
- [x] Backward compatible (or migration documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
