### PR TITLE
Fix issue #9729: Make the volunteer-opportunity spec test the real assignment flow

### DIFF
--- a/cypress/e2e/ui/people/standard.volunteer-opportunity.spec.js
+++ b/cypress/e2e/ui/people/standard.volunteer-opportunity.spec.js
@@ -3,70 +3,147 @@
 /**
  * Test for GitHub Issue #7917: Bug assigning Volunteer Opportunities
  * @see https://github.com/ChurchCRM/CRM/issues/7917
- * 
+ *
  * This test verifies that volunteer opportunities can be assigned to people
  * without causing a blank page / BadMethodCallException error.
+ *
+ * Fixture data (#9729): a fresh install seeds zero rows in
+ * volunteeropportunity_vol, and person-view.php only renders the assignment
+ * form when at least one opportunity exists. The suite therefore creates one
+ * through /api/volunteer-opportunities in `before` and deletes it in `after`,
+ * so the assign/remove round-trip is actually reachable in CI.
+ *
+ * Control shape (#9729): the assignment control is a TomSelect-enhanced
+ * `<select multiple name="VolunteerOpportunityIDs[]">` and the submit control
+ * is a `<button name="VolunteerOpportunityAssign">` — not the checkboxes /
+ * input the original spec guarded on, which is why it silently skipped.
  */
