### PR TITLE
Fix issue #9735: Unify the two recurring-event generators

### DIFF
--- a/.agents/skills/churchcrm/service-layer.md
+++ b/.agents/skills/churchcrm/service-layer.md
@@ -29,6 +29,8 @@ Located in `src/ChurchCRM/Service/`:
 - **DepositService** - Deposit slip handling
 - **SystemService** - System-wide operations
 - **UserService** - User management with optimized database operations
+- **EventService** - The one recurring-event generator (see below)
+- **RecurrenceDateGenerator** - Event-free weekly/monthly/yearly date math
 
 ## Example Usage
 
@@ -345,3 +347,15 @@ if (count($occurrenceDates) > self::MAX_REPEAT_OCCURRENCES) {
     ));
 }
 ```
+
+## One Recurrence Engine — `EventService` + `RecurrenceDateGenerator` <!-- learned: 2026-09-11 -->
+
+Recurring events had two independent implementations (issue #9735): `EventService::createRepeatEvents()` and an inline `generateRecurringEvents()` in `src/api/routes/calendar/events.php`, with different caps, titles, times and duplicate handling. They are now one path — **do not add a third**.
+
+- `ChurchCRM\Service\RecurrenceDateGenerator::generate()` — event-free date math (weekly / monthly / yearly). Anything that needs "the dates this repeats on" calls this, not a private copy of the switch.
+- `ChurchCRM\Service\EventService::createRecurringEvents()` — the only place events are created in bulk. `createRepeatEvents()` is a thin wrapper returning just the IDs.
+- Both HTTP endpoints (`POST /api/events/repeat`, `POST /api/events/generate-recurring`) and the repeat-event editor are adapters over it.
+
+The shared, documented policy lives in the `EventService` class docblock: one cap (`MAX_REPEAT_OCCURRENCES`, expressed in occurrences rather than calendar span so it means something for yearly recurrence too), caller-supplied title/times win and otherwise fall back to the event type's defaults, and `skipExisting` dedups on `(event type, calendar date)`.
+
+Endpoint adapters keep their own request/response shapes — the unification is behavioural, not a URL change.

--- a/cypress/e2e/api/private/standard/private.calendar.events-checkin.spec.js
+++ b/cypress/e2e/api/private/standard/private.calendar.events-checkin.spec.js
@@ -514,17 +514,24 @@ describe("API Event Check-in Endpoints", () => {
             );
         });
 
-        it("Returns 400 when date range exceeds 1 year", () => {
+        // #9735 replaced this endpoint's private "1 year" range cap with the
+        // one shared occurrence cap (366) that POST /events/repeat also
+        // enforces, so a two-year weekly range (~104 events) is now accepted
+        // and an over-cap range is what returns 400. Parity between the two
+        // endpoints is pinned in private.calendar.recurring-parity.spec.js.
+        it("Returns 400 when the range exceeds the shared occurrence cap", () => {
             cy.makePrivateAdminAPICall(
                 "POST",
                 "/api/events/generate-recurring",
                 {
                     eventTypeId: 1,
-                    startDate: "2026-01-01",
-                    endDate: "2028-01-01",
+                    startDate: "2040-01-01",
+                    endDate: "2050-01-01",
                 },
                 400,
-            );
+            ).then((resp) => {
+                expect(resp.body.message).to.contain("Too many occurrences");
+            });
         });
 
         it("Returns 401 when not authenticated", () => {

--- a/cypress/e2e/api/private/standard/private.calendar.recurring-parity.spec.js
+++ b/cypress/e2e/api/private/standard/private.calendar.recurring-parity.spec.js
@@ -1,0 +1,267 @@
+/// <reference types="cypress" />
+
+/**
+ * Issue #9735 — one recurrence engine.
+ *
+ * POST /events/repeat and POST /events/generate-recurring used to be two
+ * independent generators with different caps, different titles, different times
+ * and different duplicate handling. Both now funnel through
+ * EventService::createRecurringEvents(), so this spec pins the properties that
+ * unification is supposed to guarantee:
+ *
+ *  1. the same recurrence + range produces the same occurrence dates and times
+ *     on both endpoints;
+ *  2. re-running the same request with skip-existing creates nothing, on both;
+ *  3. the same occurrence cap is enforced with the same message, on both;
+ *  4. both response shapes stay backward compatible.
+ */
+describe("API Recurring Event Parity (#9735)", () => {
+    // The seeded "Church Service" type: weekly, Sunday, 10:30 default start.
+    const eventTypeId = 1;
+    const typeDefaults = {
+        recurType: "weekly",
+        recurDOW: "Sunday",
+        startTime: "10:30",
+        endTime: "11:30", // the engine's default duration is one hour
+    };
+
+    // Each test claims its own future window so re-running the suite against a
+    // database that was not reset still starts from an empty date range.
+    let windowSeq = 0;
+    const nextWindow = (weeks = 3) => {
+        const DAY_MS = 24 * 60 * 60 * 1000;
+        const base = new Date(Date.UTC(2040, 0, 1));
+        const offsetDays = (Date.now() % 3000) + windowSeq++ * 40;
+        const start = new Date(base.getTime() + offsetDays * DAY_MS);
+        const end = new Date(start.getTime() + weeks * 7 * DAY_MS);
+        return {
+            startDate: start.toISOString().slice(0, 10),
+            endDate: end.toISOString().slice(0, 10),
+        };
+    };
+
+    const fetchStartEnd = (ids) => {
+        const rows = [];
+        ids.forEach((id) => {
+            cy.makePrivateAdminAPICall("GET", `/api/events/${id}`, null, 200).then(
+                (resp) => {
+                    rows.push({
+                        start: resp.body.Start ?? resp.body.start,
+                        end: resp.body.End ?? resp.body.end,
+                    });
+                },
+            );
+        });
+        return cy.wrap(rows, { log: false });
+    };
+
+    it("Produces identical occurrence dates and times on both endpoints", () => {
+        const { startDate, endDate } = nextWindow();
+
+        cy.makePrivateAdminAPICall(
+            "POST",
+            "/api/events/generate-recurring",
+            { eventTypeId, startDate, endDate, skipExisting: false },
+            200,
+        ).then((generated) => {
+            const generatedDates = generated.body.events.map((e) => e.date);
+            expect(generatedDates.length).to.be.greaterThan(0);
+
+            cy.makePrivateAdminAPICall(
+                "POST",
+                "/api/events/repeat",
+                {
+                    Title: "Parity probe " + Date.now(),
+                    Type: eventTypeId,
+                    StartTime: typeDefaults.startTime,
+                    EndTime: typeDefaults.endTime,
+                    RecurType: typeDefaults.recurType,
+                    RecurDOW: typeDefaults.recurDOW,
+                    RangeStart: startDate,
+                    RangeEnd: endDate,
+                    PinnedCalendars: [],
+                },
+                200,
+            ).then((repeated) => {
+                // Same number of occurrences from the same recurrence + range.
+                expect(repeated.body.count).to.equal(generated.body.created);
+
+                fetchStartEnd(generated.body.events.map((e) => e.id)).then(
+                    (generatedRows) => {
+                        fetchStartEnd(repeated.body.eventIds).then((repeatRows) => {
+                            const starts = (rows) =>
+                                rows.map((r) => r.start).sort();
+                            const ends = (rows) => rows.map((r) => r.end).sort();
+                            // Identical start and end datetimes, not merely
+                            // identical dates.
+                            expect(starts(repeatRows)).to.deep.equal(
+                                starts(generatedRows),
+                            );
+                            expect(ends(repeatRows)).to.deep.equal(
+                                ends(generatedRows),
+                            );
+                        });
+                    },
+                );
+            });
+        });
+    });
+
+    it("Is idempotent on re-run for POST /events/generate-recurring", () => {
+        const { startDate, endDate } = nextWindow();
+
+        cy.makePrivateAdminAPICall(
+            "POST",
+            "/api/events/generate-recurring",
+            { eventTypeId, startDate, endDate, skipExisting: true },
+            200,
+        ).then((first) => {
+            expect(first.body.created).to.be.greaterThan(0);
+
+            cy.makePrivateAdminAPICall(
+                "POST",
+                "/api/events/generate-recurring",
+                { eventTypeId, startDate, endDate, skipExisting: true },
+                200,
+            ).then((second) => {
+                expect(second.body.created).to.equal(0);
+                expect(second.body.skipped).to.equal(first.body.created);
+            });
+        });
+    });
+
+    it("Is idempotent on re-run for POST /events/repeat with SkipExisting", () => {
+        const { startDate, endDate } = nextWindow();
+        const body = {
+            Title: "Idempotent probe " + Date.now(),
+            Type: eventTypeId,
+            StartTime: typeDefaults.startTime,
+            EndTime: typeDefaults.endTime,
+            RecurType: typeDefaults.recurType,
+            RecurDOW: typeDefaults.recurDOW,
+            RangeStart: startDate,
+            RangeEnd: endDate,
+            SkipExisting: true,
+            PinnedCalendars: [],
+        };
+
+        cy.makePrivateAdminAPICall("POST", "/api/events/repeat", body, 200).then(
+            (first) => {
+                expect(first.body.count).to.be.greaterThan(0);
+                expect(first.body.skipped).to.equal(0);
+
+                cy.makePrivateAdminAPICall(
+                    "POST",
+                    "/api/events/repeat",
+                    body,
+                    200,
+                ).then((second) => {
+                    expect(second.body.count).to.equal(0);
+                    expect(second.body.eventIds).to.deep.equal([]);
+                    expect(second.body.skipped).to.equal(first.body.count);
+                });
+            },
+        );
+    });
+
+    it("Keeps POST /events/repeat duplicating by default (SkipExisting off)", () => {
+        const { startDate, endDate } = nextWindow();
+        const body = {
+            Title: "Duplicating probe " + Date.now(),
+            Type: eventTypeId,
+            StartTime: typeDefaults.startTime,
+            EndTime: typeDefaults.endTime,
+            RecurType: typeDefaults.recurType,
+            RecurDOW: typeDefaults.recurDOW,
+            RangeStart: startDate,
+            RangeEnd: endDate,
+            PinnedCalendars: [],
+        };
+
+        cy.makePrivateAdminAPICall("POST", "/api/events/repeat", body, 200).then(
+            (first) => {
+                expect(first.body.success).to.be.true;
+                expect(first.body.count).to.be.greaterThan(0);
+                expect(first.body.eventIds).to.be.an("array");
+                expect(first.body.eventIds.length).to.equal(first.body.count);
+
+                cy.makePrivateAdminAPICall(
+                    "POST",
+                    "/api/events/repeat",
+                    body,
+                    200,
+                ).then((second) => {
+                    // Backward compatible: without SkipExisting the endpoint
+                    // still creates the whole series again.
+                    expect(second.body.count).to.equal(first.body.count);
+                    expect(second.body.skipped).to.equal(0);
+                });
+            },
+        );
+    });
+
+    describe("Shared 366-occurrence cap", () => {
+        // Weekly for ten years is ~522 occurrences — over the cap on either
+        // endpoint. The old code rejected this on /generate-recurring with a
+        // 1-year range error and accepted it on /repeat.
+        const overCap = { startDate: "2040-01-01", endDate: "2050-01-01" };
+
+        it("Rejects an over-cap request on POST /events/generate-recurring", () => {
+            cy.makePrivateAdminAPICall(
+                "POST",
+                "/api/events/generate-recurring",
+                {
+                    eventTypeId,
+                    startDate: overCap.startDate,
+                    endDate: overCap.endDate,
+                },
+                400,
+            ).then((resp) => {
+                expect(resp.body.message).to.contain("Too many occurrences");
+                expect(resp.body.message).to.contain("366");
+            });
+        });
+
+        it("Rejects the same over-cap request on POST /events/repeat", () => {
+            cy.makePrivateAdminAPICall(
+                "POST",
+                "/api/events/repeat",
+                {
+                    Title: "Over cap probe",
+                    Type: eventTypeId,
+                    StartTime: typeDefaults.startTime,
+                    EndTime: typeDefaults.endTime,
+                    RecurType: typeDefaults.recurType,
+                    RecurDOW: typeDefaults.recurDOW,
+                    RangeStart: overCap.startDate,
+                    RangeEnd: overCap.endDate,
+                    PinnedCalendars: [],
+                },
+                400,
+            ).then((resp) => {
+                expect(resp.body.message).to.contain("Too many occurrences");
+                expect(resp.body.message).to.contain("366");
+            });
+        });
+
+        it("Accepts a multi-year range that stays under the cap", () => {
+            // Previously a hard 400 on /generate-recurring ("Date range cannot
+            // exceed 1 year") while /repeat happily created the same series.
+            cy.makePrivateAdminAPICall(
+                "POST",
+                "/api/events/generate-recurring",
+                {
+                    eventTypeId,
+                    startDate: "2038-01-01",
+                    endDate: "2039-12-31",
+                    skipExisting: true,
+                },
+                200,
+            ).then((resp) => {
+                expect(resp.body.created + resp.body.skipped).to.be.greaterThan(
+                    60,
+                );
+            });
+        });
+    });
+});

--- a/src/ChurchCRM/Service/EventService.php
+++ b/src/ChurchCRM/Service/EventService.php
@@ -8,7 +8,10 @@ use ChurchCRM\model\ChurchCRM\EventAudience;
 use ChurchCRM\model\ChurchCRM\EventQuery;
 use ChurchCRM\model\ChurchCRM\EventType;
 use ChurchCRM\model\ChurchCRM\EventTypeQuery;
+use ChurchCRM\model\ChurchCRM\Map\EventTableMap;
 use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\Connection\ConnectionInterface;
+use Propel\Runtime\Propel;
 
 /**
  * Service for managing event business logic, including bulk repeat event creation.
@@ -35,10 +38,15 @@ use Propel\Runtime\ActiveQuery\Criteria;
  *   Otherwise each occurrence is titled "<Event type name> — <M j, Y>".
  * - **Times** — caller-supplied startTime/endTime win; otherwise startTime comes
  *   from the event type's default start time (falling back to 09:00) and endTime is
- *   one hour after startTime.
+ *   one hour after startTime. A derived end time that crosses midnight (start at
+ *   23:xx) lands on the following calendar day rather than wrapping back to 00:xx
+ *   on the occurrence date itself.
  * - **Idempotency** — with skipExisting, an occurrence date that already has an
  *   active event of the same type is skipped instead of duplicated. The key is
  *   (event type, calendar date), so re-running the same request creates nothing.
+ *   The whole series is written in one transaction and the existence check is a
+ *   locking read, so two concurrent calls for the same event type serialise
+ *   instead of both passing the check and inserting duplicates.
  */
 class EventService
 {
@@ -139,7 +147,7 @@ class EventService
         // ":00" to a string that already includes seconds (e.g. "09:00:00"
         // → "09:00:00:00" which would be an invalid timestamp).
         $startTime = $this->resolveStartTime($data, $type);
-        $endTime = $this->resolveEndTime($data, $startTime);
+        [$endTime, $endsNextDay] = $this->resolveEndTime($data, $startTime);
 
         $title = trim((string) ($data['title'] ?? ''));
         $desc = $data['desc'] ?? '';
@@ -176,47 +184,64 @@ class EventService
         $created = [];
         $skipped = 0;
 
-        foreach ($occurrenceDates as $occurrenceDate) {
-            $date = $occurrenceDate->format('Y-m-d');
+        // One transaction for the whole series: the existence check below is a
+        // locking read, so the check and the insert it guards cannot interleave
+        // with a concurrent call for the same event type (#9735). It also makes
+        // a series all-or-nothing instead of leaving a half-written run behind.
+        $con = Propel::getWriteConnection(EventTableMap::DATABASE_NAME);
+        $con->beginTransaction();
 
-            if ($skipExisting && $this->hasEventOnDate($typeId, $date)) {
-                $skipped++;
-                continue;
+        try {
+            foreach ($occurrenceDates as $occurrenceDate) {
+                $date = $occurrenceDate->format('Y-m-d');
+
+                if ($skipExisting && $this->hasEventOnDate($typeId, $date, $con)) {
+                    $skipped++;
+                    continue;
+                }
+
+                $eventTitle = $title !== ''
+                    ? $title
+                    : $type->getName() . ' — ' . $occurrenceDate->format('M j, Y');
+
+                $event = new Event();
+                $event->setTitle($eventTitle);
+                $event->setEventType($type);
+                $event->setDesc($desc);
+                $event->setText($text);
+                $event->setStart($date . ' ' . $startTime);
+                $event->setEnd($this->occurrenceEnd($occurrenceDate, $endTime, $endsNextDay));
+                $event->setInActive($inactive);
+
+                if ($calendars !== null) {
+                    $event->setCalendars($calendars);
+                }
+
+                // Always pass the transaction's connection: a default read
+                // connection could not see these uncommitted rows.
+                $event->save($con);
+                $event->reload(false, $con);
+                $eventId = $event->getId();
+
+                if ($linkedGroupId > 0) {
+                    $audience = new EventAudience();
+                    $audience->setEventId($eventId);
+                    $audience->setGroupId($linkedGroupId);
+                    $audience->save($con);
+                }
+
+                $created[] = [
+                    'id' => $eventId,
+                    'title' => $eventTitle,
+                    'date' => $date,
+                ];
             }
 
-            $eventTitle = $title !== ''
-                ? $title
-                : $type->getName() . ' — ' . $occurrenceDate->format('M j, Y');
+            $con->commit();
+        } catch (\Throwable $e) {
+            $con->rollBack();
 
-            $event = new Event();
-            $event->setTitle($eventTitle);
-            $event->setEventType($type);
-            $event->setDesc($desc);
-            $event->setText($text);
-            $event->setStart($date . ' ' . $startTime);
-            $event->setEnd($date . ' ' . $endTime);
-            $event->setInActive($inactive);
-
-            if ($calendars !== null) {
-                $event->setCalendars($calendars);
-            }
-
-            $event->save();
-            $event->reload();
-            $eventId = $event->getId();
-
-            if ($linkedGroupId > 0) {
-                $audience = new EventAudience();
-                $audience->setEventId($eventId);
-                $audience->setGroupId($linkedGroupId);
-                $audience->save();
-            }
-
-            $created[] = [
-                'id' => $eventId,
-                'title' => $eventTitle,
-                'date' => $date,
-            ];
+            throw $e;
         }
 
         return [
@@ -314,15 +339,38 @@ class EventService
      * The shared skipExisting key: (event type, calendar date). Deliberately
      * ignores the time of day so a series regenerated with a different start time
      * still counts as "already there".
+     *
+     * Runs as a locking read (SELECT ... FOR UPDATE) on the caller's transaction
+     * connection. With no unique constraint on (event type, date) in the schema,
+     * the lock is what stops two concurrent generations of the same event type
+     * from both seeing "nothing here" and both inserting: the range scanned on
+     * the event_type index is gap-locked for the rest of the transaction.
      */
-    private function hasEventOnDate(int $typeId, string $date): bool
+    private function hasEventOnDate(int $typeId, string $date, ConnectionInterface $con): bool
     {
         return EventQuery::create()
             ->filterByType($typeId)
             ->filterByStart($date . ' 00:00:00', Criteria::GREATER_EQUAL)
             ->filterByStart($date . ' 23:59:59', Criteria::LESS_EQUAL)
             ->filterByInActive(0)
-            ->findOne() !== null;
+            ->lockForUpdate()
+            ->findOne($con) !== null;
+    }
+
+    /**
+     * Full "Y-m-d H:i:s" end timestamp for one occurrence.
+     *
+     * The day roll-over is carried as a separate flag rather than being baked
+     * into the time string, so a derived end that crosses midnight advances the
+     * date instead of landing before its own start (#9735).
+     */
+    private function occurrenceEnd(\DateTime $occurrenceDate, string $endTime, bool $endsNextDay): string
+    {
+        $endDate = $endsNextDay
+            ? (clone $occurrenceDate)->modify('+1 day')
+            : $occurrenceDate;
+
+        return $endDate->format('Y-m-d') . ' ' . $endTime;
     }
 
     /**
@@ -350,20 +398,36 @@ class EventService
 
     /**
      * Caller end time, else one hour after the start time.
+     *
+     * @return array{0: string, 1: bool} the HH:MM:SS end time, and whether it
+     *                                   falls on the day after the occurrence date
      */
-    private function resolveEndTime(array $data, string $startTime): string
+    private function resolveEndTime(array $data, string $startTime): array
     {
         $callerTime = $this->firstNonEmptyString($data['endTime'] ?? null, null);
         if ($callerTime !== null) {
-            return self::normalizeTime($callerTime);
+            // An explicit end time is used on the occurrence date itself, as it
+            // always has been for POST /events/repeat.
+            return [self::normalizeTime($callerTime), false];
         }
 
-        $start = \DateTimeImmutable::createFromFormat('H:i:s', $startTime);
+        // Anchor the "+1 hour" on a full datetime (fixed date, UTC, so no DST
+        // shift can distort a pure wall-clock offset). Adding an hour to a
+        // bare H:i:s and re-formatting as H:i:s silently drops the day
+        // roll-over, which turned a 23:00 start into a 00:00 end on the *same*
+        // date — i.e. end before start.
+        $start = \DateTimeImmutable::createFromFormat(
+            '!Y-m-d H:i:s',
+            '2000-01-01 ' . $startTime,
+            new \DateTimeZone('UTC')
+        );
         if ($start === false) {
-            return '10:00:00';
+            return ['10:00:00', false];
         }
 
-        return $start->modify('+1 hour')->format('H:i:s');
+        $end = $start->modify('+1 hour');
+
+        return [$end->format('H:i:s'), $end->format('Y-m-d') !== '2000-01-01'];
     }
 
     /**

--- a/src/ChurchCRM/Service/EventService.php
+++ b/src/ChurchCRM/Service/EventService.php
@@ -5,59 +5,121 @@ namespace ChurchCRM\Service;
 use ChurchCRM\model\ChurchCRM\CalendarQuery;
 use ChurchCRM\model\ChurchCRM\Event;
 use ChurchCRM\model\ChurchCRM\EventAudience;
+use ChurchCRM\model\ChurchCRM\EventQuery;
+use ChurchCRM\model\ChurchCRM\EventType;
 use ChurchCRM\model\ChurchCRM\EventTypeQuery;
-use ChurchCRM\Utils\DateTimeUtils;
 use Propel\Runtime\ActiveQuery\Criteria;
 
 /**
  * Service for managing event business logic, including bulk repeat event creation.
+ *
+ * This is the **only** recurring-event generator in the codebase. Both HTTP entry
+ * points — POST /api/events/repeat and POST /api/events/generate-recurring — and the
+ * repeat-event editor UI funnel through createRecurringEvents(), so the same input
+ * always produces the same dates, the same times and the same duplicate handling
+ * (issue #9735).
+ *
+ * Documented, shared policy:
+ *
+ * - **Cap** — a single call creates at most self::MAX_REPEAT_OCCURRENCES events.
+ *   The cap is expressed in occurrences rather than calendar span because that is
+ *   the unit that bounds the actual work (rows written in one request) and it is
+ *   meaningful for all three recurrence types — a calendar horizon short enough to
+ *   protect weekly recurrence would make yearly recurrence pointless.
+ * - **Recurrence** — a caller-supplied recurType wins and its day fields fall back
+ *   to the event type's defaults, then to the legacy literals (Sunday / 1st / 01-01).
+ *   When no recurType is supplied it is read from the event type, which must then
+ *   also supply the matching day field; an incomplete event type is rejected rather
+ *   than silently defaulted.
+ * - **Title** — a caller-supplied title is used verbatim for every occurrence.
+ *   Otherwise each occurrence is titled "<Event type name> — <M j, Y>".
+ * - **Times** — caller-supplied startTime/endTime win; otherwise startTime comes
+ *   from the event type's default start time (falling back to 09:00) and endTime is
+ *   one hour after startTime.
+ * - **Idempotency** — with skipExisting, an occurrence date that already has an
+ *   active event of the same type is skipped instead of duplicated. The key is
+ *   (event type, calendar date), so re-running the same request creates nothing.
  */
 class EventService
 {
     /**
-     * Create a series of repeat events based on a template and recurrence settings.
+     * Hard cap on the number of events a single createRecurringEvents() call can
+     * generate. Prevents a wide date range (e.g. weekly for 10 years) from
+     * creating thousands of rows in one request and locking the table.
      *
-     * Generates individual Event records for each occurrence of a recurring
-     * event within a date range. Each event is independently editable after creation.
+     * This is the one cap for both HTTP entry points (#9735). 366 is "at most a
+     * year of daily occurrences".
+     */
+    public const MAX_REPEAT_OCCURRENCES = 366;
+
+    /**
+     * Fallback start time when neither the caller nor the event type supplies one.
+     */
+    private const DEFAULT_START_TIME = '09:00:00';
+
+    private RecurrenceDateGenerator $recurrenceDateGenerator;
+
+    public function __construct(?RecurrenceDateGenerator $recurrenceDateGenerator = null)
+    {
+        $this->recurrenceDateGenerator = $recurrenceDateGenerator ?? new RecurrenceDateGenerator();
+    }
+
+    /**
+     * Create a series of repeat events and return just the created IDs.
+     *
+     * Thin wrapper over createRecurringEvents() kept for callers that only care
+     * about the IDs (the repeat-event editor and POST /api/events/repeat).
      *
      * @param array{
-     *   title: string,
+     *   title?: string|null,
      *   typeId: int,
-     *   desc: string,
-     *   text: string,
-     *   startTime: string,
-     *   endTime: string,
-     *   recurType: string,
-     *   recurDOW?: string,
-     *   recurDOM?: int,
-     *   recurDOY?: string,
+     *   desc?: string,
+     *   text?: string,
+     *   startTime?: string|null,
+     *   endTime?: string|null,
+     *   recurType?: string|null,
+     *   recurDOW?: string|null,
+     *   recurDOM?: int|null,
+     *   recurDOY?: string|null,
      *   rangeStart: string,
      *   rangeEnd: string,
      *   linkedGroupId?: int,
      *   pinnedCalendars?: int[],
-     *   inactive?: int
+     *   inactive?: int,
+     *   skipExisting?: bool
      * } $data Event template and recurrence parameters
      *
      * @return int[] Array of created event IDs
      *
      * @throws \InvalidArgumentException if event type is invalid or date range is invalid
      */
-    /**
-     * Hard cap on the number of events a single createRepeatEvents() call can
-     * generate. Prevents a wide date range (e.g. weekly for 10 years) from
-     * creating thousands of rows in one request and locking the table.
-     */
-    public const MAX_REPEAT_OCCURRENCES = 366;
-
     public function createRepeatEvents(array $data): array
     {
-        $type = EventTypeQuery::create()->findOneById((int) $data['typeId']);
+        return array_column($this->createRecurringEvents($data)['events'], 'id');
+    }
+
+    /**
+     * Create a series of events for every occurrence of a recurrence within a range.
+     *
+     * Generates individual Event records so each occurrence is independently
+     * editable after creation. See the class docblock for the title / time /
+     * recurrence / idempotency / cap rules, which are identical for every caller.
+     *
+     * @param array $data Same shape as createRepeatEvents()
+     *
+     * @return array{events: array<int, array{id: int, title: string, date: string}>, skipped: int}
+     *
+     * @throws \InvalidArgumentException if event type is invalid or date range is invalid
+     */
+    public function createRecurringEvents(array $data): array
+    {
+        $type = EventTypeQuery::create()->findOneById((int) ($data['typeId'] ?? 0));
         if ($type === null) {
             throw new \InvalidArgumentException(gettext('Invalid event type ID'));
         }
 
-        // Use createFromFormat with strict ('!') anchor and explicit catch
-        // so a malformed date string returns 400 instead of bubbling up as 500.
+        // Explicit catch so a malformed date string returns 400 instead of
+        // bubbling up as a 500.
         try {
             $rangeStart = new \DateTime($data['rangeStart'] ?? '');
             $rangeStart->setTime(0, 0, 0);
@@ -71,17 +133,21 @@ class EventService
             throw new \InvalidArgumentException(gettext('Range start must be before range end'));
         }
 
+        [$recurType, $dow, $dom, $doy] = $this->resolveRecurrence($data, $type);
+
         // Normalize start/end time to HH:MM:SS so we don't end up appending
         // ":00" to a string that already includes seconds (e.g. "09:00:00"
         // → "09:00:00:00" which would be an invalid timestamp).
-        $startTime = self::normalizeTime($data['startTime'] ?? '09:00');
-        $endTime = self::normalizeTime($data['endTime'] ?? '10:00');
-        $recurType = $data['recurType'] ?? 'weekly';
-        $title = $data['title'];
+        $startTime = $this->resolveStartTime($data, $type);
+        $endTime = $this->resolveEndTime($data, $startTime);
+
+        $title = trim((string) ($data['title'] ?? ''));
         $desc = $data['desc'] ?? '';
         $text = $data['text'] ?? '';
         $inactive = (int) ($data['inactive'] ?? 0);
         $linkedGroupId = (int) ($data['linkedGroupId'] ?? 0);
+        $skipExisting = (bool) ($data['skipExisting'] ?? false);
+        $typeId = (int) $type->getId();
 
         $calendars = null;
         if (!empty($data['pinnedCalendars'])) {
@@ -92,9 +158,9 @@ class EventService
 
         $occurrenceDates = $this->generateOccurrenceDates(
             $recurType,
-            $data['recurDOW'] ?? null,
-            isset($data['recurDOM']) ? (int) $data['recurDOM'] : null,
-            $data['recurDOY'] ?? null,
+            $dow,
+            $dom,
+            $doy,
             $rangeStart,
             $rangeEnd
         );
@@ -107,18 +173,28 @@ class EventService
             ));
         }
 
-        $createdIds = [];
+        $created = [];
+        $skipped = 0;
+
         foreach ($occurrenceDates as $occurrenceDate) {
-            $eventStart = $occurrenceDate->format('Y-m-d') . ' ' . $startTime;
-            $eventEnd = $occurrenceDate->format('Y-m-d') . ' ' . $endTime;
+            $date = $occurrenceDate->format('Y-m-d');
+
+            if ($skipExisting && $this->hasEventOnDate($typeId, $date)) {
+                $skipped++;
+                continue;
+            }
+
+            $eventTitle = $title !== ''
+                ? $title
+                : $type->getName() . ' — ' . $occurrenceDate->format('M j, Y');
 
             $event = new Event();
-            $event->setTitle($title);
+            $event->setTitle($eventTitle);
             $event->setEventType($type);
             $event->setDesc($desc);
             $event->setText($text);
-            $event->setStart($eventStart);
-            $event->setEnd($eventEnd);
+            $event->setStart($date . ' ' . $startTime);
+            $event->setEnd($date . ' ' . $endTime);
             $event->setInActive($inactive);
 
             if ($calendars !== null) {
@@ -136,14 +212,81 @@ class EventService
                 $audience->save();
             }
 
-            $createdIds[] = $eventId;
+            $created[] = [
+                'id' => $eventId,
+                'title' => $eventTitle,
+                'date' => $date,
+            ];
         }
 
-        return $createdIds;
+        return [
+            'events' => $created,
+            'skipped' => $skipped,
+        ];
+    }
+
+    /**
+     * Resolve the recurrence pattern from the caller's input and the event type.
+     *
+     * A caller-supplied recurType wins, and its day fields fall back to the event
+     * type's defaults and then to the legacy literals. When the recurrence itself
+     * comes from the event type, the event type must be complete — silently
+     * defaulting a mis-configured type to "Sundays" would create the wrong events.
+     *
+     * @return array{0: string, 1: string|null, 2: int|null, 3: string|null} recurType, dow, dom, doy
+     *
+     * @throws \InvalidArgumentException when the event type's recurrence is incomplete
+     */
+    private function resolveRecurrence(array $data, EventType $type): array
+    {
+        $callerRecurType = isset($data['recurType']) && $data['recurType'] !== ''
+            ? (string) $data['recurType']
+            : null;
+
+        $recurType = $callerRecurType ?? ($type->getDefRecurType() ?: 'none');
+        if ($recurType === 'none' || $recurType === '') {
+            throw new \InvalidArgumentException(gettext('Event type has no recurrence pattern configured'));
+        }
+
+        $typeIsSource = $callerRecurType === null;
+
+        $dow = $this->firstNonEmptyString($data['recurDOW'] ?? null, $type->getDefRecurDOW());
+        if ($recurType === RecurrenceDateGenerator::RECUR_WEEKLY) {
+            if ($dow === null && $typeIsSource) {
+                throw new \InvalidArgumentException(gettext('Event type has no day-of-week configured for weekly recurrence'));
+            }
+            $dow ??= 'Sunday';
+        }
+
+        $dom = isset($data['recurDOM']) && (int) $data['recurDOM'] > 0
+            ? (int) $data['recurDOM']
+            : (int) $type->getDefRecurDOM();
+        if ($recurType === RecurrenceDateGenerator::RECUR_MONTHLY) {
+            if ($dom < 1 || $dom > 31) {
+                if ($typeIsSource) {
+                    throw new \InvalidArgumentException(gettext('Event type has no valid day-of-month configured for monthly recurrence'));
+                }
+                $dom = 1;
+            }
+        }
+
+        $doy = $this->firstNonEmptyString($data['recurDOY'] ?? null, $this->formatDefRecurDoy($type));
+        if ($recurType === RecurrenceDateGenerator::RECUR_YEARLY) {
+            if ($doy === null && $typeIsSource) {
+                throw new \InvalidArgumentException(gettext('Event type has no date configured for yearly recurrence'));
+            }
+            $doy ??= '01-01';
+        }
+
+        return [$recurType, $dow, $dom > 0 ? $dom : null, $doy];
     }
 
     /**
      * Generate all occurrence dates within a range based on recurrence settings.
+     *
+     * The single date-math entry point for every recurring-event caller; the math
+     * itself lives in the event-free RecurrenceDateGenerator so other modules can
+     * reuse it without dragging in event persistence.
      *
      * @param string      $recurType  One of: weekly, monthly, yearly
      * @param string|null $dow        Day of week name (e.g. "Sunday") — used when $recurType is 'weekly'
@@ -162,141 +305,98 @@ class EventService
         \DateTime $rangeStart,
         \DateTime $rangeEnd
     ): array {
-        switch ($recurType) {
-            case 'weekly':
-                return $this->generateWeeklyDates($dow ?? 'Sunday', $rangeStart, $rangeEnd);
-            case 'monthly':
-                return $this->generateMonthlyDates($dom ?? 1, $rangeStart, $rangeEnd);
-            case 'yearly':
-                return $this->generateYearlyDates($doy ?? '01-01', $rangeStart, $rangeEnd);
-            default:
-                return [];
-        }
+        return $this->recurrenceDateGenerator->generate($recurType, $dow, $dom, $doy, $rangeStart, $rangeEnd);
     }
 
     /**
-     * Generate weekly occurrence dates within a range.
+     * Is there already an active event of this type on this calendar date?
      *
-     * The first occurrence is the first matching day-of-week on or after $rangeStart.
-     * Subsequent occurrences are every 7 days thereafter.
-     *
-     * @param string    $dow        Day name, e.g. "Sunday"
-     * @param \DateTime $rangeStart Inclusive start
-     * @param \DateTime $rangeEnd   Inclusive end
-     *
-     * @return \DateTime[]
+     * The shared skipExisting key: (event type, calendar date). Deliberately
+     * ignores the time of day so a series regenerated with a different start time
+     * still counts as "already there".
      */
-    private function generateWeeklyDates(string $dow, \DateTime $rangeStart, \DateTime $rangeEnd): array
+    private function hasEventOnDate(int $typeId, string $date): bool
     {
-        $dates = [];
-        $current = clone $rangeStart;
-        $current->setTime(0, 0, 0);
-
-        $targetDay = strtolower($dow);
-        $currentDay = strtolower($current->format('l'));
-
-        if ($currentDay !== $targetDay) {
-            $current->modify('next ' . $targetDay);
-        }
-
-        while ($current <= $rangeEnd) {
-            $dates[] = clone $current;
-            $current->modify('+1 week');
-        }
-
-        return $dates;
+        return EventQuery::create()
+            ->filterByType($typeId)
+            ->filterByStart($date . ' 00:00:00', Criteria::GREATER_EQUAL)
+            ->filterByStart($date . ' 23:59:59', Criteria::LESS_EQUAL)
+            ->filterByInActive(0)
+            ->findOne() !== null;
     }
 
     /**
-     * Generate monthly occurrence dates within a range.
-     *
-     * One event per month, on the specified day of month (clamped to the last
-     * valid day when the month is shorter than $dom).
-     *
-     * @param int       $dom        Day of month (1–31)
-     * @param \DateTime $rangeStart Inclusive start
-     * @param \DateTime $rangeEnd   Inclusive end
-     *
-     * @return \DateTime[]
+     * Caller start time, else the event type's default, else 09:00.
      */
-    private function generateMonthlyDates(int $dom, \DateTime $rangeStart, \DateTime $rangeEnd): array
+    private function resolveStartTime(array $data, EventType $type): string
     {
-        $dates = [];
-        $current = clone $rangeStart;
-        $current->setDate((int) $current->format('Y'), (int) $current->format('m'), 1);
-        $current->setTime(0, 0, 0);
-
-        while ($current <= $rangeEnd) {
-            $year = (int) $current->format('Y');
-            $month = (int) $current->format('m');
-            $daysInMonth = DateTimeUtils::getDaysInMonth($month, $year);
-            $actualDay = min($dom, $daysInMonth);
-
-            $occurrence = new \DateTime(sprintf('%04d-%02d-%02d', $year, $month, $actualDay));
-            $occurrence->setTime(0, 0, 0);
-
-            if ($occurrence >= $rangeStart && $occurrence <= $rangeEnd) {
-                $dates[] = $occurrence;
-            }
-
-            $current->modify('+1 month');
+        $callerTime = $this->firstNonEmptyString($data['startTime'] ?? null, null);
+        if ($callerTime !== null) {
+            return self::normalizeTime($callerTime);
         }
 
-        return $dates;
+        // getDefStartTime() can return either a DateTime or a raw string
+        // depending on the Propel codegen path — handle both safely.
+        $defStartTime = $type->getDefStartTime();
+        if ($defStartTime instanceof \DateTimeInterface) {
+            return $defStartTime->format('H:i:s');
+        }
+        if (is_string($defStartTime) && $defStartTime !== '') {
+            return self::normalizeTime($defStartTime);
+        }
+
+        return self::DEFAULT_START_TIME;
     }
 
     /**
-     * Generate yearly occurrence dates within a range.
-     *
-     * One event per year, on the specified month-day (e.g. "04-12" for April 12).
-     * Dates that don't exist in a given year (e.g. Feb 29 in a non-leap year) are
-     * silently skipped.
-     *
-     * @param string    $doy        Month-day string in MM-DD format
-     * @param \DateTime $rangeStart Inclusive start
-     * @param \DateTime $rangeEnd   Inclusive end
-     *
-     * @return \DateTime[]
-     *
-     * @throws \InvalidArgumentException if $doy is not in MM-DD format
+     * Caller end time, else one hour after the start time.
      */
-    private function generateYearlyDates(string $doy, \DateTime $rangeStart, \DateTime $rangeEnd): array
+    private function resolveEndTime(array $data, string $startTime): string
     {
-        $dates = [];
-        $parts = explode('-', $doy);
-        if (count($parts) !== 2 || !is_numeric($parts[0]) || !is_numeric($parts[1])) {
-            throw new \InvalidArgumentException(
-                gettext('Invalid yearly recurrence format; expected MM-DD (e.g. 04-12)')
-            );
+        $callerTime = $this->firstNonEmptyString($data['endTime'] ?? null, null);
+        if ($callerTime !== null) {
+            return self::normalizeTime($callerTime);
         }
 
-        $month = (int) $parts[0];
-        $day = (int) $parts[1];
-
-        if ($month < 1 || $month > 12 || $day < 1 || $day > 31) {
-            throw new \InvalidArgumentException(
-                gettext('Invalid yearly recurrence format; expected MM-DD (e.g. 04-12)')
-            );
+        $start = \DateTimeImmutable::createFromFormat('H:i:s', $startTime);
+        if ($start === false) {
+            return '10:00:00';
         }
 
-        $startYear = (int) $rangeStart->format('Y');
-        $endYear = (int) $rangeEnd->format('Y');
+        return $start->modify('+1 hour')->format('H:i:s');
+    }
 
-        for ($year = $startYear; $year <= $endYear; $year++) {
-            // Skip dates that don't exist in this year (e.g. Feb 29 in a non-leap year)
-            if (!checkdate($month, $day, $year)) {
-                continue;
+    /**
+     * The event type's yearly recurrence day as an MM-DD string, or null.
+     */
+    private function formatDefRecurDoy(EventType $type): ?string
+    {
+        $doy = $type->getDefRecurDOY();
+        if ($doy instanceof \DateTimeInterface) {
+            return $doy->format('m-d');
+        }
+        if (is_string($doy) && $doy !== '') {
+            // Stored as a DATE ("2016-04-12") in some installs; keep only MM-DD.
+            $parsed = \DateTimeImmutable::createFromFormat('!Y-m-d', $doy);
+
+            return $parsed !== false ? $parsed->format('m-d') : $doy;
+        }
+
+        return null;
+    }
+
+    /**
+     * First of the two values that is a non-empty, trimmed string, else null.
+     */
+    private function firstNonEmptyString(mixed $preferred, mixed $fallback): ?string
+    {
+        foreach ([$preferred, $fallback] as $candidate) {
+            if (is_string($candidate) && trim($candidate) !== '') {
+                return trim($candidate);
             }
-
-            $occurrence = new \DateTime(sprintf('%04d-%02d-%02d', $year, $month, $day));
-            $occurrence->setTime(0, 0, 0);
-
-            if ($occurrence >= $rangeStart && $occurrence <= $rangeEnd) {
-                $dates[] = $occurrence;
-            }
         }
 
-        return $dates;
+        return null;
     }
 
     /**
@@ -314,7 +414,7 @@ class EventService
         $parsed = \DateTimeImmutable::createFromFormat('H:i:s', $time)
             ?: \DateTimeImmutable::createFromFormat('H:i', $time);
         if ($parsed === false) {
-            return '09:00:00';
+            return self::DEFAULT_START_TIME;
         }
 
         return $parsed->format('H:i:s');

--- a/src/ChurchCRM/Service/RecurrenceDateGenerator.php
+++ b/src/ChurchCRM/Service/RecurrenceDateGenerator.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace ChurchCRM\Service;
+
+use ChurchCRM\Utils\DateTimeUtils;
+
+/**
+ * Event-free recurrence date math.
+ *
+ * Produces the set of occurrence dates described by a recurrence pattern
+ * (weekly / monthly / yearly) inside an inclusive date range. It knows nothing
+ * about events, calendars or the database, so any module that needs "the dates
+ * this thing repeats on" can reuse it instead of growing another copy of the
+ * same switch statement.
+ *
+ * This is the single implementation of that math in the codebase — see
+ * EventService, which is the only event-aware caller.
+ */
+class RecurrenceDateGenerator
+{
+    public const RECUR_WEEKLY = 'weekly';
+    public const RECUR_MONTHLY = 'monthly';
+    public const RECUR_YEARLY = 'yearly';
+
+    /**
+     * Recurrence types this generator understands.
+     */
+    public const SUPPORTED_RECUR_TYPES = [
+        self::RECUR_WEEKLY,
+        self::RECUR_MONTHLY,
+        self::RECUR_YEARLY,
+    ];
+
+    /**
+     * Generate all occurrence dates within a range based on recurrence settings.
+     *
+     * Every returned DateTime is anchored at midnight — callers apply their own
+     * time-of-day.
+     *
+     * @param string      $recurType  One of: weekly, monthly, yearly
+     * @param string|null $dow        Day of week name (e.g. "Sunday") — used when $recurType is 'weekly'
+     * @param int|null    $dom        Day of month (1–31) — used when $recurType is 'monthly'
+     * @param string|null $doy        Month-day string in MM-DD format (e.g. "04-12") — used when $recurType is 'yearly'
+     * @param \DateTime   $rangeStart Inclusive start of the date range
+     * @param \DateTime   $rangeEnd   Inclusive end of the date range
+     *
+     * @return \DateTime[] Occurrence dates in ascending order; empty for an unknown $recurType
+     *
+     * @throws \InvalidArgumentException if $doy is not in MM-DD format
+     */
+    public function generate(
+        string $recurType,
+        ?string $dow,
+        ?int $dom,
+        ?string $doy,
+        \DateTime $rangeStart,
+        \DateTime $rangeEnd
+    ): array {
+        return match ($recurType) {
+            self::RECUR_WEEKLY => $this->generateWeeklyDates($dow ?? 'Sunday', $rangeStart, $rangeEnd),
+            self::RECUR_MONTHLY => $this->generateMonthlyDates($dom ?? 1, $rangeStart, $rangeEnd),
+            self::RECUR_YEARLY => $this->generateYearlyDates($doy ?? '01-01', $rangeStart, $rangeEnd),
+            default => [],
+        };
+    }
+
+    /**
+     * Generate weekly occurrence dates within a range.
+     *
+     * The first occurrence is the first matching day-of-week on or after $rangeStart.
+     * Subsequent occurrences are every 7 days thereafter.
+     *
+     * @param string    $dow        Day name, e.g. "Sunday"
+     * @param \DateTime $rangeStart Inclusive start
+     * @param \DateTime $rangeEnd   Inclusive end
+     *
+     * @return \DateTime[]
+     */
+    private function generateWeeklyDates(string $dow, \DateTime $rangeStart, \DateTime $rangeEnd): array
+    {
+        $dates = [];
+        $current = clone $rangeStart;
+        $current->setTime(0, 0, 0);
+
+        $targetDay = strtolower(trim($dow));
+        $currentDay = strtolower($current->format('l'));
+
+        if ($currentDay !== $targetDay) {
+            $current->modify('next ' . $targetDay);
+        }
+
+        while ($current <= $rangeEnd) {
+            $dates[] = clone $current;
+            $current->modify('+1 week');
+        }
+
+        return $dates;
+    }
+
+    /**
+     * Generate monthly occurrence dates within a range.
+     *
+     * One event per month, on the specified day of month (clamped to the last
+     * valid day when the month is shorter than $dom).
+     *
+     * @param int       $dom        Day of month (1–31)
+     * @param \DateTime $rangeStart Inclusive start
+     * @param \DateTime $rangeEnd   Inclusive end
+     *
+     * @return \DateTime[]
+     */
+    private function generateMonthlyDates(int $dom, \DateTime $rangeStart, \DateTime $rangeEnd): array
+    {
+        $dates = [];
+        $current = clone $rangeStart;
+        $current->setDate((int) $current->format('Y'), (int) $current->format('m'), 1);
+        $current->setTime(0, 0, 0);
+
+        while ($current <= $rangeEnd) {
+            $year = (int) $current->format('Y');
+            $month = (int) $current->format('m');
+            $daysInMonth = DateTimeUtils::getDaysInMonth($month, $year);
+            $actualDay = min($dom, $daysInMonth);
+
+            $occurrence = new \DateTime(sprintf('%04d-%02d-%02d', $year, $month, $actualDay));
+            $occurrence->setTime(0, 0, 0);
+
+            if ($occurrence >= $rangeStart && $occurrence <= $rangeEnd) {
+                $dates[] = $occurrence;
+            }
+
+            $current->modify('+1 month');
+        }
+
+        return $dates;
+    }
+
+    /**
+     * Generate yearly occurrence dates within a range.
+     *
+     * One event per year, on the specified month-day (e.g. "04-12" for April 12).
+     * Dates that don't exist in a given year (e.g. Feb 29 in a non-leap year) are
+     * silently skipped rather than rolling over into the next month.
+     *
+     * @param string    $doy        Month-day string in MM-DD format
+     * @param \DateTime $rangeStart Inclusive start
+     * @param \DateTime $rangeEnd   Inclusive end
+     *
+     * @return \DateTime[]
+     *
+     * @throws \InvalidArgumentException if $doy is not in MM-DD format
+     */
+    private function generateYearlyDates(string $doy, \DateTime $rangeStart, \DateTime $rangeEnd): array
+    {
+        $dates = [];
+        $parts = explode('-', $doy);
+        if (count($parts) !== 2 || !is_numeric($parts[0]) || !is_numeric($parts[1])) {
+            throw new \InvalidArgumentException(
+                gettext('Invalid yearly recurrence format; expected MM-DD (e.g. 04-12)')
+            );
+        }
+
+        $month = (int) $parts[0];
+        $day = (int) $parts[1];
+
+        if ($month < 1 || $month > 12 || $day < 1 || $day > 31) {
+            throw new \InvalidArgumentException(
+                gettext('Invalid yearly recurrence format; expected MM-DD (e.g. 04-12)')
+            );
+        }
+
+        $startYear = (int) $rangeStart->format('Y');
+        $endYear = (int) $rangeEnd->format('Y');
+
+        for ($year = $startYear; $year <= $endYear; $year++) {
+            // Skip dates that don't exist in this year (e.g. Feb 29 in a non-leap year)
+            if (!checkdate($month, $day, $year)) {
+                continue;
+            }
+
+            $occurrence = new \DateTime(sprintf('%04d-%02d-%02d', $year, $month, $day));
+            $occurrence->setTime(0, 0, 0);
+
+            if ($occurrence >= $rangeStart && $occurrence <= $rangeEnd) {
+                $dates[] = $occurrence;
+            }
+        }
+
+        return $dates;
+    }
+}

--- a/src/api/routes/calendar/events.php
+++ b/src/api/routes/calendar/events.php
@@ -444,7 +444,7 @@ function newEvent(Request $request, Response $response, array $args): Response
  *     path="/events/repeat",
  *     operationId="createRepeatEvents",
  *     summary="Create a series of repeat events",
- *     description="Generates individual event records for each occurrence of a recurring event within a date range. Each created event is independently editable.",
+ *     description="Generates individual event records for each occurrence of a recurring event within a date range. Each created event is independently editable. Shares one recurrence engine with POST /events/generate-recurring: the same recurrence and date range produce the same occurrence dates on both endpoints, and a single call creates at most 366 events.",
  *     tags={"Calendar"},
  *     security={{"ApiKeyAuth":{}}},
  *     @OA\RequestBody(required=true, @OA\JsonContent(
@@ -463,16 +463,18 @@ function newEvent(Request $request, Response $response, array $args): Response
  *         @OA\Property(property="RangeEnd", type="string", format="date", example="2026-12-31", description="Last date of the repetition range (inclusive)"),
  *         @OA\Property(property="PinnedCalendars", type="array", @OA\Items(type="integer"), nullable=true),
  *         @OA\Property(property="LinkedGroupId", type="integer", nullable=true),
- *         @OA\Property(property="Inactive", type="integer", enum={0,1}, nullable=true)
+ *         @OA\Property(property="Inactive", type="integer", enum={0,1}, nullable=true),
+ *         @OA\Property(property="SkipExisting", type="boolean", default=false, description="Skip occurrence dates that already have an active event of this type, making the call idempotent. Same semantics as POST /events/generate-recurring.")
  *     )),
  *     @OA\Response(response=200, description="Repeat events created",
  *         @OA\JsonContent(
  *             @OA\Property(property="success", type="boolean", example=true),
  *             @OA\Property(property="count", type="integer", example=52),
+ *             @OA\Property(property="skipped", type="integer", example=0, description="Occurrences skipped because an event of this type already existed on that date (only non-zero when SkipExisting is true)"),
  *             @OA\Property(property="eventIds", type="array", @OA\Items(type="integer"))
  *         )
  *     ),
- *     @OA\Response(response=400, description="Invalid input (bad event type, invalid dates, unknown recurrence type)"),
+ *     @OA\Response(response=400, description="Invalid input (bad event type, invalid dates, unknown recurrence type, or more than 366 occurrences)"),
  *     @OA\Response(response=401, description="Unauthorized"),
  *     @OA\Response(response=403, description="AddEvents role required")
  * )
@@ -512,7 +514,7 @@ function createRepeatEvents(Request $request, Response $response, array $args): 
 
     try {
         $service = new EventService();
-        $createdIds = $service->createRepeatEvents([
+        $result = $service->createRecurringEvents([
             'title'          => $input['Title'],
             'typeId'         => (int) $input['Type'],
             'desc'           => $input['Desc'] ?? '',
@@ -528,14 +530,20 @@ function createRepeatEvents(Request $request, Response $response, array $args): 
             'pinnedCalendars' => array_map('intval', is_array($input['PinnedCalendars'] ?? null) ? $input['PinnedCalendars'] : []),
             'linkedGroupId'  => (int) ($input['LinkedGroupId'] ?? 0),
             'inactive'       => (int) ($input['Inactive'] ?? 0),
+            // Off by default so the historical "create them all again" behaviour
+            // is unchanged; opt in for an idempotent re-run (#9735).
+            'skipExisting'   => filter_var($input['SkipExisting'] ?? false, FILTER_VALIDATE_BOOLEAN),
         ]);
     } catch (\InvalidArgumentException $e) {
         return SlimUtils::renderErrorJSON($response, $e->getMessage(), [], 400);
     }
 
+    $createdIds = array_column($result['events'], 'id');
+
     return SlimUtils::renderJSON($response, [
         'success'  => true,
         'count'    => count($createdIds),
+        'skipped'  => $result['skipped'],
         'eventIds' => $createdIds,
     ]);
 }
@@ -1343,7 +1351,7 @@ function deleteAttendance(Request $request, Response $response, array $args): Re
  *     path="/events/generate-recurring",
  *     operationId="generateRecurringEvents",
  *     summary="Generate recurring events from an EventType's recurrence settings",
- *     description="Creates multiple events between startDate and endDate based on the EventType's recurrence pattern (weekly, monthly, or yearly). Optionally skips dates where an event of the same type already exists.",
+ *     description="Creates multiple events between startDate and endDate based on the EventType's recurrence pattern (weekly, monthly, or yearly). Optionally skips dates where an event of the same type already exists. Shares one recurrence engine with POST /events/repeat: the same recurrence and date range produce the same occurrence dates on both endpoints, and a single call creates at most 366 events.",
  *     tags={"Calendar"},
  *     security={{"ApiKeyAuth":{}}},
  *     @OA\RequestBody(required=true, @OA\JsonContent(
@@ -1365,7 +1373,7 @@ function deleteAttendance(Request $request, Response $response, array $args): Re
  *             ))
  *         )
  *     ),
- *     @OA\Response(response=400, description="Invalid input"),
+ *     @OA\Response(response=400, description="Invalid input (bad event type, invalid dates, event type with no recurrence configured, or more than 366 occurrences)"),
  *     @OA\Response(response=401, description="Unauthorized"),
  *     @OA\Response(response=403, description="AddEvents role required")
  * )
@@ -1396,160 +1404,29 @@ function generateRecurringEvents(Request $request, Response $response, array $ar
         return SlimUtils::renderErrorJSON($response, gettext('endDate must be after startDate'), [], 400);
     }
 
-    // Limit range to 1 year max to prevent accidental mass-creation
-    $maxEnd = (new \DateTime($startDate))->modify('+1 year')->format('Y-m-d');
-    if ($endDate > $maxEnd) {
-        return SlimUtils::renderErrorJSON($response, gettext('Date range cannot exceed 1 year'), [], 400);
-    }
-
-    $recurType = $eventType->getDefRecurType() ?: 'none';
-    if ($recurType === 'none') {
-        return SlimUtils::renderErrorJSON($response, gettext('Event type has no recurrence pattern configured'), [], 400);
-    }
-
-    // Calculate occurrence dates
-    $dates = [];
-    $start = new \DateTime($startDate);
-    $end = new \DateTime($endDate);
-
-    switch ($recurType) {
-        case 'weekly':
-            $dow = $eventType->getDefRecurDow();
-            if (empty($dow)) {
-                return SlimUtils::renderErrorJSON($response, gettext('Event type has no day-of-week configured for weekly recurrence'), [], 400);
-            }
-            // Move to the first occurrence of the target day on or after startDate
-            $current = clone $start;
-            $targetDay = ucfirst(strtolower(trim($dow)));
-            if ($current->format('l') !== $targetDay) {
-                $current->modify("next {$targetDay}");
-            }
-            while ($current <= $end) {
-                $dates[] = $current->format('Y-m-d');
-                $current->modify('+1 week');
-            }
-            break;
-
-        case 'monthly':
-            $dom = (int) $eventType->getDefRecurDom();
-            if ($dom < 1 || $dom > 31) {
-                return SlimUtils::renderErrorJSON($response, gettext('Event type has no valid day-of-month configured for monthly recurrence'), [], 400);
-            }
-            $current = clone $start;
-            // Move to the target DOM in the current month
-            $current->setDate((int) $current->format('Y'), (int) $current->format('m'), min($dom, (int) $current->format('t')));
-            if ($current < $start) {
-                $current->modify('+1 month');
-                $current->setDate((int) $current->format('Y'), (int) $current->format('m'), min($dom, (int) $current->format('t')));
-            }
-            while ($current <= $end) {
-                $dates[] = $current->format('Y-m-d');
-                $current->modify('+1 month');
-                // Handle months with fewer days (e.g., DOM=31 in a 30-day month)
-                $current->setDate((int) $current->format('Y'), (int) $current->format('m'), min($dom, (int) $current->format('t')));
-            }
-            break;
-
-        case 'yearly':
-            $doy = $eventType->getDefRecurDoy();
-            if ($doy === null) {
-                return SlimUtils::renderErrorJSON($response, gettext('Event type has no date configured for yearly recurrence'), [], 400);
-            }
-            $doyDate = $doy instanceof \DateTime ? $doy : new \DateTime($doy);
-            $month = (int) $doyDate->format('m');
-            $day = (int) $doyDate->format('d');
-            $currentYear = (int) $start->format('Y');
-            $endYear = (int) $end->format('Y');
-            for ($y = $currentYear; $y <= $endYear; $y++) {
-                $candidate = new \DateTime("{$y}-{$month}-{$day}");
-                if ($candidate >= $start && $candidate <= $end) {
-                    $dates[] = $candidate->format('Y-m-d');
-                }
-            }
-            break;
-    }
-
-    if (empty($dates)) {
-        return SlimUtils::renderJSON($response, ['created' => 0, 'skipped' => 0, 'events' => []]);
-    }
-
-    $groupId = (int) $eventType->getGroupId();
-    // getDefStartTime() can return either a DateTime or a raw string
-    // depending on the Propel codegen path — handle both safely.
-    $startTimeStr = '09:00:00';
-    $defStartTime = $eventType->getDefStartTime();
-    if ($defStartTime instanceof \DateTimeInterface) {
-        $startTimeStr = $defStartTime->format('H:i:s');
-    } elseif (is_string($defStartTime) && $defStartTime !== '') {
-        $parsed = \DateTimeImmutable::createFromFormat('H:i:s', $defStartTime)
-            ?: \DateTimeImmutable::createFromFormat('H:i', $defStartTime);
-        if ($parsed !== false) {
-            $startTimeStr = $parsed->format('H:i:s');
-        }
-    }
-
-    // Resolve pinned calendars if provided
-    $calendars = null;
-    if (!empty($pinnedCalendarIds) && is_array($pinnedCalendarIds)) {
-        $calendars = CalendarQuery::create()
-            ->filterById($pinnedCalendarIds, Criteria::IN)
-            ->find();
-    }
-
-    $createdEvents = [];
-    $skippedCount = 0;
-
-    foreach ($dates as $date) {
-        // Check for existing event on this date
-        if ($skipExisting) {
-            $existing = EventQuery::create()
-                ->filterByType($eventTypeId)
-                ->filterByStart($date . ' 00:00:00', Criteria::GREATER_EQUAL)
-                ->filterByStart($date . ' 23:59:59', Criteria::LESS_EQUAL)
-                ->filterByInActive(0)
-                ->findOne();
-
-            if ($existing !== null) {
-                $skippedCount++;
-                continue;
-            }
-        }
-
-        $formattedDate = date('M j, Y', strtotime($date));
-        $title = $eventType->getName() . ' — ' . $formattedDate;
-
-        $eventStart = $date . ' ' . $startTimeStr;
-        $eventEnd = (new \DateTime($eventStart))->modify('+1 hour')->format('Y-m-d H:i:s');
-
-        $event = new Event();
-        $event->setTitle($title);
-        $event->setType($eventTypeId);
-        $event->setStart($eventStart);
-        $event->setEnd($eventEnd);
-        $event->setInActive(0);
-        if ($calendars !== null) {
-            $event->setCalendars($calendars);
-        }
-        $event->save();
-
-        if ($groupId > 0) {
-            $audience = new EventAudience();
-            $audience->setEventId($event->getId());
-            $audience->setGroupId($groupId);
-            $audience->save();
-        }
-
-        $createdEvents[] = [
-            'id' => $event->getId(),
-            'title' => $title,
-            'date' => $date,
-        ];
+    // Thin adapter over the one recurring-event generator (#9735). Everything
+    // this endpoint used to do inline — occurrence dates, the generated
+    // "<Type> — M j, Y" title, the event type's default start time with a
+    // one-hour duration, and skipExisting dedup — is the service's documented
+    // behaviour when the caller supplies no title, times or recurrence.
+    try {
+        $service = new EventService();
+        $result = $service->createRecurringEvents([
+            'typeId'          => $eventTypeId,
+            'rangeStart'      => $startDate,
+            'rangeEnd'        => $endDate,
+            'skipExisting'    => $skipExisting,
+            'pinnedCalendars' => array_map('intval', is_array($pinnedCalendarIds) ? $pinnedCalendarIds : []),
+            'linkedGroupId'   => (int) $eventType->getGroupId(),
+        ]);
+    } catch (\InvalidArgumentException $e) {
+        return SlimUtils::renderErrorJSON($response, $e->getMessage(), [], 400);
     }
 
     return SlimUtils::renderJSON($response, [
-        'created' => count($createdEvents),
-        'skipped' => $skippedCount,
-        'events' => $createdEvents,
+        'created' => count($result['events']),
+        'skipped' => $result['skipped'],
+        'events' => $result['events'],
     ]);
 }
 


### PR DESCRIPTION
## What Changed
`POST /api/events/repeat` and `POST /api/events/generate-recurring` had separate recurrence implementations that produced different dates, times, titles and caps from the same input, and only one was idempotent. The date math now lives in one event-free `RecurrenceDateGenerator` (the shared helper the Volunteer v2 design calls CR4), `EventService::createRecurringEvents()` is the single bulk-creation path (`createRepeatEvents()` stays as a thin wrapper for the repeat editor), and the route adapter shrinks from ~180 lines to ~45. Shared rules: one cap of 366 occurrences for both endpoints (the old 1-year range cap is retired because it made yearly recurrence pointless and the repeat editor already allows multi-year ranges); idempotency keyed on event type plus calendar date, on by default for generate-recurring and opt-in via a new `SkipExisting` flag on repeat (backward compatible, with an additive `skipped` count); caller-supplied title and times win, otherwise both derive from the event type. Side fix: yearly recurrence no longer rolls Feb 29 into March 1 in non-leap years. Hook dispatch is untouched (#9767 adds `EVENT_CREATED` for bulk paths separately).

Fixes #9735

## Type
- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
curl: identical dates and `event_start`/`event_end` from both endpoints for the same input; re-runs return 0 created / N skipped on both; both reject 522 occurrences with the same 400. New `private.calendar.recurring-parity.spec.js` 7/7; full calendar API suite on a fresh seed 73/73; `ui-admin/repeat-event-editor.spec.js` 8/8. One existing assertion on the retired 1-year cap now asserts the shared occurrence cap. The cap choice is a visible behaviour change for generate-recurring (multi-year ranges under 366 occurrences are now accepted) and is called out for maintainer judgement.

## Pre-Merge
- [x] Tested locally
- [x] No new warnings
- [x] Build passes
- [x] Backward compatible (or migration documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
