### PR TITLE
Fix issue #9742: Correct webpack entry keys and drop the .tsx example

### DIFF
--- a/.agents/skills/churchcrm/webpack-typescript.md
+++ b/.agents/skills/churchcrm/webpack-typescript.md
@@ -211,14 +211,14 @@ import './my-feature.css';  // In webpack/my-feature.ts
 > deep, and no page can load it.
 
 ```javascript
-// webpack.config.js:72-114 (real entries, trimmed)
+// webpack.config.js:72-114 — every line below is a real, currently-registered entry
+// (the real block has 42 of them; 5 shown)
 entry: {
     'calendar-event-editor': './webpack/calendar-event-editor.js',
     churchcrm: './webpack/skin-main',
     kiosk: './webpack/kiosk',                          // → webpack/kiosk/index.ts
     'people-list': './webpack/people/person-list',
     'event-checkin': './webpack/event-checkin',
-    'my-feature': './webpack/my-feature.js',           // → src/skin/v2/my-feature.min.js
 },
 output: {
     path: path.resolve('./src/skin/v2'),
@@ -230,6 +230,16 @@ output: {
 The source path may point at a directory (`'./webpack/kiosk'` resolves to
 `webpack/kiosk/index.ts` via `resolve.extensions: ['.ts', '.tsx', '.js']`) and may sit in a
 subdirectory (`'./webpack/people/person-list'`) — only the **key** must stay flat.
+
+**Adding your own entry** — illustrative only; `my-feature` is *not* registered today:
+
+```javascript
+// Example — add one line to the `entry` block in webpack.config.js
+entry: {
+    // …the 42 existing entries…
+    'my-feature': './webpack/my-feature.js',           // → src/skin/v2/my-feature.min.js
+},
+```
 
 Load the result from a view with the emitted name:
 

--- a/.agents/skills/churchcrm/webpack-typescript.md
+++ b/.agents/skills/churchcrm/webpack-typescript.md
@@ -203,54 +203,85 @@ import './my-feature.css';  // In webpack/my-feature.ts
 ```
 
 **Output Configuration (webpack.config.js):**
+
+> ⚠️ **Entry keys are flat — never prefix them with `skin/v2/`.**
+> `output.path` is already `src/skin/v2` and `output.filename` is `[name].min.js`
+> (`webpack.config.js:115-119`), so the key **is** the bundle's basename. A key of
+> `'skin/v2/my-feature'` emits `src/skin/v2/skin/v2/my-feature.min.js` — one directory too
+> deep, and no page can load it.
+
 ```javascript
+// webpack.config.js:72-114 (real entries, trimmed)
 entry: {
-    'skin/v2/my-feature': './webpack/my-feature.js',  // → src/skin/v2/my-feature.js
-    'skin/v2/my-component-app': './webpack/my-component-app.ts',
-}
+    'calendar-event-editor': './webpack/calendar-event-editor.js',
+    churchcrm: './webpack/skin-main',
+    kiosk: './webpack/kiosk',                          // → webpack/kiosk/index.ts
+    'people-list': './webpack/people/person-list',
+    'event-checkin': './webpack/event-checkin',
+    'my-feature': './webpack/my-feature.js',           // → src/skin/v2/my-feature.min.js
+},
+output: {
+    path: path.resolve('./src/skin/v2'),
+    filename: '[name].min.js',
+    publicPath: 'auto',
+},
+```
+
+The source path may point at a directory (`'./webpack/kiosk'` resolves to
+`webpack/kiosk/index.ts` via `resolve.extensions: ['.ts', '.tsx', '.js']`) and may sit in a
+subdirectory (`'./webpack/people/person-list'`) — only the **key** must stay flat.
+
+Load the result from a view with the emitted name:
+
+```php
+<script src="<?= SystemURLs::assetVersioned('/skin/v2/my-feature.min.js') ?>"></script>
 ```
 
 ## Type Definitions & Reuse
 
 ### Shared Types File
 
