### PR TITLE
Fix issue #9721: Point the PrimaryContact foreign key at primary_contact_person_id

### DIFF
--- a/cypress/data/seed.sql
+++ b/cypress/data/seed.sql
@@ -308,7 +308,7 @@ CREATE TABLE `events_event` (
 LOCK TABLES `events_event` WRITE;
 /*!40000 ALTER TABLE `events_event` DISABLE KEYS */;
 SET autocommit=0;
-INSERT INTO `events_event` VALUES (1,2,'Sunday School Class Changes','This is when the students move to new classes','','2016-11-20 12:30:00','2016-11-20 13:30:00',0,NULL,NULL,NULL,NULL),(2,1,'Christmas Service','christmas service','','2016-12-24 22:30:00','2016-12-25 01:30:00',0,NULL,NULL,NULL,NULL),(3,2,'Summer Camp','Summer Camp','','2017-06-06 09:30:00','2017-06-11 09:30:00',0,NULL,NULL,NULL,NULL);
+INSERT INTO `events_event` VALUES (1,2,'Sunday School Class Changes','This is when the students move to new classes','','2016-11-20 12:30:00','2016-11-20 13:30:00',0,NULL,NULL,NULL,NULL),(2,1,'Christmas Service','christmas service','','2016-12-24 22:30:00','2016-12-25 01:30:00',0,NULL,NULL,NULL,NULL),(3,2,'Summer Camp','Summer Camp','','2017-06-06 09:30:00','2017-06-11 09:30:00',0,NULL,2,1,NULL);
 /*!40000 ALTER TABLE `events_event` ENABLE KEYS */;
 UNLOCK TABLES;
 COMMIT;

--- a/cypress/e2e/api/private/standard/private.calendar.event-contacts.spec.js
+++ b/cypress/e2e/api/private/standard/private.calendar.event-contacts.spec.js
@@ -1,0 +1,98 @@
+/// <reference types="cypress" />
+
+/**
+ * API tests for an event's primary / secondary contact endpoints.
+ *
+ * Regression coverage for issue #9721: the `PrimaryContact` foreign key in
+ * orm/schema.xml referenced `event_type` instead of `primary_contact_person_id`,
+ * so Propel generated `getPersonRelatedByType()` and
+ * `GET /api/events/{id}/primarycontact` returned HTTP 500
+ * ("Call to undefined method: getPersonRelatedByPrimaryContactPersonId.").
+ *
+ * Seed data: event 3 ("Summer Camp") has primary contact per_ID 1 and
+ * secondary contact per_ID 2. Events 1 and 2 have neither.
+ */
+describe("API Private Calendar Event Contacts", () => {
+    const EVENT_WITH_CONTACTS = 3;
+    const EVENT_WITHOUT_CONTACTS = 1;
+
+    describe("GET /api/events/{id}/primarycontact", () => {
+        it("Returns 200 with the person JSON when a primary contact is set", () => {
+            cy.makePrivateAdminAPICall(
+                "GET",
+                `/api/events/${EVENT_WITH_CONTACTS}/primarycontact`,
+                null,
+                200,
+            ).then((response) => {
+                expect(response.body).to.exist;
+                expect(response.body).to.have.property("Id", 1);
+                expect(response.body).to.have.property("FirstName", "Church");
+                expect(response.body).to.have.property("LastName", "Admin");
+            });
+        });
+
+        it("Returns 404 when no primary contact is set", () => {
+            cy.makePrivateAdminAPICall(
+                "GET",
+                `/api/events/${EVENT_WITHOUT_CONTACTS}/primarycontact`,
+                null,
+                404,
+            ).then((response) => {
+                // Guards against the #9721 regression: a wrong foreign key
+                // surfaced as a 500 "undefined method" instead of a clean 404.
+                expect(JSON.stringify(response.body)).to.not.contain(
+                    "undefined method",
+                );
+            });
+        });
+
+        it("Returns 401 when not authenticated", () => {
+            cy.apiRequest({
+                method: "GET",
+                url: `/api/events/${EVENT_WITH_CONTACTS}/primarycontact`,
+                failOnStatusCode: false,
+            }).then((response) => {
+                expect(response.status).to.eq(401);
+            });
+        });
+    });
+
+    describe("GET /api/events/{id}/secondarycontact", () => {
+        it("Returns 200 with the person JSON when a secondary contact is set", () => {
+            cy.makePrivateAdminAPICall(
+                "GET",
+                `/api/events/${EVENT_WITH_CONTACTS}/secondarycontact`,
+                null,
+                200,
+            ).then((response) => {
+                expect(response.body).to.exist;
+                expect(response.body).to.have.property("Id", 2);
+                expect(response.body).to.have.property("FirstName", "Mathew");
+                expect(response.body).to.have.property("LastName", "Campbell");
+            });
+        });
+
+        it("Returns 404 when no secondary contact is set", () => {
+            cy.makePrivateAdminAPICall(
+                "GET",
+                `/api/events/${EVENT_WITHOUT_CONTACTS}/secondarycontact`,
+                null,
+                404,
+            ).then((response) => {
+                expect(JSON.stringify(response.body)).to.not.contain(
+                    "undefined method",
+                );
+            });
+        });
+
+        it("Returns 401 when not authenticated", () => {
+            cy.apiRequest({
+                method: "GET",
+                url: `/api/events/${EVENT_WITH_CONTACTS}/secondarycontact`,
+                failOnStatusCode: false,
+            }).then((response) => {
+                expect(response.status).to.eq(401);
+            });
+        });
+    });
+});

--- a/orm/schema.xml
+++ b/orm/schema.xml
@@ -458,7 +458,7 @@
         </foreign-key>
 
         <foreign-key foreignTable="person_per" name="PrimaryContact" refPhpName="PrimaryContactPerson" skipSql = "true">
-            <reference local="event_type" foreign="per_ID"/>
+            <reference local="primary_contact_person_id" foreign="per_ID"/>
         </foreign-key>
 
         <foreign-key foreignTable="person_per" name="SecondaryContact" refPhpName="SecondaryContactPerson" skipSql = "true">


### PR DESCRIPTION
## What Changed
The `PrimaryContact` foreign key on `events_event` in `orm/schema.xml` referenced `local="event_type"`, so Propel generated `getPersonRelatedByType()` and `GET /api/events/{id}/primarycontact` threw an undefined-method error on every call. The reference now points at `primary_contact_person_id`, matching the correct `SecondaryContact` block beside it. The FK carries `skipSql="true"`, so no database migration is needed; the seed gains a primary/secondary contact on one event so the success path has a fixture.

Fixes #9721

## Type
- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
Before: `/api/events/1/primarycontact` → 500 `Call to undefined method getPersonRelatedByPrimaryContactPersonId`. After ORM regeneration: 404 when unset, 200 with the person JSON when set (`/api/events/3/primarycontact` and `/secondarycontact`). New spec `private.calendar.event-contacts.spec.js` (6 tests) and the full calendar API regression suite (62 tests) pass. Note: nothing in the UI or API currently sets an event contact; only the two read endpoints exist.

## Pre-Merge
- [x] Tested locally
- [x] No new warnings
- [x] Build passes
- [x] Backward compatible (or migration documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
