### PR TITLE
Fix issue #9768: Pass the documented payloads to the person and family hooks

### DIFF
--- a/.agents/skills/churchcrm/plugin-development.md
+++ b/.agents/skills/churchcrm/plugin-development.md
@@ -509,10 +509,24 @@ $errorMiddleware->setDefaultErrorHandler(function (Request $request, Throwable $
 Defined in `src/ChurchCRM/Plugin/Hooks.php`:
 
 **Person**
-- `PERSON_CREATED`, `PERSON_UPDATED`, `PERSON_DELETED`
+
+| Hook | Receives | Dispatched from |
+|------|----------|-----------------|
+| `PERSON_CREATED` | `Person $person` | `Person::postInsert()` |
+| `PERSON_UPDATED` | `Person $person, array $oldData` | `Person::postUpdate()` |
+| `PERSON_DELETED` | `int $personId, array $personData` | `Person::postDelete()` |
 
 **Family**
-- `FAMILY_CREATED`, `FAMILY_UPDATED`, `FAMILY_DELETED`
+
+| Hook | Receives | Dispatched from |
+|------|----------|-----------------|
+| `FAMILY_CREATED` | `Family $family` | `Family::postInsert()` |
+| `FAMILY_UPDATED` | `Family $family, array $oldData` | `Family::postUpdate()` |
+| `FAMILY_DELETED` | `int $familyId, array $familyData` | `Family::postDelete()` |
+
+The `array` payloads are keyed by Propel **phpName** (`FirstName`, `Email`),
+not by column name and not lowercased — see `plugin-system.md` → "Hook Payloads
+Are Propel phpName Arrays".
 
 **Financial**
 - `DONATION_RECEIVED`, `DEPOSIT_CLOSED`

--- a/.agents/skills/churchcrm/plugin-system.md
+++ b/.agents/skills/churchcrm/plugin-system.md
@@ -497,14 +497,14 @@ $this->setConfigValue('lastSync', date('c'));        // Sets plugin.mailchimp.la
 ### Available Hook Points
 
 **Person Lifecycle:**
-- `PERSON_CREATED` - After person is created
-- `PERSON_UPDATED` - After person is updated
-- `PERSON_DELETED` - After person is deleted
+- `PERSON_CREATED` - After person is created — receives `Person $person`
+- `PERSON_UPDATED` - After person is updated — receives `Person $person, array $oldData`
+- `PERSON_DELETED` - After person is deleted — receives `int $personId, array $personData`
 
 **Family Lifecycle:**
-- `FAMILY_CREATED` - After family is created
-- `FAMILY_UPDATED` - After family is updated
-- `FAMILY_DELETED` - After family is deleted
+- `FAMILY_CREATED` - After family is created — receives `Family $family`
+- `FAMILY_UPDATED` - After family is updated — receives `Family $family, array $oldData`
+- `FAMILY_DELETED` - After family is deleted — receives `int $familyId, array $familyData`
 
 **Financial:**
 - `DONATION_RECEIVED` - When donation is recorded
@@ -561,15 +561,15 @@ Hook constants in `Hooks.php` are inert — nothing fires automatically. Each ho
 
 | Hook | Dispatch Location | Status |
 |------|-------------------|--------|
-| `PERSON_CREATED` | `src/ChurchCRM/Model/Person.php` `postInsert()` — after timeline note creation | ✅ Wired |
-| `PERSON_UPDATED` | `src/ChurchCRM/Model/Person.php` `postUpdate()` — after timeline note check | ✅ Wired |
-| `FAMILY_CREATED` | `src/ChurchCRM/Model/Family.php` `postInsert()` — after welcome email | ✅ Wired |
-| `FAMILY_UPDATED` | `src/ChurchCRM/Model/Family.php` `postUpdate()` — after timeline note | ✅ Wired |
+| `PERSON_CREATED` | `src/ChurchCRM/model/ChurchCRM/Person.php` `postInsert()` — after timeline note creation | ✅ Wired |
+| `PERSON_UPDATED` | `src/ChurchCRM/model/ChurchCRM/Person.php` `postUpdate()` — after timeline note check | ✅ Wired |
+| `FAMILY_CREATED` | `src/ChurchCRM/model/ChurchCRM/Family.php` `postInsert()` — after welcome email | ✅ Wired |
+| `FAMILY_UPDATED` | `src/ChurchCRM/model/ChurchCRM/Family.php` `postUpdate()` — after timeline note | ✅ Wired |
 | `CRON_RUN` | `src/ChurchCRM/Service/SystemService.php` `runTimerJobs()` | ✅ Wired |
 | `MENU_BUILDING` | Core menu builder in admin initializer | ✅ Wired |
 | `SYSTEM_CALENDARS_REGISTER` | Calendar system initialization | ✅ Wired |
-| `PERSON_DELETED` | Needs wiring in `/people/person` DELETE route | ⏳ Pending |
-| `FAMILY_DELETED` | Needs wiring in `/people/family` DELETE route | ⏳ Pending |
+| `PERSON_DELETED` | `src/ChurchCRM/model/ChurchCRM/Person.php` `postDelete()` — payload snapshotted in `preDelete()` | ✅ Wired |
+| `FAMILY_DELETED` | `src/ChurchCRM/model/ChurchCRM/Family.php` `postDelete()` — payload snapshotted in `preDelete()` | ✅ Wired |
 | `EVENT_CREATED` | Needs wiring in `EventService::createEvent()` | ⏳ Pending |
 | `EVENT_CHECKIN` | Needs wiring in `Event::checkInPerson()` | ⏳ Pending |
 | `EVENT_CHECKOUT` | Needs wiring in `Event::checkOutPerson()` | ⏳ Pending |
@@ -577,6 +577,24 @@ Hook constants in `Hooks.php` are inert — nothing fires automatically. Each ho
 | `GROUP_MEMBER_REMOVED` | Needs wiring in groups membership route | ⏳ Pending |
 | `DONATION_RECEIVED` | Needs wiring in financial donation route | ⏳ Pending |
 | `DEPOSIT_CLOSED` | Needs wiring in `FinancialService::setDeposit()` | ⏳ Pending |
+
+### Hook Payloads Are Propel phpName Arrays <!-- learned: 2026-09-11 -->
+
+The `array` half of the person/family lifecycle payloads is keyed by **Propel
+phpName** (`FirstName`, `Email`, `Name`), never by database column name
+(`per_FirstName`) and never lowercased (`email`). Reading `$oldData['email']`
+silently yields `null`.
+
+| Hook | Payload source | Keys |
+|------|----------------|------|
+| `PERSON_UPDATED` / `FAMILY_UPDATED` | `select('*')` read in `preUpdate()`, re-keyed to phpName | persisted columns only |
+| `PERSON_DELETED` / `FAMILY_DELETED` | `toArray()` snapshotted in `preDelete()` | persisted columns **plus** the model's derived keys (`FullName`, `Address`, `HasPhoto`, `FamilyString`) |
+
+Both snapshots are taken only when `HookManager::hasAction()` reports a
+listener, so an install with no plugins pays nothing for them. Dispatching from
+the Propel callbacks rather than from the routes means the member cascade in
+`DELETE /api/family/{id}?deleteMembers=true` fires `PERSON_DELETED` for each
+deleted member — the old route-level dispatch never reached that path (#9768).
 
 ---
 

--- a/cypress/e2e/api/private/standard/private.people.hooks.spec.js
+++ b/cypress/e2e/api/private/standard/private.people.hooks.spec.js
@@ -1,0 +1,201 @@
+/// <reference types="cypress" />
+
+/**
+ * Regression cover for the person/family plugin-hook dispatch points changed
+ * in #9768.
+ *
+ * PERSON_UPDATED / FAMILY_UPDATED are dispatched from Person::postUpdate() /
+ * Family::postUpdate() with an $oldData snapshot taken in preUpdate(), and
+ * PERSON_DELETED / FAMILY_DELETED moved out of the API delete routes into
+ * Person::postDelete() / Family::postDelete(), with the payload snapshotted in
+ * preDelete() before the child-row cascade. Those Propel callbacks sit directly
+ * in the save/delete path of every person and family, so a mistake there breaks
+ * people writes outright rather than just the hook.
+ *
+ * This spec drives every path that reaches one of those dispatch points — the
+ * legacy MVC editor forms (PersonEditor.php / FamilyEditor.php), the API role
+ * and activate routes, DELETE /api/person/{id}, and the member cascade in
+ * DELETE /api/family/{id}?deleteMembers=true — and asserts the write landed.
+ *
+ * Structure note: every browser-form step runs in before(), ahead of the first
+ * cy.request(). cy.request() shares the browser cookie jar, so an x-api-key
+ * call made mid-spec flips the PHP session to APITokenAuthentication and any
+ * later cy.visit() lands on the login page. The same ordering is used by
+ * private.people.family.delete-image-cleanup.spec.js.
+ *
+ * What this spec deliberately does NOT assert: that a plugin callback ran.
+ * There is no hook-observability endpoint (HookManager::didAction() counts are
+ * per-PHP-request and nothing exposes them), no existing Cypress pattern for
+ * asserting a hook fired, and no test plugin in the repo. That half of #9768
+ * was verified by registering person and family listeners and reading the app
+ * log — the procedure and its output are recorded in the commit body.
+ */
+describe("API People Hooks - dispatch path regression", () => {
+    const tag = `HookPpl${Date.now()}`;
+    const renamed = `Renamed${tag}`;
+
+    // Everything this spec creates, so after() can remove it again (#9769).
+    const createdPersonIds = [];
+    const createdFamilyIds = [];
+
+    const ids = {};
+
+    /** Create a family-less person through the legacy MVC editor form. */
+    const createPerson = (firstName, key) => {
+        cy.visit("/PersonEditor.php");
+        cy.get("#FirstName").type(firstName);
+        cy.get("#LastName").type(tag);
+        cy.get("#Gender").select("1");
+        cy.get("#Classification").select("1");
+        cy.get("button[name='PersonSubmit']").click();
+        cy.url().should("match", /people\/view\/\d+/);
+        cy.url().then((url) => {
+            const personId = Number.parseInt(url.match(/\/people\/view\/(\d+)/)[1], 10);
+            expect(personId, "person created via PersonEditor").to.be.greaterThan(0);
+            createdPersonIds.push(personId);
+            ids[key] = personId;
+        });
+    };
+
+    /** Create a family with one member through the legacy MVC editor form. */
+    const createFamilyWithMember = (suffix, key) => {
+        cy.visit("/FamilyEditor.php");
+        cy.get("#FamilyName").type(`Fam${tag}${suffix}`);
+        cy.get('input[name="FirstName1"]').type(`${tag}${suffix}`);
+        cy.get('select[name="Classification1"]').select("1", { force: true });
+        cy.get('button[name="FamilySubmit"]').click();
+
+        cy.location("pathname").then((pathname) => {
+            const familyId = Number.parseInt(pathname.split("/").pop(), 10);
+            expect(familyId, "family created via FamilyEditor").to.be.greaterThan(0);
+            createdFamilyIds.push(familyId);
+            ids[key] = familyId;
+        });
+    };
+
+    before(() => {
+        cy.setupStandardSession();
+
+        createPerson(`Upd${tag}`, "personUpd");
+        createPerson(`Del${tag}`, "personDel");
+        createFamilyWithMember("A", "familyA");
+        createFamilyWithMember("B", "familyB");
+
+        // MVC update path — Person::postUpdate() fires from the legacy editor
+        // save, the same callback the hook dispatch now hangs off.
+        cy.then(() => {
+            cy.visit(`/PersonEditor.php?PersonID=${ids.personUpd}`);
+            cy.get("#FirstName").clear().type(renamed);
+            cy.get("button[name='PersonSubmit']").click();
+            cy.url().should("match", /people\/view\/\d+/);
+        });
+
+        // Resolve the two family members by their unique first names. This is
+        // the first cy.request() of the spec — no cy.visit() may follow it.
+        cy.then(() => {
+            ["A", "B"].forEach((suffix) => {
+                cy.makePrivateAdminAPICall(
+                    "GET",
+                    `/api/persons/search/${tag}${suffix}`,
+                    null,
+                    200,
+                ).then((resp) => {
+                    expect(resp.body).to.be.an("array").and.to.have.length.greaterThan(0);
+                    const personId = resp.body[0].objid;
+                    createdPersonIds.push(personId);
+                    ids[`member${suffix}`] = personId;
+                });
+            });
+        });
+    });
+
+    after(() => {
+        // Leave the database exactly as the spec found it.
+        createdFamilyIds.forEach((familyId) => {
+            cy.makePrivateAdminAPICall(
+                "DELETE",
+                `/api/family/${familyId}?deleteMembers=true`,
+                null,
+                [200, 404],
+            );
+        });
+        createdPersonIds.forEach((personId) => {
+            cy.makePrivateAdminAPICall("DELETE", `/api/person/${personId}`, null, [200, 404]);
+        });
+    });
+
+    it("Persists a person update made through the MVC editor", () => {
+        cy.makePrivateAdminAPICall("GET", `/api/person/${ids.personUpd}`, null, 200).then(
+            (resp) => {
+                expect(resp.body.FirstName, "MVC update persisted").to.equal(renamed);
+            },
+        );
+    });
+
+    it("Persists a person update made through the API role route", () => {
+        cy.makePrivateAdminAPICall("POST", `/api/person/${ids.personUpd}/role/3`, null, 200)
+            .its("body.success")
+            .should("eq", true);
+
+        cy.makePrivateAdminAPICall("GET", `/api/person/${ids.personUpd}`, null, 200).then(
+            (resp) => {
+                expect(resp.body.FmrId, "API role update persisted").to.equal(3);
+            },
+        );
+    });
+
+    it("Deletes a person through the API", () => {
+        cy.makePrivateAdminAPICall("DELETE", `/api/person/${ids.personDel}`, null, 200)
+            .its("body.success")
+            .should("eq", true);
+
+        cy.makePrivateAdminAPICall("GET", `/api/person/${ids.personDel}`, null, 404);
+    });
+
+    it("Persists a family update made through the API activate route", () => {
+        cy.makePrivateAdminAPICall(
+            "POST",
+            `/api/family/${ids.familyA}/activate/false`,
+            null,
+            200,
+        )
+            .its("body.success")
+            .should("eq", true);
+
+        cy.makePrivateAdminAPICall("GET", `/api/family/${ids.familyA}`, null, 200).then(
+            (resp) => {
+                expect(resp.body.DateDeactivated, "deactivate persisted").to.not.be.null;
+            },
+        );
+
+        cy.makePrivateAdminAPICall(
+            "POST",
+            `/api/family/${ids.familyA}/activate/true`,
+            null,
+            200,
+        );
+
+        cy.makePrivateAdminAPICall("GET", `/api/family/${ids.familyA}`, null, 200).then(
+            (resp) => {
+                expect(resp.body.DateDeactivated, "reactivate persisted").to.be.null;
+            },
+        );
+    });
+
+    it("Deletes a family and cascades to its members", () => {
+        cy.makePrivateAdminAPICall(
+            "DELETE",
+            `/api/family/${ids.familyB}?deleteMembers=true`,
+            null,
+            200,
+        )
+            .its("body.success")
+            .should("eq", true);
+
+        // The family row and the cascaded member row are both gone. The
+        // member's removal runs through Person::postDelete(), which is the path
+        // the old route-level PERSON_DELETED dispatch never reached.
+        cy.makePrivateAdminAPICall("GET", `/api/family/${ids.familyB}`, null, 404);
+        cy.makePrivateAdminAPICall("GET", `/api/person/${ids.memberB}`, null, 404);
+    });
+});

--- a/src/ChurchCRM/model/ChurchCRM/Family.php
+++ b/src/ChurchCRM/model/ChurchCRM/Family.php
@@ -34,6 +34,17 @@ class Family extends BaseFamily implements PhotoInterface
     private ?Photo $photo = null;
     private bool $skipPostUpdateNote = false;
 
+    /**
+     * Snapshot of the persisted row, taken in preUpdate()/preDelete() and
+     * handed to the FAMILY_UPDATED / FAMILY_DELETED listeners afterwards.
+     *
+     * Null means "nothing listening" — the snapshot is skipped when no plugin
+     * has registered for the hook, so installs with no plugins pay nothing.
+     *
+     * @var array<string, mixed>|null
+     */
+    private ?array $hookDataSnapshot = null;
+
     public function getAddress(): string
     {
         $address = [];
@@ -91,7 +102,7 @@ class Family extends BaseFamily implements PhotoInterface
         return '';
     }
 
-    public function postInsert(ConnectionInterface $con = null): void
+    public function postInsert(?ConnectionInterface $con = null): void
     {
         $this->createTimeLineNote('create');
         NewPersonOrFamilyEmail::sendIfConfigured($this);
@@ -99,13 +110,58 @@ class Family extends BaseFamily implements PhotoInterface
         HookManager::doAction(Hooks::FAMILY_CREATED, $this);
     }
 
-    public function postUpdate(ConnectionInterface $con = null): void
+    /**
+     * Capture the pre-update state so FAMILY_UPDATED can report what changed.
+     *
+     * select() is used rather than a normal find so the read bypasses object
+     * hydration and the instance pool — findPk() would just hand back $this,
+     * which already holds the new values. Runs on the save connection, inside
+     * the same transaction, before doSave() writes the new row.
+     */
+    public function preUpdate(?ConnectionInterface $con = null): bool
+    {
+        $this->hookDataSnapshot = null;
+
+        if (HookManager::hasAction(Hooks::FAMILY_UPDATED)) {
+            $row = FamilyQuery::create()
+                ->filterById((int) $this->getId())
+                ->select('*')
+                ->findOne($con);
+
+            $this->hookDataSnapshot = is_array($row) ? self::toPhpNameKeys($row) : [];
+        }
+
+        return parent::preUpdate($con);
+    }
+
+    /**
+     * Re-key a select('*') row from "Fully\Qualified\Model.PhpName" to just
+     * "PhpName", so FAMILY_UPDATED's $oldData matches the shape of
+     * FAMILY_DELETED's $familyData (which comes from toArray(TYPE_PHPNAME)).
+     *
+     * @param array<string, mixed> $row
+     *
+     * @return array<string, mixed>
+     */
+    private static function toPhpNameKeys(array $row): array
+    {
+        $keyed = [];
+        foreach ($row as $column => $value) {
+            $lastDot = strrpos((string) $column, '.');
+            $keyed[$lastDot === false ? $column : substr((string) $column, $lastDot + 1)] = $value;
+        }
+
+        return $keyed;
+    }
+
+    public function postUpdate(?ConnectionInterface $con = null): void
     {
         if (!empty($this->getDateLastEdited()) && !$this->skipPostUpdateNote) {
             $this->createTimeLineNote('edit');
         }
 
-        HookManager::doAction(Hooks::FAMILY_UPDATED, $this);
+        HookManager::doAction(Hooks::FAMILY_UPDATED, $this, $this->hookDataSnapshot ?? []);
+        $this->hookDataSnapshot = null;
     }
 
     /**
@@ -115,9 +171,32 @@ class Family extends BaseFamily implements PhotoInterface
      */
     public function preDelete(?ConnectionInterface $con = null): bool
     {
+        // Snapshot before the photo is unlinked, so FAMILY_DELETED listeners
+        // see the family as it actually was. (The API route unlinks or deletes
+        // the members before it deletes the family, so the derived
+        // FamilyString key reflects that emptied membership — the persisted
+        // family columns are unaffected.)
+        $this->hookDataSnapshot = HookManager::hasAction(Hooks::FAMILY_DELETED)
+            ? $this->toArray()
+            : null;
+
         $this->getPhoto()->delete();
 
         return parent::preDelete($con);
+    }
+
+    /**
+     * Fire FAMILY_DELETED for every path that removes a family.
+     *
+     * This lives on the model rather than in the API route, mirroring
+     * Person::postDelete(): Propel calls postDelete() exactly once per
+     * delete(), so every path fires the hook exactly once and no future caller
+     * can forget to.
+     */
+    public function postDelete(?ConnectionInterface $con = null): void
+    {
+        HookManager::doAction(Hooks::FAMILY_DELETED, (int) $this->getId(), $this->hookDataSnapshot ?? []);
+        $this->hookDataSnapshot = null;
     }
 
     public function getPeopleSorted(): array

--- a/src/ChurchCRM/model/ChurchCRM/Person.php
+++ b/src/ChurchCRM/model/ChurchCRM/Person.php
@@ -33,6 +33,17 @@ class Person extends BasePerson implements PhotoInterface
     private ?Photo $photo = null;
     private bool $skipPostUpdateNote = false;
 
+    /**
+     * Snapshot of the persisted row, taken in preUpdate()/preDelete() and
+     * handed to the PERSON_UPDATED / PERSON_DELETED listeners afterwards.
+     *
+     * Null means "nothing listening" — the snapshot is skipped when no plugin
+     * has registered for the hook, so installs with no plugins pay nothing.
+     *
+     * @var array<string, mixed>|null
+     */
+    private ?array $hookDataSnapshot = null;
+
     public function getFullName(): string
     {
         return $this->getFormattedName(SystemConfig::getIntValue('iPersonNameStyle'));
@@ -166,13 +177,58 @@ class Person extends BasePerson implements PhotoInterface
         HookManager::doAction(Hooks::PERSON_CREATED, $this);
     }
 
+    /**
+     * Capture the pre-update state so PERSON_UPDATED can report what changed.
+     *
+     * select() is used rather than a normal find so the read bypasses object
+     * hydration and the instance pool — findPk() would just hand back $this,
+     * which already holds the new values. Runs on the save connection, inside
+     * the same transaction, before doSave() writes the new row.
+     */
+    public function preUpdate(?ConnectionInterface $con = null): bool
+    {
+        $this->hookDataSnapshot = null;
+
+        if (HookManager::hasAction(Hooks::PERSON_UPDATED)) {
+            $row = PersonQuery::create()
+                ->filterById((int) $this->getId())
+                ->select('*')
+                ->findOne($con);
+
+            $this->hookDataSnapshot = is_array($row) ? self::toPhpNameKeys($row) : [];
+        }
+
+        return parent::preUpdate($con);
+    }
+
+    /**
+     * Re-key a select('*') row from "Fully\Qualified\Model.PhpName" to just
+     * "PhpName", so PERSON_UPDATED's $oldData matches the shape of
+     * PERSON_DELETED's $personData (which comes from toArray(TYPE_PHPNAME)).
+     *
+     * @param array<string, mixed> $row
+     *
+     * @return array<string, mixed>
+     */
+    private static function toPhpNameKeys(array $row): array
+    {
+        $keyed = [];
+        foreach ($row as $column => $value) {
+            $lastDot = strrpos((string) $column, '.');
+            $keyed[$lastDot === false ? $column : substr((string) $column, $lastDot + 1)] = $value;
+        }
+
+        return $keyed;
+    }
+
     public function postUpdate(?ConnectionInterface $con = null): void
     {
         if (!empty($this->getDateLastEdited()) && !$this->skipPostUpdateNote) {
             $this->createTimeLineNote('edit');
         }
 
-        HookManager::doAction(Hooks::PERSON_UPDATED, $this);
+        HookManager::doAction(Hooks::PERSON_UPDATED, $this, $this->hookDataSnapshot ?? []);
+        $this->hookDataSnapshot = null;
     }
 
     private function createTimeLineNote(string $type): void
@@ -580,6 +636,13 @@ class Person extends BasePerson implements PhotoInterface
 
     public function preDelete(?ConnectionInterface $con = null): bool
     {
+        // Snapshot before the cleanup below removes the rows toArray() reads
+        // (the photo behind HasPhoto), so PERSON_DELETED listeners see the
+        // person as they actually were.
+        $this->hookDataSnapshot = HookManager::hasAction(Hooks::PERSON_DELETED)
+            ? $this->toArray()
+            : null;
+
         // Remove the uploaded image from disk. Call Photo::delete() directly
         // rather than $this->deletePhoto(), which gates on the current user's
         // delete-records permission and writes a Note that NoteQuery below
@@ -615,6 +678,22 @@ class Person extends BasePerson implements PhotoInterface
         NoteQuery::create()->filterByPerson($this)->delete($con);
 
         return parent::preDelete($con);
+    }
+
+    /**
+     * Fire PERSON_DELETED for every path that removes a person.
+     *
+     * This lives on the model rather than in the API route because people are
+     * deleted from more than one place — DELETE /api/person/{id} and the
+     * member cascade in DELETE /api/family/{id}?deleteMembers=true, which
+     * never reached the route-level dispatch at all. Propel calls postDelete()
+     * exactly once per delete(), so every path fires the hook exactly once and
+     * no future caller can forget to.
+     */
+    public function postDelete(?ConnectionInterface $con = null): void
+    {
+        HookManager::doAction(Hooks::PERSON_DELETED, (int) $this->getId(), $this->hookDataSnapshot ?? []);
+        $this->hookDataSnapshot = null;
     }
 
     public function getProperties()

--- a/src/api/routes/people/people-family.php
+++ b/src/api/routes/people/people-family.php
@@ -11,8 +11,6 @@ use ChurchCRM\model\ChurchCRM\FamilyQuery;
 use ChurchCRM\model\ChurchCRM\Note;
 use ChurchCRM\model\ChurchCRM\Token;
 use ChurchCRM\model\ChurchCRM\TokenQuery;
-use ChurchCRM\Plugin\Hook\HookManager;
-use ChurchCRM\Plugin\Hooks;
 use ChurchCRM\Service\FamilyService;
 use ChurchCRM\Service\SystemService;
 use ChurchCRM\Slim\Middleware\Request\Auth\DeleteRecordRoleAuthMiddleware;
@@ -512,8 +510,8 @@ $app->group('/family/{familyId:[0-9]+}', function (RouteCollectorProxy $group): 
         // Delete the family record itself. Family::preDelete() removes the
         // photo file from disk; member deletion above triggers Person::preDelete
         // for each member, which cleans up their photos too (#1697).
+        // FAMILY_DELETED is dispatched from Family::postDelete(). See #9768.
         $family->delete();
-        HookManager::doAction(Hooks::FAMILY_DELETED, $familyId);
 
         return SlimUtils::renderJSON($response, ['success' => true]);
     })->add(DeleteRecordRoleAuthMiddleware::class);

--- a/src/api/routes/people/people-person.php
+++ b/src/api/routes/people/people-person.php
@@ -5,8 +5,6 @@ use ChurchCRM\dto\Cart;
 use ChurchCRM\dto\Photo;
 use ChurchCRM\Exceptions\PhotoSizeException;
 use ChurchCRM\model\ChurchCRM\ListOptionQuery;
-use ChurchCRM\Plugin\Hook\HookManager;
-use ChurchCRM\Plugin\Hooks;
 use ChurchCRM\Service\SystemService;
 use ChurchCRM\Slim\Middleware\Request\Auth\DeleteRecordRoleAuthMiddleware;
 use ChurchCRM\Slim\Middleware\Request\Auth\EditRecordsRoleAuthMiddleware;
@@ -229,9 +227,10 @@ $app->group('/person/{personId:[0-9]+}', function (RouteCollectorProxy $group): 
         if (AuthenticationManager::getCurrentUser()->getId() === (int) $person->getId()) {
             throw new HttpForbiddenException($request, gettext("Can't delete yourself"));
         }
-        $personId = $person->getId();
+        // PERSON_DELETED is dispatched from Person::postDelete() so that the
+        // family-member cascade in DELETE /family/{id}?deleteMembers=true
+        // fires it too. See #9768.
         $person->delete();
-        HookManager::doAction(Hooks::PERSON_DELETED, $personId);
 
         return SlimUtils::renderSuccessJSON($response);
     })->add(DeleteRecordRoleAuthMiddleware::class);

--- a/src/plugins/core/mailchimp/src/MailChimpPlugin.php
+++ b/src/plugins/core/mailchimp/src/MailChimpPlugin.php
@@ -272,7 +272,8 @@ class MailChimpPlugin extends AbstractPlugin
         }
 
         $newEmail = $person->getEmail();
