### PR TITLE
Fix issue #9727: Make the birthday-email run claim atomic and isolate timer jobs

### DIFF
--- a/cypress/e2e/api/private/admin/private.admin.background-timerjobs.spec.js
+++ b/cypress/e2e/api/private/admin/private.admin.background-timerjobs.spec.js
@@ -1,0 +1,118 @@
+/// <reference types="cypress" />
+
+/**
+ * POST /api/background/timerjobs under concurrency — regression coverage for
+ * issue #9727.
+ *
+ * BirthdayEmailService::run() guarded duplicate sends with a check-then-set on
+ * the `sLastBirthdayEmailRunDate` config value. Footer.js fires the timer-job
+ * endpoint on every page load, so several requests routinely passed the check
+ * together and then collided on the `config_cfg` primary key: 7 of 8 concurrent
+ * requests returned HTTP 500, and because the exception escaped
+ * SystemService::runTimerJobs() they also skipped the CRON_RUN hook.
+ *
+ * The requests are fired with fetch(..., { credentials: "omit" }) so each one
+ * gets its own PHP session — a shared session is serialised by PHP's session
+ * lock and cannot reproduce the race.
+ */
+describe("API Private Admin - Background Timer Jobs concurrency", () => {
+    const CONCURRENT_REQUESTS = 8;
+    const MARKER = "sLastBirthdayEmailRunDate";
+    const FEATURE = "bEnableBirthdayEmails";
+
+    let originalMarker;
+    let originalFeature;
+
+    const configUrl = (name) => `/admin/api/system/config/${name}`;
+
+    const readConfig = (name) =>
+        cy
+            .makePrivateAdminAPICall("GET", configUrl(name), null, 200)
+            .then((response) => response.body.value);
+
+    const writeConfig = (name, value) =>
+        cy.makePrivateAdminAPICall("POST", configUrl(name), { value: value }, 200);
+
+    /** Today's date in the app's configured timezone, as the service formats it. */
+    const todayString = () => {
+        const now = new Date();
+        const pad = (n) => String(n).padStart(2, "0");
+        return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
+    };
+
+    /**
+     * Fire CONCURRENT_REQUESTS timer-job requests in parallel and resolve with
+     * the list of HTTP status codes.
+     */
+    const fireConcurrentTimerJobs = () =>
+        cy.window().then((win) => {
+            const apiKey = Cypress.env("admin.api.key");
+            const calls = Array.from({ length: CONCURRENT_REQUESTS }, () =>
+                win.fetch("/api/background/timerjobs", {
+                    method: "POST",
+                    headers: { "x-api-key": apiKey },
+                    // Each request must get its own PHP session, or the session
+                    // lock serialises them and there is no race to test.
+                    credentials: "omit",
+                }),
+            );
+            return Promise.all(calls).then((responses) =>
+                responses.map((response) => response.status),
+            );
+        });
+
+    before(() => {
+        readConfig(MARKER).then((value) => {
+            originalMarker = value;
+        });
+        readConfig(FEATURE).then((value) => {
+            originalFeature = value;
+        });
+    });
+
+    beforeEach(() => {
+        // Same-origin page so fetch() can reach the API; no session needed
+        // because the requests authenticate with the admin API key.
+        cy.visit("/session/begin");
+        writeConfig(FEATURE, "1");
+    });
+
+    after(() => {
+        writeConfig(MARKER, originalMarker ?? "");
+        writeConfig(FEATURE, originalFeature ?? "0");
+    });
+
+    it("returns 200 for every concurrent request when the run marker is unset", () => {
+        // The #9727 reproduction: no marker row, so every request races to
+        // INSERT it and all but one used to fail with a duplicate-key 500.
+        writeConfig(MARKER, "");
+
+        fireConcurrentTimerJobs().then((statuses) => {
+            expect(statuses).to.have.length(CONCURRENT_REQUESTS);
+            statuses.forEach((status) => expect(status).to.equal(200));
+        });
+
+        // Exactly one request claimed the day.
+        readConfig(MARKER).should("equal", todayString());
+    });
+
+    it("returns 200 for every concurrent request when the run marker is stale", () => {
+        writeConfig(MARKER, "2000-01-01");
+
+        fireConcurrentTimerJobs().then((statuses) => {
+            statuses.forEach((status) => expect(status).to.equal(200));
+        });
+
+        readConfig(MARKER).should("equal", todayString());
+    });
+
+    it("returns 200 for every concurrent request when the run already happened today", () => {
+        writeConfig(MARKER, todayString());
+
+        fireConcurrentTimerJobs().then((statuses) => {
+            statuses.forEach((status) => expect(status).to.equal(200));
+        });
+
+        readConfig(MARKER).should("equal", todayString());
+    });
+});

