### PR TITLE
Fix issue #9739: Replace slim-mvc proposal transcript with real inventory

### DIFF
--- a/.agents/skills/churchcrm/SKILL.md
+++ b/.agents/skills/churchcrm/SKILL.md
@@ -22,7 +22,7 @@ Project-specific skills for AI agents and developers working on ChurchCRM. Each 
 **Additional skills:**
 | Skill | When to Use |
 |-------|------------|
-| [Slim MVC Skill](./slim-mvc-skill.md) | MVC route groups, security patterns, migration guidance (optional) |
+| [Slim MVC Skill](./slim-mvc-skill.md) | Inventory of the Slim apps under `src/`, their role gates, and the shared API entity middleware |
 | [Configuration Management](./configuration-management.md) | Settings, SystemConfig, admin panels |
 
 ## Database

--- a/.agents/skills/churchcrm/slim-mvc-skill.md
+++ b/.agents/skills/churchcrm/slim-mvc-skill.md
@@ -16,9 +16,14 @@ Two kinds of Slim app
 | Kind | Bootstrap | Prefixes |
 |------|-----------|----------|
 | **MVC (HTML) modules** | `MvcAppFactory::create('/<prefix>', [...])` | `/admin`, `/event`, `/finance`, `/fundraiser`, `/groups`, `/people`, `/v2` |
-| **Bespoke apps** | `AppFactory::create()` + `SlimUtils::getBasePath()` in their own `index.php` | `/api`, `/external`, `/kiosk`, `/plugins`, `/session`, `/setup` |
+| **Bespoke apps** | `AppFactory::create()` + `SlimUtils::getBasePath()` in their own `index.php` | `/api`, `/external`, `/kiosk`, `/plugins`, `/session`, `/setup`&nbsp;† |
 
-`MvcAppFactory` (`src/ChurchCRM/Slim/MvcAppFactory.php:35-62`) supplies the shared stack: base path, body parsing, routing, the HTML error handler, and the middleware chain `AuthMiddleware` → `ChurchInfoRequiredMiddleware` → optional role middleware → `CorsMiddleware`. API-only entry points deliberately do **not** use it — they need a JSON error handler and a different middleware set (`MvcAppFactory.php:17-18`).
+&nbsp;† `/setup` is the exception: it calls `AppFactory::create()` like the rest, but computes its
+base path by parsing `$_SERVER['SCRIPT_NAME']` (`src/setup/index.php:15-16`) instead of calling
+`SlimUtils::getBasePath()`, because that helper depends on `Config.php`, which does not exist
+yet while the installer runs. The other five all call `SlimUtils::getBasePath('/<prefix>')`.
+
+`MvcAppFactory` (`src/ChurchCRM/Slim/MvcAppFactory.php:35-62`) supplies the shared stack: base path, body parsing, routing, the HTML error handler, and the middleware chain, whose **execution order** is `AuthMiddleware` → `ChurchInfoRequiredMiddleware` → optional role middleware → `CorsMiddleware` (added in the reverse of that order at `MvcAppFactory.php:54-59`, per Slim 4 LIFO). API-only entry points deliberately do **not** use it — they need a JSON error handler and a different middleware set (`MvcAppFactory.php:17-18`).
 
 Middleware: FamilyMiddleware <!-- learned: 2026-03-03 -->
 
@@ -62,7 +67,7 @@ Bespoke Slim apps (not `MvcAppFactory`)
 
 | Prefix | Entry point | Notes |
 |--------|-------------|-------|
