### PR TITLE
Fix issue #9780: Point cy.deletePersonByName at the real delete route

### DIFF
--- a/cypress/support/ui-commands.js
+++ b/cypress/support/ui-commands.js
@@ -222,18 +222,45 @@ Cypress.Commands.add('createPersonWithBirthday', (personData) => {
     cy.url().should("contain", "people/view/");
 });
 
+/**
+ * Deletes the first person matching a global search on `name`.
+ *
+ * Two things this used to get wrong (#9780):
+ *  - It deleted through /api/persons/{id}, which is not a route. The /persons
+ *    group only serves collection endpoints (/latest, /updated, /birthday,
+ *    /search/{query}, ...); a single person is DELETE /api/person/{id}.
+ *  - It read the person id from `children[0].id`, which is a DOM slug such as
+ *    "person-name-1". The numeric id only appears in the child's `uri`
+ *    ("/people/view/22"), and the first result group is not necessarily the
+ *    Persons group — addresses, families and groups share the response.
+ *
+ * Both failures were silent: cy.apiRequest does not fail on status, so the
+ * 404 went unnoticed and the person stayed in the database.
+ */
 Cypress.Commands.add('deletePersonByName', (name) => {
     cy.apiRequest({
         method: 'GET',
-        url: '/api/search/' + name
+        url: `/api/search/${encodeURIComponent(name)}`,
     }).then((response) => {
-        if (response.body && response.body.length > 0) {
-            const personId = response.body[0].children[0].id;
-            cy.apiRequest({
-                method: 'DELETE',
-                url: `/api/persons/${personId}`
-            });
-        }
+        expect(response.status, `GET /api/search/${name}`).to.equal(200);
+
+        const personId = (response.body || [])
+            .flatMap((group) => group.children || [])
+            .map((child) => /\/people\/view\/(\d+)/.exec(child.uri || ''))
+            .filter((match) => match !== null)
+            .map((match) => Number(match[1]))[0];
+
+        expect(personId, `person id for "${name}"`).to.be.a('number');
+
+        cy.apiRequest({
+            method: 'DELETE',
+            url: `/api/person/${personId}`,
+        }).then((deleteResponse) => {
+            expect(
+                deleteResponse.status,
+                `DELETE /api/person/${personId} for "${name}"`,
+            ).to.equal(200);
+        });
     });
 });
 


### PR DESCRIPTION
## What Changed
`cy.deletePersonByName` deleted through `/api/persons/{id}`, a route that does not exist. It also read the person id from a DOM slug rather than the result's `uri`, and assumed the first search group is Persons. It now extracts the id from the first `/people/view/{id}` uri in any group, deletes via `DELETE /api/person/{id}`, and asserts 200 on both calls. It remains unused: the one natural pairing, `cy.createPersonWithBirthday`, is itself stale against the current person editor and is filed separately.

Fixes #9780

## Type
- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [x] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
curl: `DELETE /api/persons/22` and `/api/people/22` → 404 with the person surviving; the fixed command, exercised by a throwaway spec (create → delete → `GET /api/person/{id}` 404), passes.

## Pre-Merge
- [x] Tested locally
- [x] No new warnings
- [x] Build passes
- [x] Backward compatible (or migration documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