-        $oldEmail = $oldData['email'] ?? null;
+        // PERSON_UPDATED's $oldData is keyed by Propel phpName (see #9768).
+        $oldEmail = $oldData['Email'] ?? null;
 
         // If email changed, update in MailChimp
         if ($oldEmail !== null && $oldEmail !== $newEmail) {
@@ -289,7 +290,8 @@ class MailChimpPlugin extends AbstractPlugin
             return;
         }
 
-        $email = $personData['email'] ?? null;
+        // PERSON_DELETED's $personData is keyed by Propel phpName (see #9768).
+        $email = $personData['Email'] ?? null;
         if (!empty($email)) {
             $this->service->unsubscribeFromAllLists($email);
         }


### PR DESCRIPTION
## What Changed
`PERSON_UPDATED`/`FAMILY_UPDATED` now receive the documented `array $oldData` (snapshotted in new `preUpdate()` hooks with `select('*')`, gated on `HookManager::hasAction()`), and `PERSON_DELETED`/`FAMILY_DELETED` are dispatched from new `postDelete()` model hooks with the row snapshot taken before the cascade, instead of from the two API routes. Moving the delete dispatch into the model was necessary, not cosmetic: the member cascade in `DELETE /api/family/{id}?deleteMembers=true` deletes people through a query and never reached the route-level dispatch. The core MailChimp plugin's handlers read `$oldData['email']`, but payload keys are Propel phpNames, so they now read `'Email'` (those handlers could never have run before). Also: `Family::postInsert()/postUpdate()` gain the explicit nullable types PHP 8.4 requires, and the plugin skill docs gain a payload/dispatch table and corrected paths.

Fixes #9768

## Type
- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
New `private.people.hooks.spec.js` (5 tests) drives PersonEditor, FamilyEditor, role and status routes, person delete and family delete with member cascade. Full API suite 671/671; people and family UI suites 153 tests, 0 failing, on a fresh seed. Hook payloads verified with temporary listeners (removed): each operation fired exactly once with two arguments, `$oldData` carried the pre-save value, and each cascaded member fired its own `PERSON_DELETED`; probe output is in the commit body.

## Pre-Merge
- [x] Tested locally
- [x] No new warnings
- [x] Build passes
- [x] Backward compatible (or migration documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
