### PR TITLE
Fix issue #9736: Convert events_event and event_types to utf8mb4

### DIFF
--- a/cypress/data/seed.sql
+++ b/cypress/data/seed.sql
@@ -298,7 +298,7 @@ CREATE TABLE `events_event` (
   `primary_contact_person_id` int(11) DEFAULT NULL,
   `event_url` text DEFAULT NULL,
   PRIMARY KEY (`event_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -397,7 +397,7 @@ CREATE TABLE `event_types` (
   `type_active` int(1) NOT NULL DEFAULT 1,
   `type_grpid` mediumint(9) DEFAULT NULL,
   PRIMARY KEY (`type_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/cypress/e2e/api/private/standard/private.calendar.events-emoji.spec.js
+++ b/cypress/e2e/api/private/standard/private.calendar.events-emoji.spec.js
@@ -1,0 +1,123 @@
+/// <reference types="cypress" />
+
+/**
+ * Regression test for #9736 — `events_event` was utf8mb3, so any 4-byte
+ * character (every emoji) in an event title made the INSERT fail with
+ * SQLSTATE[22007] and POST /api/events answered HTTP 500, leaking the raw
+ * INSERT statement.
+ *
+ * Guards the full round-trip: create with an emoji title, read it back byte
+ * for byte, then delete. A 3-byte control character is exercised alongside it
+ * so a failure points at the 4-byte case specifically.
+ */
+
+const EMOJI_TITLE = "Cypress emoji event 🎂🎉";
+const BMP_TITLE = "Cypress BMP event ✓";
+const START = "2099-09-20T09:00:00";
+const END = "2099-09-20T10:00:00";
+
+describe("API Private Calendar Events — utf8mb4 titles (#9736)", () => {
+    /** @type {number[]} */
+    const createdIds = [];
+
+    /**
+     * Look an event up by exact title through GET /api/events.
+     * POST /api/events answers {"success":true} without the new id.
+     */
+    const findEventIdByTitle = (title) =>
+        cy.makePrivateAdminAPICall("GET", "/api/events", null, 200).then((response) => {
+            const matches = response.body.Events.filter((event) => event.Title === title);
+            expect(matches, `exactly one event titled "${title}"`).to.have.length(1);
+            createdIds.push(matches[0].Id);
+            return matches[0].Id;
+        });
+
+    before(() => {
+        // Clear anything an interrupted earlier run left behind, so the
+        // "exactly one" lookups below stay deterministic.
+        cy.makePrivateAdminAPICall("GET", "/api/events", null, 200).then((response) => {
+            response.body.Events.filter(
+                (event) => event.Title === EMOJI_TITLE || event.Title === BMP_TITLE,
+            ).forEach((event) => {
+                cy.request({
+                    method: "DELETE",
+                    url: `/api/events/${event.Id}`,
+                    headers: { "x-api-key": Cypress.env("admin.api.key") },
+                    failOnStatusCode: false,
+                });
+            });
+        });
+    });
+
+    after(() => {
+        // Best-effort cleanup: an id already removed by the delete test answers
+        // 404, which is fine here.
+        [...new Set(createdIds)].forEach((id) => {
+            cy.request({
+                method: "DELETE",
+                url: `/api/events/${id}`,
+                headers: { "x-api-key": Cypress.env("admin.api.key") },
+                failOnStatusCode: false,
+            });
+        });
+    });
+
+    it("creates an event whose title contains 4-byte characters", () => {
+        cy.makePrivateAdminAPICall(
+            "POST",
+            "/api/events",
+            {
+                Title: EMOJI_TITLE,
+                Type: 1,
+                Start: START,
+                End: END,
+                PinnedCalendars: [1],
+            },
+            200,
+        ).then((response) => {
+            expect(response.body.success).to.eq(true);
+        });
+    });
+
+    it("reads the 4-byte title back unchanged", () => {
+        findEventIdByTitle(EMOJI_TITLE).then((id) => {
+            cy.makePrivateAdminAPICall("GET", `/api/events/${id}`, null, 200).then((response) => {
+                expect(response.body.Title).to.eq(EMOJI_TITLE);
+                // Explicitly assert the astral code points survived, not just
+                // that the strings compare equal after some lossy substitution.
+                expect([...response.body.Title].some((ch) => ch.codePointAt(0) > 0xffff)).to.eq(
+                    true,
+                    "title should still contain a 4-byte character",
+                );
+            });
+        });
+    });
+
+    it("still accepts a 3-byte character title (control)", () => {
+        cy.makePrivateAdminAPICall(
+            "POST",
+            "/api/events",
+            {
+                Title: BMP_TITLE,
+                Type: 1,
+                Start: START,
+                End: END,
+                PinnedCalendars: [1],
+            },
+            200,
+        );
+
+        findEventIdByTitle(BMP_TITLE).then((id) => {
+            cy.makePrivateAdminAPICall("GET", `/api/events/${id}`, null, 200).then((response) => {
+                expect(response.body.Title).to.eq(BMP_TITLE);
+            });
+        });
+    });
+
+    it("deletes the emoji event", () => {
+        findEventIdByTitle(EMOJI_TITLE).then((id) => {
+            cy.makePrivateAdminAPICall("DELETE", `/api/events/${id}`, null, 200);
+            cy.makePrivateAdminAPICall("GET", `/api/events/${id}`, null, 404);
+        });
+    });
+});

--- a/src/mysql/install/Install.sql
+++ b/src/mysql/install/Install.sql
@@ -129,7 +129,7 @@ CREATE TABLE `events_event` (
   `secondary_contact_person_id` INT DEFAULT NULL,
   `event_url` text,
   PRIMARY KEY  (`event_id`)
-) ENGINE=InnoDB CHARACTER SET utf8 COLLATE utf8_unicode_ci AUTO_INCREMENT=1;
+) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci AUTO_INCREMENT=1;
 
 --
 -- Dumping data for table `events_event`
@@ -185,7 +185,7 @@ CREATE TABLE `event_types` (
   `type_grpid` mediumint(9),
 
   PRIMARY KEY  (`type_id`)
-) ENGINE=InnoDB CHARACTER SET utf8 COLLATE utf8_unicode_ci  AUTO_INCREMENT=3 ;
+) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci  AUTO_INCREMENT=3 ;
 
 --
 -- Dumping data for table `event_types`

