### PR TITLE
Fix issue #9771: Return 400, not 413, for complete photo bodies that lack imgBase64

### DIFF
--- a/cypress/e2e/api/private/standard/private.people.family.photo.spec.js
+++ b/cypress/e2e/api/private/standard/private.people.family.photo.spec.js
@@ -217,6 +217,25 @@ describe("API Private Photo and Avatar - Family", () => {
                 expect(response.body).to.have.property("message");
             });
         });
+
+        it("should reject an oversized body with no image data with 400, not 413", () => {
+            // Regression for #9771. The 413 branch is only for a body PHP threw
+            // away for being larger than the server accepts. This body arrives
+            // complete and simply has no imgBase64, so it is a malformed request.
+            // 3 MB is well over the 2 MB upload_max_filesize the project's PHP
+            // images set — the value the handler compared Content-Length against —
+            // and far under their 2 GB post_max_size, so PHP receives and parses
+            // it in full.
+            cy.makePrivateAdminAPICall(
+                "POST",
+                `/api/family/${testFamilyId}/photo`,
+                JSON.stringify({ notImgBase64: "a".repeat(3 * 1024 * 1024) }),
+                400
+            ).then((response) => {
+                expect(response.body.success).to.eq(false);
+                expect(response.body.message).to.include("Missing image data");
+            });
+        });
     });
 
     describe("DELETE /api/family/{id}/photo", () => {

--- a/cypress/e2e/api/private/standard/private.people.family.photo.spec.js
+++ b/cypress/e2e/api/private/standard/private.people.family.photo.spec.js
@@ -236,6 +236,26 @@ describe("API Private Photo and Avatar - Family", () => {
                 expect(response.body.message).to.include("Missing image data");
             });
         });
+
+        it("should reject an oversized unparseable body with 400, not 413", () => {
+            // Regression for #9771, second path: the body arrives in full but
+            // BodyParsingMiddleware cannot decode it, so getParsedBody() is null
+            // and the decision falls to the raw body. slim/psr7 caches
+            // php://input, so the bytes are still readable after the middleware
+            // consumed them and the handler can tell "arrived but unparseable"
+            // (400) from "never arrived" (413). Sent as invalid JSON under
+            // Content-Type: application/json, over 2 MB so Content-Length alone
+            // would have produced a 413.
+            cy.makePrivateAdminAPICall(
+                "POST",
+                `/api/family/${testFamilyId}/photo`,
+                '{"notImgBase64": "' + "a".repeat(3 * 1024 * 1024),
+                400
+            ).then((response) => {
+                expect(response.body.success).to.eq(false);
+                expect(response.body.message).to.include("Missing image data");
+            });
+        });
     });
 
     describe("DELETE /api/family/{id}/photo", () => {

--- a/cypress/e2e/api/private/standard/private.people.photo.spec.js
+++ b/cypress/e2e/api/private/standard/private.people.photo.spec.js
@@ -269,6 +269,26 @@ describe("API Private Photo and Avatar - Person", () => {
                 expect(response.body.message).to.include("Missing image data");
             });
         });
+
+        it("should reject an oversized unparseable body with 400, not 413", () => {
+            // Regression for #9771, second path: the body arrives in full but
+            // BodyParsingMiddleware cannot decode it, so getParsedBody() is null
+            // and the decision falls to the raw body. slim/psr7 caches
+            // php://input, so the bytes are still readable after the middleware
+            // consumed them and the handler can tell "arrived but unparseable"
+            // (400) from "never arrived" (413). Sent as invalid JSON under
+            // Content-Type: application/json, over 2 MB so Content-Length alone
+            // would have produced a 413.
+            cy.makePrivateAdminAPICall(
+                "POST",
+                `/api/person/${testPersonId}/photo`,
+                '{"notImgBase64": "' + "a".repeat(3 * 1024 * 1024),
+                400
+            ).then((response) => {
+                expect(response.body.success).to.eq(false);
+                expect(response.body.message).to.include("Missing image data");
+            });
+        });
     });
 
     describe("DELETE /api/person/{id}/photo", () => {

--- a/cypress/e2e/api/private/standard/private.people.photo.spec.js
+++ b/cypress/e2e/api/private/standard/private.people.photo.spec.js
@@ -250,6 +250,25 @@ describe("API Private Photo and Avatar - Person", () => {
                 expect(response.body).to.have.property("message");
             });
         });