-| `/api` | `src/api/index.php` | REST endpoints used by the frontend and external clients. JSON error handler; `CorsMiddleware` + `AuthMiddleware` + `VersionMiddleware`. Routes grouped by domain under `src/api/routes/{calendar,finance,people,public,system,users}/`. Keep the API surface backward-compatible. |
+| `/api` | `src/api/index.php` | REST endpoints used by the frontend and external clients. JSON error handler. Middleware **execution order** is `VersionMiddleware` → `AuthMiddleware` → `CorsMiddleware` — the reverse of the `$app->add()` sequence at `src/api/index.php:29-31`, because Slim 4 is LIFO (last added = first executed). Routes grouped by domain under `src/api/routes/{calendar,finance,people,public,system,users}/`. Keep the API surface backward-compatible. |
 | `/external` | `src/external/index.php` | `src/external/routes/` — `calendar.php`, `register.php`, `system.php`, `verify.php`. Often unauthenticated or token-based; validate inputs strictly. |
 | `/kiosk` | `src/kiosk/index.php` | `src/kiosk/routes/` — `admin.php`, `device.php`, `api/`. Kiosk device token/cookie flows with a deliberately limited action set. |
 | `/plugins` | `src/plugins/index.php` | `/plugins/management/*` and `/plugins/api/*` (admin only), plus `/plugins/{plugin-name}/…` registered by each enabled plugin. Plugin routes run with the plugin's own permission settings — see `plugin-security-scan.md`. |

--- a/.agents/skills/churchcrm/slim-mvc-skill.md
+++ b/.agents/skills/churchcrm/slim-mvc-skill.md
@@ -1,15 +1,24 @@
 ---
-title: "Slim MVCs — Routes, Uses, Security & Migration Guidance"
-intent: "Inventory Slim MVCs and provide migration guidance for group apps"
-tags: ["slim","mvc","routing","migration","security"]
+title: "Slim MVCs — Routes, Uses & Security"
+intent: "Inventory the Slim apps under src/ and the entity middleware they share"
+tags: ["slim","mvc","routing","security"]
 prereqs: ["[[routing-architecture]]","[[slim-4-best-practices]]"]
 complexity: "intermediate"
 ---
 
-**Slim MVCs — Skill: Routes, Uses, Security & Migration Guidance**
+**Slim MVCs — Skill: Routes, Uses & Security**
 
 Overview
-- **Purpose:** Inventory current Slim MVCs (route groups / folders), explain what each is used for, list security and operational considerations, and provide a migration plan to create new MVC apps/groups (SundaySchool, Congregation) and move appropriate `v2` and `api` functionality into them.
+- **Purpose:** Inventory the Slim applications that make up ChurchCRM, say what each one serves, and record the security considerations that apply when adding routes to them. For the conventions *inside* a route file — base paths, `require` mounting, menu registration — see [`routing-architecture.md`](./routing-architecture.md).
+
+Two kinds of Slim app
+
+| Kind | Bootstrap | Prefixes |
+|------|-----------|----------|
+| **MVC (HTML) modules** | `MvcAppFactory::create('/<prefix>', [...])` | `/admin`, `/event`, `/finance`, `/fundraiser`, `/groups`, `/people`, `/v2` |
+| **Bespoke apps** | `AppFactory::create()` + `SlimUtils::getBasePath()` in their own `index.php` | `/api`, `/external`, `/kiosk`, `/plugins`, `/session`, `/setup` |
+
+`MvcAppFactory` (`src/ChurchCRM/Slim/MvcAppFactory.php:35-62`) supplies the shared stack: base path, body parsing, routing, the HTML error handler, and the middleware chain `AuthMiddleware` → `ChurchInfoRequiredMiddleware` → optional role middleware → `CorsMiddleware`. API-only entry points deliberately do **not** use it — they need a JSON error handler and a different middleware set (`MvcAppFactory.php:17-18`).
 
 Middleware: FamilyMiddleware <!-- learned: 2026-03-03 -->
 
@@ -18,8 +27,12 @@ Middleware: FamilyMiddleware <!-- learned: 2026-03-03 -->
 Example:
 
 ```php
-// attach middleware to the route
-$group->get('/neighbors/{familyId:[0-9]+}', 'getMapNeighbors')->add(\ChurchCRM\Slim\Middleware\Api\FamilyMiddleware::class);
+// src/api/routes/map.php:9, :17-21 (trimmed) — attach middleware to the route
+use ChurchCRM\Slim\Middleware\Api\FamilyMiddleware;
+
+$app->group('/map', function (RouteCollectorProxy $group): void {
+    $group->get('/neighbors/{familyId:[0-9]+}', 'getMapNeighbors')->add(FamilyMiddleware::class);
+});
 
 // handler reads the validated family from the request
 function getMapNeighbors(Request $request, Response $response, array $args) {
@@ -29,87 +42,56 @@ function getMapNeighbors(Request $request, Response $response, array $args) {
 }
 ```
 
