### PR TITLE
Fix issue #9796: Gate the bootstrap debug line on the bootstrapper debug flag

### DIFF
--- a/src/ChurchCRM/Bootstrapper.php
+++ b/src/ChurchCRM/Bootstrapper.php
@@ -89,10 +89,16 @@ class Bootstrapper
 
         try {
             SystemURLs::init($sRootPath, $URL, dirname(__DIR__));
-            // Debug: Output document root and log path
-            $docRoot = SystemURLs::getDocumentRoot();
-            $logPath = LoggerUtils::buildLogFilePath('debug');
-            error_log("[Bootstrap Debug] DocumentRoot: $docRoot, LogPath: $logPath");
+            // Report where the application thinks its document root and log file
+            // are. Only emitted when $debugBootstrapper is enabled in Config.php:
+            // the application logger is not configured yet at this point (and the
+            // whole purpose of the line is to find out where that log would go),
+            // so this diagnostic has to use error_log().
+            if (!empty($debugBootstrapper)) {
+                $docRoot = SystemURLs::getDocumentRoot();
+                $logPath = LoggerUtils::buildLogFilePath('debug');
+                error_log("[Bootstrap Debug] DocumentRoot: $docRoot, LogPath: $logPath");
+            }
         } catch (\Exception $e) {
             self::handleBootstrapFailure($e, 'SystemURLs initialization failed');
         }


### PR DESCRIPTION
## What Changed
`Bootstrapper::init()` called `error_log("[Bootstrap Debug] …")` unconditionally, so every request wrote a line to the web server error log and every CLI run (for example the cron entry point in #9793) printed to stderr, which cron mails to the admin. The call is now wrapped in `if (!empty($debugBootstrapper))`, the flag the method already reads a few lines later to pick the bootstrap log level. `error_log` is kept rather than the app logger because the app logger does not exist yet at that point, and the line reports where that logger's file will be.

Fixes #9796

## Type
- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
Host PHP against the dev database: unpatched, `php -r 'include "Include/Config.php";'` prints the debug line; patched with debug off it prints nothing and the bootstrap still completes (`VersionUtils::getInstalledVersion()` returns 7.7.0); with `$debugBootstrapper = true` the line returns. `npm run build:php` and `npm run lint` pass.

## Pre-Merge
- [x] Tested locally
- [x] No new warnings
- [x] Build passes
- [x] Backward compatible (or migration documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
