### PR TITLE
Fix issue #9733: Add an optional Reply-To to BaseEmail

### DIFF
--- a/.agents/skills/churchcrm/php-best-practices.md
+++ b/.agents/skills/churchcrm/php-best-practices.md
@@ -693,6 +693,44 @@ if (!mail($to, $subject, $body)) {
 }
 ```
 
+### Outbound Email: `BaseEmail` and `Reply-To` <!-- learned: 2026-09-11 -->
+
+Every transactional email extends `ChurchCRM\Emails\BaseEmail`
+(`src/ChurchCRM/Emails/`), which wraps PHPMailer, applies the SMTP settings,
+and sets **`From` = the church address** (`ChurchMetaData::getChurchEmail()` /
+`getChurchName()`). `From` is deliberately the church address on every message
+so SPF/DKIM stay aligned — **never override it per-sender.**
+
+To make a reply reach the person or role that actually triggered the mail, set
+a `Reply-To` instead (issue #9733):
+
+```php
+$email = new VolunteerAssignmentEmail([$volunteer->getEmail()]);
+$email->setReplyTo($coordinator->getEmail(), $coordinator->getFullName());
+if (!$email->send()) {
+    LoggerUtils::getAppLogger()->warning('Assignment email failed', ['error' => $email->getError()]);
+}
+```
+
+Semantics worth knowing before you use it:
+
+- **Opt-in.** An email that never calls `setReplyTo()` sends exactly the message
+  it sent before — no `Reply-To` header at all. No existing subclass sets one.
+- **Applied in `send()`, not in the setter.** Calling `setReplyTo()` twice
+  replaces the address (last call wins) and the sent message carries exactly
+  one `Reply-To`; resending the same instance does not accumulate headers.
+- **An invalid address is ignored, not fatal.** `setReplyTo()` validates with
+  `filter_var(..., FILTER_VALIDATE_EMAIL)` and logs a warning
+  (`Ignoring invalid Reply-To address`) if it fails, so a bad coordinator
+  address never stops the mail going out. `getReplyTo()` returns `null` in that
+  case — assert on it if you need to know whether the address took.
+
+**Verifying mail locally:** the dev profile captures SMTP in Mailpit
+(`http://localhost:8025`). `curl -sS 'http://localhost:8025/api/v1/messages?limit=50'`
+returns a `ReplyTo` array per message. Note Mailpit is in the compose `test`
+profile only, **not** the `ci-root` / `ci-subdir` profiles — CI has no SMTP
+capture, so header-level email assertions cannot live in a Cypress spec.
+
 ### Algorithm Performance
 
 When matching items between collections, use hash-based lookups not nested loops:

--- a/src/ChurchCRM/Emails/BaseEmail.php
+++ b/src/ChurchCRM/Emails/BaseEmail.php
@@ -118,6 +118,16 @@ abstract class BaseEmail
      * Applied at send time rather than in setReplyTo() so a caller can change
      * its mind before sending, and so resending the same instance does not
      * accumulate duplicate Reply-To headers.
+     *
+     * PHPMailer is constructed without exceptions, so addReplyTo() reports
+     * failure by returning false and setting ErrorInfo. The filter_var() guard
+     * in setReplyTo() does not make that unreachable: PHPMailer applies its own
+     * validateAddress(), and an internationalised domain is rejected outright
+     * when the intl/mbstring extensions needed to punycode it are missing.
+     * Unchecked, the mail would then go out with no Reply-To header, send()
+     * would still return true, and getReplyTo() would keep reporting an address
+     * that was never applied. Log it and forget the address instead, so the
+     * getter stays honest.
      */
     private function applyReplyTo(): void
     {
@@ -126,7 +136,14 @@ abstract class BaseEmail
         }
 
         $this->mail->clearReplyTos();
-        $this->mail->addReplyTo($this->replyTo['address'], $this->replyTo['name']);
+        if (!$this->mail->addReplyTo($this->replyTo['address'], $this->replyTo['name'])) {
+            LoggerUtils::getAppLogger()->warning('PHPMailer rejected Reply-To address', [
+                'address'    => $this->replyTo['address'],
+                'emailClass' => static::class,
+                'error'      => $this->mail->ErrorInfo,
+            ]);
+            $this->replyTo = null;
+        }
     }
 
     public function getError(): string

--- a/src/ChurchCRM/Emails/BaseEmail.php
+++ b/src/ChurchCRM/Emails/BaseEmail.php
@@ -6,6 +6,7 @@ use ChurchCRM\dto\ChurchMetaData;
 use ChurchCRM\dto\SystemConfig;
 use ChurchCRM\dto\SystemURLs;
 use ChurchCRM\Service\SystemService;
