### PR TITLE
Fix issue #9777: Stop the person-initial-style spec deleting a tracked photo fixture

### DIFF
--- a/cypress/e2e/api/private/admin/private.admin.person.initial.style.setting.spec.js
+++ b/cypress/e2e/api/private/admin/private.admin.person.initial.style.setting.spec.js
@@ -1,29 +1,53 @@
 /// <reference types="cypress" />
 
+/**
+ * Person avatar behaviour after a photo is deleted, plus the
+ * iPersonInitialStyle system setting.
+ *
+ * These tests used to delete person 2's photo. Person 2's photo *is* the
+ * tracked fixture cypress/data/images/people/2.png: the dev and test compose
+ * profiles bind-mount cypress/data/images/people as Images/Person, so the
+ * delete removed a tracked file from the working tree and left `git status`
+ * dirty after every run (issue #9777). It also silently broke any later spec
+ * that expects person 2 to have a photo.
+ *
+ * The tests now upload a throwaway photo to a person with no tracked fixture
+ * and delete that instead, and after() leaves no photo behind.
+ */
 describe("API Private Admin Person Initial Setting", () => {
-    it("Delete Person Image / Avatar info available for client-side rendering", () => {
+    // Person 28 has no file under cypress/data/images/people, so nothing this
+    // spec uploads or deletes can touch a tracked fixture.
+    const testPersonId = 28;
+    const PHOTO_URL = `/api/person/${testPersonId}/photo`;
+    const AVATAR_URL = `/api/person/${testPersonId}/avatar`;
+    // Smallest valid 1x1 PNG.
+    const BASE64_PNG =
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+
+    beforeEach(() => {
+        // Give the person a photo of our own to delete.
         cy.makePrivateAdminAPICall(
-            "DELETE",
-            "/api/person/2/photo",
-            null,
+            "POST",
+            PHOTO_URL,
+            JSON.stringify({ imgBase64: BASE64_PNG }),
             200,
         );
+    });
+
+    after(() => {
+        // The delete is idempotent (200 with no photo present), so this is safe
+        // whether or not a test left one behind.
+        cy.makePrivateAdminAPICall("DELETE", PHOTO_URL, null, 200);
+    });
+
+    it("Delete Person Image / Avatar info available for client-side rendering", () => {
+        cy.makePrivateAdminAPICall("DELETE", PHOTO_URL, null, 200);
 
         // After deleting photo, /photo endpoint returns 404 (no uploaded photo)
-        cy.makePrivateAdminAPICall(
-            "GET",
-            "/api/person/2/photo",
-            null,
-            404,
-        );
+        cy.makePrivateAdminAPICall("GET", PHOTO_URL, null, 404);
 
         // Avatar info endpoint returns data for client-side rendering
-        cy.makePrivateAdminAPICall(
-            "GET",
-            "/api/person/2/avatar",
-            null,
-            200,
-        ).then((resp) => {
+        cy.makePrivateAdminAPICall("GET", AVATAR_URL, null, 200).then((resp) => {
             expect(resp.body).to.have.property("initials");
             expect(resp.body).to.have.property("hasPhoto");
             expect(resp.body.hasPhoto).to.eq(false);
@@ -48,28 +72,13 @@ describe("API Private Admin Person Initial Setting", () => {
             expect(resp.body.value).to.eq(json.value);
         });
 
-        cy.makePrivateAdminAPICall(
-            "DELETE",
-            "/api/person/2/photo",
-            null,
-            200,
-        );
+        cy.makePrivateAdminAPICall("DELETE", PHOTO_URL, null, 200);
 
         // After deleting photo, /photo endpoint returns 404
-        cy.makePrivateAdminAPICall(
-            "GET",
-            "/api/person/2/photo",
-            null,
-            404,
-        );
+        cy.makePrivateAdminAPICall("GET", PHOTO_URL, null, 404);
 
         // Avatar info endpoint returns data for client-side rendering
-        cy.makePrivateAdminAPICall(
-            "GET",
-            "/api/person/2/avatar",
-            null,
-            200,
-        ).then((resp) => {
+        cy.makePrivateAdminAPICall("GET", AVATAR_URL, null, 200).then((resp) => {
             expect(resp.body).to.have.property("initials");
         });
     });

--- a/cypress/e2e/api/private/standard/private.people.family.photo.spec.js
+++ b/cypress/e2e/api/private/standard/private.people.family.photo.spec.js
@@ -1,6 +1,10 @@
 /// <reference types="cypress" />
 
 describe("API Private Photo and Avatar - Family", () => {
+    // Family 6 deliberately has no file under cypress/data/images/family,
+    // which the dev and test compose profiles bind-mount as Images/Family.
+    // Pointing these upload/delete tests at family 42 would delete a tracked
+    // fixture from the working tree — see issue #9777.
     const testFamilyId = 6; // Test family from demo database
     const invalidFamilyId = 99999;
 

--- a/cypress/e2e/api/private/standard/private.people.photo.spec.js
+++ b/cypress/e2e/api/private/standard/private.people.photo.spec.js
@@ -1,6 +1,11 @@
 /// <reference types="cypress" />
 
 describe("API Private Photo and Avatar - Person", () => {
+    // Person 28 deliberately has no file under cypress/data/images/people,
+    // which the dev and test compose profiles bind-mount as Images/Person.
+    // Pointing these upload/delete tests at a person that does (1, 2, 5, 10,
+    // 44, 213, 214) would delete a tracked fixture from the working tree —
+    // see issue #9777.
     const testPersonId = 28; // Test person from demo database
     const invalidPersonId = 99999;
 


### PR DESCRIPTION
## What Changed
The tracked fixture `cypress/data/images/people/2.png` was being deleted on every run, but not by the two specs the issue named: the culprit is `private.admin.person.initial.style.setting.spec.js`, which deleted person 2's photo through the bind-mounted images directory. It now uploads a throwaway PNG to person 28 and deletes that instead. This also removes a hazard for `new-system/05-post-reset-verification.spec.js`, which relies on person 2 having a photo.

Fixes #9777

## Type
- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [x] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
Each suspect spec was run against a clean tree to identify the culprit. Two consecutive runs of the three photo specs: 34 passing each, `git status cypress/data` clean both times.

## Pre-Merge
- [x] Tested locally
- [x] No new warnings
- [x] Build passes
- [x] Backward compatible (or migration documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