+
+        it("should reject an oversized body with no image data with 400, not 413", () => {
+            // Regression for #9771. The 413 branch is only for a body PHP threw
+            // away for being larger than the server accepts. This body arrives
+            // complete and simply has no imgBase64, so it is a malformed request.
+            // 3 MB is well over the 2 MB upload_max_filesize the project's PHP
+            // images set — the value the handler compared Content-Length against —
+            // and far under their 2 GB post_max_size, so PHP receives and parses
+            // it in full.
+            cy.makePrivateAdminAPICall(
+                "POST",
+                `/api/person/${testPersonId}/photo`,
+                JSON.stringify({ notImgBase64: "a".repeat(3 * 1024 * 1024) }),
+                400
+            ).then((response) => {
+                expect(response.body.success).to.eq(false);
+                expect(response.body.message).to.include("Missing image data");
+            });
+        });
     });
 
     describe("DELETE /api/person/{id}/photo", () => {

--- a/src/ChurchCRM/Service/SystemService.php
+++ b/src/ChurchCRM/Service/SystemService.php
@@ -106,6 +106,16 @@ class SystemService
 
     private static function parseSize(string $size): float
     {
+        $size = trim($size);
+
+        // A negative value (conventionally -1) means "no limit" to PHP — most
+        // commonly memory_limit=-1. The character-stripping below would turn
+        // '-1' into 1 byte, and min() in getMaxUploadFileSize() would then
+        // report a 1-byte upload limit for the whole install.
+        if ($size !== '' && $size[0] === '-') {
+            return (float) PHP_INT_MAX;
+        }
+
         $unit = preg_replace('/[^bkmgtpezy]/i', '', $size); // Remove the non-unit characters from the size.
         $size = preg_replace('/[^0-9\.]/', '', $size); // Remove the non-numeric characters from the size.
         if ($unit) {

--- a/src/ChurchCRM/Slim/SlimUtils.php
+++ b/src/ChurchCRM/Slim/SlimUtils.php
@@ -492,6 +492,17 @@ class SlimUtils
      * judging on the header alone turns every complete body over 2 MB into a
      * misleading size error (issues #9719, #9771).
      *
+     * Re-reading the body here is safe even though `BodyParsingMiddleware`
+     * already consumed it: slim/psr7's `ServerRequestFactory` wraps
+     * `php://input` in a `Stream` backed by a `php://temp` cache
+     * (`ServerRequestFactory::createFromGlobals()`), and `Stream::__toString()`
+     * replays that cache once the stream is finished, ahead of its
+     * `isSeekable()` branch. So `(string) $body` returns the original bytes
+     * for a body that arrived but could not be parsed — invalid JSON, or a
+     * content type with no registered parser — and only returns '' when
+     * nothing arrived at all. `getSize()` is null for `php://input`, which is
+     * why it cannot carry this check on its own.
+     *
      * Residual, and not fixable from here: a short body sent with a huge,
      * lying Content-Length truncates the request, PHP receives nothing, and
      * that is indistinguishable from a body discarded for size.

--- a/src/ChurchCRM/Slim/SlimUtils.php
+++ b/src/ChurchCRM/Slim/SlimUtils.php
@@ -3,6 +3,7 @@ namespace ChurchCRM\Slim;
 
 use ChurchCRM\dto\Photo;
 use ChurchCRM\dto\SystemURLs;
+use ChurchCRM\Service\SystemService;
 use ChurchCRM\Utils\LoggerUtils;
 use Exception;
 use Psr\Http\Message\ResponseInterface as Response;
@@ -475,6 +476,45 @@ class SlimUtils
         }
 
         return $route->getArgument($name);
+    }
+
+    /**
+     * Whether PHP discarded this request's body because it was larger than the
+     * server accepts, which is the only case that justifies answering 413.
+     *
+     * PHP throws the *whole* body away when it exceeds the accepted size, so
+     * "nothing arrived at all" is the only honest signal: an empty parsed body,
+     * a raw body reporting size 0 (or unknown), and no raw bytes. A body that
+     * did arrive but is missing an expected field is a malformed request (400)
+     * no matter what its Content-Length claims — the limit here is
+     * `min(upload_max_filesize, post_max_size, memory_limit)`, which on a stock
+     * config is upload_max_filesize (2M) and sits far below post_max_size, so
+     * judging on the header alone turns every complete body over 2 MB into a
+     * misleading size error (issues #9719, #9771).
+     *
+     * Residual, and not fixable from here: a short body sent with a huge,
+     * lying Content-Length truncates the request, PHP receives nothing, and
+     * that is indistinguishable from a body discarded for size.
+     */
+    public static function isBodyDiscardedForSize(Request $request): bool
+    {
+        if (!empty($request->getParsedBody())) {
+            return false;
+        }
+
+        $body = $request->getBody();
+        $bodySize = $body->getSize();
+        if ($bodySize !== null && $bodySize !== 0) {
+            return false;
+        }
+
+        if ((string) $body !== '') {
+            return false;
+        }
+
+        $contentLength = (int) ($request->getServerParams()['CONTENT_LENGTH'] ?? 0);
+
+        return $contentLength > SystemService::getMaxUploadFileSize(false);
     }
 
     /**

--- a/src/api/routes/people/people-family.php
+++ b/src/api/routes/people/people-family.php
@@ -152,7 +152,8 @@ $app->group('/family/{familyId:[0-9]+}', function (RouteCollectorProxy $group): 
      *         )
      *     ),
      *     @OA\Response(response=400, description="Failed to upload photo"),
-     *     @OA\Response(response=403, description="EditRecords role required")
+     *     @OA\Response(response=403, description="EditRecords role required"),
+     *     @OA\Response(response=413, description="PHP discarded the request body because it exceeded the server upload limit")
      * )
      */
     $group->post('/photo', function (Request $request, Response $response): Response {
@@ -160,11 +161,11 @@ $app->group('/family/{familyId:[0-9]+}', function (RouteCollectorProxy $group): 
         $family = $request->getAttribute('family');
         $input = $request->getParsedBody();
 
-        // Detect when PHP discarded the request body because post_max_size was exceeded
         if (empty($input) || !isset($input['imgBase64'])) {
-            $contentLength = (int)($request->getServerParams()['CONTENT_LENGTH'] ?? 0);
-            $maxSize = SystemService::getMaxUploadFileSize(false);
-            if ($contentLength > 0 && $contentLength > $maxSize) {
+            // 413 only when PHP genuinely threw the body away for size; a body
+            // that arrived without imgBase64 is a malformed request whatever its
+            // Content-Length claims (issue #9771).
+            if (SlimUtils::isBodyDiscardedForSize($request)) {
                 return SlimUtils::renderErrorJSON(
                     $response,
                     sprintf(gettext('File size exceeds the server limit of %s'), SystemService::getMaxUploadFileSize(true)),

--- a/src/api/routes/people/people-person.php
+++ b/src/api/routes/people/people-person.php
@@ -126,11 +126,11 @@ $app->group('/person/{personId:[0-9]+}', function (RouteCollectorProxy $group): 
         $person = $request->getAttribute('person');
         $input = $request->getParsedBody();
 
-        // Detect when PHP discarded the request body because post_max_size was exceeded
         if (empty($input) || !isset($input['imgBase64'])) {
-            $contentLength = (int)($request->getServerParams()['CONTENT_LENGTH'] ?? 0);
-            $maxSize = SystemService::getMaxUploadFileSize(false);
-            if ($contentLength > 0 && $contentLength > $maxSize) {
+            // 413 only when PHP genuinely threw the body away for size; a body
+            // that arrived without imgBase64 is a malformed request whatever its
+            // Content-Length claims (issue #9771).
+            if (SlimUtils::isBodyDiscardedForSize($request)) {
                 return SlimUtils::renderErrorJSON(
                     $response,
                     sprintf(gettext('File size exceeds the server limit of %s'), SystemService::getMaxUploadFileSize(true)),


### PR DESCRIPTION
## What Changed
The person and family photo upload routes inferred "the body was discarded for size" from an empty parsed body plus a large Content-Length, so any complete JSON body over `upload_max_filesize` that simply lacked `imgBase64` got a misleading 413. A new `SlimUtils::isBodyDiscardedForSize(Request)` returns true only when the parsed body is empty, the stream size is 0/null and the raw body is empty, and then consults Content-Length; both routes use it. The church-logo route on #9719 carries the same logic inline and can adopt the helper after merge.

Also, from review (`005bdbe7b`):
- `SystemService::parseSize()` now treats a negative PHP ini size (`memory_limit=-1`) as unlimited. It previously parsed as **1 byte**, collapsing `getMaxUploadFileSize()` to a 1-byte limit for the whole install — which would have made `Photo::setImageFromBase64()` reject every photo and published `maxUploadSizeBytes: 1` to the front end.
- The helper's docblock now records *why* re-reading the body after `BodyParsingMiddleware` is safe: slim/psr7 backs `php://input` with a `php://temp` cache and `Stream::__toString()` replays it ahead of its `isSeekable()` branch.
- Both photo specs gained a regression test for a body that arrives in full but cannot be parsed — the only case that actually exercises the raw-body guard.

Fixes #9771

## Type
- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
Against the Docker dev stack (`upload_max_filesize=2M`, `post_max_size=2G`, `memory_limit=2G`):

| request | result |
|---|---|
| valid JSON, 3 MB, no `imgBase64` | 400 (was 413) |
| invalid JSON, 3 MB, `application/json` | 400 |
| 3 MB under `application/octet-stream` / `text/plain` / no Content-Type | 400 |
| `{}`, empty body | 400 |
| raw socket, `Content-Length: 3145728`, 2 bytes then half-close | 413 |
| valid 10×10 PNG `imgBase64` | 200, photo stored and served back as `image/png` |

Photo API specs: **36 passing** (person 19 + family 17). Mutation-checked — deleting the `(string) $body !== ''` guard fails only the two new unparseable-body tests.

## Files Changed
- `src/ChurchCRM/Slim/SlimUtils.php` — new `isBodyDiscardedForSize()` helper
- `src/api/routes/people/people-person.php`, `src/api/routes/people/people-family.php` — use the helper; document the 413 response
- `src/ChurchCRM/Service/SystemService.php` — `parseSize()` handles unlimited (negative) ini values
- `cypress/e2e/api/private/standard/private.people.photo.spec.js`, `private.people.family.photo.spec.js` — two regression tests each

## Pre-Merge
- [x] Tested locally
- [x] No new warnings
- [x] Build passes
- [x] Backward compatible (or migration documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
