### PR TITLE
docs: Add 413 response to POST /person/{id}/photo OpenAPI documentation

### DIFF
--- a/src/api/routes/people/people-person.php
+++ b/src/api/routes/people/people-person.php
@@ -76,7 +76,8 @@ use Slim\HttpCache\Cache;
  *     @OA\Response(response=400, description="Invalid image data or upload failed"),
  *     @OA\Response(response=401, description="Unauthorized"),
  *     @OA\Response(response=403, description="EditRecords role required"),
- *     @OA\Response(response=404, description="Person not found")
+ *     @OA\Response(response=404, description="Person not found"),
+ *     @OA\Response(response=413, description="PHP discarded the request body because it exceeded the server upload limit")
  * )
  * @OA\Delete(
  *     path="/person/{personId}/photo",


### PR DESCRIPTION
## Summary
Add missing OpenAPI documentation for the 413 Payload Too Large response to the person photo upload endpoint, matching the documentation already added to the family photo endpoint in PR #9783.

## Changes
- Added `@OA\Response(response=413, ...)` to the POST /person/{personId}/photo endpoint documentation
- Ensures API consumers understand when PHP discards the request body (413) versus a malformed request (400)

## Related
- Related to PR #9783 (Fix issue #9771: Return 400, not 413, for complete photo bodies that lack imgBase64)
- Fixes documentation completeness for issue #9771

🤖 Generated with [Claude Code](https://claude.com/claude-code)