+use ChurchCRM\Utils\LoggerUtils;
 use Twig\Loader\FilesystemLoader;
 use Twig\Environment;
 use PHPMailer\PHPMailer\PHPMailer;
@@ -14,6 +15,18 @@ abstract class BaseEmail
 {
     protected PHPMailer $mail;
     protected Environment $twig;
+
+    /**
+     * Optional Reply-To, as ['address' => string, 'name' => string].
+     *
+     * Held here rather than pushed straight into PHPMailer so that the last
+     * setReplyTo() call wins and send() adds exactly one Reply-To header.
+     * Null — the default — means no Reply-To header at all, which is the
+     * historical behaviour of every email this class sends.
+     *
+     * @var array{address: string, name: string}|null
+     */
+    private ?array $replyTo = null;
 
     /**
      * @param string[] $toAddresses
@@ -49,13 +62,71 @@ abstract class BaseEmail
         $this->mail->SMTPDebug = 0;
     }
 
+    /**
+     * Set the address a recipient's reply should go to.
+     *
+     * From stays the church address (SPF/DKIM alignment); this only adds a
+     * Reply-To header, so mail about a specific group, event or assignment can
+     * be answered by the coordinator responsible for it instead of the church's
+     * general inbox.
+     *
+     * Opt-in: an email that never calls this sends exactly the message it sent
+     * before, with no Reply-To header. Calling it more than once replaces the
+     * previous value rather than adding a second address.
+     *
+     * An invalid address is ignored with a logged warning rather than throwing —
+     * a bad coordinator address must not stop the mail from going out.
+     */
+    public function setReplyTo(string $address, string $name = ''): void
+    {
+        $address = trim($address);
+
+        if (filter_var($address, FILTER_VALIDATE_EMAIL) === false) {
+            LoggerUtils::getAppLogger()->warning('Ignoring invalid Reply-To address', [
+                'address'    => $address,
+                'emailClass' => static::class,
+            ]);
+
+            return;
+        }
+
+        $this->replyTo = ['address' => $address, 'name' => trim($name)];
+    }
+
+    /**
+     * The configured Reply-To address, or null when none is set.
+     */
+    public function getReplyTo(): ?string
+    {
+        return $this->replyTo['address'] ?? null;
+    }
+
     public function send(): bool
     {
         if (SystemConfig::isEmailEnabled()) {
+            $this->applyReplyTo();
+
             return $this->mail->send();
         }
 
         return false; // email disabled or SMTP misconfigured — skip so we don't crash.
+    }
+
+    /**
+     * Hand the stored Reply-To to PHPMailer, exactly once per instance.
+     *
+     * Applied at send time rather than in setReplyTo() so a caller can change
+     * its mind before sending, and so resending the same instance does not
+     * accumulate duplicate Reply-To headers.
+     */
+    private function applyReplyTo(): void
+    {
+        if ($this->replyTo === null) {
+            return;
+        }
+
+        $this->mail->clearReplyTos();
+        $this->mail->addReplyTo($this->replyTo['address'], $this->replyTo['name']);
     }
 
     public function getError(): string


### PR DESCRIPTION
## What Changed
`BaseEmail` sets a single From and never a Reply-To, so replies to any system email go to the church address. This adds `setReplyTo(string $address, string $name = ''): void` and `getReplyTo(): ?string`; the address is applied in `send()` through PHPMailer's `clearReplyTos()` + `addReplyTo()`. Invalid addresses are ignored with a logged warning and the send proceeds. No existing email is changed: none of the nine subclasses or their constructors is touched, and messages without a Reply-To are byte-identical. Documented beside the existing email guidance in `php-best-practices.md`. Two deliberate choices, explained in the commit body: the setter is public (subclasses and callers both need it, matching `addStringAttachment()`), and there is no constructor argument (every subclass defines its own constructor signature).

Fixes #9733

## Type
- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
Mailpit raw headers: no setter → no Reply-To; `setReplyTo('coordinator@example.com','Volunteer Coordinator')` → `Reply-To: Volunteer Coordinator <coordinator@example.com>`; invalid address → no header plus a logged warning, `send()` still true; called twice → exactly one header with the second address. Existing flows (debug email, account lock/unlock mail) still send no Reply-To. Email/user/password-reset specs 49/49. No Cypress assertion on headers: nothing calls the setter yet, and Mailpit is only in the `test` compose profile, not the CI profiles.

## Pre-Merge
- [x] Tested locally
- [x] No new warnings
- [x] Build passes
- [x] Backward compatible (or migration documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
