### PR TITLE
Fix issue #9726: Render notify type 'error' as a red danger toast

### DIFF
--- a/.agents/skills/churchcrm/frontend-development.md
+++ b/.agents/skills/churchcrm/frontend-development.md
@@ -189,22 +189,25 @@ window.CRM.notify(i18next.t('Operation completed'), {
 });
 
 window.CRM.notify(i18next.t('An error occurred'), {
-    type: 'error'
+    type: 'danger'
 });
 
 // ❌ WRONG - Never use alert()
 alert('Operation completed');
 ```
 
-**Notification types:**
+**Notification types:** <!-- learned: 2026-09-11 -->
+- `danger` - Red, failures (`error` is an accepted alias — see issue #9726)
 - `success` - Green, success operations
-- `error` - Red, failures
-- `warning` - Orange, warnings
+- `warning` - Orange/yellow, warnings
 - `info` - Blue, informational
 
+Any other value falls through to the `info` style, so a typo silently renders
+a blue notice instead of failing.
+
 **Options:**
-- `delay` - Auto-dismiss time in milliseconds (default: 5000)
-- `type` - Notification type (default: 'success')
+- `delay` - Auto-dismiss time in milliseconds (default: 3000)
+- `type` - Notification type (default: 'info')
 
 ## Confirmations (CRITICAL)
 

--- a/cypress/e2e/ui/system/notifier.spec.js
+++ b/cypress/e2e/ui/system/notifier.spec.js
@@ -1,0 +1,52 @@
+/// <reference types="cypress" />
+
+/**
+ * window.CRM.notify() type mapping — regression coverage for issue #9726.
+ *
+ * src/skin/js/notifier.js branched on "danger", "success" and "warning" only,
+ * so type: "error" — used by ~40 call sites — fell through to the info branch
+ * and rendered a blue informational toast instead of a red error toast.
+ * "error" is now an accepted alias for "danger".
+ */
+describe("window.CRM.notify() notification types", () => {
+    const ERROR_RED = "rgb(237, 61, 61)"; // Notyf default error colour
+    const INFO_BLUE = "rgb(23, 162, 184)"; // Bootstrap 4 $info
+
+    /**
+     * Fire a notification and resolve the computed background colour of the
+     * toast's ripple element (Notyf paints the toast colour there).
+     */
+    const notifyAndReadColor = (type) => {
+        cy.window().then((win) => {
+            win.CRM.notify(`probe ${type}`, { type: type, delay: 20000 });
+        });
+        return cy
+            .get(".notyf__toast", { timeout: 8000 })
+            .last()
+            .find(".notyf__ripple")
+            .should("exist")
+            .then(($ripple) => $ripple.css("background-color"));
+    };
+
+    beforeEach(() => {
+        cy.setupAdminSession();
+        cy.visit("/v2/dashboard");
+        cy.window().its("CRM.notify").should("be.a", "function");
+    });
+
+    it('renders type: "error" as a red error toast', () => {
+        notifyAndReadColor("error").should("equal", ERROR_RED);
+    });
+
+    it('renders type: "danger" as a red error toast', () => {
+        notifyAndReadColor("danger").should("equal", ERROR_RED);
+    });
+
+    it('still renders type: "info" as a blue informational toast', () => {
+        notifyAndReadColor("info").should("equal", INFO_BLUE);
+    });
+
+    it('falls back to the info style for an unknown type', () => {
+        notifyAndReadColor("not-a-real-type").should("equal", INFO_BLUE);
+    });
+});

--- a/src/skin/js/notifier.js
+++ b/src/skin/js/notifier.js
@@ -50,7 +50,9 @@ export function notify(messageOrObject, options = {}) {
 
   // Map bootstrap-notify types to Notyf
   // Using Bootstrap 4.6.2 theme colors for consistency
-  if (type === "danger") {
+  // "error" is an accepted alias for "danger": bootstrap-notify used the
+  // Bootstrap contextual name, but most call sites spell it "error".
+  if (type === "danger" || type === "error") {
     notyfInstance.error({
       message: message,
       duration: duration,


### PR DESCRIPTION
## What Changed
`window.CRM.notify(..., {type: 'error'})` fell through to the info branch in `notifier.js` and rendered blue; about 40 call sites use that spelling. `error` is now an alias of `danger`. The frontend skill's notify documentation is corrected (it also had the wrong `delay` and default `type`).

Fixes #9726

## Type
- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
Computed toast colour in Chrome: `type: 'error'` before `rgb(23,162,184)` (info), after `rgb(237,61,61)` (danger); `info` unchanged. New `cypress/e2e/ui/system/notifier.spec.js` (4 tests) passes and fails against the unfixed bundle.

## Pre-Merge
- [x] Tested locally
- [x] No new warnings
- [x] Build passes
- [x] Backward compatible (or migration documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