--- a/cypress/e2e/api/private/admin/private.admin.background-timerjobs.spec.js
+++ b/cypress/e2e/api/private/admin/private.admin.background-timerjobs.spec.js
@@ -25,6 +25,20 @@ describe("API Private Admin - Background Timer Jobs concurrency", () => {
 
     const configUrl = (name) => `/admin/api/system/config/${name}`;
 
+    /**
+     * Absolute URL of the timer-job endpoint.
+     *
+     * cy.request()/cy.visit() concatenate baseUrl onto a relative URL, but
+     * win.fetch() is the browser's own fetch: it resolves a root-relative path
+     * against the page *origin*, which drops the install's base path. On the
+     * subdirectory profile ("http://host/churchcrm/") the literal
+     * "/api/background/timerjobs" therefore reached http://host/api/... and
+     * 404'd. Composing the URL from baseUrl keeps the base path, and stripping
+     * the trailing slash first avoids a "//api/..." double slash at the root.
+     */
+    const timerJobsUrl = () =>
+        `${Cypress.config("baseUrl").replace(/\/+$/, "")}/api/background/timerjobs`;
+
     const readConfig = (name) =>
         cy
             .makePrivateAdminAPICall("GET", configUrl(name), null, 200)
@@ -48,7 +62,7 @@ describe("API Private Admin - Background Timer Jobs concurrency", () => {
         cy.window().then((win) => {
             const apiKey = Cypress.env("admin.api.key");
             const calls = Array.from({ length: CONCURRENT_REQUESTS }, () =>
-                win.fetch("/api/background/timerjobs", {
+                win.fetch(timerJobsUrl(), {
                     method: "POST",
                     headers: { "x-api-key": apiKey },
                     // Each request must get its own PHP session, or the session

--- a/src/ChurchCRM/Service/BirthdayEmailService.php
+++ b/src/ChurchCRM/Service/BirthdayEmailService.php
@@ -4,18 +4,32 @@ namespace ChurchCRM\Service;
 
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\Emails\notifications\BirthdayEmail;
+use ChurchCRM\model\ChurchCRM\Config;
+use ChurchCRM\model\ChurchCRM\ConfigQuery;
 use ChurchCRM\model\ChurchCRM\PersonQuery;
 use ChurchCRM\Utils\DateTimeUtils;
 use ChurchCRM\Utils\LoggerUtils;
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\Exception\PropelException;
 
 class BirthdayEmailService
 {
     /**
+     * Config key holding the date (Y-m-d) birthday emails last went out.
+     */
+    private const LAST_RUN_CONFIG_NAME = 'sLastBirthdayEmailRunDate';
+
+    /**
      * Sends birthday greeting emails to everyone whose birthday is today,
      * if the feature is enabled and it has not already run today.
      *
-     * Safe to call multiple times per day (idempotent) and safe to call
-     * even when the feature is disabled (no-ops immediately).
+     * Safe to call concurrently: the "already ran today" marker is claimed
+     * atomically, so exactly one caller per day does the work and the rest
+     * return without sending or throwing. Safe to call when the feature is
+     * disabled (no-ops immediately).
+     *
+     * The guard is per-run, not per-recipient: an individual send that fails
+     * is logged as a warning and is not retried by a later run today.
      */
     public static function run(): void
     {
@@ -27,13 +41,11 @@ class BirthdayEmailService
         $today = new \DateTime('now', $tz);
         $todayString = $today->format('Y-m-d');
 
-        if (SystemConfig::getValue('sLastBirthdayEmailRunDate') === $todayString) {
-            // Already ran today; avoid duplicate sends.
+        // Claim the day before sending, so a crash cannot result in duplicate
+        // emails and so concurrent timer-job requests cannot both send.
+        if (!self::claimRunForToday($todayString)) {
             return;
         }
-
-        // Persist before sending so a crash cannot result in duplicate emails.
-        SystemConfig::setValue('sLastBirthdayEmailRunDate', $todayString);
 
         $logger = LoggerUtils::getAppLogger();
         $sentCount = 0;
@@ -64,5 +76,58 @@ class BirthdayEmailService
         }
 
         $logger?->info("BirthdayEmailService: sent {$sentCount} birthday email(s), skipped {$skippedCount} (no email on file)");
+    }
+
+    /**
+     * Atomically claim today's birthday-email run.
+     *
+     * Returns true for exactly one caller per day. `runTimerJobs` fires on
+     * every page load, so several requests routinely reach this point together;
+     * a plain read-then-write collided on the `config_cfg` primary key and threw
+     * an uncaught "Unable to execute INSERT statement" (issue #9727).
+     *
+     * Both paths below are single statements, so the database — not PHP —
+     * decides the winner:
+     *   - row present: a conditional UPDATE that only matches rows not already
+     *     holding today's date; losers see zero affected rows.
+     *   - row absent: the INSERT itself, whose primary key rejects the losers.
+     */
+    private static function claimRunForToday(string $todayString): bool
+    {
+        $existing = ConfigQuery::create()->findOneByName(self::LAST_RUN_CONFIG_NAME);
+
+        if ($existing !== null) {
+            if ($existing->getValue() === $todayString) {
+                return false;
+            }
+
+            $affectedRows = ConfigQuery::create()
+                ->filterByName(self::LAST_RUN_CONFIG_NAME)
+                ->filterByValue($todayString, Criteria::NOT_EQUAL)
+                ->update(['Value' => $todayString]);
+
+            return $affectedRows > 0;
+        }
+
+        try {
+            $config = new Config();
+            $config->setName(self::LAST_RUN_CONFIG_NAME);
+            $config->setValue($todayString);
+            $config->save();
+        } catch (PropelException $e) {
+            // Another request inserted the marker between our read and our
+            // write. Confirm that is what happened before standing down, so a
+            // genuine database failure is still surfaced.
+            $winner = ConfigQuery::create()->findOneByName(self::LAST_RUN_CONFIG_NAME);
+            if ($winner !== null && $winner->getValue() === $todayString) {
+                LoggerUtils::getAppLogger()?->debug('BirthdayEmailService: another run claimed today first');
+
+                return false;
+            }
+
+            throw $e;
+        }
+
+        return true;
     }
 }

--- a/src/ChurchCRM/Service/SystemService.php
+++ b/src/ChurchCRM/Service/SystemService.php
@@ -75,15 +75,44 @@ class SystemService
     {
         LoggerUtils::getAppLogger()->debug('Starting background job processing');
 
-        BirthdayEmailService::run();
+        self::runTimerJob('BirthdayEmailService', static function (): void {
+            BirthdayEmailService::run();
+        });
 
         // Fire the CRON_RUN hook so plugins can register scheduled tasks.
         // Each active plugin registers a handler on Hooks::CRON_RUN in boot().
         // HookManager catches and logs any per-plugin errors so one failing
         // plugin cannot block the others.
-        HookManager::doAction(Hooks::CRON_RUN);
+        self::runTimerJob('CRON_RUN hook', static function (): void {
+            HookManager::doAction(Hooks::CRON_RUN);
+        });
 
         LoggerUtils::getAppLogger()->debug('Finished background job processing');
+    }
+
+    /**
+     * Run a single timer job, logging and swallowing any failure.
+     *
+     * One job must never be able to stop the jobs that follow it, nor the
+     * CRON_RUN hook (issue #9727): before this, an exception in
+     * BirthdayEmailService::run() aborted the whole request, so every plugin's
+     * scheduled work was silently skipped and the caller got an HTTP 500.
+     * This gives the job list the same isolation HookManager already gives
+     * individual plugins.
+     */
+    private static function runTimerJob(string $jobName, callable $job): void
+    {
+        try {
+            $job();
+        } catch (\Throwable $e) {
+            LoggerUtils::getAppLogger()->error('Timer job failed', [
+                'job' => $jobName,
+                'exception' => $e::class,
+                'message' => $e->getMessage(),
+                'file' => $e->getFile(),
+                'line' => $e->getLine(),
+            ]);
+        }
     }
 
     // Returns a file size limit in bytes based on the PHP upload_max_filesize


### PR DESCRIPTION
## What Changed
Concurrent `POST /api/background/timerjobs` requests raced on the `sLastBirthdayEmailRunDate` check-then-set: losers threw a duplicate-key error on `config_cfg` (HTTP 500) and, because that ran before the `CRON_RUN` hook, the hook was skipped. The run is now claimed atomically (conditional UPDATE, or the INSERT itself as the lock with the duplicate-key case treated as "already ran today"), and `SystemService::runTimerJobs()` wraps each job so a failure is logged and the remaining jobs and the `CRON_RUN` hook still run.

Fixes #9727

## Type
- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
Reproduced with 8 concurrent requests on independent API-key sessions: before `500 ×7, 200 ×1`, 1 of 8 runs reached `CRON_RUN`; after `200 ×8`, all 8 reached the hook, exactly one email sent. Stale-marker and already-ran-today cases verified; a deliberately throwing job returns 200 with the failure logged. New `private.admin.background-timerjobs.spec.js` (3 tests) passes and fails against master. Per-recipient send tracking (the issue's third suggestion) is a schema change and is deliberately left for a follow-up.

## Pre-Merge
- [x] Tested locally
- [x] No new warnings
- [x] Build passes
- [x] Backward compatible (or migration documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