--- a/src/mysql/upgrade.json
+++ b/src/mysql/upgrade.json
@@ -106,7 +106,11 @@
   },
   "current": {
     "versions": ["7.6.4"],
-    "scripts": ["/mysql/upgrade/7.7.0-2fa-grace-period.sql", "/mysql/upgrade/7.7.0-add-person-deceased-date.sql"],
+    "scripts": [
+      "/mysql/upgrade/7.7.0-2fa-grace-period.sql",
+      "/mysql/upgrade/7.7.0-add-person-deceased-date.sql",
+      "/mysql/upgrade/7.7.0-events-utf8mb4.sql"
+    ],
     "dbVersion": "7.7.0"
   }
 }

--- a/src/mysql/upgrade/7.7.0-events-utf8mb4.sql
+++ b/src/mysql/upgrade/7.7.0-events-utf8mb4.sql
@@ -1,0 +1,90 @@
+-- ChurchCRM 7.7.0 — Convert the events tables to utf8mb4
+-- Closes #9736: an emoji in an event title returns HTTP 500
+--
+-- `events_event` and `event_types` were created with MySQL's 3-byte `utf8`
+-- (utf8mb3). Any 4-byte character — every emoji — makes the INSERT fail with
+-- SQLSTATE[22007] "Incorrect string value", surfacing as a 500 from
+-- POST /api/events (and from the event-type editor for `type_name`).
+--
+-- This mirrors the `note_nte` conversion in 7.3.1-cleanup.sql (#8856) and the
+-- project rule in .agents/skills/churchcrm/db-schema-migration.md:
+-- "Any table that stores user-generated text must use utf8mb4_unicode_ci".
+--
+-- Deliberately scoped to the events tables. A fresh install still has ~50 other
+-- utf8mb3 tables (person_per, family_fam, group_grp, calendars, …); converting
+-- those is tracked separately.
+--
+-- Safety: both tables are keyed only on their INTEGER primary key and neither
+-- participates in a foreign key, so widening the character columns cannot
+-- overflow InnoDB's 3072-byte index limit or break an FK charset match. The two
+-- guards below assert that on the live schema before anything is altered — if a
+-- site added a long index or a character-column FK, the upgrade aborts with a
+-- named error instead of half-converting the schema.
+
+-- Guard 1: no index on these tables may exceed InnoDB's 3072-byte key limit
+-- once every character column is charged 4 bytes per character.
+SET @events_max_key_bytes := (
+    SELECT IFNULL(MAX(k.key_bytes), 0)
+    FROM (
+        SELECT s.TABLE_NAME, s.INDEX_NAME,
+               SUM(
+                   CASE
+                       WHEN c.CHARACTER_MAXIMUM_LENGTH IS NULL THEN 8
+                       ELSE IFNULL(s.SUB_PART, c.CHARACTER_MAXIMUM_LENGTH) * 4
+                   END
+               ) AS key_bytes
+        FROM information_schema.STATISTICS s
+        JOIN information_schema.COLUMNS c
+          ON c.TABLE_SCHEMA = s.TABLE_SCHEMA
+         AND c.TABLE_NAME   = s.TABLE_NAME
+         AND c.COLUMN_NAME  = s.COLUMN_NAME
+        WHERE s.TABLE_SCHEMA = DATABASE()
+          AND s.TABLE_NAME IN ('events_event', 'event_types')
+        GROUP BY s.TABLE_NAME, s.INDEX_NAME
+    ) k
+);
+
+SET @events_guard_sql := IF(
+    @events_max_key_bytes > 3072,
+    'SELECT 1 FROM `ABORT_events_utf8mb4_index_would_exceed_3072_bytes`',
+    'DO 0'
+);
+PREPARE events_guard FROM @events_guard_sql;
+EXECUTE events_guard;
+DEALLOCATE PREPARE events_guard;
+
+-- Guard 2: no foreign key may join these tables on a character column — the
+-- charset of both sides would have to change together.
+SET @events_char_fk_count := (
+    SELECT COUNT(*)
+    FROM information_schema.KEY_COLUMN_USAGE u
+    JOIN information_schema.COLUMNS c
+      ON c.TABLE_SCHEMA = u.TABLE_SCHEMA
+     AND c.TABLE_NAME   = u.TABLE_NAME
+     AND c.COLUMN_NAME  = u.COLUMN_NAME
+    WHERE u.TABLE_SCHEMA = DATABASE()
+      AND u.REFERENCED_TABLE_NAME IS NOT NULL
+      AND c.CHARACTER_SET_NAME IS NOT NULL
+      AND (
+            u.TABLE_NAME IN ('events_event', 'event_types')
+         OR u.REFERENCED_TABLE_NAME IN ('events_event', 'event_types')
+      )
+);
+
+SET @events_fk_guard_sql := IF(
+    @events_char_fk_count > 0,
+    'SELECT 1 FROM `ABORT_events_utf8mb4_character_column_foreign_key`',
+    'DO 0'
+);
+PREPARE events_fk_guard FROM @events_fk_guard_sql;
+EXECUTE events_fk_guard;
+DEALLOCATE PREPARE events_fk_guard;
+
+-- Convert. CONVERT TO CHARACTER SET rewrites the table default and every
+-- character column, so `event_title`, `event_desc`, `event_text`, `event_url`
+-- and `type_name` all accept 4-byte characters afterwards.
+ALTER TABLE `events_event`
+    CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+ALTER TABLE `event_types`
+    CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;


### PR DESCRIPTION
## What Changed
A 4-byte character (an emoji) in an event title made `POST /api/events` return HTTP 500 because `events_event` was utf8mb3; `event_types.type_name` is user-entered and failed identically, so both tables are converted. A new upgrade script `src/mysql/upgrade/7.7.0-events-utf8mb4.sql` (registered in `upgrade.json`, following the `note_nte` precedent from #8856) converts them, guarded so it aborts, leaving the table unconverted, if any index would exceed InnoDB's 3072-byte key limit at 4 bytes per character or a character-column FK touches the tables; neither holds today. `Install.sql` and the Cypress seed are updated to match. The other utf8mb3 tables are deliberately untouched and listed in the commit body.

Fixes #9736

## Type
- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
Before: `POST /api/events {"Title":"probe 🎂"}` → 500 leaking the INSERT; after → 200, `HEX(event_title)` shows the 4-byte sequence, GET round-trips it. The script runs cleanly and idempotently through `SQLUtils::sqlImport`; with a deliberately long composite index in place it aborts as designed. New `private.calendar.events-emoji.spec.js` (4 tests) passes; database left identical to seed.

## Pre-Merge
- [x] Tested locally
- [x] No new warnings
- [x] Build passes
- [x] Backward compatible (or migration documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
