### PR TITLE
Fix issue #9740: Make table-action-menu.md the action-menu authority

### DIFF
--- a/.agents/skills/churchcrm/icon-management.md
+++ b/.agents/skills/churchcrm/icon-management.md
@@ -119,7 +119,7 @@ Use Bootstrap margin utilities: `me-1` (small), `me-2` (standard), `me-3` (large
 | **Settings/Config** | `fa-cog` or `fa-sliders` | `<i class="fa-solid fa-cog me-2"></i>` |
 | **Search/Find** | `fa-magnifying-glass` | `<i class="fa-solid fa-magnifying-glass me-2"></i>` |
 | **Filter** | `fa-filter` | `<i class="fa-solid fa-filter me-2"></i>` |
-| **Menu/Dropdown** | `fa-ellipsis-v` (vertical) or `fa-ellipsis` (horizontal) | `<i class="fa-solid fa-ellipsis-v"></i>` |
+| **Menu/Dropdown** | `fa-ellipsis-vertical` (vertical) or `fa-ellipsis` (horizontal) | `<i class="fa-solid fa-ellipsis-vertical"></i>` — row action menus: see [`table-action-menu.md`](./table-action-menu.md) |
 
 ### Dashboard / Status Icons
 
@@ -167,7 +167,7 @@ When migrating from Tabler icons (deprecated), use this mapping:
 | `ti-circle-check` | `fa-circle-check` |
 | `ti-credit-card` | `fa-credit-card` |
 | `ti-device-floppy` | `fa-floppy-disk` |
-| `ti-dots-vertical` | `fa-ellipsis-v` |
+| `ti-dots-vertical` | `fa-ellipsis-vertical` |
 | `ti-download` | `fa-download` |
 | `ti-edit` | `fa-pencil` |
 | `ti-eye` | `fa-eye` |

--- a/.agents/skills/churchcrm/responsive-design-guidelines.md
+++ b/.agents/skills/churchcrm/responsive-design-guidelines.md
@@ -50,7 +50,7 @@ codebase:
 - Stat cards: `col-6` (two-up, never stack to one-up — looks empty on 375px)
 - Main columns: `col-12` (stack everything)
 - Form fields: `col-12`
-- Tables: **must** be wrapped in `.table-responsive` — UNLESS rows have action dropdowns, in which case use `<div style="overflow: visible;">` instead (`data-bs-display="static"` alone does NOT prevent clipping — see [`table-action-menu.md`](./table-action-menu.md))
+- Tables: **must** be wrapped in `.table-responsive` — UNLESS rows have action dropdowns, in which case [`table-action-menu.md`](./table-action-menu.md) → "Overflow / Dropdown Clipping" owns the rule (`overflow-x: clip; overflow-y: visible`; `data-bs-display="static"` alone does NOT prevent clipping)
 - Touch targets: minimum **44×44px** (Apple HIG)
 - Page headers: use icon-only buttons (`font-size: 0` trick, see `_tabler-bridge.scss`)
 - Labels on multi-step forms: hide under 400px (`d-none d-sm-inline`)
@@ -70,7 +70,7 @@ codebase:
   balanced two-column layouts. Do NOT use the 8/4 split at md — it cramps the
   narrow column.
 - Form fields: `col-md-6` for paired fields (name/email, date range)
-- Tables: wrap in `.table-responsive` — UNLESS rows have action dropdowns, in which case use `<div style="overflow: visible;">` instead (see `table-action-menu.md`)
+- Tables: wrap in `.table-responsive` — UNLESS rows have action dropdowns, in which case follow [`table-action-menu.md`](./table-action-menu.md) → "Overflow / Dropdown Clipping"
 - Card header tabs: keep visible but consider shorter labels
   (`<span class="d-none d-xl-inline">Latest Families</span><span class="d-xl-none">New</span>`)
 
@@ -176,30 +176,32 @@ On mobile and tablet they stack automatically (both become `col-12`).
 
 ### Tables must be wrapped — but NOT with `.table-responsive` if the rows have action dropdowns <!-- learned: 2026-04-09 -->
 
-> [!WARNING] Critical conflict with [`table-action-menu.md`](./table-action-menu.md)
+> [!NOTE] The wrapper rule lives in [`table-action-menu.md`](./table-action-menu.md)
 > `.table-responsive` sets `overflow-x: auto`, which (per CSS spec) forces
 > `overflow-y: auto` as well — and that **clips absolutely-positioned row
-> dropdowns on their last rows**. For tables that have per-row action menus
-> (the `ti-dots-vertical` dropdown pattern), you **must** use
-> `<div style="overflow: visible;">` as the wrapper instead. See the Overflow
-> section of `table-action-menu.md` for the full root cause.
+> dropdowns on their last rows**. Tables with per-row action menus therefore need a
+> different wrapper. [`table-action-menu.md`](./table-action-menu.md) →
+> "Overflow / Dropdown Clipping" is the single source of truth for that wrapper, the
+> root cause, and the trigger markup. The summary below repeats its conclusion only —
+> if the two ever disagree, `table-action-menu.md` wins.
 
 **Decision flow for every table in a card:**
 
 ```
 Does the table have per-row action dropdowns?
-├── YES → Use <div style="overflow: visible;"> (dropdowns can escape)
-│         Accept horizontal overflow on phones — it's the lesser evil
-│         compared to broken action menus.
+├── YES → Use <div style="overflow-x: clip; overflow-y: visible;">
+│         Horizontal overflow stays clipped; the dropdown can still escape
+│         downward. (The older <div style="overflow: visible;"> also stops the
+│         clipping but drops horizontal containment — see table-action-menu.md.)
 └── NO  → Use .table-responsive (proper mobile horizontal scroll)
 ```
 
 ```html
 <!-- ✅ CORRECT — table with row action dropdowns -->
-<div class="card-body" style="overflow: visible;">
-    <div style="overflow: visible;">
+<div class="card-body">
+    <div style="overflow-x: clip; overflow-y: visible;">
         <table class="table table-vcenter table-hover card-table">
-            <!-- rows with ti-dots-vertical dropdown in last <td> -->
+            <!-- rows whose last <td> holds the fa-ellipsis-vertical dropdown -->
         </table>
     </div>
 </div>
@@ -311,7 +313,7 @@ there when introducing a new page or fixing a responsive bug.
 | `col-lg-8 col-md-8` main content | Use `col-lg-8` only; stack on md |
 | Inline `width: 300px` on inputs | Use `col-md-*` wrappers + `w-100` |
 | Bare `<table class="table">` in card (no row dropdowns) | Wrap in `.table-responsive` |
-| Bare `<table class="table">` in card (WITH row dropdowns) | Wrap in `<div style="overflow: visible;">` — `.table-responsive` clips dropdowns (see `table-action-menu.md`) |
+| Bare `<table class="table">` in card (WITH row dropdowns) | Wrap in `<div style="overflow-x: clip; overflow-y: visible;">` — `.table-responsive` clips dropdowns (see [`table-action-menu.md`](./table-action-menu.md)) |
 | `navbar-expand-lg` on vertical navbar | The canonical Tabler sidebar is `navbar-expand-xl` |
 | Hardcoded icon `font-size: 12px` on touch targets | Default (≥16px) or bigger for mobile |
 | Long labels crammed into card tabs | Use `d-none d-xl-inline` + `d-xl-none` short label pair |

--- a/.agents/skills/churchcrm/table-action-menu.md
+++ b/.agents/skills/churchcrm/table-action-menu.md
@@ -6,6 +6,12 @@ tags: ["frontend", "tabler", "tables", "dropdowns", "cart", "ux"]
 
 # Skill: Table Action Menu <!-- learned: 2026-03-23 -->
 
+> **This file is the single source of truth for row action menus** — the trigger markup,
+> the trigger icon, and the wrapper that stops the dropdown being clipped.
+> `responsive-design-guidelines.md`, `tabler-components.md` and `icon-management.md` defer
+> to it. If any of them disagrees, this file wins and the other one is the bug.
+> <!-- learned: 2026-09-11 -->
+
 ## Rule
 
 Every table row that has per-row actions **must** use the standard Tabler action dropdown. No exceptions. This applies to PHP templates and JS-rendered DataTables columns alike.
@@ -19,7 +25,7 @@ Every table row that has per-row actions **must** use the standard Tabler action
     <div class="dropdown">
         <button class="btn btn-sm btn-ghost-secondary" type="button"
                 data-bs-toggle="dropdown" aria-expanded="false">
-            <i class="fa-solid fa-ellipsis-v"></i>
+            <i class="fa-solid fa-ellipsis-vertical"></i>
         </button>
         <div class="dropdown-menu dropdown-menu-end">
             <a class="dropdown-item" href="Editor.php?ID=<?= $id ?>">
@@ -48,7 +54,24 @@ window.CRM.renderPersonActionMenu(personId, fullName, { familyId, inCart })
 
 // Standard family action menu: View → Edit → [divider] → Cart → [divider] → Delete
 window.CRM.renderFamilyActionMenu(familyId, familyName, { inCart })
+
+// Standard event action menu: View → Edit → [divider] → Activate/Deactivate → [divider] → Delete
+window.CRM.renderEventActionMenu(eventId, eventTitle, { inactive })
 ```
+
+All three emit the canonical trigger verbatim
+(`src/skin/js/CRMJSOM.js:612-613`, `:683-684`, `:768-769`):
+
+```html
+<button class="btn btn-sm btn-ghost-secondary" type="button" data-bs-toggle="dropdown" data-bs-display="static" aria-expanded="false">
+  <i class="fa-solid fa-ellipsis-vertical"></i>
+</button>
+```
+
+**`fa-ellipsis-vertical`, never `fa-ellipsis-v`.** Font Awesome 7.3.1 ships `.fa-ellipsis-v`
+as a backwards-compatibility alias so both render, but the codebase uses
+`fa-ellipsis-vertical` in all 37 places and hand-written markup must match the shared
+renderers.
 
 - `familyId` — optional; when provided, adds a "View Family" item after Edit
 - `inCart` — optional; flips cart button to RemoveFromCart state
@@ -97,7 +120,7 @@ For families, Delete links to `SelectDelete.php?FamilyID={id}`.
 | Rule | ✅ Correct | ❌ Wrong |
 |------|-----------|---------|
 | Trigger class | `btn-ghost-secondary` | `btn-outline-secondary`, `btn-secondary` |
-| Trigger icon | `fa-solid fa-ellipsis-v` | `fa-solid fa-ellipsis-v`, `fa-ellipsis-v` |
+| Trigger icon | `fa-solid fa-ellipsis-vertical` | `fa-solid fa-ellipsis-v`, `fa-ellipsis-v`, `ti ti-dots-vertical` |
 | Menu alignment | `dropdown-menu-end` | `dropdown-menu-right` |
 | Aria attribute | `aria-expanded="false"` only | `aria-haspopup="true"` |
 | Inline styles | none | `style="z-index:..."`, `style="position:..."` |
@@ -136,7 +159,7 @@ codebase audit of three still-broken instances that already had it.
                         <button class="btn btn-sm btn-ghost-secondary"
                                 data-bs-toggle="dropdown"
                                 data-bs-display="static">
-                            <i class="fa-solid fa-ellipsis-v"></i>
+                            <i class="fa-solid fa-ellipsis-vertical"></i>
                         </button>
                         <div class="dropdown-menu dropdown-menu-end">...</div>
                     </div>
@@ -160,15 +183,30 @@ content to overflow the viewport. `overflow-x: clip` clips horizontal overflow (
 `scroll`, not `clip`. This preserves horizontal containment while letting the dropdown
 menu escape downward.
 
-**Reference implementations** (canonical per-wrapper pattern):
+**Reference implementations** (every `overflow-x: clip` wrapper in the tree):
 - `src/people/views/self-register.php:55` ← canonical reference
-- `src/event/views/list-events.php`
-- `src/groups/views/group-view.php`
-- `src/event/views/types-list.php`
-- `src/people/views/family-view.php:190, 264, 636`
+- `src/people/views/family-view.php:204, 283, 670`
 - `src/people/views/family-list.php:62`
-- `src/people/views/person-view.php:408`
-- `src/DepositSlipEditor.php:277`
+- `src/people/views/person-view.php:417`
+- `src/finance/views/funds/index.php:111`
+- `src/DepositSlipEditor.php:281`
+
+### The superseded form: `overflow: visible` <!-- learned: 2026-09-11 -->
+
+Before #9373/#9383 the documented wrapper was `<div style="overflow: visible;">`. It does
+stop the clipping, but it removes **all** overflow containment, so a wide table spills out
+of its card and pushes the page into horizontal scroll on a phone. Roughly 19 views still
+carry it — e.g. `src/event/views/list-events.php:196-197`,
+`src/groups/views/group-view.php:210`, `src/event/views/types-list.php:14`.
+
+Treat `overflow: visible` as **legacy, not wrong-and-broken**: do not churn a file just to
+convert it, but when you touch a table wrapper for any other reason, upgrade it to
+`overflow-x: clip; overflow-y: visible;`.
+
+```bash
+# Find the remaining ones
+grep -rn "overflow: visible" src/ --include="*.php"
+```
 
 ### Still required: `data-bs-display="static"` on each trigger
 
@@ -182,7 +220,7 @@ on its own, but still needed.
         data-bs-toggle="dropdown"
         data-bs-display="static"
         aria-expanded="false">
-    <i class="fa-solid fa-ellipsis-v"></i>
+    <i class="fa-solid fa-ellipsis-vertical"></i>
 </button>
 ```
 
@@ -286,7 +324,7 @@ No Delete action is shown on the cart page — users can only remove from cart, 
 
 ## Checklist Before Committing Any Table Change
 
-- [ ] Trigger uses `btn-ghost-secondary` + `fa-solid fa-ellipsis-v`
+- [ ] Trigger uses `btn-ghost-secondary` + `fa-solid fa-ellipsis-vertical`
 - [ ] Menu uses `dropdown-menu-end` (not `dropdown-menu-right`)
 - [ ] No `aria-haspopup` attribute
 - [ ] No inline styles on trigger, menu, `<td>`, or `.dropdown`

--- a/.agents/skills/churchcrm/table-action-menu.md
+++ b/.agents/skills/churchcrm/table-action-menu.md
@@ -46,7 +46,7 @@ Add `w-1` to the `<th>` / `<td>` so the column shrinks to fit the icon button an
 
 ## Shared JS Renderers (use these — do NOT duplicate inline) <!-- learned: 2026-03-24 -->
 
-`CRMJSOM.js` exposes two shared renderers on `window.CRM`. **Always use these** in DataTable `render:` functions instead of writing raw HTML strings.
+`CRMJSOM.js` exposes three shared renderers on `window.CRM`. **Always use these** in DataTable `render:` functions instead of writing raw HTML strings.
 
 ```javascript
 // Standard person action menu: View → Edit → [View Family?] → [divider] → Cart → [divider] → Delete
@@ -55,7 +55,7 @@ window.CRM.renderPersonActionMenu(personId, fullName, { familyId, inCart })
 // Standard family action menu: View → Edit → [divider] → Cart → [divider] → Delete
 window.CRM.renderFamilyActionMenu(familyId, familyName, { inCart })
 
-// Standard event action menu: View → Edit → [divider] → Activate/Deactivate → [divider] → Delete
+// Standard event action menu: View → Edit → Check-in → [divider] → Activate/Deactivate → [divider] → Delete
 window.CRM.renderEventActionMenu(eventId, eventTitle, { inactive })
 ```
 

--- a/.agents/skills/churchcrm/tabler-components.md
+++ b/.agents/skills/churchcrm/tabler-components.md
@@ -165,7 +165,7 @@ When redesigning or fixing UX on any page, apply **all** of the following — no
 | Element | ✅ Tabler Standard | ❌ Wrong |
 |---------|-------------------|---------|
 | Card emphasis | `card-status-top bg-{color}` (thin line) | `card-header bg-primary` (solid blue bar) |
-| Icons | `ti ti-*` (Tabler icons) | `fa-solid fa-*` (FontAwesome) |
+| Icons | `fa-solid fa-*` / `fa-regular` / `fa-brands` (Font Awesome — see [`icon-management.md`](./icon-management.md)) | `ti ti-*` (Tabler icons — webfont removed in #9491) |
 | Form labels | `form-label` | `control-label`, `fw-bold` on labels |
 | Select elements | `form-select` | `form-control` on `<select>` |
 | Form wrapper | Plain `<form>` | `class="well form-horizontal"` |
@@ -338,9 +338,17 @@ Colors: `bg-primary`, `bg-success`, `bg-danger`, `bg-warning`, `bg-info`.
 | `.card-table` | Remove card-body padding for full-width table |
 | `.w-1` | Shrink column to content width (for action buttons) |
 
-### DataTable Card Structure — Use `table-responsive`, Not `card-body p-0` <!-- learned: 2026-03-29 -->
+### DataTable Card Structure — Use `table-responsive`, Not `card-body p-0` <!-- learned: 2026-03-29, scoped: 2026-09-11 -->
 
-The correct Tabler pattern for a card containing a full-width DataTable is `table-responsive` directly on the card. The legacy `card-body p-0` + `overflow:visible` hack is an **anti-pattern** — remove it whenever found.
+> **Applies only to tables with no per-row action dropdown.** If the rows have an action
+> menu, `.table-responsive` clips it and
+> [`table-action-menu.md`](./table-action-menu.md) → "Overflow / Dropdown Clipping" owns the
+> rule instead (`<div style="overflow-x: clip; overflow-y: visible;">`). That file is the
+> single source of truth for action-menu tables; do not apply the guidance below to them.
+
+For a card containing a full-width DataTable **without** row dropdowns, the correct Tabler
+pattern is `table-responsive` directly on the card. The legacy `card-body p-0` +
+`overflow:visible` padding hack is an **anti-pattern** in that case — remove it whenever found.
 
 ```html
 <!-- ✅ CORRECT -->
@@ -372,6 +380,8 @@ The correct Tabler pattern for a card containing a full-width DataTable is `tabl
 **Finding violations:**
 ```bash
 grep -r "card-body p-0" src/ --include="*.php" -l
+# overflow:visible is only a violation when the table has NO row dropdowns —
+# check each hit against table-action-menu.md before changing it
 grep -r "overflow: visible" src/ --include="*.php" -l
 ```
 
@@ -1064,72 +1074,38 @@ Settings saved via `POST /api/user/{userId}/setting/{settingName}` with `{value:
 
 ---
 
-## 14. Iconography Dual System
+## 14. Iconography — Font Awesome Only <!-- corrected: 2026-09-11 -->
 
-### UI Actions → Tabler Icons (`ti-`)
+ChurchCRM uses **Font Awesome 7.3+ exclusively**. Tabler's icon webfont was removed in
+#9491 — `@tabler/icons-webfont` is no longer a dependency
+(`grep -rn "@tabler/icons" package.json webpack.config.js` → 0 hits) and no `ti-dots-vertical`
+remains in `src/`. The "dual system" that used to be documented here (`ti ti-pencil` for UI
+actions, `fa-solid` for domain entities) no longer exists: **every** icon is `fa-solid`,
+`fa-regular` or `fa-brands`.
 
-```html
-<i class="ti ti-pencil"></i>      <!-- Edit -->
-<i class="ti ti-trash"></i>       <!-- Delete -->
-<i class="ti ti-device-floppy"></i> <!-- Save -->
-<i class="ti ti-x"></i>           <!-- Close -->
-<i class="ti ti-search"></i>      <!-- Search -->
-<i class="ti ti-filter"></i>      <!-- Filter -->
-<i class="ti ti-settings"></i>    <!-- Settings -->
-<i class="ti ti-plus"></i>        <!-- Add -->
-<i class="ti ti-download"></i>    <!-- Download -->
-<i class="ti ti-upload"></i>      <!-- Upload -->
-<i class="ti ti-maximize"></i>    <!-- Fullscreen -->
-<i class="ti ti-menu-2"></i>      <!-- Menu toggle -->
-<i class="ti ti-logout"></i>      <!-- Sign out -->
-<i class="ti ti-key"></i>         <!-- Password -->
-<i class="ti ti-shield"></i>      <!-- Security/2FA -->
-<i class="fa-solid fa-bug"></i>       <!-- Report issue (FA: ti-bug fails post-7.6.0, see #9441) -->
-<i class="fa-solid fa-book"></i>      <!-- Documentation (FA: ti-book fails post-7.6.0, see #9441) -->
-<i class="fa-solid fa-headset"></i>   <!-- Support (FA: ti-headset fails post-7.6.0, see #9441) -->
-<i class="fa-solid fa-file-csv"></i>  <!-- DataTables CSV export (FA: ti-table-export fails post-7.6.0, see #9441) -->
-<i class="fa-solid fa-print"></i>     <!-- DataTables print (FA: ti-printer fails post-7.6.0, see #9441) -->
-<i class="ti ti-confetti"></i>    <!-- New release -->
-<i class="ti ti-users"></i>       <!-- Group/team -->
-```
+[`icon-management.md`](./icon-management.md) is the single source of truth for icon choice.
+It carries the per-action icon table, the free-tier rules, and a `ti-*` → `fa-*` mapping for
+any legacy markup you still find.
 
-### Domain Entities → FontAwesome 7 Solid
+For the row action menu trigger specifically, see
+[`table-action-menu.md`](./table-action-menu.md) — it is `fa-solid fa-ellipsis-vertical`.
 
-```html
-<i class="fa-solid fa-user"></i>                       <!-- Person -->
-<i class="fa-solid fa-house-user"></i>                 <!-- Family -->
-<i class="fa-solid fa-people-group"></i>               <!-- Group -->
-<i class="fa-solid fa-circle-dollar-to-slot"></i>      <!-- Finance -->
-<i class="fa-solid fa-calendar-days"></i>              <!-- Event -->
-<i class="fa-solid fa-cart-shopping"></i>              <!-- Cart -->
-<i class="fa-solid fa-clipboard-check"></i>            <!-- Check-in -->
-```
-
-### CSS for Tabler Icons (add to Header-HTML-Scripts.php)
-
-```html
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@latest/tabler-icons.min.css">
-```
-
-Or install via npm and add to webpack:
-```bash
-npm install @tabler/icons-webfont
-```
-```scss
-// In churchcrm.scss
-@import "~@tabler/icons-webfont/dist/tabler-icons.min.css";
+> Some older examples further up this file still show `ti ti-*` classes. They are stale for
+> the same reason; substitute the Font Awesome equivalent from `icon-management.md`.
 
 ---
 
 ### Navbar/Toolbar Icon Reliability: Use FA Solid for These Specific Glyphs <!-- learned: 2026-08-15 -->
 
+**Historical — superseded by #9491, which removed the Tabler icon webfont outright.**
+Kept for anyone reading old markup or an old branch.
+
 Post-7.6.0 (issue #9441): `ti-bug`, `ti-book`, `ti-headset`, `ti-table-export`, and `ti-printer`
 failed to render (empty squares) for affected users in the top navbar while every surrounding
 FA icon rendered correctly. Root cause is glyph-specific Tabler webfont rendering failure in
-certain upgrade/cache states. PR #9442 incomplete — only fixed `fa-duotone` → `fa-solid`
-for the cart; the ti→fa swaps it described were not landed.
-
-**Rule:** Use `fa-solid` for these five icons in navbar/toolbar contexts — never `ti`:
+certain upgrade/cache states. The five swaps below landed; #9491 then removed the webfont
+entirely, so `ti` is not an option for *any* glyph now — see
+[`icon-management.md`](./icon-management.md).
 
 | Ti icon (avoid) | FA solid replacement |
 |-----------------|---------------------|
@@ -1139,8 +1115,7 @@ for the cart; the ti→fa swaps it described were not landed.
 | `ti ti-table-export` | `fa-solid fa-file-csv` |
 | `ti ti-printer` | `fa-solid fa-print` |
 
-All FA-free v7.3.1 solid glyphs confirmed present. No webpack rebuild needed — both font
-families are already bundled in `churchcrm.min.css`.
+All FA free v7.3.1 solid glyphs confirmed present.
 
 ---
 


### PR DESCRIPTION
## What Changed
Three skill files disagreed about the action-menu trigger icon and the dropdown-overflow fix. `table-action-menu.md` is now the single authority (trigger icon `fa-ellipsis-vertical`, reference implementations redrawn from the real `overflow-x: clip` wrappers, `overflow: visible` documented as superseded); `responsive-design-guidelines.md` defers to it; `tabler-components.md` has its anti-pattern claim scoped correctly, its icon section pointed at `icon-management.md`, and an inverted checklist row fixed.

Every corrected statement was checked against the code at `850c70a8c` and cites the file it comes from, and fabricated examples were replaced with trimmed real code so the doc cannot drift again.

Fixes #9740

## Type
- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
Documentation only (`.agents/skills/`); no code changed. Pre-commit hooks (locale check, YAML validation) pass.

## Pre-Merge
- [x] Tested locally
- [x] No new warnings
- [x] Build passes
- [x] Backward compatible (or migration documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
