### PR TITLE
Fix issue #9779: Bound the admin logs download test

### DIFF
--- a/cypress/e2e/ui-admin/admin.logs.spec.js
+++ b/cypress/e2e/ui-admin/admin.logs.spec.js
@@ -1,4 +1,50 @@
 describe('Admin System Logs - UI Tests', () => {
+  // The download test used to fetch whatever log file happened to be first in
+  // the table. On a long-lived dev instance with ORM debug logging that is
+  // hundreds of megabytes, and cy.request() buffers the whole body, so the
+  // spec hung instead of failing (issue #9779). The spec now creates the log
+  // it downloads: it clears the log directory, makes one request whose URL
+  // carries a unique marker, and checks the advertised size before asking for
+  // any bytes.
+  const MARKER = `logs-spec-${Date.now()}`;
+
+  // Generous, but four orders of magnitude below the 269 MB file that hung the
+  // original test. Nothing this spec produces comes close.
+  const MAX_LOG_KB = 5 * 1024;
+
+  const LOG_LEVEL_URL = '/admin/api/system/config/sLogLevel';
+  const SET_LOG_LEVEL_URL = '/admin/api/system/logs/loglevel';
+  const DEBUG_LOG_LEVEL = 100;
+
+  before(() => {
+    // Force DEBUG just long enough for the marker request to be recorded, then
+    // put the configured level back so the rest of the spec logs normally.
+    cy.makePrivateAdminAPICall('GET', LOG_LEVEL_URL, null, 200).then((response) => {
+      const originalLevel = response.body.value;
+
+      cy.makePrivateAdminAPICall(
+        'POST',
+        SET_LOG_LEVEL_URL,
+        { value: DEBUG_LOG_LEVEL },
+        200,
+      );
+
+      // Start from an empty log directory — this is what bounds the download.
+      cy.makePrivateAdminAPICall('DELETE', '/admin/api/system/logs', null, 200);
+
+      // Every app-log line records the request URL in its context, so a 404 on
+      // a marked path writes a small, identifiable log we can assert on.
+      cy.makePrivateAdminAPICall('GET', `/api/person/999999/${MARKER}`, null, 404);
+
+      cy.makePrivateAdminAPICall(
+        'POST',
+        SET_LOG_LEVEL_URL,
+        { value: Number(originalLevel) },
+        200,
+      );
+    });
+  });
+
   beforeEach(() => {
     cy.setupAdminSession();
   });
@@ -93,46 +139,95 @@ describe('Admin System Logs - UI Tests', () => {
     });
   });
 
