### PR TITLE
Fix issue #9781: Claim a NULL birthday-email run marker instead of blocking forever

### DIFF
--- a/cypress/e2e/api/private/admin/private.admin.background-timerjobs.spec.js
+++ b/cypress/e2e/api/private/admin/private.admin.background-timerjobs.spec.js
@@ -19,9 +19,11 @@ describe("API Private Admin - Background Timer Jobs concurrency", () => {
     const CONCURRENT_REQUESTS = 8;
     const MARKER = "sLastBirthdayEmailRunDate";
     const FEATURE = "bEnableBirthdayEmails";
+    const TIMEZONE = "sTimeZone";
 
     let originalMarker;
     let originalFeature;
+    let configuredTimezone;
 
     const configUrl = (name) => `/admin/api/system/config/${name}`;
 
@@ -47,12 +49,24 @@ describe("API Private Admin - Background Timer Jobs concurrency", () => {
     const writeConfig = (name, value) =>
         cy.makePrivateAdminAPICall("POST", configUrl(name), { value: value }, 200);
 
-    /** Today's date in the app's configured timezone, as the service formats it. */
-    const todayString = () => {
-        const now = new Date();
-        const pad = (n) => String(n).padStart(2, "0");
-        return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
-    };
+    /**
+     * Today's date in the app's configured timezone, as the service formats it.
+     *
+     * BirthdayEmailService builds the marker from
+     * DateTimeUtils::getConfiguredTimezone(), i.e. the `sTimeZone` system
+     * setting. `new Date()` on the Cypress runner gives the runner's local
+     * wall-clock date instead (UTC in CI), so the two disagree on the calendar
+     * date whenever the runner and the install sit on different sides of
+     * midnight. Derive the expected string from `sTimeZone`, read once in
+     * before(). "en-CA" formats as ISO-style YYYY-MM-DD.
+     */
+    const todayString = () =>
+        new Intl.DateTimeFormat("en-CA", {
+            timeZone: configuredTimezone,
+            year: "numeric",
+            month: "2-digit",
+            day: "2-digit",
+        }).format(new Date());
 
     /**
      * Fire CONCURRENT_REQUESTS timer-job requests in parallel and resolve with
@@ -76,6 +90,11 @@ describe("API Private Admin - Background Timer Jobs concurrency", () => {
         });
 
     before(() => {
+        readConfig(TIMEZONE).then((value) => {
+            // Empty falls back to the runner's local zone, which is what the
+            // assertion used before — never worse than the old behaviour.
+            configuredTimezone = value || undefined;
+        });
         readConfig(MARKER).then((value) => {
             originalMarker = value;
         });
@@ -111,6 +130,14 @@ describe("API Private Admin - Background Timer Jobs concurrency", () => {
     });
 
     it("returns 200 for every concurrent request when the run marker is stale", () => {
+        // A NULL cfg_value is the same "stale marker" case and used to block
+        // birthday emails for good, because SQL evaluates `NULL <> :today` as
+        // UNKNOWN so the conditional UPDATE matched nothing. It cannot be set up
+        // from here: POSTing a config value never writes NULL (an empty value
+        // equals the default, which deletes the row), and Cypress has no raw-SQL
+        // task in this project. The claim now filters
+        // `cfg_value <> :today OR cfg_value IS NULL`; the NULL path is covered
+        // by direct-SQL verification on the dev stack.
         writeConfig(MARKER, "2000-01-01");
 
         fireConcurrentTimerJobs().then((statuses) => {

--- a/src/ChurchCRM/Service/BirthdayEmailService.php
+++ b/src/ChurchCRM/Service/BirthdayEmailService.php
@@ -91,6 +91,12 @@ class BirthdayEmailService
      *   - row present: a conditional UPDATE that only matches rows not already
      *     holding today's date; losers see zero affected rows.
      *   - row absent: the INSERT itself, whose primary key rejects the losers.
+     *
+     * `cfg_value` is nullable, and in SQL `NULL <> 'anything'` is UNKNOWN, not
+     * TRUE — a bare `<>` filter would never match a NULL marker row and would
+     * suppress birthday emails for good. The claim therefore matches
+     * `cfg_value <> :today OR cfg_value IS NULL`, so a NULL marker is treated
+     * like any other stale one and gets claimed.
      */
     private static function claimRunForToday(string $todayString): bool
     {
@@ -101,9 +107,17 @@ class BirthdayEmailService
                 return false;
             }
 
+            // `_or()` merges both filters on cfg_value into one parenthesised
+            // group: `cfg_name = :name AND (cfg_value <> :today OR cfg_value IS
+            // NULL)`. A raw `where('cfg_value IS NULL OR cfg_value <> ?')` would
+            // be appended without parentheses and bind as
+            // `name = :name AND cfg_value IS NULL OR cfg_value <> :today`,
+            // which updates every other config row.
             $affectedRows = ConfigQuery::create()
                 ->filterByName(self::LAST_RUN_CONFIG_NAME)
                 ->filterByValue($todayString, Criteria::NOT_EQUAL)
+                ->_or()
+                ->filterByValue(null, Criteria::ISNULL)
                 ->update(['Value' => $todayString]);
 
             return $affectedRows > 0;
@@ -120,7 +134,11 @@ class BirthdayEmailService
             // genuine database failure is still surfaced.
             $winner = ConfigQuery::create()->findOneByName(self::LAST_RUN_CONFIG_NAME);
             if ($winner !== null && $winner->getValue() === $todayString) {
-                LoggerUtils::getAppLogger()?->debug('BirthdayEmailService: another run claimed today first');
+                // The re-read cannot prove the failure was the primary-key
+                // collision rather than, say, a dropped connection, so log the
+                // swallowed exception: the outcome is safe either way, but a
+                // genuine infrastructure failure must stay visible.
+                LoggerUtils::getAppLogger()?->debug('BirthdayEmailService: another run claimed today first (insert failed with: ' . $e->getMessage() . ')');
 
                 return false;
             }


### PR DESCRIPTION
## What Changed
Follow-up to the merged #9758. `BirthdayEmailService::claimRunForToday()` filtered the conditional claim with `cfg_value <> :today`; in SQL a NULL value never satisfies `<>`, so a NULL `sLastBirthdayEmailRunDate` row matched zero rows, every run concluded another run had claimed the day, and birthday emails never sent again. The condition is now `cfg_value <> :today OR cfg_value IS NULL`, built with Propel's `_or()` so it is correctly parenthesised against the `cfg_name` filter (a raw appended `where()` would have produced `A AND B OR C` and updated unrelated config rows). The swallowed `PropelException` message is now included in the debug log line. The spec's "today" is computed in the app's configured `sTimeZone` rather than the runner's local zone.

Fixes #9781

## Type
- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
NULL marker inserted directly, then 8 concurrent `POST /api/background/timerjobs`: before → 200 ×8, marker still NULL, 0 emails; after → 200 ×8, marker set to today, exactly 1 email. Timezone: with `sTimeZone=Pacific/Kiritimati` the old spec failed 3/3 on the date, the new spec passes 3/3. `private.admin.background-timerjobs.spec.js`: 3 passing. The NULL case is not covered by Cypress on purpose: no route can write a NULL config value (an empty POST equals the default and deletes the row) and there is no raw-SQL task; documented in the spec.

## Pre-Merge
- [x] Tested locally
- [x] No new warnings
- [x] Build passes
- [x] Backward compatible (or migration documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