-Current MVCs (folders & primary route files)
-- **API (`/api`)**: [src/api/routes](src/api/routes) — REST endpoints used by the frontend and external clients (people, families, calendar, finance, auth-related endpoints). Security: authenticated via app auth middleware; uses JSON error handling via centralized helpers. Keep backward-compatible API surface while migrating.
-- **v2 UI (`/v2`)**: [src/v2/routes](src/v2/routes) — new(er) UI routes, server-side endpoints supporting JS/TS frontend (people, person, family, cart, calendar, user). Security: page-level permission checks and server-side rendering of initial state; interacts with services.
-- **Admin (`/admin`)**: [src/admin/routes](src/admin/routes) — Admin pages and admin-only API endpoints (system config, logs, upgrade, user-admin). Security: requires admin roles; sensitive operations.
-- **Finance (`/finance`)**: [src/finance/routes](src/finance/routes) — Finance-specific MVC for dashboards, pledges, reports, deposit/payment APIs. Security: finance role gating; audit-sensitive.
-- **Kiosk (`/kiosk`)**: [src/kiosk/routes](src/kiosk/routes) — Kiosk UI and kiosk-scoped `/api` group. Security: kiosk token/cookie flows and limited actions.
-- **External / Public (`/external`, `/public`, `/register`, `/system`)**: [src/external/routes](src/external/routes), public API routes under `src/api/routes/public` — public-facing endpoints (register, calendar feeds, verification). Security: often unauthenticated or special token-based flows; must validate inputs strictly.
-- **Plugins (`/plugins`)**: [src/plugins/routes](src/plugins/routes) and `src/plugins/core/*/routes` — plugin-provided MVCs. Security: plugin isolation; plugin routes may bypass assumptions if they use globals.
-- **Setup (`/setup`)**: [src/setup/routes/setup.php] — installer/setup flows; sensitive, run once.
-- **Session/auth flows (`/session`)**: [src/session/routes] — login, password reset, MFA flows.
+`FamilyMiddleware` is one of a family of entity middlewares in `src/ChurchCRM/Slim/Middleware/Api/`, all extending `AbstractEntityMiddleware`: `CalendarMiddleware`, `DepositMiddleware`, `FamilyMiddleware`, `FamilyReadMiddleware`, `GroupMiddleware`, `KioskDeviceMiddleware`, `NoteMiddleware`, `PersonMiddleware`, `PropertyMiddleware`, `PublicCalendarMiddleware`, `UserMiddleware`. A subclass supplies only `getRouteParamName()`, `getAttributeName()` and `loadEntity()`, plus an optional `postEntityLoad()` permission hook — `FamilyMiddleware::postEntityLoad()` is what enforces the family-scope restriction for EditSelf-only users (GHSA-jjcj-h3cm-p7x7). Use `FamilyReadMiddleware` for read-only endpoints that must stay reachable without that scope check.
+
+Current MVC modules (`MvcAppFactory`)
+
+| Prefix | Entry point | Module role gate | Routes / what it serves |
+|--------|-------------|------------------|-------------------------|
+| `/admin` | `src/admin/index.php` | `AdminRoleAuthMiddleware` | `src/admin/routes/` — `/admin/`, `/admin/get-started`, `/admin/system/*` pages and `/admin/api/*` (system config, logs, upgrade, user admin, database, import/export). Sensitive operations; admin role required. |
+| `/event` | `src/event/index.php` | `ViewEventsRoleAuthMiddleware` | `src/event/routes/` — dashboard, calendars, check-in, editor, types, repeat editor, view, audit. Write routes additionally `->add(new AddEventsRoleAuthMiddleware())`. |
+| `/finance` | `src/finance/index.php` | `FinanceRoleAuthMiddleware` | `src/finance/routes/` — dashboard, reports, pledges, deposits, funds, plus `routes/api/funds-api.php`. Audit-sensitive. |
+| `/fundraiser` | `src/fundraiser/index.php` | `ManageFundraisersRoleAuthMiddleware` | `src/fundraiser/routes/` — fundraiser, donors, donated items, paddle numbers, batch winner, reports. Routes are additionally wrapped in `CSRFMiddleware` and `FundraiserEnabledMiddleware`. |
+| `/groups` | `src/groups/index.php` | `ManageGroupRoleAuthMiddleware` | `src/groups/routes/` — dashboard, view, editor, properties form, member role/properties, reports, cart, and `sundayschool.php`. |
+| `/people` | `src/people/index.php` | none at module level | `src/people/routes/` — dashboard, list, family, person, view, cart, self-register, map. Per-route permission checks. |
+| `/v2` | `src/v2/index.php` | none at module level | `src/v2/routes/` — dashboard/root, search, user, user-current, email, text, cart. Server-rendered initial state for the JS/TS frontend. |
+
+**Sunday School is not its own module.** It ships inside `/groups`: routes in `src/groups/routes/sundayschool.php` (gated by `SundaySchoolEnabledMiddleware`) with views under `src/groups/views/sundayschool/`. There is no `src/groups/congregation/`.
+
+Bespoke Slim apps (not `MvcAppFactory`)
+
+| Prefix | Entry point | Notes |
+|--------|-------------|-------|
+| `/api` | `src/api/index.php` | REST endpoints used by the frontend and external clients. JSON error handler; `CorsMiddleware` + `AuthMiddleware` + `VersionMiddleware`. Routes grouped by domain under `src/api/routes/{calendar,finance,people,public,system,users}/`. Keep the API surface backward-compatible. |
+| `/external` | `src/external/index.php` | `src/external/routes/` — `calendar.php`, `register.php`, `system.php`, `verify.php`. Often unauthenticated or token-based; validate inputs strictly. |
+| `/kiosk` | `src/kiosk/index.php` | `src/kiosk/routes/` — `admin.php`, `device.php`, `api/`. Kiosk device token/cookie flows with a deliberately limited action set. |
+| `/plugins` | `src/plugins/index.php` | `/plugins/management/*` and `/plugins/api/*` (admin only), plus `/plugins/{plugin-name}/…` registered by each enabled plugin. Plugin routes run with the plugin's own permission settings — see `plugin-security-scan.md`. |
+| `/session` | `src/session/index.php` | Login, two-factor, and `src/session/routes/password-reset.php`. |
+| `/setup` | `src/setup/index.php` | Installer. Computes its base path from `SCRIPT_NAME` with no `Config.php` dependency, because it runs before one exists. Sensitive; runs once. |
 
 Notes about how routes are organized
 - Routes are grouped by purpose and placed under `src/<area>/routes` (see `src/v2/routes`, `src/api/routes`, `src/admin/routes`, etc.).
