### PR TITLE
Fix issue #9778: Stop the password spec rotating a seeded user's API key

### DIFF
--- a/cypress/e2e/ui/user/standard.user.password.spec.js
+++ b/cypress/e2e/ui/user/standard.user.password.spec.js
@@ -63,27 +63,99 @@ describe("Standard User Password", () => {
         cy.contains("Your new password is too similar to your old one");
     });
 
+});
+
+/**
+ * The only test here that actually succeeds in changing a password, and so the
+ * only one with a side effect.
+ *
+ * User::updatePassword() rotates usr_apiKey (GHSA-f2fq-4rmp-9x8c). This test
+ * used to run against tony.wade (user 3), whose seeded key is the
+ * `user.api.key` fixture that cypress/configs/*.ts hand to
+ * cy.makePrivateUserAPICall — so a single run destroyed it and every later run
+ * against the same database failed with 401 until the database was reseeded
+ * (issue #9778). Restoring the seeded value afterwards is not possible from a
+ * spec: no route sets an API key to a chosen value, /user/{id}/apikey/regen
+ * only generates a random one and the field on the user settings page is
+ * readonly.
+ *
+ * So the test creates its own user, does the round trip against that, and
+ * deletes it again. Nothing seeded is touched.
+ */
+describe("Standard User Password - successful change", () => {
+    // Person 24 (Clyde Ray) is seeded, has no user account, and is not
+    // referenced by any other spec. Person 25 is deliberately avoided:
+    // ui-admin/admin.user.spec.js creates and deletes a user for it.
+    const PERSON_ID = 24;
+    const FIRST_PASSWORD = "TheFirstPasswordForTheThrowawayUser";
+    const SECOND_PASSWORD = "SomeThingsAreBetterLeftUnChangedJustKidding";
+
+    let loginName;
+
+    // The delete route is declared as $group->delete('/') inside the
+    // /api/user/{userId} group, so the trailing slash is load-bearing:
+    // /admin/api/user/24 is a 404, /admin/api/user/24/ is the route.
+    const deleteTestUser = () =>
+        cy.makePrivateAdminAPICall(
+            "DELETE",
+            `/admin/api/user/${PERSON_ID}/`,
+            null,
+            // 404 when a previous run already cleaned up.
+            [200, 404],
+        );
+
+    before(() => {
+        cy.setupAdminSession({ forceLogin: true });
+        deleteTestUser();
+        // makePrivateAdminAPICall replaces the browser session, so log in again
+        // before driving the admin UI.
+        cy.setupAdminSession({ forceLogin: true });
+
+        cy.visit(`admin/system/users/new?personId=${PERSON_ID}`);
+        cy.get("#UserName")
+            .invoke("val")
+            .then((value) => {
+                expect(value, "auto-populated login name").to.not.be.empty;
+                loginName = value;
+            });
+        cy.get("#SaveButton").click();
+        // createUser() failures re-render the editor rather than redirecting, and
+        // the editor URL also contains "admin/system/users" — so assert we left
+        // the /new form, not merely that the path looks right.
+        cy.url().should("include", "admin/system/users").and("not.include", "/new");
+
+        // createUser() assigns a random password and sets NeedPasswordChange.
+        // adminSetUserPassword() gives us a password we know and clears the
+        // must-change flag, so the user can log in normally.
+        cy.visit(`admin/system/user/${PERSON_ID}/changePassword`);
+        cy.get("#NewPassword1").type(FIRST_PASSWORD);
+        cy.get("#NewPassword2").type(FIRST_PASSWORD);
+        cy.get("#NewPassword1").closest("form").submit();
+        cy.contains("Password Change Successful");
+    });
+
+    after(() => {
+        cy.setupAdminSession({ forceLogin: true });
+        deleteTestUser();
+    });
+
     it("Change then back", () => {
+        cy.visit("/session/end");
+        cy.loginWithCredentials(loginName, FIRST_PASSWORD, "pw-round-trip-1");
         cy.visit("v2/user/current/changepassword");
-        cy.get("#OldPassword").type("basicjoe");
-        cy.get("#NewPassword1").type(
-            "SomeThingsAreBetterLeftUnChangedJustKidding",
-        );
-        cy.get("#NewPassword2").type(
-            "SomeThingsAreBetterLeftUnChangedJustKidding",
-        );
+        cy.get("#OldPassword").type(FIRST_PASSWORD);
+        cy.get("#NewPassword1").type(SECOND_PASSWORD);
+        cy.get("#NewPassword2").type(SECOND_PASSWORD);
         cy.get("#passwordChangeForm").submit();
         cy.url().should("contain", "/v2/user/current/changepassword");
         cy.contains("Password Change Successful");
 
         cy.visit("/session/end");
-        cy.loginWithCredentials("tony.wade@example.com", "SomeThingsAreBetterLeftUnChangedJustKidding", "temp-session");
+        cy.loginWithCredentials(loginName, SECOND_PASSWORD, "pw-round-trip-2");
         cy.visit("v2/user/current/changepassword");
-        cy.get("#OldPassword").type(
-            "SomeThingsAreBetterLeftUnChangedJustKidding",
-        );
-        cy.get("#NewPassword1").type("basicjoe");
-        cy.get("#NewPassword2").type("basicjoe");
+        cy.get("#OldPassword").type(SECOND_PASSWORD);
+        cy.get("#NewPassword1").type(FIRST_PASSWORD);
+        cy.get("#NewPassword2").type(FIRST_PASSWORD);
         cy.get("#passwordChangeForm").submit();
         cy.url().should("contain", "/v2/user/current/changepassword");
         cy.contains("Password Change Successful");


### PR DESCRIPTION
## What Changed
The key rotation was not in an API spec: `ui/user/standard.user.password.spec.js` ("Change then back") rotates `usr_apiKey` as a side effect of changing the password, which broke `makePrivateUserAPICall` on every later run. Restoring a seeded key from a spec is impossible (no set-key route; regeneration is random; the settings field is read-only), so the test now creates its own user for person 24 with a known password, does the round trip, and deletes the user. Along the way it fixes an assertion that passed on failure because the editor re-renders at a URL still containing the expected fragment.

Fixes #9778

## Type
- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [x] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
Two consecutive runs without reseeding: 6 passing each, the seeded key byte-identical afterwards, no leftover user row. Notes specs using `makePrivateUserAPICall` (56 tests) confirm the key still works.

## Pre-Merge
- [x] Tested locally
- [x] No new warnings
- [x] Build passes
- [x] Backward compatible (or migration documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
