### PR TITLE
Fix issue #9769: Make specs clean up their rows and guard the test database against drift

### DIFF
--- a/cypress/configs/docker-admin.config.ts
+++ b/cypress/configs/docker-admin.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'cypress'
 import { verifyDownloadTasks } from 'cy-verify-downloads';
+import { registerRowCountGuard } from './row-count-guard';
 
 import base from './base.config'
 
@@ -65,6 +66,9 @@ export default defineConfig({
         printLogsToFile: 'always'
       });
       on('task', verifyDownloadTasks);
+      // Test-database drift guard (#9769) — read-only row counts, plus the
+      // env flag cypress/support/e2e.js checks before arming the guard.
+      registerRowCountGuard(on, config);
       on('before:browser:launch', (browser, launchOptions) => {
         if (browser.name === 'chrome') {
           launchOptions.args.push('--disable-dev-shm-usage');

--- a/cypress/configs/docker-ui.config.ts
+++ b/cypress/configs/docker-ui.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'cypress'
 import { verifyDownloadTasks } from 'cy-verify-downloads';
+import { registerRowCountGuard } from './row-count-guard';
 
 import base from './base.config'
 
@@ -81,6 +82,9 @@ export default defineConfig({
         printLogsToFile: 'always'
       });
       on('task', verifyDownloadTasks);
+      // Test-database drift guard (#9769) — read-only row counts, plus the
+      // env flag cypress/support/e2e.js checks before arming the guard.
+      registerRowCountGuard(on, config);
       on('before:browser:launch', (browser, launchOptions) => {
         if (browser.name === 'chrome') {
           launchOptions.args.push('--disable-dev-shm-usage');

--- a/cypress/configs/docker.config.ts
+++ b/cypress/configs/docker.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'cypress'
 import { verifyDownloadTasks } from 'cy-verify-downloads';
+import { registerRowCountGuard } from './row-count-guard';
 
 import base from './base.config'
 export default defineConfig({
@@ -70,6 +71,9 @@ export default defineConfig({
         printLogsToFile: 'always'
       });
       on('task', verifyDownloadTasks);
+      // Test-database drift guard (#9769) — read-only row counts, plus the
+      // env flag cypress/support/e2e.js checks before arming the guard.
+      registerRowCountGuard(on, config);
       on('before:browser:launch', (browser, launchOptions) => {
         if (browser.name === 'chrome') {
           launchOptions.args.push('--disable-dev-shm-usage');

--- a/cypress/configs/row-count-guard.ts
+++ b/cypress/configs/row-count-guard.ts
@@ -1,0 +1,143 @@
+/**
+ * Test-database drift guard (#9769).
+ *
+ * Registers a read-only `rowCounts` Cypress task. `cypress/support/e2e.js`
+ * calls it once before and once after every spec file and fails the run if a
+ * spec left rows behind.
+ *
+ * The counts are read straight from MySQL rather than through the HTTP API
+ * because there is no endpoint that reports a row count for note_nte,
+ * event_attend or calendar_events. mysql2 is already a devDependency
+ * (locale/scripts/locale-build-db.js uses it) and every compose profile
+ * publishes the database port on the host, so the Cypress node process can
+ * reach it.
+ *
+ * The guard is fail-soft about *connecting*: if the database cannot be
+ * reached it disables itself with a single warning instead of failing specs.
+ * That keeps it inert in environments where the port is not published or is a
+ * different one (the CI subdir jobs publish 3307 — set ROW_GUARD_DB_PORT to
+ * enable it there). It is fail-hard about *drift*: once connected, any
+ * unexplained growth fails the spec file that caused it.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Tables a spec must leave exactly as it found them. These are the tables
+ * #9769 observed drifting; each one is cheap to COUNT(*).
+ *
+ * note_nte is counted but only reported, never failed — see SOFT_TABLES.
+ */
+export const GUARDED_TABLES = [
+  'events_event',
+  'note_nte',
+  'event_attend',
+  'calendar_events',
+  'person_per',
+  'family_fam',
+];
+
+/**
+ * Tables whose growth is reported but never fails a spec.
+ *
+ * note_nte is an append-only audit log that the *application* writes to on
+ * almost every person or family write it is asked to perform: editing a person
+ * adds an "Updated" timeline note, uploading a photo adds one, checking someone
+ * in or out adds one, and even DELETE /api/note/{id} adds a `delete-note` row
+ * in place of the note it removed. None of that is test litter and no endpoint
+ * removes it, so a spec cannot restore the count without deleting the person
+ * the note hangs off. Failing on it would mean an allowance in most of the
+ * suite, which is noise rather than a signal.
+ */
+export const SOFT_TABLES = ['note_nte'];
+
+/** Parse docker/.env for the compose database credentials. */
+function readDockerEnv(projectRoot: string): Record<string, string> {
+  const envPath = path.join(projectRoot, 'docker', '.env');
+  const parsed: Record<string, string> = {};
+  try {
+    for (const line of fs.readFileSync(envPath, 'utf8').split('\n')) {
+      const match = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*?)\s*$/);
+      if (match) {
+        parsed[match[1]] = match[2];
+      }
+    }
+  } catch (err) {
+    // No docker/.env (e.g. a non-docker checkout) — fall back to env vars.
+  }
+  return parsed;
+}
+
+export function registerRowCountGuard(on: any, config: any) {
+  const projectRoot = config?.projectRoot || process.cwd();
+  const dockerEnv = readDockerEnv(projectRoot);
+
+  const connectionOptions = {
+    host: process.env.ROW_GUARD_DB_HOST || '127.0.0.1',
+    port: Number(process.env.ROW_GUARD_DB_PORT || process.env.DATABASE_PORT || 3306),
+    user: process.env.MYSQL_USER || dockerEnv.MYSQL_USER || 'churchcrm',
+    password: process.env.MYSQL_PASSWORD || dockerEnv.MYSQL_PASSWORD || 'changeme',
+    database: process.env.MYSQL_DATABASE || dockerEnv.MYSQL_DATABASE || 'churchcrm',
+    connectTimeout: 5000,
+  };
+
+  // null = not tried yet, false = tried and unavailable (stay disabled).
+  let pool: any = null;
+  let disabledReason: string | null = null;
+
+  const getPool = () => {
+    if (pool === null && disabledReason === null) {
+      try {
+        // Required lazily so a checkout without node_modules/mysql2 still runs.
+        const mysql = require('mysql2/promise');
+        pool = mysql.createPool({ ...connectionOptions, connectionLimit: 1 });
+      } catch (err: any) {
+        disabledReason = `mysql2 is not installed (${err.message})`;
+      }
+    }
+    return pool;
+  };
+
+  on('task', {
+    /**
+     * SELECT COUNT(*) for each guarded table.
+     *
+     * @returns {{available: true, counts: Record<string, number>, softTables: string[]}}
+     *        | {{available: false, reason: string}}
+     */
+    async rowCounts() {
+      if (disabledReason !== null) {
+        return { available: false, reason: disabledReason };
+      }
+
+      const activePool = getPool();
+      if (!activePool) {
+        return { available: false, reason: disabledReason };
+      }
+
+      try {
+        const counts: Record<string, number> = {};
+        for (const table of GUARDED_TABLES) {
+          const [rows] = await activePool.query(`SELECT COUNT(*) AS c FROM \`${table}\``);
+          counts[table] = Number(rows[0].c);
+        }
+        return { available: true, counts, softTables: SOFT_TABLES };
+      } catch (err: any) {
+        disabledReason =
+          `cannot read row counts from ${connectionOptions.host}:${connectionOptions.port}` +
+          `/${connectionOptions.database} (${err.message}) — set ROW_GUARD_DB_PORT to point at` +
+          ' the database this run is using';
+        pool = false;
+        return { available: false, reason: disabledReason };
+      }
+    },
+  });
+
+  // Tell the support file the task exists. Configs that do not call this
+  // (new-system, locale, upgrade) leave the guard switched off, which is what
+  // we want for suites that deliberately reseed or import demo data.
+  config.env = { ...config.env, rowCountGuard: true };
+
+  return config;
+}

--- a/cypress/e2e/api/private/people/people.attendance.spec.js
+++ b/cypress/e2e/api/private/people/people.attendance.spec.js
@@ -26,8 +26,18 @@ describe("Person Attendance History API", () => {
     });
 
     after(() => {
-        // Cleanup: checkout person 2 from event 1 (removes the attendance record)
+        // Cleanup: checkout person 2 from event 1, then remove the attendance
+        // row itself. Checking out only stamps a checkout date — the
+        // event_attend row stays, which used to leave one behind per run
+        // (#9769). DELETE /events/{id}/attendance/{personId} is what actually
+        // removes it.
         cy.makePrivateAdminAPICall("POST", `/api/events/${EVENT_ID}/checkout`, { personId: PERSON_WITH_ATTENDANCE }, 200);
+        cy.makePrivateAdminAPICall(
+            "DELETE",
+            `/api/events/${EVENT_ID}/attendance/${PERSON_WITH_ATTENDANCE}`,
+            null,
+            [200, 404],
+        );
     });
 
     context("GET /api/attendance/person/:id — admin caller", () => {

--- a/cypress/e2e/api/private/standard/private-notes-timeline.spec.js
+++ b/cypress/e2e/api/private/standard/private-notes-timeline.spec.js
@@ -10,6 +10,12 @@
  * - Notes=1 non-admin sees only their own private notes; other users' private notes are absent
  */
 describe("API Private Notes Timeline Visibility", () => {
+
+    // Every note this spec creates is deleted again. DELETE /api/note/{id}
+    // still writes a `delete-note` audit row onto the same timeline in its
+    // place, so note_nte does not come back to its seed count — that is the
+    // application's audit trail, not spec litter, which is why the row-count
+    // guard only reports note_nte rather than failing on it (#9769).
     // -----------------------------------------------------------------------
     // Timeline privacy: Creator can see private note in full
     // -----------------------------------------------------------------------

--- a/cypress/e2e/api/private/standard/private.calendar.events-audit.spec.js
+++ b/cypress/e2e/api/private/standard/private.calendar.events-audit.spec.js
@@ -10,6 +10,34 @@ describe("API Event Audit Endpoints", () => {
     // No browser login — these are pure API tests using x-api-key auth
     // (cy.makePrivateAdminAPICall sets the header for us).
 
+    // The event this spec quick-creates, so after() can remove it again
+    // (#9769). Deleting the event also removes its event_attend rows.
+    const createdEventIds = [];
+
+    // Checking a person in writes a timeline note on that person
+    // (Event::addTimelineNote()) and nothing removes it when the event goes —
+    // that note is the person's attendance history. note_nte is therefore only
+    // reported by the row-count guard, not failed on (#9769).
+
+    after(() => {
+        cy.cleanupEvents(createdEventIds);
+    });
+
+    /**
+     * Record an event for cleanup, but only when the API actually created one:
+     * POST /events/quick-create returns `created: false` and the existing
+     * event's id when one already exists for that date+type, and deleting that
+     * would destroy a row the spec did not create.
+     */
+    const trackQuickCreated = (response) => {
+        if (
+            response?.body?.created !== false &&
+            typeof response?.body?.eventId === "number"
+        ) {
+            createdEventIds.push(response.body.eventId);
+        }
+    };
+
     describe("GET /api/events/audit/stuck", () => {
         it("returns a count + events array", () => {
             cy.makePrivateAdminAPICall("GET", "/api/events/audit/stuck", null, 200).then(
@@ -70,6 +98,7 @@ describe("API Event Audit Endpoints", () => {
             ).then((createResp) => {
                 const eventId = createResp.body.eventId;
                 expect(eventId).to.be.a("number");
+                trackQuickCreated(createResp);
 
                 // 2. Check person 1 in (no checkout). The event is active by
                 // default so the inactive guard does NOT apply.

--- a/cypress/e2e/api/private/standard/private.calendar.events-checkin.spec.js
+++ b/cypress/e2e/api/private/standard/private.calendar.events-checkin.spec.js
@@ -15,6 +15,36 @@ describe("API Event Check-in Endpoints", () => {
     // No browser login — these are pure API tests using x-api-key auth
     // (cy.makePrivateAdminAPICall sets the header for us).
 
+    // Every event this spec creates, so after() can remove them again (#9769).
+    // Without this the spec left 7 events and 10 attendance rows in the
+    // database on every run. Deleting an event cascades its event_attend and
+    // calendar_events rows, so the events list is all that needs tracking.
+    const createdEventIds = [];
+
+    // Only events are tracked. Checking a person in or out also writes a note on
+    // that person's timeline (Event::addTimelineNote()), but that note is the
+    // person's attendance history: it deliberately outlives the event and no
+    // API removes it, which is why the row-count guard reports note_nte rather
+    // than failing on it (#9769).
+    after(() => {
+        cy.cleanupEvents(createdEventIds);
+    });
+
+    /**
+     * Record an event for cleanup, but only when the API actually created one:
+     * POST /events/quick-create returns `created: false` and the existing
+     * event's id when one already exists for that date+type, and deleting that
+     * would destroy a row the spec did not create.
+     */
+    const trackQuickCreated = (response) => {
+        if (
+            response?.body?.created !== false &&
+            typeof response?.body?.eventId === "number"
+        ) {
+            createdEventIds.push(response.body.eventId);
+        }
+    };
+
     describe("GET /api/events", () => {
         it("Returns the events list wrapped in an Events array", () => {
             // Make sure at least one event exists so the response shape is meaningful
@@ -23,7 +53,7 @@ describe("API Event Check-in Endpoints", () => {
                 "/api/events/quick-create",
                 { eventTypeId: 1 },
                 200,
-            );
+            ).then(trackQuickCreated);
 
             cy.makePrivateAdminAPICall("GET", "/api/events", null, 200).then((response) => {
                 expect(response.body).to.have.property("Events");
@@ -59,6 +89,7 @@ describe("API Event Check-in Endpoints", () => {
             ).then((response) => {
                 expect(response.body).to.have.property("eventId");
                 expect(response.body.eventId).to.be.a("number");
+                trackQuickCreated(response);
                 expect(response.body).to.have.property("title");
                 expect(response.body.title).to.be.a("string");
                 expect(response.body).to.have.property("created");
@@ -82,6 +113,7 @@ describe("API Event Check-in Endpoints", () => {
                     200,
                 ).then((second) => {
                     expect(second.body.eventId).to.equal(first.body.eventId);
+                    trackQuickCreated(first);
                     expect(second.body.created).to.be.false;
                 });
             });
@@ -95,6 +127,7 @@ describe("API Event Check-in Endpoints", () => {
                 200,
             ).then((response) => {
                 expect(response.body).to.have.property("eventId");
+                trackQuickCreated(response);
                 // Title uses event type name (not group name) when an event type is auto-detected
                 expect(response.body.title).to.be.a("string").and.not.be.empty;
             });
@@ -138,7 +171,8 @@ describe("API Event Check-in Endpoints", () => {
                 "/api/events/quick-create",
                 { eventTypeId: 1 },
                 200,
-            ).then(() => {
+            ).then((createResponse) => {
+                trackQuickCreated(createResponse);
                 cy.makePrivateAdminAPICall(
                     "GET",
                     "/api/events/today",
@@ -185,6 +219,7 @@ describe("API Event Check-in Endpoints", () => {
             ).then((response) => {
                 expect(response.body).to.have.property("eventId");
                 testEventId = response.body.eventId;
+                trackQuickCreated(response);
             });
         });
 
@@ -435,6 +470,7 @@ describe("API Event Check-in Endpoints", () => {
                 expect(response.body.events.length).to.equal(
                     response.body.created,
                 );
+                createdEventIds.push(...response.body.events.map((e) => e.id));
 
                 if (response.body.events.length > 0) {
                     const evt = response.body.events[0];
@@ -460,6 +496,7 @@ describe("API Event Check-in Endpoints", () => {
                 { eventTypeId: 1, startDate, endDate, skipExisting: true },
                 200,
             ).then((first) => {
+                createdEventIds.push(...(first.body.events || []).map((e) => e.id));
                 cy.makePrivateAdminAPICall(
                     "POST",
                     "/api/events/generate-recurring",
@@ -559,6 +596,7 @@ describe("API Event Check-in Endpoints", () => {
             ).then((response) => {
                 expect(response.body).to.have.property("eventId");
                 eventId = response.body.eventId;
+                trackQuickCreated(response);
             });
         });
 
@@ -639,6 +677,7 @@ describe("API Event Check-in Endpoints", () => {
             ).then((response) => {
                 expect(response.body).to.have.property("eventId");
                 eventId = response.body.eventId;
+                trackQuickCreated(response);
                 // Check someone in so we have an attendance record to delete
                 cy.makePrivateAdminAPICall(
                     "POST",

--- a/cypress/e2e/api/private/standard/private.calendar.repeat-events.spec.js
+++ b/cypress/e2e/api/private/standard/private.calendar.repeat-events.spec.js
@@ -8,6 +8,14 @@ describe("API Repeat Events", () => {
     // No browser login — these are pure API tests using x-api-key auth
     // (cy.makePrivateAdminAPICall sets the header for us).
 
+    // Every event this spec creates, so after() can remove them again (#9769).
+    // Without this the spec left 22 events in the database on every run.
+    const createdEventIds = [];
+
+    after(() => {
+        cy.cleanupEvents(createdEventIds);
+    });
+
     describe("POST /api/events/repeat", () => {
         // Use eventTypeId 1 (the seeded "Church Service" type) the same way
         // the other passing event API specs do, instead of fetching it.
@@ -42,6 +50,7 @@ describe("API Repeat Events", () => {
                 expect(response.body.count).to.be.at.least(0);
                 expect(response.body.eventIds).to.be.an("array");
                 expect(response.body.eventIds.length).to.equal(response.body.count);
+                createdEventIds.push(...response.body.eventIds);
             });
         });
 
@@ -66,6 +75,7 @@ describe("API Repeat Events", () => {
                 // Monthly on 1st Jan–Dec = 12 events
                 expect(response.body.count).to.equal(12);
                 expect(response.body.eventIds.length).to.equal(12);
+                createdEventIds.push(...response.body.eventIds);
             });
         });
 
@@ -89,6 +99,7 @@ describe("API Repeat Events", () => {
                 expect(response.body.success).to.be.true;
                 // Yearly on Dec 25, 2020-2025 = 6 events
                 expect(response.body.count).to.equal(6);
+                createdEventIds.push(...response.body.eventIds);
             });
         });
 

--- a/cypress/e2e/api/private/standard/private.calendar.timezone.spec.js
+++ b/cypress/e2e/api/private/standard/private.calendar.timezone.spec.js
@@ -20,6 +20,43 @@ describe("API Calendar - Timezone Round-trip", () => {
     // event specs, avoids a dependency on type-listing order.
     const eventTypeId = 1;
 
+    // Every event this spec creates, so after() can remove them again (#9769).
+    // Without this the spec left 6 events and a pinned calendar row behind on
+    // every run. Deleting the event cascades its calendar_events row.
+    const createdEventIds = [];
+
+    after(() => {
+        cy.cleanupEvents(createdEventIds);
+    });
+
+    /**
+     * Record an event for cleanup, but only when the API actually created one:
+     * POST /events/quick-create returns `created: false` and the existing
+     * event's id when one already exists for that date+type, and deleting that
+     * would destroy a row the spec did not create.
+     */
+    const trackQuickCreated = (response) => {
+        if (
+            response?.body?.created !== false &&
+            typeof response?.body?.eventId === "number"
+        ) {
+            createdEventIds.push(response.body.eventId);
+        }
+    };
+
+    /**
+     * POST /api/events/ returns only {success:true}, so resolve the id the
+     * same way the rest of the event specs do — by title, off the listing.
+     */
+    const trackEventByTitle = (title) =>
+        cy.makePrivateAdminAPICall("GET", "/api/events/", null, 200).then((resp) => {
+            const match = resp.body.Events.find((e) => e.Title === title);
+            if (match) {
+                createdEventIds.push(match.Id);
+            }
+            return match;
+        });
+
     /**
      * Extract the HH:MM:SS component from a datetime string that may be
      * either "YYYY-MM-DD HH:MM:SS" (Propel toArray default for naive columns)
@@ -76,9 +113,8 @@ describe("API Calendar - Timezone Round-trip", () => {
             );
 
             // Find the event we just created and verify its stored times
-            cy.makePrivateAdminAPICall("GET", "/api/events/", null, 200).then(
-                (resp) => {
-                    const mine = resp.body.Events.find((e) => e.Title === title);
+            trackEventByTitle(title).then(
+                (mine) => {
                     expect(mine, `event "${title}" must exist in /api/events`).to.exist;
 
                     // Date component must match exactly — no overflow into
@@ -106,6 +142,7 @@ describe("API Calendar - Timezone Round-trip", () => {
             ).then((createResp) => {
                 const eventId = createResp.body.eventId;
                 expect(eventId).to.be.a("number");
+                trackQuickCreated(createResp);
 
                 cy.makePrivateAdminAPICall(
                     "GET",
@@ -164,6 +201,7 @@ describe("API Calendar - Timezone Round-trip", () => {
                 expect(resp.body.count).to.equal(3);
                 const ids = resp.body.eventIds;
                 expect(ids).to.have.length(3);
+                createdEventIds.push(...ids);
 
                 // Check each occurrence preserves the 09:00 / 10:30 contract.
                 ids.forEach((id) => {
@@ -231,6 +269,8 @@ describe("API Calendar - Timezone Round-trip", () => {
                 },
                 200,
             );
+
+            trackEventByTitle(title);
 
             const rangeStart = "2030-08-01";
             const rangeEnd = "2030-08-31";

--- a/cypress/e2e/api/private/standard/private.notes.spec.js
+++ b/cypress/e2e/api/private/standard/private.notes.spec.js
@@ -17,6 +17,12 @@ describe("API Private Notes", () => {
         cy.setupAdminSession();
     });
 
+    // Every note this spec creates is deleted again. DELETE /api/note/{id}
+    // still writes a `delete-note` audit row onto the same timeline in its
+    // place, so note_nte does not come back to its seed count — that is the
+    // application's audit trail, not spec litter, which is why the row-count
+    // guard only reports note_nte rather than failing on it (#9769).
+
     // -----------------------------------------------------------------------
     // Person notes
     // -----------------------------------------------------------------------

--- a/cypress/e2e/api/private/standard/private.notes.visibility.spec.js
+++ b/cypress/e2e/api/private/standard/private.notes.visibility.spec.js
@@ -23,6 +23,12 @@
  *      Use this fixture whenever you need to test the "no Notes flag → 403" path.
  */
 describe("Notes Visibility Policy (#9036)", () => {
+
+    // Every note this spec creates is deleted again. DELETE /api/note/{id}
+    // still writes a `delete-note` audit row onto the same timeline in its
+    // place, so note_nte does not come back to its seed count — that is the
+    // application's audit trail, not spec litter, which is why the row-count
+    // guard only reports note_nte rather than failing on it (#9769).
     // Note IDs created in before() and cleaned up in after()
     const fixtures = {};
 

--- a/cypress/e2e/api/public/public.register.spec.js
+++ b/cypress/e2e/api/public/public.register.spec.js
@@ -1,6 +1,22 @@
 /// <reference types="cypress" />
 
 describe("API Public Registration", () => {
+    // The family the happy-path test registers, so after() can remove it and
+    // its member again (#9769) — a public registration is a real family+person
+    // write and used to be left behind on every run.
+    let registeredFamilyId;
+
+    after(() => {
+        if (registeredFamilyId) {
+            cy.makePrivateAdminAPICall(
+                "DELETE",
+                `/api/family/${registeredFamilyId}?deleteMembers=true`,
+                null,
+                [200, 404],
+            );
+        }
+    });
+
     it("Should allow family registration without authentication", () => {
         const testFamily = {
             Name: "Cypress Test Family",
@@ -35,6 +51,7 @@ describe("API Public Registration", () => {
         }).then((resp) => {
             expect(resp.status).to.eq(200);
             expect(resp.body).to.have.property('Id');
+            registeredFamilyId = resp.body.Id;
             expect(resp.body.Name).to.eq(testFamily.Name);
             expect(resp.body.Address1).to.eq(testFamily.Address1);
             expect(resp.body.Email).to.eq(testFamily.Email);

--- a/cypress/e2e/ui-admin/admin.csvimport.spec.js
+++ b/cypress/e2e/ui-admin/admin.csvimport.spec.js
@@ -34,6 +34,58 @@ describe(
             freshAdminLogin();
         });
 
+        // The importer creates real people and families, and nothing used to
+        // remove them — one pass left 22 people and 8 families behind (#9769).
+        // Every fixture gives its rows a distinctive LastName, so the imported
+        // records can be found again and deleted by family (which takes the
+        // members with it) and then by person for anyone unaffiliated.
+        const IMPORTED_LAST_NAMES = [
+            "ImportTest",
+            "ExtTest",
+            "ExtSfxTest",
+            "BareYrTest",
+            "CountryTest",
+            "ClsRoleTest",
+        ];
+
+        after(() => {
+            const personIds = [];
+
+            IMPORTED_LAST_NAMES.forEach((lastName) => {
+                cy.makePrivateAdminAPICall(
+                    "GET",
+                    `/api/persons/search/${lastName}`,
+                    null,
+                    200,
+                ).then((resp) => {
+                    (resp.body || []).forEach((hit) => {
+                        if (hit.objid) {
+                            personIds.push(hit.objid);
+                        }
+                    });
+                });
+            });
+
+            cy.then(() => {
+                const familyIds = [];
+                personIds.forEach((personId) => {
+                    cy.makePrivateAdminAPICall("GET", `/api/person/${personId}`, null, [
+                        200, 404,
+                    ]).then((resp) => {
+                        const familyId = Number(resp.body?.FamId || 0);
+                        if (familyId > 0 && !familyIds.includes(familyId)) {
+                            familyIds.push(familyId);
+                        }
+                    });
+                });
+
+                cy.then(() => {
+                    cy.cleanupFamilies(familyIds);
+                    cy.cleanupPeople(personIds);
+                });
+            });
+        });
+
         it("Verify CSV Import", () => {
             cy.visit("admin/import/csv");
             // Attach file to the hidden file input (force needed since it's d-none)

--- a/cypress/e2e/ui-admin/admin.event.types.spec.js
+++ b/cypress/e2e/ui-admin/admin.event.types.spec.js
@@ -3,6 +3,26 @@
 describe("Event Types Management", () => {
   const eventTypeName = "Test Event Type " + Date.now();
 
+  // Events these tests quick-create, removed again in after() so the seeded
+  // database does not grow with every run (#9769). Only ids the API reports as
+  // newly created are tracked: quick-create returns `created: false` and an
+  // existing event's id when one already exists for that date+type, and
+  // deleting that would remove a row the spec did not create.
+  const createdEventIds = [];
+
+  const trackQuickCreated = (response) => {
+    if (
+      response?.body?.created !== false &&
+      typeof response?.body?.eventId === "number"
+    ) {
+      createdEventIds.push(response.body.eventId);
+    }
+  };
+
+  after(() => {
+    cy.cleanupEvents(createdEventIds);
+  });
+
   beforeEach(() => {
     cy.setupAdminSession();
   });
@@ -46,7 +66,7 @@ describe("Event Types Management", () => {
       "/api/events/quick-create",
       { eventTypeId: 1 },
       200,
-    );
+    ).then(trackQuickCreated);
 
     // cy.request / makePrivateAdminAPICall resets the PHP session; use the
     // canonical session-cache command with forceLogin to re-establish a
@@ -67,7 +87,7 @@ describe("Event Types Management", () => {
       "/api/events/quick-create",
       { eventTypeId: 1 },
       200,
-    );
+    ).then(trackQuickCreated);
 
     // cy.request / makePrivateAdminAPICall resets the PHP session; use the
     // canonical session-cache command with forceLogin to re-establish a
@@ -90,7 +110,7 @@ describe("Event Types Management", () => {
       "/api/events/quick-create",
       { eventTypeId: 1 },
       200,
-    );
+    ).then(trackQuickCreated);
 
     // cy.request / makePrivateAdminAPICall resets the PHP session; use the
     // canonical session-cache command with forceLogin to re-establish a

--- a/cypress/e2e/ui-admin/admin.events.dashboard.spec.js
+++ b/cypress/e2e/ui-admin/admin.events.dashboard.spec.js
@@ -10,6 +10,12 @@
  * data being populated, only on the seeded event types being present
  * (which the other passing event specs also rely on).
  */
+// Events createTestEvent() actually created, removed again in after() so the
+// seeded database does not grow with every run (#9769). quick-create returns
+// `created: false` and an existing event's id when one already exists for that
+// date+type, so only genuinely new ids are tracked.
+const createdEventIds = [];
+
 function createTestEvent(callback) {
     cy.makePrivateAdminAPICall(
         "POST",
@@ -18,12 +24,20 @@ function createTestEvent(callback) {
         200,
     ).then((createResp) => {
         expect(createResp.body).to.have.property("eventId");
+        if (createResp.body.created !== false) {
+            createdEventIds.push(createResp.body.eventId);
+        }
         callback(createResp.body.eventId);
     });
 }
 
 describe("Events Dashboard (MVC)", () => {
     beforeEach(() => cy.setupAdminSession());
+
+    // Outermost suite — runs once every nested describe has finished.
+    after(() => {
+        cy.cleanupEvents(createdEventIds);
+    });
 
     it("should display the events dashboard with stat cards", () => {
         cy.visit("event/dashboard");

--- a/cypress/e2e/ui-admin/admin.events.past-archiving.spec.js
+++ b/cypress/e2e/ui-admin/admin.events.past-archiving.spec.js
@@ -47,6 +47,25 @@ describe("Past Events Archiving (#8849)", () => {
     let pastByDateEventId;
     let pastByInactiveEventId;
 
+    // Events this spec quick-creates, removed again in after() so the seeded
+    // database does not grow with every run (#9769). quick-create returns
+    // `created: false` and an existing event's id when one already exists for
+    // that date+type, so only genuinely new ids are tracked.
+    const createdEventIds = [];
+
+    const trackQuickCreated = (response) => {
+        if (
+            response?.body?.created !== false &&
+            typeof response?.body?.eventId === "number"
+        ) {
+            createdEventIds.push(response.body.eventId);
+        }
+    };
+
+    after(() => {
+        cy.cleanupEvents(createdEventIds);
+    });
+
     before(() => {
         // Create a future event — will appear in the "Current Events" section.
         // We create it for next year so it won't flip to "past" mid-run.
@@ -58,6 +77,7 @@ describe("Past Events Archiving (#8849)", () => {
         ).then((resp) => {
             expect(resp.body).to.have.property("eventId");
             currentEventId = resp.body.eventId;
+            trackQuickCreated(resp);
         });
 
         // Create an event for a past date (last month) — End < NOW.
@@ -69,6 +89,7 @@ describe("Past Events Archiving (#8849)", () => {
         ).then((resp) => {
             expect(resp.body).to.have.property("eventId");
             pastByDateEventId = resp.body.eventId;
+            trackQuickCreated(resp);
         });
 
         // Create another event for today then deactivate it — InActive = 1.
@@ -80,6 +101,7 @@ describe("Past Events Archiving (#8849)", () => {
         ).then((resp) => {
             expect(resp.body).to.have.property("eventId");
             pastByInactiveEventId = resp.body.eventId;
+            trackQuickCreated(resp);
 
             // Now deactivate it so it appears in the "past" section.
             cy.makePrivateAdminAPICall(

--- a/cypress/e2e/ui-admin/event-editor.spec.js
+++ b/cypress/e2e/ui-admin/event-editor.spec.js
@@ -7,6 +7,25 @@
  * live in cypress/e2e/ui/events/standard.calendar.spec.js.
  */
 describe("Event Editor page", () => {
+    // Titles the save tests use, so after() can look their ids up and remove
+    // them (#9769). The saves happen in the browser, so there is no response
+    // body to read an id out of; deleting an event cascades its
+    // calendar_events rows.
+    const createdEventTitles = [];
+
+    after(() => {
+        if (createdEventTitles.length === 0) {
+            return;
+        }
+        cy.makePrivateAdminAPICall("GET", "/api/events", null, 200).then((resp) => {
+            cy.cleanupEvents(
+                (resp.body.Events || [])
+                    .filter((e) => createdEventTitles.includes(e.Title))
+                    .map((e) => e.Id),
+            );
+        });
+    });
+
     beforeEach(() => {
         cy.setupAdminSession();
     });
@@ -98,7 +117,10 @@ describe("Event Editor page", () => {
 
         visitNewEditorForFirstType();
 
-        cy.get("#event-title-input").type(`No Calendar Page ${Date.now()}`);
+        const title = `No Calendar Page ${Date.now()}`;
+        createdEventTitles.push(title);
+
+        cy.get("#event-title-input").type(title);
         cy.get("#calendarsEmptyHint").should("be.visible");
 
         cy.get("#event-editor-save").click();
@@ -111,6 +133,7 @@ describe("Event Editor page", () => {
 
     it("persists InActive and LinkedGroupId when set in the Advanced section", () => {
         const title = `Advanced Persist ${Date.now()}`;
+        createdEventTitles.push(title);
         cy.intercept("POST", "**/api/events").as("createEvent");
 
         visitNewEditorForFirstType();
@@ -137,7 +160,10 @@ describe("Event Editor page", () => {
 
         visitNewEditorForFirstType();
 
-        cy.get("#event-title-input").type(`Default Type Page ${Date.now()}`);
+        const title = `Default Type Page ${Date.now()}`;
+        createdEventTitles.push(title);
+
+        cy.get("#event-title-input").type(title);
         cy.tomSelectByValue("#pinnedCalendarsSelect", "1");
         cy.get("#event-editor-save").click();
 

--- a/cypress/e2e/ui-admin/repeat-event-editor.spec.js
+++ b/cypress/e2e/ui-admin/repeat-event-editor.spec.js
@@ -1,6 +1,24 @@
 /// <reference types="cypress" />
 
 describe('Repeat Event Editor', () => {
+    // Titles the two generating tests use, so after() can look the generated
+    // occurrences up and remove them (#9769). Each submit creates several
+    // events sharing one title, and the form gives back no ids.
+    const createdEventTitles = [];
+
+    after(() => {
+        if (createdEventTitles.length === 0) {
+            return;
+        }
+        cy.makePrivateAdminAPICall('GET', '/api/events', null, 200).then((resp) => {
+            cy.cleanupEvents(
+                (resp.body.Events || [])
+                    .filter((e) => createdEventTitles.includes(e.Title))
+                    .map((e) => e.Id),
+            );
+        });
+    });
+
     beforeEach(() => {
         cy.setupAdminSession();
     });
@@ -69,6 +87,7 @@ describe('Repeat Event Editor', () => {
             cy.visit('/event/repeat-editor/' + typeId);
 
             const uniqueTitle = 'WeeklyRepeat' + Date.now();
+            createdEventTitles.push(uniqueTitle);
 
             cy.get('input[name="EventTitle"]').clear().type(uniqueTitle);
             cy.get('#StartTime').clear().type('09:00');
@@ -105,6 +124,7 @@ describe('Repeat Event Editor', () => {
             cy.visit('/event/repeat-editor/' + typeId);
 
             const uniqueTitle = 'AdditionalInfoRepeat' + Date.now();
+            createdEventTitles.push(uniqueTitle);
             const descBody = 'Weekly description body for Quill';
             const textBody = 'Sermon notes body for Quill';
 

--- a/cypress/e2e/ui/events/standard.calendar.spec.js
+++ b/cypress/e2e/ui/events/standard.calendar.spec.js
@@ -199,6 +199,42 @@ describe("Standard Calendar", () => {
  * admin session instead of the standard one used above.
  */
 describe("Standard Calendar — save (admin-session)", () => {
+    // The events and calendars these tests create through the UI, tracked by
+    // the unique titles they use so after() can look their ids up and remove
+    // them (#9769). The saves happen in the browser, so there is no response
+    // body to read an id out of.
+    const createdEventTitles = [];
+    const createdCalendarNames = [];
+
+    after(() => {
+        if (createdEventTitles.length > 0) {
+            cy.makePrivateAdminAPICall("GET", "/api/events", null, 200).then((resp) => {
+                const ids = (resp.body.Events || [])
+                    .filter((e) => createdEventTitles.includes(e.Title))
+                    .map((e) => e.Id);
+                cy.cleanupEvents(ids);
+            });
+        }
+
+        if (createdCalendarNames.length > 0) {
+            cy.makePrivateAdminAPICall("GET", "/api/calendars", null, 200).then((resp) => {
+                const calendars = Array.isArray(resp.body)
+                    ? resp.body
+                    : resp.body.Calendars || [];
+                calendars
+                    .filter((c) => createdCalendarNames.includes(c.Name))
+                    .forEach((c) => {
+                        cy.makePrivateAdminAPICall(
+                            "DELETE",
+                            `/api/calendars/${c.Id}`,
+                            null,
+                            [200, 404],
+                        );
+                    });
+            });
+        }
+    });
+
     beforeEach(() => {
         // Suppress Bootstrap/FullCalendar's null.focus() race: when the previous
         // test's closeModal() fires refreshAllFullCalendarSources(), FullCalendar
@@ -227,6 +263,7 @@ describe("Standard Calendar — save (admin-session)", () => {
      */
     it("New event saves successfully with a pinned calendar + default Event Type", () => {
         const title = "Default Type Test - " + Cypress._.random(0, 1e6);
+        createdEventTitles.push(title);
         cy.intercept("POST", "**/api/events").as("createEvent");
 
         cy.visit("event/calendars");
@@ -274,6 +311,7 @@ describe("Standard Calendar — save (admin-session)", () => {
      */
     it("New event saves without a pinned calendar (empty PinnedCalendars array)", () => {
         const title = "No Calendar Test - " + Cypress._.random(0, 1e6);
+        createdEventTitles.push(title);
         cy.intercept("POST", "**/api/events").as("createEvent");
 
         cy.visit("event/calendars");
@@ -311,6 +349,7 @@ describe("Standard Calendar — save (admin-session)", () => {
      */
     it("Additional Information is visible in the event viewer overlay", () => {
         const title = `TextViewTest ${Date.now()}`;
+        createdEventTitles.push(title);
         const descBody = "Service description body";
         const textBody = "Sermon notes body for Easter Sunday";
 
@@ -355,6 +394,7 @@ describe("Standard Calendar — save (admin-session)", () => {
 
     it("Create New Calendar", () => {
         const title = "Calendar: " + new Date().getTime();
+        createdCalendarNames.push(title);
 
         cy.visit("event/calendars");
         cy.contains("Calendar");
@@ -370,6 +410,8 @@ describe("Standard Calendar — save (admin-session)", () => {
     });
 
     it("InActive and LinkedGroupId flow into the POST /api/events payload", () => {
+        const title = `Modal Advanced ${Date.now()}`;
+        createdEventTitles.push(title);
         cy.intercept("POST", "**/api/events").as("createEvent");
 
         cy.visit("event/calendars");
@@ -379,7 +421,7 @@ describe("Standard Calendar — save (admin-session)", () => {
         // and cause input events to land on the wrong element, leaving event.Title
         // empty and the save button permanently disabled. trigger("input") fires the
         // input event listener that updates event.Title and calls fireValidity().
-        cy.get("#event-title-input").should("be.visible").invoke("val", `Modal Advanced ${Date.now()}`).trigger("input");
+        cy.get("#event-title-input").should("be.visible").invoke("val", title).trigger("input");
         cy.tomSelectByValue("#pinnedCalendarsSelect", "1");
 
         cy.get('[data-bs-target="#eventAdvancedFields"]').click();

--- a/cypress/e2e/ui/events/standard.event-detail.spec.js
+++ b/cypress/e2e/ui/events/standard.event-detail.spec.js
@@ -32,6 +32,32 @@ describe("Event Detail - Did Not Attend List", () => {
     let absentCount;        // number of members not checked in (set in before())
     let checkedInName;      // full name of the one checked-in member (set in before())
 
+    // The events this spec quick-creates, so after() can remove them again
+    // (#9769). Only ids the API reports as newly created are tracked:
+    // quick-create returns `created: false` and an existing event's id when one
+    // already exists for that date+type, and deleting that would destroy a row
+    // the spec did not create. Deleting an event cascades its event_attend and
+    // calendar_events rows.
+    const createdEventIds = [];
+
+    const trackQuickCreated = (response) => {
+        if (
+            response?.body?.created !== false &&
+            typeof response?.body?.eventId === "number"
+        ) {
+            createdEventIds.push(response.body.eventId);
+        }
+    };
+
+    after(() => {
+        cy.cleanupEvents(createdEventIds);
+    });
+
+    // Checking members in writes a note on each person's timeline
+    // (Event::addTimelineNote()). That note is the person's attendance history:
+    // it deliberately outlives the event and no API removes it — note_nte is
+    // only reported by the row-count guard, not failed on (#9769).
+
     before(() => {
         const yesterday = new Date();
         yesterday.setDate(yesterday.getDate() - 1);
@@ -48,6 +74,7 @@ describe("Event Detail - Did Not Attend List", () => {
         ).then((resp) => {
             expect(resp.body).to.have.property("eventId");
             pastGroupEventId = resp.body.eventId;
+            trackQuickCreated(resp);
 
             cy.makePrivateAdminAPICall(
                 "POST",
@@ -106,6 +133,7 @@ describe("Event Detail - Did Not Attend List", () => {
         ).then((resp) => {
             expect(resp.body).to.have.property("eventId");
             pastNoGroupEventId = resp.body.eventId;
+            trackQuickCreated(resp);
 
             cy.makePrivateAdminAPICall(
                 "POST",

--- a/cypress/e2e/ui/events/standard.events.spec.js
+++ b/cypress/e2e/ui/events/standard.events.spec.js
@@ -10,6 +10,16 @@
 describe("Standard User - Event Check-in", () => {
     let testEventId;
 
+    // Only set when the API reports the event as newly created: quick-create
+    // returns `created: false` and an existing event's id when one already
+    // exists for that date+type, and deleting that would remove a row the spec
+    // did not create (#9769).
+    let createdEventId;
+
+    after(() => {
+        cy.cleanupEvents(createdEventId ? [createdEventId] : []);
+    });
+
     before(() => {
         // Create the event we'll use throughout this suite via the admin API
         // (the standard user can't create events). We use eventTypeId: 1 — the
@@ -22,6 +32,9 @@ describe("Standard User - Event Check-in", () => {
         ).then((createResp) => {
             expect(createResp.body).to.have.property("eventId");
             testEventId = createResp.body.eventId;
+            if (createResp.body.created !== false) {
+                createdEventId = testEventId;
+            }
         });
     });
 

--- a/cypress/e2e/ui/guest/guest.family.reg.spec.js
+++ b/cypress/e2e/ui/guest/guest.family.reg.spec.js
@@ -1,6 +1,15 @@
 /// <reference types="cypress" />
 
 describe("Family Reg", () => {
+    // The family the registration test submits, so after() can remove it and
+    // its five members again (#9769). The id comes off the intercepted
+    // registration response — the UI only shows a confirmation dialog.
+    const registeredFamilyIds = [];
+
+    after(() => {
+        cy.cleanupFamilies(registeredFamilyIds);
+    });
+
     before(() => {
         // Ensure church name is "Main St. Cathedral" regardless of what other tests may have set.
         // admin.church-info.spec.js saves "Test Church" and does not restore it.
@@ -13,6 +22,7 @@ describe("Family Reg", () => {
     });
 
     it("Adam Family Registration", () => {
+        cy.intercept("POST", "**/api/public/register/family").as("registerFamily");
         cy.visit("external/register/");
         cy.contains("Main St. Cathedral");
 
@@ -68,6 +78,13 @@ describe("Family Reg", () => {
 
         // Step 3: Review and Submit
         cy.get("#submit-registration").click();
+
+        cy.wait("@registerFamily").then((interception) => {
+            const familyId = interception.response?.body?.Id;
+            if (familyId) {
+                registeredFamilyIds.push(familyId);
+            }
+        });
 
         // Verify success dialog with updated welcome message
         cy.get(".bootbox-body").should("contain", "We're so glad your family has joined us!");

--- a/cypress/e2e/ui/people/person.attendance.spec.js
+++ b/cypress/e2e/ui/people/person.attendance.spec.js
@@ -55,6 +55,15 @@ describe("Person Attendance History Tab", () => {
         // makePrivateAdminAPICall() authenticates via x-api-key alone — it needs no
         // browser session, so no login call here (see file header).
         cy.makePrivateAdminAPICall("POST", `/api/events/${EVENT_ID}/checkout`, { personId: PERSON_WITH_ATTENDANCE }, 200);
+        // Checking out only stamps a checkout date — the event_attend row
+        // stays, which used to leave one behind per run (#9769). This is what
+        // actually removes it.
+        cy.makePrivateAdminAPICall(
+            "DELETE",
+            `/api/events/${EVENT_ID}/attendance/${PERSON_WITH_ATTENDANCE}`,
+            null,
+            [200, 404],
+        );
     });
 
     context("Tab navigation", () => {

--- a/cypress/e2e/ui/people/standard.cart-to-family.spec.js
+++ b/cypress/e2e/ui/people/standard.cart-to-family.spec.js
@@ -26,11 +26,24 @@
  *     - fam_ID 1 = Campbell
  *
  * Test order is intentional — non-destructive tests run before T3/T4 which
- * assign persons to families (modifying their per_fam_ID permanently in this
- * test run).
+ * assign persons to families.
+ *
+ * Those assignments used to be permanent: the two families T3/T6 create stayed
+ * in the database and persons 27/36/37 kept their new per_fam_ID, so the spec
+ * only passed once per seeded database and every run added a family (#9769).
+ * after() now deletes the created families *without* deleteMembers — which
+ * unlinks their members back to per_fam_ID = 0 — and puts person 37 back to
+ * "Unassigned" through the person editor, since no API moves a person between
+ * families.
  */
 describe("Cart to Family — UI", () => {
     const ROUTE = "/people/cart/to-family";
+
+    /** Families created by T3/T6, removed in after(). */
+    const createdFamilyIds = [];
+
+    /** Seeded free people the destructive tests assign to a family. */
+    const REASSIGNED_PERSON_IDS = [37];
 
     /**
      * Direct form login — creates a fresh PHP session with local auth.
@@ -79,6 +92,36 @@ describe("Cart to Family — UI", () => {
         // an empty cart — no separate emptyCart() call is needed.
         freshAdminLogin();
     });
+
+    after(() => {
+        // No deleteMembers: DELETE /api/family/{id} unlinks the members instead
+        // of deleting them, which is exactly what restores persons 27 and 36.
+        createdFamilyIds.forEach((familyId) => {
+            cy.makePrivateAdminAPICall("DELETE", `/api/family/${familyId}`, null, [
+                200, 404,
+            ]);
+        });
+
+        // Person 37 was moved into the seeded Campbell family (fam_ID 1), which
+        // no endpoint can undo — put it back through the editor form.
+        REASSIGNED_PERSON_IDS.forEach((personId) => {
+            freshAdminLogin();
+            cy.visit(`/PersonEditor.php?PersonID=${personId}`);
+            cy.get("#familyId").select("0", { force: true });
+            cy.get("#FamilyRole").select("0", { force: true });
+            cy.get('button[name="PersonSubmit"]').click();
+            cy.url().should("contain", "people/view/");
+        });
+    });
+
+    /** Record the family id from the /people/family/{id} URL after a submit. */
+    const trackCreatedFamily = () =>
+        cy.location("pathname").then((pathname) => {
+            const match = pathname.match(/\/people\/family\/(\d+)/);
+            if (match) {
+                createdFamilyIds.push(Number.parseInt(match[1], 10));
+            }
+        });
 
     // ── T1: Empty cart → empty state ────────────────────────────────────────
     it("T1 — shows empty state when cart is empty", () => {
@@ -140,6 +183,7 @@ describe("Cart to Family — UI", () => {
         cy.get("#cartToFamilySubmit").click();
         // Redirected to the new family page
         cy.url().should("match", /\/people\/family\/\d+/);
+        trackCreatedFamily();
         // Cart is empty server-side
         getCart().then((resp) => {
             expect(resp.body.PeopleCart).to.deep.equal([]);
@@ -178,6 +222,7 @@ describe("Cart to Family — UI", () => {
         cy.get("#cartToFamilySubmit").click();
         // No 500 — redirect to new family page
         cy.url().should("match", /\/people\/family\/\d+/);
+        trackCreatedFamily();
         // Cart is empty
         getCart().then((resp) => {
             expect(resp.body.PeopleCart).to.deep.equal([]);

--- a/cypress/e2e/ui/people/standard.deceased-person.spec.js
+++ b/cypress/e2e/ui/people/standard.deceased-person.spec.js
@@ -13,17 +13,18 @@
  */
 
 describe("Deceased Person Flag", () => {
-    // Track created person IDs for deterministic cleanup (cannot search deceased via API)
+    // Track created person and family IDs for deterministic cleanup (deceased
+    // people cannot be found through the living-only search API).
     const createdPersonIds = [];
+    const createdFamilyIds = [];
 
     after(() => {
-        // Delete all persons created by this suite by ID (bypass living-only search filter)
-        createdPersonIds.forEach((personId) => {
-            cy.apiRequest({
-                method: "DELETE",
-                url: `/api/persons/${personId}`,
-            });
-        });
+        // Families first, so their members go with them; then any unaffiliated
+        // person left over. The previous cleanup posted to /api/persons/{id},
+        // which is not a route — every delete 404ed unnoticed and the whole
+        // suite's people stayed in the database (#9769).
+        cy.cleanupFamilies(createdFamilyIds);
+        cy.cleanupPeople(createdPersonIds);
     });
 
     beforeEach(() => cy.setupStandardSession());
@@ -248,6 +249,7 @@ describe("Deceased Person Flag", () => {
         cy.location("pathname")
             .then((p) => parseInt(p.match(/family\/(\d+)/)[1], 10))
             .then((familyId) => {
+                createdFamilyIds.push(familyId);
                 // family-view.php uses .card-table tables (not #members which is person-list.php)
                 cy.get("table.card-table tbody a[href*='/people/view/']", { timeout: 10000 }).then(($links) => {
                     [...$links].forEach((a) =>

--- a/cypress/e2e/ui/people/standard.family.spec.js
+++ b/cypress/e2e/ui/people/standard.family.spec.js
@@ -6,7 +6,9 @@
 // a spec file runs *after* the support file's own root after(), which is where
 // the row-count drift guard checks its snapshot; and the cleanup calls go out
 // with x-api-key, which flips the PHP session to APITokenAuthentication and
-// would send any later cy.visit() to the login page.
+// would send any later cy.visit() to the login page. A top-level afterEach()
+// flushes the list early when a test fails, for the runs that never reach that
+// last describe.
 const createdFamilyIds = [];
 
 /** Record the family id from the /people/family/{id} URL the editor lands on. */
@@ -18,6 +20,21 @@ function trackFamilyFromUrl() {
         }
     });
 }
+
+// Safety net for the end-of-file after() below. That hook only fires if the
+// runner reaches the last describe, which it does not when a suite-level hook
+// blows up or the run is started with --bail; the families created earlier
+// would then survive and the drift guard would fail the *next* run instead.
+// Flushing after a failed test costs nothing on the green path (the array is
+// only non-empty once a family has actually been created) and the following
+// beforeEach re-establishes the UI session through cy.session(), so the
+// x-api-key calls cannot leak into a later cy.visit().
+afterEach(function () {
+    if (this.currentTest?.state !== "failed" || createdFamilyIds.length === 0) {
+        return;
+    }
+    cy.cleanupFamilies(createdFamilyIds.splice(0));
+});
 
 describe("Standard Family", () => {
     beforeEach(() => cy.setupStandardSession());
@@ -172,6 +189,8 @@ describe("Family Editor — edit existing record (PR #9351 prepared-statement sm
 describe("Standard Family Activation", () => {
     // Last suite in the file — cleanup for every family the earlier suites
     // created happens here, so no cy.visit() follows the x-api-key calls.
+    // The top-level afterEach() above covers the case where the run never
+    // reaches this suite.
     after(() => {
         cy.cleanupFamilies(createdFamilyIds.splice(0));
     });

--- a/cypress/e2e/ui/people/standard.family.spec.js
+++ b/cypress/e2e/ui/people/standard.family.spec.js
@@ -1,5 +1,24 @@
 /// <reference types="cypress" />
 
+// Families these suites create through FamilyEditor, removed again when each
+// suite finishes so the seeded database does not grow with every run (#9769).
+// The hook lives inside the LAST describe on purpose. A root-level after() in
+// a spec file runs *after* the support file's own root after(), which is where
+// the row-count drift guard checks its snapshot; and the cleanup calls go out
+// with x-api-key, which flips the PHP session to APITokenAuthentication and
+// would send any later cy.visit() to the login page.
+const createdFamilyIds = [];
+
+/** Record the family id from the /people/family/{id} URL the editor lands on. */
+function trackFamilyFromUrl() {
+    cy.location("pathname").then((pathname) => {
+        const match = pathname.match(/\/people\/family\/(\d+)/);
+        if (match) {
+            createdFamilyIds.push(Number.parseInt(match[1], 10));
+        }
+    });
+}
+
 describe("Standard Family", () => {
     beforeEach(() => cy.setupStandardSession());
 
@@ -65,6 +84,7 @@ describe("Standard Family", () => {
 
         // Should redirect to family view page
         cy.location("pathname").should("include", "/people/family/");
+        trackFamilyFromUrl();
         // Page subtitle shows Family Profile
         cy.contains("Family Profile");
         // Family members table should show all members
@@ -112,6 +132,7 @@ describe("Family Wedding Date Edit Workflow", () => {
         cy.get('button[name="FamilySubmit"]').click();
 
         cy.location("pathname").should("include", "/people/family/");
+        trackFamilyFromUrl();
         cy.contains("Family Profile");
         cy.get("i.fa-ring").should("not.exist");
         cy.contains(familyName).should("exist");
@@ -149,6 +170,12 @@ describe("Family Editor — edit existing record (PR #9351 prepared-statement sm
 });
 
 describe("Standard Family Activation", () => {
+    // Last suite in the file — cleanup for every family the earlier suites
+    // created happens here, so no cy.visit() follows the x-api-key calls.
+    after(() => {
+        cy.cleanupFamilies(createdFamilyIds.splice(0));
+    });
+
     beforeEach(() => {
         // Reset family 3 to active BEFORE registering intercepts so the setup
         // call is not captured by @updateToActive — only UI-triggered requests

--- a/cypress/e2e/ui/people/standard.person.new.spec.js
+++ b/cypress/e2e/ui/people/standard.person.new.spec.js
@@ -3,7 +3,36 @@ const personViewPath = "people/view/";
 
 describe("Standard Person", () => {
     const uniqueSeed = Date.now().toString();
-    
+
+    // People this spec adds through PersonEditor, removed again in after() so
+    // the seeded database does not grow with every run (#9769). The third test
+    // also creates a family from the person's last name, and deleting a person
+    // does not take their family with them — so the family id is read back off
+    // each person before anything is deleted.
+    const createdPersonIds = [];
+
+    after(() => {
+        const familyIds = [];
+
+        createdPersonIds.forEach((personId) => {
+            cy.makePrivateAdminAPICall("GET", `/api/person/${personId}`, null, [
+                200, 404,
+            ]).then((resp) => {
+                const familyId = Number(resp.body?.FamId || 0);
+                if (familyId > 0) {
+                    familyIds.push(familyId);
+                }
+            });
+        });
+
+        cy.then(() => {
+            // deleteMembers takes the person with the family; whatever is left
+            // over is an unaffiliated person.
+            cy.cleanupFamilies(familyIds);
+            cy.cleanupPeople(createdPersonIds);
+        });
+    });
+
     beforeEach(() => cy.setupStandardSession());
 
     it("Add Full Person", () => {
@@ -25,6 +54,7 @@ describe("Standard Person", () => {
         cy.get('button[name="PersonSubmit"]').click();
 
         cy.url().should("contain", personViewPath);
+        cy.trackPersonFromUrl(createdPersonIds);
         cy.contains(name);
 
         // Re-open editor and verify the zero-padded month/day were saved correctly.
@@ -54,6 +84,7 @@ describe("Standard Person", () => {
         cy.get('button[name="PersonSubmit"]').click();
 
         cy.url().should("contain", personViewPath);
+        cy.trackPersonFromUrl(createdPersonIds);
         cy.contains(name);
 
         // make sure edit works - click Edit button in toolbar
@@ -90,6 +121,7 @@ describe("Standard Person", () => {
 
         // Should redirect to PersonView without error
         cy.url().should("contain", personViewPath);
+        cy.trackPersonFromUrl(createdPersonIds);
         cy.contains(firstName);
     });
 });

--- a/cypress/e2e/ui/people/standard.person.search.spec.js
+++ b/cypress/e2e/ui/people/standard.person.search.spec.js
@@ -2,7 +2,15 @@
 
 describe("Standard Person", () => {
     const uniqueSeed = Date.now().toString();
-    
+
+    // People this spec adds through PersonEditor, removed again in after()
+    // so the seeded database does not grow with every run (#9769).
+    const createdPersonIds = [];
+
+    after(() => {
+        cy.cleanupPeople(createdPersonIds);
+    });
+
     beforeEach(() => cy.setupStandardSession());
     
     it("Add Person only first and last name", () => {
@@ -14,6 +22,7 @@ describe("Standard Person", () => {
         cy.get('button[name="PersonSubmit"]').click();
 
         cy.url().should("contain", "people/view/");
+        cy.trackPersonFromUrl(createdPersonIds);
         cy.contains(name).should("be.visible");
     });
 
@@ -26,6 +35,7 @@ describe("Standard Person", () => {
         // Click FAB save button
         cy.get('button[name="PersonSubmit"]').click();
         cy.url().should("contain", "people/view/");
+        cy.trackPersonFromUrl(createdPersonIds);
         cy.contains(firstName).should("be.visible");
     });
 

--- a/cypress/e2e/ui/plugins/community-plugin-lifecycle.spec.js
+++ b/cypress/e2e/ui/plugins/community-plugin-lifecycle.spec.js
@@ -25,7 +25,9 @@ describe('Community Plugin Lifecycle', () => {
     after(() => {
         if (createdPersonId) {
             cy.setupAdminSession();
-            cy.makePrivateAdminAPICall('DELETE', `/api/people/${createdPersonId}`, null, [200, 204, 404]);
+            // /api/person/{id} — not /api/people/{id}, which does not exist and
+            // silently 404ed, leaving the person behind on every run (#9769).
+            cy.makePrivateAdminAPICall('DELETE', `/api/person/${createdPersonId}`, null, [200, 404]);
         }
     });
 

--- a/cypress/support/api-commands.js
+++ b/cypress/support/api-commands.js
@@ -267,3 +267,108 @@ Cypress.Commands.add(
         });
     },
 );
+
+// ---------------------------------------------------------------------------
+// Cleanup helpers (#9769)
+// ---------------------------------------------------------------------------
+
+/**
+ * Delete every event id in `eventIds`, so a spec can undo what it created.
+ *
+ * Deactivates first: DELETE /api/events/{id} refuses (409) to remove an active
+ * event that still has people checked in, which is exactly the state the
+ * check-in specs leave their events in. Deleting an event cascades its
+ * calendar_events, event_attend and event_audience rows via Event::preDelete().
+ *
+ * Ids that are already gone (404) are ignored, so the helper is safe to call
+ * from an after() hook that runs after a failed test.
+ *
+ * @param {Array<number|string>} eventIds
+ */
+Cypress.Commands.add("cleanupEvents", (eventIds) => {
+    const ids = (eventIds || []).filter((id) => Number.isFinite(Number(id)));
+    ids.forEach((eventId) => {
+        cy.makePrivateAdminAPICall(
+            "POST",
+            `/api/events/${eventId}/status`,
+            { active: false },
+            [200, 400, 403, 404],
+        );
+        cy.makePrivateAdminAPICall("DELETE", `/api/events/${eventId}`, null, [
+            200, 404, 409,
+        ]);
+    });
+});
+
+/**
+ * Delete every note id in `noteIds`.
+ *
+ * NOTE: DELETE /api/note/{id} writes a `delete-note` audit row for the
+ * timeline, so removing N notes leaves N audit rows behind — the note table
+ * cannot be returned to its exact seed count through the API. Specs that call
+ * this still declare the residue with cy.allowRowDrift("note_nte", …). The
+ * point of calling it is to take the spec's test *content* back off the
+ * person/family timelines, not to zero the row count.
+ *
+ * @param {Array<number|string>} noteIds
+ */
+Cypress.Commands.add("cleanupNotes", (noteIds) => {
+    const ids = (noteIds || []).filter((id) => Number.isFinite(Number(id)));
+    ids.forEach((noteId) => {
+        cy.makePrivateAdminAPICall("DELETE", `/api/note/${noteId}`, null, [
+            200, 403, 404,
+        ]);
+    });
+});
+
+/**
+ * Delete every person id in `personIds`.
+ *
+ * Ids that are already gone (404) are ignored, so the helper is safe to call
+ * from an after() hook that runs after a failed test.
+ *
+ * @param {Array<number|string>} personIds
+ */
+Cypress.Commands.add("cleanupPeople", (personIds) => {
+    const ids = (personIds || []).filter((id) => Number.isFinite(Number(id)));
+    ids.forEach((personId) => {
+        cy.makePrivateAdminAPICall("DELETE", `/api/person/${personId}`, null, [
+            200, 403, 404,
+        ]);
+    });
+});
+
+/**
+ * Delete every family id in `familyIds`, together with its members.
+ *
+ * @param {Array<number|string>} familyIds
+ */
+Cypress.Commands.add("cleanupFamilies", (familyIds) => {
+    const ids = (familyIds || []).filter((id) => Number.isFinite(Number(id)));
+    ids.forEach((familyId) => {
+        cy.makePrivateAdminAPICall(
+            "DELETE",
+            `/api/family/${familyId}?deleteMembers=true`,
+            null,
+            [200, 403, 404],
+        );
+    });
+});
+
+/**
+ * Record the person id out of the /people/view/{id} URL the legacy
+ * PersonEditor redirects to after a save, pushing it onto `collector` so an
+ * after() hook can clean it up (#9769).
+ *
+ * @param {Array<number>} collector
+ */
+Cypress.Commands.add("trackPersonFromUrl", (collector) => {
+    return cy.url().then((url) => {
+        const match = url.match(/\/people\/view\/(\d+)/);
+        const personId = match ? Number.parseInt(match[1], 10) : null;
+        if (personId) {
+            collector.push(personId);
+        }
+        return personId;
+    });
+});

--- a/cypress/support/commands.d.ts
+++ b/cypress/support/commands.d.ts
@@ -301,5 +301,53 @@ declare namespace Cypress {
      * @param localeValue - The locale field value from locales.json
      */
     setupLocaleAdminSession(localeValue: string): Chainable<void>;
+
+    /**
+     * Deactivate then delete each event id, ignoring ids that are already
+     * gone. Use from an after() hook so a spec removes the events it created
+     * (#9769). Deleting an event cascades its calendar_events, event_attend
+     * and event_audience rows.
+     * @param eventIds - Event ids to remove
+     */
+    cleanupEvents(eventIds: Array<number | string>): Chainable<void>;
+
+    /**
+     * Delete each note id, ignoring ids that are already gone (#9769).
+     * DELETE /api/note/{id} writes a `delete-note` audit row, so this takes
+     * the spec's content off the timeline but does not restore the row count —
+     * pair it with cy.allowRowDrift("note_nte", …).
+     * @param noteIds - Note ids to remove
+     */
+    cleanupNotes(noteIds: Array<number | string>): Chainable<void>;
+
+    /**
+     * Declare that this spec file cannot fully restore `table`, so the
+     * row-count drift guard in cypress/support/e2e.js tolerates up to
+     * `maxDelta` extra rows. Call it from the spec's own before() hook.
+     * @param table - Guarded table name, e.g. "note_nte"
+     * @param maxDelta - Maximum number of rows the spec may leave behind
+     * @param reason - Why the rows cannot be removed (required)
+     */
+    allowRowDrift(table: string, maxDelta: number, reason: string): Chainable<void>;
+
+    /**
+     * Delete each person id, ignoring ids that are already gone (#9769).
+     * @param personIds - Person ids to remove
+     */
+    cleanupPeople(personIds: Array<number | string>): Chainable<void>;
+
+    /**
+     * Delete each family id together with its members, ignoring ids that are
+     * already gone (#9769).
+     * @param familyIds - Family ids to remove
+     */
+    cleanupFamilies(familyIds: Array<number | string>): Chainable<void>;
+
+    /**
+     * Read the person id out of the current /people/view/{id} URL and push it
+     * onto `collector` for an after() hook to clean up (#9769).
+     * @param collector - Array the id is appended to
+     */
+    trackPersonFromUrl(collector: number[]): Chainable<number | null>;
   }
 }

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -74,3 +74,112 @@ if (!app.document.head.querySelector('[data-hide-command-log-request]')) {
   style.setAttribute('data-hide-command-log-request', '');
   app.document.head.appendChild(style);
 }
+
+// ---------------------------------------------------------------------------
+// Test-database drift guard (#9769)
+// ---------------------------------------------------------------------------
+//
+// Several specs used to create events and notes and never remove them, so a
+// local dev database grew by dozens of events and hundreds of notes per run
+// (CI never noticed because every job seeds a fresh database). These hooks
+// snapshot a handful of row counts before each spec file and fail the spec
+// file if it finished with more rows than it started with.
+//
+// The counts come from the `rowCounts` task registered by
+// cypress/configs/row-count-guard.ts. Only the three docker configs register
+// it; the new-system / locale / upgrade configs deliberately do not, because
+// those suites reseed the database or import demo data on purpose. When the
+// task is absent (or the database is unreachable) the guard disables itself.
+//
+// A spec that genuinely cannot restore a table declares the shortfall itself:
+//
+//   before(() => {
+//       cy.allowRowDrift("family_fam", 1, "reason the row cannot be removed");
+//   });
+//
+// Anything beyond a declared allowance fails, naming the table and the delta.
+//
+// note_nte is the one exception: it is an append-only timeline that the
+// application writes to on nearly every person/family write (an edit, a photo
+// upload, a check-in, even deleting a note leaves a `delete-note` row), and no
+// endpoint removes those rows. Growth there is reported in the Cypress log but
+// never fails a spec — see SOFT_TABLES in cypress/configs/row-count-guard.ts.
+
+const rowGuard = {
+    enabled: false,
+    baseline: null,
+    allowances: {},
+};
+
+Cypress.Commands.add("allowRowDrift", (table, maxDelta, reason) => {
+    if (!reason) {
+        throw new Error(
+            `cy.allowRowDrift("${table}", ${maxDelta}) needs a reason — the allowance is a documented exception, not a mute button`,
+        );
+    }
+    rowGuard.allowances[table] = { maxDelta, reason };
+});
+
+before(function () {
+    rowGuard.enabled = false;
+    rowGuard.baseline = null;
+    rowGuard.allowances = {};
+
+    if (!Cypress.env("rowCountGuard")) {
+        return;
+    }
+
+    cy.task("rowCounts", null, { log: false }).then((result) => {
+        if (!result || !result.available) {
+            // Fail-soft: a database we cannot reach must not fail every spec.
+            cy.log(`Row-count guard disabled: ${result ? result.reason : "no result"}`);
+            return;
+        }
+        rowGuard.enabled = true;
+        rowGuard.baseline = result.counts;
+    });
+});
+
+after(function () {
+    if (!rowGuard.enabled || !rowGuard.baseline) {
+        return;
+    }
+
+    const baseline = rowGuard.baseline;
+    const allowances = rowGuard.allowances;
+
+    cy.task("rowCounts", null, { log: false }).then((result) => {
+        if (!result || !result.available) {
+            return;
+        }
+
+        const softTables = result.softTables || [];
+        const offenders = [];
+        Object.keys(baseline).forEach((table) => {
+            const delta = result.counts[table] - baseline[table];
+            const allowance = allowances[table];
+            const allowed = allowance ? allowance.maxDelta : 0;
+            if (delta <= allowed) {
+                return;
+            }
+            const description =
+                `${table}: +${delta} row(s) (${baseline[table]} -> ${result.counts[table]}` +
+                (allowance ? `, declared allowance ${allowed}: ${allowance.reason}` : "") +
+                ")";
+            if (softTables.includes(table)) {
+                cy.log(`Row-count guard (reported, not failed): ${description}`);
+            } else {
+                offenders.push(description);
+            }
+        });
+
+        if (offenders.length > 0) {
+            throw new Error(
+                `This spec file left rows behind in the test database (#9769).\n` +
+                    `${offenders.join("\n")}\n` +
+                    "Delete what the spec creates in an after()/afterEach() hook, or declare the " +
+                    "shortfall with cy.allowRowDrift(table, maxDelta, reason).",
+            );
+        }
+    });
+});

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -155,6 +155,7 @@ after(function () {
 
         const softTables = result.softTables || [];
         const offenders = [];
+        const reported = [];
         Object.keys(baseline).forEach((table) => {
             const delta = result.counts[table] - baseline[table];
             const allowance = allowances[table];
@@ -167,16 +168,37 @@ after(function () {
                 (allowance ? `, declared allowance ${allowed}: ${allowance.reason}` : "") +
                 ")";
             if (softTables.includes(table)) {
-                cy.log(`Row-count guard (reported, not failed): ${description}`);
+                reported.push(description);
             } else {
                 offenders.push(description);
             }
         });
 
+        // Cypress.log() writes to the command log synchronously. cy.log() only
+        // *enqueues* a command, and everything enqueued inside this callback is
+        // abandoned the instant the throw below fires — so a spec that tripped a
+        // soft and a hard table in the same run used to lose the soft
+        // diagnostics entirely.
+        reported.forEach((description) => {
+            Cypress.log({
+                name: "row-count-guard",
+                displayName: "row-count-guard",
+                message: `reported, not failed: ${description}`,
+            });
+        });
+
         if (offenders.length > 0) {
+            // The soft-table drift is repeated here as well: the command log is
+            // easy to miss next to a failure, and the error message is what ends
+            // up in CI output.
+            const alsoReported =
+                reported.length > 0
+                    ? `Also reported (soft tables, not failed):\n${reported.join("\n")}\n`
+                    : "";
             throw new Error(
                 `This spec file left rows behind in the test database (#9769).\n` +
                     `${offenders.join("\n")}\n` +
+                    alsoReported +
                     "Delete what the spec creates in an after()/afterEach() hook, or declare the " +
                     "shortfall with cy.allowRowDrift(table, maxDelta, reason).",
             );


### PR DESCRIPTION
## What Changed
The issue named four leaking specs; measuring every spec file individually found 23 across the api, ui and ui-admin suites, including three that already tried to clean up but silently failed (two deleted through routes that do not exist, two "cleaned up" attendance by checking out, which only stamps a date). Every spec now tracks what it creates and removes it through `cy.cleanupEvents / cleanupNotes / cleanupPeople / cleanupFamilies`, which accept only a successful delete (200) or an already-absent record (404) and then **re-read every id and fail unless it is gone** — a 400/403/409 is a failed cleanup, not evidence of absence.

A row-count guard (`cypress/configs/row-count-guard.ts`, a read-only `rowCounts` task registered by the three docker configs, plus root `before()/after()` hooks in `cypress/support/e2e.js`) snapshots `events_event`, `event_attend`, `calendar_events`, `person_per`, `family_fam` and `note_nte` per spec file and fails the file naming the table and the delta when the count **grew** (leaked rows) or **shrank** (seeded rows deleted). `cy.allowRowDrift(table, max, reason)` is the documented escape hatch and only covers growth: the accepted delta is `[0, max]`. `note_nte` growth is reported (Cypress command log + a `[row-count-guard]` line on the terminal so it shows in CI output) but not enforced: the app writes audit notes on nearly every person/family write and `DELETE /api/note/{id}` writes a replacement audit row, so that table cannot return to seed by design; shrinkage of `note_nte` still fails.

The guard is **required**: a snapshot it cannot take — opening or closing — fails the spec with a connection error naming host/port/database and how to fix it, instead of silently switching off. Every CI job (`build-test-package.yml` and `build-test-nightly.yml`, root and subdirectory) sets `ROW_GUARD_DB_PORT` to the port its database is actually published on (`3306` for `ci-root`, `3307` = `DATABASE_SUBDIR_PORT` for `ci-subdir`) plus `ROW_GUARD_REQUIRED=1`. A local run may opt out explicitly with `ROW_GUARD_DISABLED=1`; `ROW_GUARD_REQUIRED=1` makes that opt-out ineffective.

Limitation, stated in the code: `COUNT(*)` is an aggregate, so one leaked row replacing one deleted seeded row in the same spec is invisible to the guard. The per-id re-read in the cleanup helpers covers the rows a spec knows about; the guard cannot tell one row from another.

Quick-create sites check the `created` flag before tracking an id, since the endpoint returns an existing event's id when one already matches.

Fixes #9769

## Type
- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [x] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
Original pass (each suite from `docker:dev:reset:db`, seed 3 events / 1 attend / 3 pins / 123 people / 21 families): api suite went from +47 events, +10 attend, +1 pin, +1 person, +1 family and 12 guard failures to exactly seed with 666/666 passing; ui from +26 people, +5 families, +1 attend, +1 event to exactly seed, 759 tests, 0 failing; ui-admin from +22 people, +8 families, +11 events, +2 pins to exactly seed, 282/282.

Review pass (after merging master, on an isolated docker stack with `ROW_GUARD_DB_PORT` + `ROW_GUARD_REQUIRED=1`, i.e. the CI wiring): the touched specs pass — api 124/124 (9 files), ui 86/86 (11 files), ui-admin 39/39 (5 files) — and the guard caught one real leak the merge brought in (`standard.event-detail.spec.js`, "Responsive Actions" from #9854, fixed here). The row counts after the runs matched the seed exactly. The failure modes the review asked for were each demonstrated on the same stack (leaked row, unavailable opening/closing snapshot, cleanup 403 and 409, deleted seeded row) — see the follow-up comment for the exact output.

## Pre-Merge
- [x] Tested locally
- [x] No new warnings
- [x] Build passes
- [x] Backward compatible (or migration documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