-- Business logic should live in `src/ChurchCRM/Service/` (Service layer) and not in route handlers. Migration must preserve or move service code, not just routes.
-- Per repository conventions: use Perpl ORM Query classes, `SlimUtils::renderErrorJSON()` for API errors, and `RedirectUtils` for page redirects.
+- A route file registers on the ambient `$app` and is pulled in with a bare `require` from the module's `index.php`. Route paths are **relative to the module base path** — see [`routing-architecture.md`](./routing-architecture.md) → "Route paths are relative to the module base path".
+- Business logic should live in `src/ChurchCRM/Service/` (Service layer) and not in route handlers. Services are instantiated directly (`new PersonService()`) — there is no DI container; see [`service-layer.md`](./service-layer.md).
+- Per repository conventions: use Propel ORM Query classes, `SlimUtils::renderErrorJSON()` for API errors, and `RedirectUtils` for page redirects.
 
 Security & operational considerations (general)
-- **Auth & permissions:** Many routes rely on role-based checks (admin, finance, edit records). When moving routes between MVCs, ensure the same middleware and permission checks remain or are migrated.
-- **Backward compatibility:** External clients or the frontend may call `/api` or `/v2` endpoints. Maintain stable routes (or provide compatibility redirects/shims) during migration.
-- **Locale / i18n:** Adding gettext() strings requires running `npm run locale:build` and `npm run build` before committing translations. Migration that changes UI strings must follow this process.
+- **Auth & permissions:** Many routes rely on role-based checks (admin, finance, edit records). When moving routes between apps, ensure the same middleware and permission checks remain or are migrated. Role middlewares all live in `src/ChurchCRM/Slim/Middleware/Request/Auth/`.
+- **Backward compatibility:** External clients and the frontend call `/api` and `/v2` endpoints. Keep those routes stable while refactoring.
+- **Locale / i18n:** Wrap new UI strings in `gettext()` / `i18next.t()` and commit only the source change. **Never run `npm run locale:build`** — term extraction and `locale/terms/messages.po` are owned by automation outside this repo (see `i18n-localization.md`).
 - **Tests & CI:** Update or add Cypress tests for new endpoints; clear logs before running tests per repo policy.