-  it('Should verify download endpoint for the first log file', () => {
+  it('Should download the log file it created, bounded by the advertised size', () => {
     cy.visit('admin/system/logs');
 
-    // Skip download test when no log files exist
-    cy.get('body').then(($body) => {
-      if ($body.find('#logFilesTable tbody tr').length === 0) {
-        cy.log('No log files found — skipping download endpoint check');
-        return;
-      }
+    // before() guarantees at least the application log exists, so an empty
+    // table is a failure, not a reason to skip.
+    cy.get('#logFilesTable tbody tr').should('have.length.at.least', 1);
 
-      // Ensure download action exists and extract the log file name
-      cy.get('#logFilesTable tbody tr').first().within(() => {
-        cy.get('.download-log').should('exist').invoke('attr', 'data-log-name').as('logName');
-      });
+    cy.get('#logFilesTable tbody tr')
+      .then(($rows) => {
+        const appLog = [...$rows]
+          .map((row) => ({
+            name: row.querySelector('.download-log')?.getAttribute('data-log-name'),
+            // Size column renders as "12.34 KB" via number_format(), which adds
+            // thousands separators once a file passes 1000 KB.
+            sizeKb: Number.parseFloat(
+              (row.children[1].textContent || '').replace(/,/g, ''),
+            ),
+          }))
+          .find((entry) => entry.name && entry.name.endsWith('-app.log'));
 
-      // Build the expected download URL and request it directly to verify the endpoint
-      cy.get('@logName').then((logName) => {
+        expect(appLog, 'application log row in the table').to.not.be.undefined;
+        // Read the size off the page and refuse to download an unbounded file.
+        // This is the check that would have failed fast on the 269 MB log
+        // instead of hanging.
+        expect(appLog.sizeKb, `size of ${appLog.name} in KB`)
+          .to.be.a('number')
+          .and.to.be.lessThan(MAX_LOG_KB);
+
+        return cy.wrap(appLog.name, { log: false });
+      })
+      .then((logName) => {
         cy.window().then((win) => {
-          const origin = win.location && win.location.origin ? win.location.origin : Cypress.config('baseUrl');
-          const rootPath = (win.CRM && win.CRM.root) ? win.CRM.root : '/';
-          const relative = rootPath + (rootPath.endsWith('/') ? '' : '/') + 'admin/api/system/logs/' + encodeURIComponent(logName) + '/download';
+          const origin =
+            win.location && win.location.origin
+              ? win.location.origin
+              : Cypress.config('baseUrl');
+          const rootPath = win.CRM && win.CRM.root ? win.CRM.root : '/';
+          const relative =
+            rootPath +
+            (rootPath.endsWith('/') ? '' : '/') +
+            'admin/api/system/logs/' +
+            encodeURIComponent(logName) +
+            '/download';
           const url = new URL(relative, origin).toString();
-          cy.log('download url: ' + url);
-          cy.request({ url, encoding: 'utf8', failOnStatusCode: false }).then((resp) => {
-            cy.log('download status: ' + resp.status);
-            cy.log('download headers: ' + JSON.stringify(resp.headers));
 
+          cy.request({
+            url,
+            encoding: 'utf8',
+            failOnStatusCode: false,
+            // An explicit timeout so an oversized file fails the test rather
+            // than hanging the run.
+            timeout: 20000,
+          }).then((resp) => {
             expect(resp.status, `download status for ${logName} (${url})`).to.equal(200);
 
-            const cd = resp.headers && (resp.headers['content-disposition'] || resp.headers['Content-Disposition']);
-            cy.log('cd=' + cd);
+            const headers = resp.headers || {};
+            const cd = headers['content-disposition'] || headers['Content-Disposition'];
             expect(cd, 'Content-Disposition header present').to.be.a('string');
-            expect(cd.toLowerCase(), 'Content-Disposition mentions attachment').to.include('attachment');
-            expect(cd, 'Content-Disposition mentions filename').to.match(/filename\s*=\s*"?.+"?/);
+            expect(cd.toLowerCase(), 'Content-Disposition mentions attachment').to.include(
+              'attachment',
+            );
+            expect(cd, 'Content-Disposition names the file').to.include(logName);
 
-            expect(resp.body && resp.body.length, 'download body non-empty').to.be.greaterThan(10);
+            // The route sets Content-Length from the raw file, but Apache
+            // gzips text/plain, so what arrives is the compressed length and
+            // it will not match the decoded body. Assert both are present and
+            // inside the bound rather than that they are equal.
+            const contentLength = Number(
+              headers['content-length'] || headers['Content-Length'],
+            );
+            expect(contentLength, 'Content-Length header').to.be.greaterThan(0);
+            expect(contentLength, 'Content-Length within the bound').to.be.lessThan(
+              MAX_LOG_KB * 1024,
+            );
+            expect(resp.body.length, 'decoded body within the bound')
+              .to.be.greaterThan(10)
+              .and.to.be.lessThan(MAX_LOG_KB * 1024);
+
+            // First bytes: a Monolog line opens with an ISO-8601 timestamp.
+            expect(resp.body.slice(0, 200), 'first log line').to.match(
+              /^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+            );
+            // And it is the log this spec created, not whatever was lying around.
+            expect(resp.body, 'log contains the marker written in before()').to.include(
+              MARKER,
+            );
           });
         });
       });
-    });
   });
 
 });

--- a/cypress/e2e/ui-admin/admin.logs.spec.js
+++ b/cypress/e2e/ui-admin/admin.logs.spec.js
@@ -16,11 +16,15 @@ describe('Admin System Logs - UI Tests', () => {
   const SET_LOG_LEVEL_URL = '/admin/api/system/logs/loglevel';
   const DEBUG_LOG_LEVEL = 100;
 
+  // Captured in before() and restored in after(). Cypress aliases do not survive
+  // from before() to after(), so this has to be a closure-level binding.
+  let originalLevel;
+
   before(() => {
     // Force DEBUG just long enough for the marker request to be recorded, then
     // put the configured level back so the rest of the spec logs normally.
     cy.makePrivateAdminAPICall('GET', LOG_LEVEL_URL, null, 200).then((response) => {
-      const originalLevel = response.body.value;
+      originalLevel = response.body.value;
 
       cy.makePrivateAdminAPICall(
         'POST',
@@ -43,6 +47,22 @@ describe('Admin System Logs - UI Tests', () => {
         200,
       );
     });
+  });
+
+  // Safety net. Every call in before() is a queued Cypress command, so an
+  // unexpected status on any of them aborts the queue and the restore above is
+  // never reached — leaving the server at DEBUG for every spec that follows.
+  // Mocha runs after() even when before() fails, and re-posting the level the
+  // happy path already restored is a no-op.
+  after(() => {
+    if (originalLevel !== undefined) {
+      cy.makePrivateAdminAPICall(
+        'POST',
+        SET_LOG_LEVEL_URL,
+        { value: Number(originalLevel) },
+        200,
+      );
+    }
   });
 
   beforeEach(() => {
@@ -163,8 +183,15 @@ describe('Admin System Logs - UI Tests', () => {
         // Read the size off the page and refuse to download an unbounded file.
         // This is the check that would have failed fast on the 269 MB log
         // instead of hanging.
+        // .a('number') alone would pass for NaN (typeof NaN === 'number'), and
+        // the bound below would then fail with "expected NaN to be less than
+        // 5120" instead of naming the real problem: an unparseable size cell.
+        // satisfy(Number.isFinite) says that directly and, unlike
+        // `.and.not.to.be.NaN`, keeps the chain positive — chai's negation flag
+        // survives .and, so a `not` here would invert the lessThan that follows.
         expect(appLog.sizeKb, `size of ${appLog.name} in KB`)
           .to.be.a('number')
+          .and.to.satisfy(Number.isFinite)
           .and.to.be.lessThan(MAX_LOG_KB);
 
         return cy.wrap(appLog.name, { log: false });


### PR DESCRIPTION
## What Changed
The log-download test fetched whatever `src/logs/*.log` contained. It now clears logs in `before()`, forces one request with a unique marker at DEBUG, restores the level, reads the file size from the page and refuses to download above a 5 MB cap, uses a 20 s request timeout, and asserts Content-Disposition, the first bytes (ISO-8601 Monolog timestamp) and the marker. Note: the indefinite hang did not reproduce locally (a 354 MB log downloaded in under 3 s because Apache gzips text), so the fix targets the unbounded download itself; the reported freeze likely needs a memory-constrained runner.

From review (`fe8a08e67`):
- `originalLevel` moved to a closure binding and re-posted from an `after()` hook. Every call in `before()` is a queued Cypress command, so an unexpected status aborts the queue before the restore and strands the server at DEBUG for every spec that follows; Mocha runs `after()` even when `before()` fails. The happy-path restore stays in `before()` so the rest of this spec runs at the configured level.
- The size cell is now checked with `satisfy(Number.isFinite)`, because `.to.be.a('number')` passes for `NaN`.

Fixes #9779

## Type
- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [x] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
`npx cypress run --config-file cypress/configs/docker-admin.config.ts --spec cypress/e2e/ui-admin/admin.logs.spec.js` — **6 passing**.

Guard proven by lowering the cap to 1 byte (fails before any request). With a 354 MB dummy log present: 6 passing in 5 s. Content-Length is the compressed length, so it is deliberately not compared to the decoded body.

Review fixes proven by injection:
- Forcing the `DELETE` in `before()` to assert a wrong status leaves `sLogLevel` at 100 without the `after()` hook (original 200) and restores it to 200 with the hook.
- Forcing the size parse to `NaN` fails as `size of 2026-09-11-app.log in KB: expected NaN to satisfy [Function: isFinite]` instead of `expected NaN to be less than 5120`.

## Files Changed
- `cypress/e2e/ui-admin/admin.logs.spec.js`

## Pre-Merge
- [x] Tested locally
- [x] No new warnings
- [x] Build passes
- [x] Backward compatible (or migration documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