+`webpack/types/` holds **ambient declaration files only** — `window.d.ts` (the global
+`window.CRM` namespace injected by PHP templates) and `avatar-initials.d.ts`. They are not
+importable modules; they declare globals. Do not add exported interfaces there.
+
+Put exported interfaces in a `types.ts` next to the feature that owns them, the way the kiosk
+entry does:
+
 ```typescript
-// webpack/types/api-models.ts
-export interface Person {
-    id: number;
+// webpack/kiosk/types.ts (trimmed)
+export interface ClassMember {
+    displayName: string;
     firstName: string;
-    lastName: string;
-    familyId: number;
+    classRole: string;
+    personId: number;
+    familyId: number | null;
 }
 
-export interface Family {
-    id: number;
-    name: string;
-    address: string;
-}
-
-export interface ApiResponse<T> {
-    success: boolean;
-    data?: T;
-    message?: string;
-    errors?: Record<string, string>;
+export interface PersonApiData {
+    Id: number;
+    FirstName: string;
 }
 ```
 
 ### Using Shared Types
 
 ```typescript
-// webpack/person-viewer.ts
-import type { Person, ApiResponse } from './types/api-models';
-import { fetchAPIJSON } from './api-utils';
+// webpack/kiosk/kiosk-jsom.ts:8-18 — sibling import of the feature's own types
+import type { ClassMember, PersonApiData } from './types';
+// webpack/people/geo-refresh.js:9 — the shared typed fetch helper
+import { fetchAPIJSON } from '../api-utils';
 
 async function viewPerson(id: number): Promise<void> {
-    const response = await fetchAPIJSON<ApiResponse<Person>>(`person/${id}`);
-    if (response.success && response.data) {
-        console.log(`${response.data.firstName} ${response.data.lastName}`);
-    }
+    // fetchAPIJSON<T>() is generic — pass the interface as T, it returns Promise<T>
+    const person = await fetchAPIJSON<PersonApiData>(`person/${id}`);
+    console.log(`${person.FirstName} (#${person.Id})`);
 }
 ```
+
+`fetchAPIJSON` (`webpack/api-utils.ts:109`) throws on a non-OK response rather than returning
+a `{ success, data }` envelope, so wrap the call in `try`/`catch` — there is no `.success`
+flag to test.
 
 ## Best Practices
 
@@ -337,16 +368,21 @@ window.CRM.notify('Settings saved', { type: 'success' });
 ```
 
 ### 8. Code Splitting
-Separate concerns into different entry points:
+Separate concerns into different entry points — one per page or feature, with a **flat** key
+(see "Output Configuration" above; a `skin/v2/` prefix would double the output path):
 
 ```javascript
-// webpack.config.js
+// webpack.config.js:72-114 (real entries)
 entry: {
-    'skin/v2/admin': './webpack/admin-dashboard.js',     // Admin pages
-    'skin/v2/photo-uploader': './webpack/photo-uploader.js',  // Photo upload
-    'skin/v2/kiosk': './webpack/kiosk/registration.tsx', // Kiosk app
+    'admin-dashboard': './webpack/admin-dashboard',      // Admin dashboard page
+    'photo-uploader': './webpack/photo-uploader-entry',  // Photo upload
+    kiosk: './webpack/kiosk',                            // Kiosk app (TypeScript)
+    'event-checkin': './webpack/event-checkin',          // Event check-in page
 }
 ```
+
+There are no `.tsx` files in the repository — React was removed in #8513. TypeScript entries
+are plain `.ts` modules.
 
 ---
 


### PR DESCRIPTION
## What Changed
`webpack-typescript.md` showed entry keys that would double the output path (`output.path` is already `src/skin/v2`) and a `.tsx` entry that does not exist. Both snippets are replaced with real entries from `webpack.config.js`, the invented `webpack/types/api-models.ts` layout is replaced with the real one (ambient `.d.ts` under `webpack/types/`, feature-local `types.ts` for exported interfaces), and a response-envelope example that `fetchAPIJSON` does not actually return is corrected.

Every corrected statement was checked against the code at `850c70a8c` and cites the file it comes from, and fabricated examples were replaced with trimmed real code so the doc cannot drift again.

Fixes #9742

## Type
- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
Documentation only (`.agents/skills/`); no code changed. Pre-commit hooks (locale check, YAML validation) pass.

## Pre-Merge
- [x] Tested locally
- [x] No new warnings
- [x] Build passes
- [x] Backward compatible (or migration documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