-- **Plugin compatibility:** Plugins register routes; changing core route namespaces may break plugins. Provide compatibility layer or plugin migration docs.
+- **Plugin compatibility:** Plugins register routes and menu items; changing core route namespaces may break them. Provide a compatibility layer or plugin migration notes.
 
-Design for new MVCs: Groups apps (SundaySchool, Congregation)
-- **Goal:** Create two new MVC areas under `src/groups/sunday-school` and `src/groups/congregation` (or `src/groups/sundaySchool`, `src/groups/congregation`) that host group-related UI and APIs for these domains.
-- **What to include in each MVC:**
-  - Group management UI (list, enroll/unenroll people, schedules)
-  - Group-specific API endpoints (memberships, rosters, attendance)
-  - Service-layer logic in `src/ChurchCRM/Service/Group*Service.php` (re-use/extract from existing `people-groups` logic)
-  - Permission checks (manage groups / edit records) and audit logging
+Adding a new MVC module
+1. Create `src/<module>/index.php` calling `MvcAppFactory::create('/<module>', [...])` with `dashboardUrl`, `dashboardText` and (if the module needs one) `roleMiddleware`.
+2. Add `src/<module>/routes/*.php` — one file per resource — and `require` each from `index.php`.
+3. Add `src/<module>/views/*.php` rendered through `PhpRenderer`.
+4. Add an `.htaccess` that blocks direct PHP access and routes everything through Slim (copy `src/event/.htaccess`).
+5. Register the menu entry in `src/ChurchCRM/Config/Menu/Menu.php`.
+6. Put business logic in `src/ChurchCRM/Service/<Feature>Service.php`, not in the route handler.
 
-Mapping v2 & api into new Groups MVCs
-- **Move candidates from `v2` and `api`:**
-  - `v2/routes/people.php`, `v2/routes/person.php`, `v2/routes/family.php` → only UI pieces that present group membership should be adapted to call new Groups services/APIs; do NOT move generic person/family CRUD unless grouping-specific UI demands it.
-  - `api/routes/people/people-groups.php` and `api/routes/people/people-persons.php` (membership-related endpoints) → move or replicate into `src/groups/<app>/routes` (group-scoped endpoints).
-  - Calendar and attendance flows that are group-specific → migrate into the group MVCs (e.g., `v2/routes/calendar.php`, `api/routes/calendar/*` where relevant).
-- **Keep where they belong:**
-  - Core `api` endpoints for `persons`, `families`, `payments`, `deposits`, and other cross-cutting domain APIs stay under `src/api/routes` unless strongly group-scoped.
-  - Admin functionality remains under `src/admin/routes`.
+Full worked detail for each step lives in [`routing-architecture.md`](./routing-architecture.md).
 