+
+const PERSON_ID = 1;
+const PERSON_VIEW_URL = `/people/view/${PERSON_ID}`;
+// volunteeropportunity_vol.vol_Name is capped at 30 chars by the API
+const OPPORTUNITY_NAME = "Cypress Sound Desk";
+const OPPORTUNITY_DESC = "Created by standard.volunteer-opportunity.spec.js";
+const VOLUNTEER_SELECT = '#volunteer select[name="VolunteerOpportunityIDs[]"]';
+
 describe("Volunteer Opportunity Assignment - Issue #7917", () => {
+    /** @type {number} */
+    let opportunityId;
+
+    const adminApiHeaders = () => ({ "x-api-key": Cypress.env("admin.api.key") });
+
+    before(() => {
+        // Remove any leftover opportunity from an interrupted earlier run so the
+        // "That name already exists." guard cannot make this suite flaky.
+        cy.request({
+            method: "GET",
+            url: "/api/volunteer-opportunities",
+            headers: adminApiHeaders(),
+        }).then((listRes) => {
+            const stale = listRes.body.volunteerOpportunities.filter((opp) => opp.name === OPPORTUNITY_NAME);
+            stale.forEach((opp) => {
+                cy.request({
+                    method: "DELETE",
+                    url: `/api/volunteer-opportunities/${opp.id}`,
+                    headers: adminApiHeaders(),
+                    failOnStatusCode: false,
+                });
+            });
+        });
+
+        cy.request({
+            method: "POST",
+            url: "/api/volunteer-opportunities",
+            headers: adminApiHeaders(),
+            body: { name: OPPORTUNITY_NAME, description: OPPORTUNITY_DESC, active: true },
+        }).then((res) => {
+            expect(res.status).to.eq(201);
+            opportunityId = res.body.volunteerOpportunity.id;
+            expect(opportunityId, "seeded volunteer opportunity id").to.be.greaterThan(0);
+        });
+    });
+
+    after(() => {
+        if (!opportunityId) {
+            return;
+        }
+        // Drop any assignment a failed test may have left behind — the API
+        // refuses (409) to delete an opportunity that is still assigned.
+        cy.setupAdminSession();
+        cy.request({
+            url: `${PERSON_VIEW_URL}?RemoveVO=${opportunityId}`,
+            failOnStatusCode: false,
+        });
+        cy.request({
+            method: "DELETE",
+            url: `/api/volunteer-opportunities/${opportunityId}`,
+            headers: adminApiHeaders(),
+        })
+            .its("status")
+            .should("eq", 200);
+    });
+
     beforeEach(() => {
         cy.setupAdminSession();
     });
 
     it("should assign a volunteer opportunity without error", () => {
-        // Visit a person's profile page
-        cy.visit("/people/view/1");
+        cy.visit(PERSON_VIEW_URL);
         cy.contains("Person Profile");
 
-        // Click on the Volunteer tab in the profile (use specific id to avoid sidebar matches)
-        cy.get('#nav-item-volunteer').click();
-        cy.get('#volunteer').should('be.visible');
+        // Open the Volunteer tab (use specific id to avoid sidebar matches)
+        cy.get("#nav-item-volunteer").click();
+        cy.get("#volunteer").should("be.visible");
 
+        // The assignment form must be rendered — the seeded opportunity above
+        // guarantees count($allVolunteerOppsData) > 0.
+        cy.get(VOLUNTEER_SELECT).should("exist");
+        cy.get('#volunteer button[name="VolunteerOpportunityAssign"]').should("exist");
 
-        // Check if there are volunteer opportunities to assign
-        cy.get('#volunteer').then(($volunteerTab) => {
-            // Look for the volunteer opportunity select/checkbox elements
-            if ($volunteerTab.find('input[name="VolunteerOpportunityIDs[]"]').length > 0) {
-                // Get an unassigned opportunity checkbox
-                cy.get('input[name="VolunteerOpportunityIDs[]"]:not(:checked)').first().then(($checkbox) => {
-                    if ($checkbox.length > 0) {
-                        const opportunityId = $checkbox.val();
+        // Drive the real TomSelect control, not the hidden <select>.
+        cy.tomSelectIsInitialized(VOLUNTEER_SELECT);
+        cy.tomSelectByText(VOLUNTEER_SELECT, OPPORTUNITY_NAME);
+        cy.tomSelectGetSelected(VOLUNTEER_SELECT).should("contain.text", OPPORTUNITY_NAME);
 
-                        // Check the opportunity
-                        cy.wrap($checkbox).check({ force: true });
-
-                        // Submit the form - try multiple possible submit controls to be resilient
-                        cy.get('input[name="VolunteerOpportunityAssign"]').then(($btn) => {
-                            if ($btn.length) {
-                                cy.wrap($btn).click();
-                            } else {
-                                cy.contains('button', /assign/i).click();
-                            }
-                        });
-
-                        // Should not show an error - page should reload successfully
-                        cy.url().should('contain', 'people/view/1');
-                        cy.contains('Person Profile');
-
-                        // The opportunity should now be assigned (listed in assigned section)
-                        cy.get('#nav-item-volunteer').click();
-                        cy.get('#volunteer').should('be.visible');
-
-                        // Clean up: Remove the assigned opportunity (look for remove button by href)
-                        cy.get(`a[href*="RemoveVO=${opportunityId}"]`).first().click();
-                        cy.url().should('contain', 'people/view/1');
-                    } else {
-                        cy.log('No unassigned volunteer opportunities available to test');
-                    }
-                });
-            } else {
-                cy.log('No volunteer opportunities configured in the system');
-            }
+        // Close the still-open TomSelect dropdown; its "No results" panel
+        // overlays the submit button underneath it.
+        cy.get(VOLUNTEER_SELECT).then(($select) => {
+            $select[0].tomselect.close();
+            $select[0].tomselect.blur();
         });
+
+        cy.get('#volunteer button[name="VolunteerOpportunityAssign"]').click();
+
+        // The POST handler redirects back to the person view — #7917 was a
+        // BadMethodCallException that produced a blank page here instead.
+        cy.url().should("contain", `people/view/${PERSON_ID}`);
+        cy.contains("Person Profile");
+        cy.get("body").should("not.contain", "BadMethodCallException");
+        cy.get("body").should("not.contain", "Fatal error");
+
+        // The assignment must now be listed on the Volunteer tab.
+        cy.get("#nav-item-volunteer").click();
+        cy.get("#volunteer").should("be.visible");
+        cy.get("#volunteer table tbody").should("contain.text", OPPORTUNITY_NAME);
+        cy.get(`#volunteer a[href*="RemoveVO=${opportunityId}"]`).should("exist");
+
+        // The opportunity is assigned, so it must no longer be offered for assignment.
+        cy.get(VOLUNTEER_SELECT).find(`option[value="${opportunityId}"]`).should("not.exist");
+
+        // Remove it again and assert the round-trip actually unwound.
+        cy.get(`#volunteer a[href*="RemoveVO=${opportunityId}"]`).first().click();
+        cy.url().should("contain", `people/view/${PERSON_ID}`);
+        cy.get("#nav-item-volunteer").click();
+        cy.get("#volunteer").should("be.visible");
+        cy.get(`#volunteer a[href*="RemoveVO=${opportunityId}"]`).should("not.exist");
+        cy.get("#volunteer").should("contain.text", "No volunteer opportunity assignments yet.");
+        // ...and it is offered for assignment again.
+        cy.get(VOLUNTEER_SELECT).find(`option[value="${opportunityId}"]`).should("exist");
     });
 
     it("should display volunteer tab content without errors", () => {
         // Visit a person's profile page
-        cy.visit("/people/view/1");
+        cy.visit(PERSON_VIEW_URL);
         cy.contains("Person Profile");
 
         // Click on the Volunteer tab
@@ -74,7 +151,7 @@ describe("Volunteer Opportunity Assignment - Issue #7917", () => {
 
         // Volunteer tab should be visible and functional
         cy.get("#volunteer").should("be.visible");
-        
+
         // Should not have any PHP errors on page
         cy.get("body").should("not.contain", "Fatal error");
         cy.get("body").should("not.contain", "BadMethodCallException");


### PR DESCRIPTION
## What Changed
The first test in `standard.volunteer-opportunity.spec.js` passed vacuously: it gated on checkbox selectors the template no longer renders (it is a TomSelect multi-select), and a fresh install seeds no opportunities, so the tested branch was unreachable. The spec now creates an opportunity through the API in `before` (and removes it, and any assignment, in `after`), drives the real TomSelect control with the project's `tomSelect*` commands, and asserts the assignment persists on the person view, the option is no longer offered, and removal unwinds it.

Fixes #9729

## Type
- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [x] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
2/2 passing. Deliberate breaks fail each test: disabling `PersonService::addVolunteerOpportunity()` fails the assignment test; injecting a `BadMethodCallException` into the tab fails the regression test. Database left at 0 opportunities / 0 assignments. Note: the spec always used an admin session despite its `standard.` filename prefix; the assignment form needs EditRecords and the opportunity API needs Admin, so admin is kept.

## Pre-Merge
- [x] Tested locally
- [x] No new warnings
- [x] Build passes
- [x] Backward compatible (or migration documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