-Cost, Risk & Effort estimate
-- **Low-effort, low-risk tasks:**
-  - Adding new route groups under `src/groups/*` that call existing services (minimal changes).
-  - Adding adapters/wrappers that route `api` calls to new group APIs while keeping original `/api` routes as compatibility shims.
-- **Medium effort / moderate risk:**
-  - Extracting service logic from route handlers into `Service` classes when logic currently lives inline; requires tests and regression validation.
-  - Updating frontend code (v2 JS/TS) to call new group endpoints; moderate work if the frontend is modular.
-- **High effort / high risk:**
-  - Removing or renaming existing `/api` routes used by external integrations — breaking API clients and plugins.
-  - Migrating authentication/authorization semantics between route namespaces (must preserve security semantics exactly).
+---
 
-Risks & mitigations
-- **Broken clients / plugins:** Provide compatibility shims (keep old `/api` endpoints forwarding to new services) and deprecate with a timeline.
-- **Permission regressions:** Add automated tests covering role scenarios; review `User::can*` usage and object-level checks.
-- **i18n drift:** Run locale build, update PO files, and include translations in PRs.
-- **Data migration:** Prefer no DB schema changes; keep data models but introduce group-specific join tables or metadata incrementally.
-
-What will be left behind (and cleanup steps)
-- Legacy route handlers in `src/v2/routes` that are generic person/family endpoints — keep as compatibility but mark as deprecated.
-- Admin APIs remain in `src/admin/routes` (no change).
-- Plugin routes in `src/plugins` — may need opt-in migration documentation.
-- Ensure `src/api/routes/public` endpoints remain unchanged for public flows.
-
-Recommended migration checklist (practical steps)
-1. Create `src/groups/sundaySchool/routes/*` and `src/groups/congregation/routes/*` with initial route skeletons that call existing services.
-2. Extract or wrap group-related business logic into `src/ChurchCRM/Service/GroupService.php` (or `SundaySchoolService`, `CongregationService`) re-using `PersonService`/`GroupService` patterns.
-3. Add unit/integration tests + Cypress e2e tests for group flows.
-4. Add compatibility endpoints in `src/api/routes/people/` that forward to new group endpoints and log deprecation warnings in headers.
-5. Update `v2` frontend to call new group APIs (feature-flag roll-out).
-6. Run `npm run locale:build` and `npm run build` if new UI strings were added.
-7. Communicate plugin migration steps and document API deprecation timeline.
-
-Decision notes
-- Prefer incremental rollout: add new MVCs and adapters first, then update UI to consume them, then remove old endpoints once usage is verified.
-- Do NOT change database ownership or core person/family CRUD unless required — keep domain model stable.
-
-Deliverables
-- This skill document (the file you are reading).
-- A short mapping of which `v2` and `api` endpoints should move (see section "Mapping v2 & api into new Groups MVCs").
-
-If you want, I can now:
-- create the `src/groups/` skeleton with route files for `sundaySchool` and `congregation`,
-- extract the existing `people-groups` service code into `src/ChurchCRM/Service/GroupService.php`, and
-- add compatibility routes in `src/api/routes/people/` that forward to the new group routes.
+Last updated: September 11, 2026


### PR DESCRIPTION
## What Changed
`slim-mvc-skill.md` was an unfinished proposal transcript (cost/risk sections, a closing offer to continue). It is now an inventory: the seven `MvcAppFactory` modules and six bespoke Slim apps with entry points and role gates, the `FamilyMiddleware` section extended with its real call site and the eleven `AbstractEntityMiddleware` subclasses. Also removes an instruction to run `npm run locale:build`, which the git-workflow and code-standards skills forbid, and fixes the `SKILL.md` index row.

Every corrected statement was checked against the code at `850c70a8c` and cites the file it comes from, and fabricated examples were replaced with trimmed real code so the doc cannot drift again.

Fixes #9739

## Type
- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
Documentation only (`.agents/skills/`); no code changed. Pre-commit hooks (locale check, YAML validation) pass.

## Pre-Merge
- [x] Tested locally
- [x] No new warnings
- [x] Build passes
- [x] Backward compatible (or migration documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
