### PR TITLE
locale: translate all locales (7.7.0)

### DIFF
--- a/locale/terms/missing/af/af-1.json
+++ b/locale/terms/missing/af/af-1.json
@@ -1,50 +1,50 @@
 {
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "A geocoding error occurred — try again later": "'n Geokoderingsfout het voorgekom — probeer later weer",
+  "Address is incomplete (missing city, state, and ZIP)": "Adres is onvolledig (stad, provinsie en poskode ontbreek)",
+  "All families already have coordinates.": "Alle families het reeds koördinate.",
+  "Failed to update coordinates": "Kon nie koördinate opdateer nie",
+  "Failed to update family coordinates": "Kon nie familie se koördinate opdateer nie",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Alle {{geocoded}} families is gegeokodeer. Die kaart is nou op datum.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "{{geocoded}} families is gegeokodeer. {{failed}} kon nie opgelos word nie — sien besonderhede hieronder.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "{{geocoded}} van {{total}} families is gegeokodeer. {{overflow}} is nog nie verwerk nie — loop weer om voort te gaan.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Families word gegeokodeer… dit kan tot 'n minuut neem. Jy kan hierdie bladsy oop hou.",
+  "Geocoding…": "Besig om te geokodeer…",
+  "No address on file": "Geen adres aangeteken nie",
+  "No match found — check the street address, city, and ZIP": "Geen ooreenkoms gevind nie — kontroleer die straatadres, stad en poskode",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Aantal dae wat gebruikers het om vir 2FA te registreer nadat dit verpligtend gemaak is. Stel op 0 om dit onmiddellik af te dwing (verouderde gedrag). Om 'n aktiewe genadetydperk te verkort kan gebruikers onmiddellik uitsluit.",
+  "Open a family to fix its address, then run this again.": "Maak 'n familie oop om die adres reg te stel, en loop dit dan weer.",
+  "Set up now": "Stel nou op",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Dit vind kaartkoördinate vir elke familie waarvoor dit ontbreek, deur OpenStreetMap te gebruik. Dit verwerk tot 50 families per loop; 'n volle groep neem ongeveer 'n minuut. Jy kan hierdie bladsy oop hou terwyl dit loop. Gaan voort?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "Twee-faktor-verifikasie word vereis. Jy het %d dag om te registreer.",
+    "other": "Twee-faktor-verifikasie word vereis. Jy het %d dae om te registreer."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Onbekende familie",
+  "Update All Coordinates": "Opdateer Alle Koördinate",
+  "Update All Family Coordinates": "Opdateer Alle Familiekoördinate",
+  "Update Coordinates": "Opdateer Koördinate",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} lid gekopieer",
+    "other": "{{count}} lede gekopieer"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Hierdie lys het {{count}} ontvanger — te veel vir 'n mailto:-skakel. Gebruik eerder Kopieer Adresse.",
+    "other": "Hierdie lys het {{count}} ontvangers — te veel vir 'n mailto:-skakel. Gebruik eerder Kopieer Adresse."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Te veel ontvangers vir die e-posprogram ({{count}} > {{max}}). Gebruik eerder Kopieer Adresse.",
+    "other": "Te veel ontvangers vir die e-posprogram ({{count}} > {{max}}). Gebruik eerder Kopieer Adresse."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} minuut oor",
+    "other": "{{count}} minute oor"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} familie kon nie gegeokodeer word nie",
+    "other": "{{count}} families kon nie gegeokodeer word nie"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…en nog {{count}}. Loop weer om die res te sien.",
+    "other": "…en nog {{count}}. Loop weer om die res te sien."
   }
 }

--- a/locale/terms/missing/am/am-1.json
+++ b/locale/terms/missing/am/am-1.json
@@ -1,52 +1,52 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "የጂኦኮዲንግ ስህተት ተከስቷል — በኋላ እንደገና ይሞክሩ",
+  "Address is incomplete (missing city, state, and ZIP)": "አድራሻው ያልተሟላ ነው (ከተማ፣ ክልል እና ዚፕ ኮድ ይጎድላል)",
+  "All families already have coordinates.": "ሁሉም ቤተሰቦች አስቀድሞ መጋጠሚያዎች አሏቸው።",
+  "Failed to update coordinates": "መጋጠሚያዎችን ማዘመን አልተሳካም",
+  "Failed to update family coordinates": "የቤተሰብ መጋጠሚያዎችን ማዘመን አልተሳካም",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "ሁሉንም {{geocoded}} ቤተሰቦች በጂኦኮድ ተሠርተዋል። ካርታው አሁን ወቅታዊ ነው።",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "{{geocoded}} ቤተሰቦች በጂኦኮድ ተሠርተዋል። {{failed}} ሊፈቱ አልቻሉም — ከታች ዝርዝሩን ይመልከቱ።",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "ከ{{total}} ቤተሰቦች መካከል {{geocoded}} በጂኦኮድ ተሠርተዋል። {{overflow}} ገና አልተሠሩም — ለመቀጠል እንደገና ያሂዱ።",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "ቤተሰቦችን በጂኦኮድ በማድረግ ላይ… ይህ እስከ አንድ ደቂቃ ሊወስድ ይችላል። ይህን ገጽ ክፍት አድርገው ማቆየት ይችላሉ።",
+  "Geocoding…": "በጂኦኮድ በማድረግ ላይ…",
+  "No address on file": "የተመዘገበ አድራሻ የለም",
+  "No match found — check the street address, city, and ZIP": "ምንም ተመሳሳይ አልተገኘም — የመንገድ አድራሻውን፣ ከተማውን እና ዚፕ ኮዱን ያረጋግጡ",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "ተጠቃሚዎች የሁለት-ደረጃ ማረጋገጫን (2FA) ግዴታ ከሆነ በኋላ ለመመዝገብ የሚኖራቸው የቀናት ብዛት። ወዲያውኑ ለማስፈጸም (የቀድሞ ባህሪ) ወደ 0 ያዘጋጁ። ንቁ የሆነውን የማቆያ ጊዜ ማሳጠር ተጠቃሚዎችን ወዲያውኑ ሊዘጋባቸው ይችላል።",
+  "Open a family to fix its address, then run this again.": "አድራሻውን ለማስተካከል ቤተሰቡን ይክፈቱ፣ ከዚያም ይህን እንደገና ያሂዱ።",
+  "Set up now": "አሁን ያዋቅሩ",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "ይህ OpenStreetMap ተጠቅሞ መጋጠሚያ ለሌላቸው ለእያንዳንዱ ቤተሰብ የካርታ መጋጠሚያዎችን ያገኛል። በአንድ ሩጫ እስከ 50 ቤተሰቦችን ያካሂዳል፤ ሙሉ ስብስብ ወደ አንድ ደቂቃ ያህል ይወስዳል። እየሄደ ሳለ ይህን ገጽ ክፍት አድርገው ማቆየት ይችላሉ። ይቀጥሉ?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "ባለሁለት-ደረጃ ማረጋገጫ ያስፈልጋል። ለመመዝገብ %d ቀን አለዎት።",
+    "other": "ባለሁለት-ደረጃ ማረጋገጫ ያስፈልጋል። ለመመዝገብ %d ቀናት አሉዎት።"
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "ያልታወቀ ቤተሰብ",
+  "Update All Coordinates": "ሁሉንም መጋጠሚያዎች አዘምን",
+  "Update All Family Coordinates": "ሁሉንም የቤተሰብ መጋጠሚያዎች አዘምን",
+  "Update Coordinates": "መጋጠሚያዎችን አዘምን",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} አባል ተቀድቷል",
+    "other": "{{count}} አባላት ተቀድተዋል"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "ይህ ዝርዝር {{count}} ተቀባይ አለው — ለmailto: አገናኝ በጣም ብዙ ነው። በምትኩ አድራሻዎችን ቅዳ ይጠቀሙ።",
+    "other": "ይህ ዝርዝር {{count}} ተቀባዮች አሉት — ለmailto: አገናኝ በጣም ብዙ ናቸው። በምትኩ አድራሻዎችን ቅዳ ይጠቀሙ።"
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "ለኢሜይል ደንበኛ በጣም ብዙ ተቀባዮች ({{count}} > {{max}})። በምትኩ አድራሻዎችን ቅዳ ይጠቀሙ።",
+    "other": "ለኢሜይል ደንበኛ በጣም ብዙ ተቀባዮች ({{count}} > {{max}})። በምትኩ አድራሻዎችን ቅዳ ይጠቀሙ።"
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} ደቂቃ ቀርቷል",
+    "other": "{{count}} ደቂቃዎች ቀርተዋል"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} ቤተሰብ በጂኦኮድ ሊሠራ አልቻለም",
+    "other": "{{count}} ቤተሰቦች በጂኦኮድ ሊሠሩ አልቻሉም"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…እና {{count}} ተጨማሪ። ቀሪውን ለማየት እንደገና ያሂዱ።",
+    "other": "…እና {{count}} ተጨማሪዎች። ቀሪውን ለማየት እንደገና ያሂዱ።"
   }
 }

--- a/locale/terms/missing/ar/ar-1.json
+++ b/locale/terms/missing/ar/ar-1.json
@@ -1,56 +1,56 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "حدث خطأ في تحديد الموقع الجغرافي — حاول مرة أخرى لاحقًا",
+  "Address is incomplete (missing city, state, and ZIP)": "العنوان غير مكتمل (المدينة والمحافظة والرمز البريدي مفقودة)",
+  "All families already have coordinates.": "جميع العائلات لديها إحداثيات بالفعل.",
+  "Failed to update coordinates": "فشل تحديث الإحداثيات",
+  "Failed to update family coordinates": "فشل تحديث إحداثيات العائلة",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "تم تحديد إحداثيات جميع العائلات البالغ عددها {{geocoded}}. الخريطة محدّثة الآن.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "تم تحديد إحداثيات {{geocoded}} عائلة. تعذّر تحديد {{failed}} — راجع التفاصيل أدناه.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "تم تحديد إحداثيات {{geocoded}} من أصل {{total}} عائلة. لم تتم معالجة {{overflow}} بعد — شغّل العملية مرة أخرى للمتابعة.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "جارٍ تحديد إحداثيات العائلات… قد يستغرق ذلك حتى دقيقة واحدة. يمكنك إبقاء هذه الصفحة مفتوحة.",
+  "Geocoding…": "جارٍ تحديد الإحداثيات…",
+  "No address on file": "لا يوجد عنوان مسجل",
+  "No match found — check the street address, city, and ZIP": "لم يتم العثور على تطابق — تحقق من عنوان الشارع والمدينة والرمز البريدي",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "عدد الأيام المتاحة للمستخدمين للتسجيل في المصادقة الثنائية بعد أن تصبح إلزامية. اضبطها على 0 للتطبيق الفوري (السلوك القديم). قد يؤدي تقصير فترة السماح النشطة إلى إقفال وصول المستخدمين فورًا.",
+  "Open a family to fix its address, then run this again.": "افتح ملف عائلة لإصلاح عنوانها، ثم كرر هذه العملية.",
+  "Set up now": "إعداد الآن",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "يعثر هذا على إحداثيات الخريطة لكل عائلة تفتقر إليها، باستخدام OpenStreetMap. تتم معالجة ما يصل إلى 50 عائلة في كل تشغيل؛ وتستغرق الدفعة الكاملة نحو دقيقة واحدة. يمكنك إبقاء هذه الصفحة مفتوحة أثناء التشغيل. هل تريد المتابعة؟",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "zero": "",
-    "one": "",
-    "two": "",
-    "few": "",
-    "many": "",
-    "other": ""
+    "zero": "المصادقة الثنائية مطلوبة. لديك %d يوم للتسجيل.",
+    "one": "المصادقة الثنائية مطلوبة. لديك يوم واحد للتسجيل.",
+    "two": "المصادقة الثنائية مطلوبة. لديك يومان للتسجيل.",
+    "few": "المصادقة الثنائية مطلوبة. لديك %d أيام للتسجيل.",
+    "many": "المصادقة الثنائية مطلوبة. لديك %d يومًا للتسجيل.",
+    "other": "المصادقة الثنائية مطلوبة. لديك %d يوم للتسجيل."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "عائلة غير معروفة",
+  "Update All Coordinates": "تحديث جميع الإحداثيات",
+  "Update All Family Coordinates": "تحديث جميع إحداثيات العائلات",
+  "Update Coordinates": "تحديث الإحداثيات",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "تم نسخ عضو واحد",
+    "other": "تم نسخ {{count}} أعضاء"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "تحتوي هذه القائمة على مستلم واحد — كثير جدًا لرابط mailto. استخدم نسخ العناوين بدلاً من ذلك.",
+    "other": "تحتوي هذه القائمة على {{count}} مستلمين — كثير جدًا لرابط mailto. استخدم نسخ العناوين بدلاً من ذلك."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "عدد المستلمين كبير جدًا لعميل البريد الإلكتروني ({{count}} > {{max}}). استخدم نسخ العناوين بدلاً من ذلك.",
+    "other": "عدد المستلمين كبير جدًا لعميل البريد الإلكتروني ({{count}} > {{max}}). استخدم نسخ العناوين بدلاً من ذلك."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "دقيقة واحدة متبقية",
+    "other": "{{count}} دقيقة متبقية"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "تعذّر تحديد إحداثيات عائلة واحدة",
+    "other": "تعذّر تحديد إحداثيات {{count}} عائلة"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…وواحدة أخرى. أعد التشغيل لرؤية الباقي.",
+    "other": "…و{{count}} أخرى. أعد التشغيل لرؤية الباقي."
   }
 }

--- a/locale/terms/missing/cs/cs-1.json
+++ b/locale/terms/missing/cs/cs-1.json
@@ -1,56 +1,56 @@
 {
-  "Fundraising": "",
-  "Data": "",
-  "CSV": "",
-  "N/A": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "Fundraising": "Fundraising",
+  "Data": "Data",
+  "CSV": "CSV",
+  "N/A": "N/A",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "Došlo k chybě geokódování — zkuste to prosím později",
+  "Address is incomplete (missing city, state, and ZIP)": "Adresa je neúplná (chybí město, stát a PSČ)",
+  "All families already have coordinates.": "Všechny rodiny již mají souřadnice.",
+  "Failed to update coordinates": "Aktualizace souřadnic se nezdařila",
+  "Failed to update family coordinates": "Aktualizace souřadnic rodiny se nezdařila",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Geokódování dokončeno pro všech {{geocoded}} rodin. Mapa je nyní aktuální.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Geokódováno {{geocoded}} rodin. {{failed}} se nepodařilo vyřešit — podrobnosti najdete níže.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Geokódováno {{geocoded}} z {{total}} rodin. {{overflow}} zatím nezpracováno — spusťte akci znovu pro pokračování.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Geokódování rodin… může to trvat až minutu. Tuto stránku můžete ponechat otevřenou.",
+  "Geocoding…": "Geokódování…",
+  "No address on file": "Adresa není k dispozici",
+  "No match found — check the street address, city, and ZIP": "Nebyla nalezena žádná shoda — zkontrolujte ulici, město a PSČ",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Počet dní, které mají uživatelé na aktivaci dvoufaktorového ověření poté, co se stane povinným. Nastavením na 0 se vynutí okamžitě (původní chování). Zkrácení aktivní ochranné lhůty může uživatele okamžitě zamknout mimo systém.",
+  "Open a family to fix its address, then run this again.": "Otevřete rodinu a opravte její adresu, poté akci spusťte znovu.",
+  "Set up now": "Nastavit nyní",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Tato funkce najde souřadnice na mapě pro všechny rodiny, kterým chybí, pomocí OpenStreetMap. Za jedno spuštění zpracuje až 50 rodin; celá dávka trvá přibližně minutu. Během zpracování můžete tuto stránku ponechat otevřenou. Pokračovat?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "few": "",
-    "other": ""
+    "one": "Je vyžadováno dvoufaktorové ověření. Na aktivaci máte %d den.",
+    "few": "Je vyžadováno dvoufaktorové ověření. Na aktivaci máte %d dny.",
+    "other": "Je vyžadováno dvoufaktorové ověření. Na aktivaci máte %d dní."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Neznámá rodina",
+  "Update All Coordinates": "Aktualizovat všechny souřadnice",
+  "Update All Family Coordinates": "Aktualizovat souřadnice všech rodin",
+  "Update Coordinates": "Aktualizovat souřadnice",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Zkopírován {{count}} člen",
+    "other": "Zkopírováno {{count}} členů"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Tento seznam obsahuje {{count}} příjemce — příliš mnoho pro odkaz mailto:. Použijte místo toho Kopírovat adresy.",
+    "other": "Tento seznam obsahuje {{count}} příjemců — příliš mnoho pro odkaz mailto:. Použijte místo toho Kopírovat adresy."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Příliš mnoho příjemců pro e-mailového klienta ({{count}} > {{max}}). Použijte místo toho Kopírovat adresy.",
+    "other": "Příliš mnoho příjemců pro e-mailového klienta ({{count}} > {{max}}). Použijte místo toho Kopírovat adresy."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "Zbývá {{count}} minuta",
+    "other": "Zbývá {{count}} minut"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "Nepodařilo se geokódovat {{count}} rodinu",
+    "other": "Nepodařilo se geokódovat {{count}} rodin"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…a {{count}} další. Spusťte akci znovu, abyste viděli zbytek.",
+    "other": "…a {{count}} dalších. Spusťte akci znovu, abyste viděli zbytek."
   }
 }

--- a/locale/terms/missing/de/de-1.json
+++ b/locale/terms/missing/de/de-1.json
@@ -1,53 +1,53 @@
 {
-  "Code": "",
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "Code": "Code",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "Bei der Geokodierung ist ein Fehler aufgetreten – bitte versuchen Sie es später erneut",
+  "Address is incomplete (missing city, state, and ZIP)": "Die Adresse ist unvollständig (Stadt, Bundesland und Postleitzahl fehlen)",
+  "All families already have coordinates.": "Alle Familien haben bereits Koordinaten.",
+  "Failed to update coordinates": "Aktualisierung der Koordinaten fehlgeschlagen",
+  "Failed to update family coordinates": "Aktualisierung der Familienkoordinaten fehlgeschlagen",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Alle {{geocoded}} Familien wurden geokodiert. Die Karte ist jetzt aktuell.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "{{geocoded}} Familien wurden geokodiert. {{failed}} konnten nicht aufgelöst werden – siehe Details unten.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "{{geocoded}} von {{total}} Familien wurden geokodiert. {{overflow}} wurden noch nicht verarbeitet – führen Sie den Vorgang erneut aus, um fortzufahren.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Familien werden geokodiert … dies kann bis zu einer Minute dauern. Sie können diese Seite geöffnet lassen.",
+  "Geocoding…": "Geokodierung läuft …",
+  "No address on file": "Keine Adresse hinterlegt",
+  "No match found — check the street address, city, and ZIP": "Keine Übereinstimmung gefunden – bitte Straße, Stadt und Postleitzahl überprüfen",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Anzahl der Tage, die Benutzern zur Verfügung stehen, um sich nach der verpflichtenden Einführung für die Zwei-Faktor-Authentifizierung (2FA) zu registrieren. Auf 0 setzen, um dies sofort zu erzwingen (bisheriges Verhalten). Eine Verkürzung einer laufenden Übergangsfrist kann Benutzer sofort aussperren.",
+  "Open a family to fix its address, then run this again.": "Öffnen Sie eine Familie, um deren Adresse zu korrigieren, und führen Sie diesen Vorgang anschließend erneut aus.",
+  "Set up now": "Jetzt einrichten",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Dies ermittelt mithilfe von OpenStreetMap die Kartenkoordinaten für alle Familien, denen sie fehlen. Es werden bis zu 50 Familien pro Durchlauf verarbeitet; ein vollständiger Durchlauf dauert etwa eine Minute. Sie können diese Seite währenddessen geöffnet lassen. Fortfahren?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "Die Zwei-Faktor-Authentifizierung ist erforderlich. Sie haben noch %d Tag Zeit, sich zu registrieren.",
+    "other": "Die Zwei-Faktor-Authentifizierung ist erforderlich. Sie haben noch %d Tage Zeit, sich zu registrieren."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Unbekannte Familie",
+  "Update All Coordinates": "Alle Koordinaten aktualisieren",
+  "Update All Family Coordinates": "Alle Familienkoordinaten aktualisieren",
+  "Update Coordinates": "Koordinaten aktualisieren",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} Mitglied kopiert",
+    "other": "{{count}} Mitglieder kopiert"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Diese Liste hat {{count}} Empfänger – zu viele für einen mailto:-Link. Verwenden Sie stattdessen „Adressen kopieren“.",
+    "other": "Diese Liste hat {{count}} Empfänger – zu viele für einen mailto:-Link. Verwenden Sie stattdessen „Adressen kopieren“."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Zu viele Empfänger für das E-Mail-Programm ({{count}} > {{max}}). Verwenden Sie stattdessen „Adressen kopieren“.",
+    "other": "Zu viele Empfänger für das E-Mail-Programm ({{count}} > {{max}}). Verwenden Sie stattdessen „Adressen kopieren“."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} Minute übrig",
+    "other": "{{count}} Minuten übrig"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} Familie konnte nicht geokodiert werden",
+    "other": "{{count}} Familien konnten nicht geokodiert werden"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "… und {{count}} weitere. Führen Sie den Vorgang erneut aus, um den Rest zu sehen.",
+    "other": "… und {{count}} weitere. Führen Sie den Vorgang erneut aus, um den Rest zu sehen."
   }
 }

--- a/locale/terms/missing/el/el-1.json
+++ b/locale/terms/missing/el/el-1.json
@@ -1,52 +1,52 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "Παρουσιάστηκε σφάλμα γεωκωδικοποίησης — δοκιμάστε ξανά αργότερα",
+  "Address is incomplete (missing city, state, and ZIP)": "Η διεύθυνση είναι ελλιπής (λείπει η πόλη, η πολιτεία και ο ταχυδρομικός κώδικας)",
+  "All families already have coordinates.": "Όλες οι οικογένειες έχουν ήδη συντεταγμένες.",
+  "Failed to update coordinates": "Αποτυχία ενημέρωσης συντεταγμένων",
+  "Failed to update family coordinates": "Αποτυχία ενημέρωσης συντεταγμένων οικογένειας",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Έγινε γεωκωδικοποίηση και των {{geocoded}} οικογενειών. Ο χάρτης είναι πλέον ενημερωμένος.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Έγινε γεωκωδικοποίηση {{geocoded}} οικογενειών. {{failed}} δεν ήταν δυνατό να επιλυθούν — δείτε λεπτομέρειες παρακάτω.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Έγινε γεωκωδικοποίηση {{geocoded}} από {{total}} οικογένειες. {{overflow}} δεν έχουν επεξεργαστεί ακόμη — εκτελέστε ξανά για να συνεχίσετε.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Γίνεται γεωκωδικοποίηση οικογενειών… αυτό μπορεί να διαρκέσει έως ένα λεπτό. Μπορείτε να αφήσετε αυτή τη σελίδα ανοιχτή.",
+  "Geocoding…": "Γεωκωδικοποίηση…",
+  "No address on file": "Δεν υπάρχει καταχωρημένη διεύθυνση",
+  "No match found — check the street address, city, and ZIP": "Δεν βρέθηκε αντιστοιχία — ελέγξτε τη διεύθυνση, την πόλη και τον ταχυδρομικό κώδικα",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Αριθμός ημερών που έχουν οι χρήστες για να εγγραφούν στον έλεγχο ταυτότητας δύο παραγόντων (2FA) αφότου καταστεί υποχρεωτικός. Ορίστε 0 για άμεση επιβολή (παλαιά συμπεριφορά). Η μείωση μιας ενεργής περιόδου χάριτος ενδέχεται να αποκλείσει αμέσως τους χρήστες.",
+  "Open a family to fix its address, then run this again.": "Ανοίξτε μια οικογένεια για να διορθώσετε τη διεύθυνσή της και, στη συνέχεια, εκτελέστε το ξανά.",
+  "Set up now": "Ρύθμιση τώρα",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Αυτό εντοπίζει συντεταγμένες χάρτη για κάθε οικογένεια που δεν τις διαθέτει, χρησιμοποιώντας το OpenStreetMap. Επεξεργάζεται έως 50 οικογένειες ανά εκτέλεση· μια πλήρης παρτίδα διαρκεί περίπου ένα λεπτό. Μπορείτε να αφήσετε αυτή τη σελίδα ανοιχτή όσο εκτελείται. Συνέχεια;",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "Απαιτείται έλεγχος ταυτότητας δύο παραγόντων. Έχετε %d ημέρα για εγγραφή.",
+    "other": "Απαιτείται έλεγχος ταυτότητας δύο παραγόντων. Έχετε %d ημέρες για εγγραφή."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Άγνωστη οικογένεια",
+  "Update All Coordinates": "Ενημέρωση Όλων των Συντεταγμένων",
+  "Update All Family Coordinates": "Ενημέρωση Όλων των Συντεταγμένων Οικογενειών",
+  "Update Coordinates": "Ενημέρωση Συντεταγμένων",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Αντιγράφηκε {{count}} μέλος",
+    "other": "Αντιγράφηκαν {{count}} μέλη"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Αυτή η λίστα έχει {{count}} παραλήπτη — πάρα πολλούς για σύνδεσμο mailto:. Χρησιμοποιήστε αντ' αυτού την Αντιγραφή Διευθύνσεων.",
+    "other": "Αυτή η λίστα έχει {{count}} παραλήπτες — πάρα πολλούς για σύνδεσμο mailto:. Χρησιμοποιήστε αντ' αυτού την Αντιγραφή Διευθύνσεων."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Πάρα πολλοί παραλήπτες για τον πελάτη email ({{count}} > {{max}}). Χρησιμοποιήστε αντ' αυτού την Αντιγραφή Διευθύνσεων.",
+    "other": "Πάρα πολλοί παραλήπτες για τον πελάτη email ({{count}} > {{max}}). Χρησιμοποιήστε αντ' αυτού την Αντιγραφή Διευθύνσεων."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "Απομένει {{count}} λεπτό",
+    "other": "Απομένουν {{count}} λεπτά"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} οικογένεια δεν ήταν δυνατό να γεωκωδικοποιηθεί",
+    "other": "{{count}} οικογένειες δεν ήταν δυνατό να γεωκωδικοποιηθούν"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…και {{count}} ακόμη. Εκτελέστε ξανά για να δείτε τα υπόλοιπα.",
+    "other": "…και {{count}} ακόμη. Εκτελέστε ξανά για να δείτε τα υπόλοιπα."
   }
 }

--- a/locale/terms/missing/es-AR/es-AR-1.json
+++ b/locale/terms/missing/es-AR/es-AR-1.json
@@ -1,52 +1,52 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "Ocurrió un error de geocodificación — intentá de nuevo más tarde",
+  "Address is incomplete (missing city, state, and ZIP)": "La dirección está incompleta (faltan ciudad, provincia y código postal)",
+  "All families already have coordinates.": "Todas las familias ya tienen coordenadas.",
+  "Failed to update coordinates": "No se pudieron actualizar las coordenadas",
+  "Failed to update family coordinates": "No se pudieron actualizar las coordenadas de la familia",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Se geocodificaron las {{geocoded}} familias. El mapa está actualizado.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Se geocodificaron {{geocoded}} familias. {{failed}} no se pudieron resolver — mirá los detalles abajo.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Se geocodificaron {{geocoded}} de {{total}} familias. {{overflow}} aún no se procesaron — ejecutalo de nuevo para continuar.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Geocodificando familias… esto puede tardar hasta un minuto. Podés dejar esta página abierta.",
+  "Geocoding…": "Geocodificando…",
+  "No address on file": "No hay dirección registrada",
+  "No match found — check the street address, city, and ZIP": "No se encontraron coincidencias — verificá la calle, la ciudad y el código postal",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Cantidad de días que tienen los usuarios para habilitar la autenticación de dos factores (2FA) después de que se vuelva obligatoria. Poné 0 para exigirlo de inmediato (comportamiento heredado). Acortar un período de gracia activo puede bloquear el acceso a los usuarios de inmediato.",
+  "Open a family to fix its address, then run this again.": "Abrí una familia para corregir su dirección y volvé a ejecutar esto.",
+  "Set up now": "Configurar ahora",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Esto busca las coordenadas del mapa para cada familia a la que le falten, usando OpenStreetMap. Procesa hasta 50 familias por ejecución; un lote completo tarda aproximadamente un minuto. Podés dejar esta página abierta mientras se ejecuta. ¿Continuar?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "Se requiere la autenticación de dos factores. Tenés %d día para habilitarla.",
+    "other": "Se requiere la autenticación de dos factores. Tenés %d días para habilitarla."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Familia desconocida",
+  "Update All Coordinates": "Actualizar todas las coordenadas",
+  "Update All Family Coordinates": "Actualizar todas las coordenadas de las familias",
+  "Update Coordinates": "Actualizar coordenadas",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Se copió {{count}} miembro",
+    "other": "Se copiaron {{count}} miembros"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Esta lista tiene {{count}} destinatario — son demasiados para un enlace mailto:. Usá Copiar direcciones en su lugar.",
+    "other": "Esta lista tiene {{count}} destinatarios — son demasiados para un enlace mailto:. Usá Copiar direcciones en su lugar."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Usá Copiar direcciones en su lugar.",
+    "other": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Usá Copiar direcciones en su lugar."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "Queda {{count}} minuto",
+    "other": "Quedan {{count}} minutos"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "No se pudo geocodificar {{count}} familia",
+    "other": "No se pudieron geocodificar {{count}} familias"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…y {{count}} más. Ejecutalo de nuevo para ver el resto.",
+    "other": "…y {{count}} más. Ejecutalo de nuevo para ver el resto."
   }
 }

--- a/locale/terms/missing/es-CO/es-CO-1.json
+++ b/locale/terms/missing/es-CO/es-CO-1.json
@@ -1,53 +1,53 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "Ocurrió un error de geocodificación — inténtelo de nuevo más tarde",
+  "Address is incomplete (missing city, state, and ZIP)": "La dirección está incompleta (falta la ciudad, el departamento y el código postal)",
+  "All families already have coordinates.": "Todas las familias ya tienen coordenadas.",
+  "Failed to update coordinates": "No se pudieron actualizar las coordenadas",
+  "Failed to update family coordinates": "No se pudieron actualizar las coordenadas de la familia",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Se geocodificaron las {{geocoded}} familias. El mapa está actualizado.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Se geocodificaron {{geocoded}} familias. {{failed}} no se pudieron resolver — vea los detalles a continuación.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Se geocodificaron {{geocoded}} de {{total}} familias. {{overflow}} aún no se han procesado — ejecútelo de nuevo para continuar.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Geocodificando familias… esto puede tardar hasta un minuto. Puede mantener esta página abierta.",
+  "Geocoding…": "Geocodificando…",
+  "No address on file": "No hay dirección registrada",
+  "No match found — check the street address, city, and ZIP": "No se encontró ninguna coincidencia — verifique la dirección, la ciudad y el código postal",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Número de días que tienen los usuarios para inscribirse en la autenticación de dos factores (2FA) después de que se vuelva obligatoria. Configure en 0 para exigirla de inmediato (comportamiento heredado). Acortar un período de gracia activo puede bloquear el acceso a los usuarios de inmediato.",
+  "Open a family to fix its address, then run this again.": "Abra una familia para corregir su dirección y luego ejecute esto de nuevo.",
+  "Set up now": "Configurar ahora",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Esto busca las coordenadas del mapa para cada familia a la que le falten, utilizando OpenStreetMap. Procesa hasta 50 familias por ejecución; un lote completo tarda aproximadamente un minuto. Puede mantener esta página abierta mientras se ejecuta. ¿Continuar?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "many": "",
-    "other": ""
+    "one": "Se requiere autenticación de dos factores. Tiene %d día para inscribirse.",
+    "many": "Se requiere autenticación de dos factores. Tiene %d días para inscribirse.",
+    "other": "Se requiere autenticación de dos factores. Tiene %d días para inscribirse."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Familia desconocida",
+  "Update All Coordinates": "Actualizar todas las coordenadas",
+  "Update All Family Coordinates": "Actualizar todas las coordenadas de las familias",
+  "Update Coordinates": "Actualizar coordenadas",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Se copió {{count}} miembro",
+    "other": "Se copiaron {{count}} miembros"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Esta lista tiene {{count}} destinatario — demasiados para un enlace mailto:. Use Copiar direcciones en su lugar.",
+    "other": "Esta lista tiene {{count}} destinatarios — demasiados para un enlace mailto:. Use Copiar direcciones en su lugar."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Use Copiar direcciones en su lugar.",
+    "other": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Use Copiar direcciones en su lugar."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} minuto restante",
+    "other": "{{count}} minutos restantes"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} familia no se pudo geocodificar",
+    "other": "{{count}} familias no se pudieron geocodificar"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…y {{count}} más. Ejecútelo de nuevo para ver el resto.",
+    "other": "…y {{count}} más. Ejecútelo de nuevo para ver el resto."
   }
 }

--- a/locale/terms/missing/es-MX/es-MX-1.json
+++ b/locale/terms/missing/es-MX/es-MX-1.json
@@ -1,52 +1,52 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "Ocurrió un error de geocodificación. Inténtelo de nuevo más tarde.",
+  "Address is incomplete (missing city, state, and ZIP)": "La dirección está incompleta (falta ciudad, estado y código postal)",
+  "All families already have coordinates.": "Todas las familias ya tienen coordenadas.",
+  "Failed to update coordinates": "Error al actualizar las coordenadas",
+  "Failed to update family coordinates": "Error al actualizar las coordenadas de la familia",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Se geocodificaron las {{geocoded}} familias. El mapa ahora está actualizado.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Se geocodificaron {{geocoded}} familias. {{failed}} no se pudieron resolver; consulte los detalles a continuación.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Se geocodificaron {{geocoded}} de {{total}} familias. {{overflow}} aún no se han procesado; ejecute de nuevo para continuar.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Geocodificando familias… esto puede tardar hasta un minuto. Puede dejar esta página abierta.",
+  "Geocoding…": "Geocodificando…",
+  "No address on file": "No hay dirección registrada",
+  "No match found — check the street address, city, and ZIP": "No se encontró ninguna coincidencia; verifique la calle, la ciudad y el código postal",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Número de días que los usuarios tienen para inscribirse en la autenticación de dos factores (2FA) después de que se vuelve obligatoria. Establezca 0 para exigirla de inmediato (comportamiento heredado). Acortar un período de gracia activo puede bloquear el acceso de los usuarios de inmediato.",
+  "Open a family to fix its address, then run this again.": "Abra una familia para corregir su dirección y luego ejecute esto de nuevo.",
+  "Set up now": "Configurar ahora",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Esto busca las coordenadas del mapa para cada familia a la que le falten, usando OpenStreetMap. Procesa hasta 50 familias por ejecución; un lote completo tarda aproximadamente un minuto. Puede dejar esta página abierta mientras se ejecuta. ¿Desea continuar?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "Se requiere autenticación de dos factores. Tiene %d día para inscribirse.",
+    "other": "Se requiere autenticación de dos factores. Tiene %d días para inscribirse."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Familia desconocida",
+  "Update All Coordinates": "Actualizar todas las coordenadas",
+  "Update All Family Coordinates": "Actualizar todas las coordenadas de las familias",
+  "Update Coordinates": "Actualizar coordenadas",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Se copió {{count}} miembro",
+    "other": "Se copiaron {{count}} miembros"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Esta lista tiene {{count}} destinatario; son demasiados para un enlace mailto:. Use Copiar direcciones en su lugar.",
+    "other": "Esta lista tiene {{count}} destinatarios; son demasiados para un enlace mailto:. Use Copiar direcciones en su lugar."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Use Copiar direcciones en su lugar.",
+    "other": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Use Copiar direcciones en su lugar."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "queda {{count}} minuto",
+    "other": "quedan {{count}} minutos"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} familia no se pudo geocodificar",
+    "other": "{{count}} familias no se pudieron geocodificar"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…y {{count}} más. Ejecute de nuevo para ver el resto.",
+    "other": "…y {{count}} más. Ejecute de nuevo para ver el resto."
   }
 }

--- a/locale/terms/missing/es-SV/es-SV-1.json
+++ b/locale/terms/missing/es-SV/es-SV-1.json
@@ -1,52 +1,52 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "Ocurrió un error de geocodificación — inténtelo de nuevo más tarde",
+  "Address is incomplete (missing city, state, and ZIP)": "La dirección está incompleta (falta ciudad, departamento y código postal)",
+  "All families already have coordinates.": "Todas las familias ya tienen coordenadas.",
+  "Failed to update coordinates": "No se pudieron actualizar las coordenadas",
+  "Failed to update family coordinates": "No se pudieron actualizar las coordenadas de la familia",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Se geocodificaron las {{geocoded}} familias. El mapa está actualizado.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Se geocodificaron {{geocoded}} familias. {{failed}} no se pudieron resolver — vea los detalles a continuación.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Se geocodificaron {{geocoded}} de {{total}} familias. {{overflow}} aún no se han procesado — ejecute de nuevo para continuar.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Geocodificando familias… esto puede tardar hasta un minuto. Puede dejar esta página abierta.",
+  "Geocoding…": "Geocodificando…",
+  "No address on file": "No hay dirección registrada",
+  "No match found — check the street address, city, and ZIP": "No se encontró ninguna coincidencia — verifique la dirección, la ciudad y el código postal",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Número de días que los usuarios tienen para inscribirse en la autenticación de dos factores (2FA) después de que esta se vuelva obligatoria. Establezca 0 para aplicarla de inmediato (comportamiento heredado). Acortar un período de gracia activo puede bloquear el acceso a los usuarios de inmediato.",
+  "Open a family to fix its address, then run this again.": "Abra una familia para corregir su dirección y luego ejecute esto de nuevo.",
+  "Set up now": "Configurar ahora",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Esto busca las coordenadas del mapa para cada familia que no las tenga, usando OpenStreetMap. Procesa hasta 50 familias por ejecución; un lote completo tarda aproximadamente un minuto. Puede dejar esta página abierta mientras se ejecuta. ¿Desea continuar?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "Se requiere la autenticación de dos factores. Tiene %d día para inscribirse.",
+    "other": "Se requiere la autenticación de dos factores. Tiene %d días para inscribirse."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Familia desconocida",
+  "Update All Coordinates": "Actualizar todas las coordenadas",
+  "Update All Family Coordinates": "Actualizar todas las coordenadas de las familias",
+  "Update Coordinates": "Actualizar coordenadas",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Se copió {{count}} miembro",
+    "other": "Se copiaron {{count}} miembros"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Esta lista tiene {{count}} destinatario — demasiados para un enlace mailto:. Use Copiar direcciones en su lugar.",
+    "other": "Esta lista tiene {{count}} destinatarios — demasiados para un enlace mailto:. Use Copiar direcciones en su lugar."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Use Copiar direcciones en su lugar.",
+    "other": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Use Copiar direcciones en su lugar."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "Queda {{count}} minuto",
+    "other": "Quedan {{count}} minutos"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} familia no se pudo geocodificar",
+    "other": "{{count}} familias no se pudieron geocodificar"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…y {{count}} más. Ejecute de nuevo para ver el resto.",
+    "other": "…y {{count}} más. Ejecute de nuevo para ver el resto."
   }
 }

--- a/locale/terms/missing/es/es-1.json
+++ b/locale/terms/missing/es/es-1.json
@@ -1,52 +1,52 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "Se produjo un error de geocodificación — inténtelo de nuevo más tarde",
+  "Address is incomplete (missing city, state, and ZIP)": "La dirección está incompleta (faltan ciudad, estado y código postal)",
+  "All families already have coordinates.": "Todas las familias ya tienen coordenadas.",
+  "Failed to update coordinates": "Error al actualizar las coordenadas",
+  "Failed to update family coordinates": "Error al actualizar las coordenadas de la familia",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Se geocodificaron las {{geocoded}} familias. El mapa está ahora actualizado.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Se geocodificaron {{geocoded}} familias. {{failed}} no se pudieron resolver — vea los detalles a continuación.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Se geocodificaron {{geocoded}} de {{total}} familias. {{overflow}} aún no se procesaron — ejecútelo de nuevo para continuar.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Geocodificando familias… esto puede tardar hasta un minuto. Puede dejar esta página abierta.",
+  "Geocoding…": "Geocodificando…",
+  "No address on file": "No hay dirección registrada",
+  "No match found — check the street address, city, and ZIP": "No se encontró ninguna coincidencia — verifique la calle, la ciudad y el código postal",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Número de días que tienen los usuarios para inscribirse en la autenticación de dos factores (2FA) después de que se vuelva obligatoria. Establezca 0 para aplicarla de inmediato (comportamiento heredado). Acortar un período de gracia activo puede bloquear el acceso de los usuarios de inmediato.",
+  "Open a family to fix its address, then run this again.": "Abra una familia para corregir su dirección y luego ejecute esto de nuevo.",
+  "Set up now": "Configurar ahora",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Esto busca las coordenadas del mapa para cada familia a la que le falten, utilizando OpenStreetMap. Procesa hasta 50 familias por ejecución; un lote completo tarda aproximadamente un minuto. Puede dejar esta página abierta mientras se ejecuta. ¿Continuar?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "Se requiere la autenticación de dos factores. Tiene %d día para inscribirse.",
+    "other": "Se requiere la autenticación de dos factores. Tiene %d días para inscribirse."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Familia desconocida",
+  "Update All Coordinates": "Actualizar todas las coordenadas",
+  "Update All Family Coordinates": "Actualizar todas las coordenadas de las familias",
+  "Update Coordinates": "Actualizar coordenadas",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Se copió {{count}} miembro",
+    "other": "Se copiaron {{count}} miembros"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Esta lista tiene {{count}} destinatario — demasiados para un enlace mailto:. Use Copiar direcciones en su lugar.",
+    "other": "Esta lista tiene {{count}} destinatarios — demasiados para un enlace mailto:. Use Copiar direcciones en su lugar."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Use Copiar direcciones en su lugar.",
+    "other": "Demasiados destinatarios para el cliente de correo ({{count}} > {{max}}). Use Copiar direcciones en su lugar."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "queda {{count}} minuto",
+    "other": "quedan {{count}} minutos"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} familia no se pudo geocodificar",
+    "other": "{{count}} familias no se pudieron geocodificar"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…y {{count}} más. Ejecútelo de nuevo para ver el resto.",
+    "other": "…y {{count}} más. Ejecútelo de nuevo para ver el resto."
   }
 }

--- a/locale/terms/missing/et/et-1.json
+++ b/locale/terms/missing/et/et-1.json
@@ -1,52 +1,52 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "Geokodeerimisel tekkis viga — proovige hiljem uuesti",
+  "Address is incomplete (missing city, state, and ZIP)": "Aadress on puudulik (puuduvad linn, maakond ja sihtnumber)",
+  "All families already have coordinates.": "Kõigil peredel on juba koordinaadid.",
+  "Failed to update coordinates": "Koordinaatide uuendamine ebaõnnestus",
+  "Failed to update family coordinates": "Pere koordinaatide uuendamine ebaõnnestus",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Geokodeeriti kõik {{geocoded}} peret. Kaart on nüüd ajakohane.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Geokodeeriti {{geocoded}} peret. {{failed}} ei õnnestunud lahendada — vt üksikasju allpool.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Geokodeeriti {{geocoded}} peret {{total}}-st. {{overflow}} on veel töötlemata — jätkamiseks käivitage uuesti.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Perede geokodeerimine… see võib võtta kuni minuti. Võite selle lehe lahti hoida.",
+  "Geocoding…": "Geokodeerimine…",
+  "No address on file": "Aadress puudub",
+  "No match found — check the street address, city, and ZIP": "Vastet ei leitud — kontrollige tänava aadressi, linna ja sihtnumbrit",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Päevade arv, mis kasutajatel on kaheastmelise autentimise (2FA) seadistamiseks pärast selle kohustuslikuks muutumist. Kohese jõustamise jaoks (varasem käitumine) määrake väärtuseks 0. Aktiivse ajapikenduse lühendamine võib kasutajad kohe välja lukustada.",
+  "Open a family to fix its address, then run this again.": "Avage pere, et parandada tema aadress, seejärel käivitage see uuesti.",
+  "Set up now": "Seadista kohe",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "See leiab kaardikoordinaadid iga pere jaoks, kellel need puuduvad, kasutades OpenStreetMap'i. Ühe käivitusega töödeldakse kuni 50 peret; terve partii võtab aega umbes minuti. Võite selle lehe töötamise ajal lahti hoida. Kas jätkata?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "Kaheastmeline autentimine on kohustuslik. Teil on selle seadistamiseks %d päev.",
+    "other": "Kaheastmeline autentimine on kohustuslik. Teil on selle seadistamiseks %d päeva."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Tundmatu pere",
+  "Update All Coordinates": "Uuenda kõiki koordinaate",
+  "Update All Family Coordinates": "Uuenda kõigi perede koordinaate",
+  "Update Coordinates": "Uuenda koordinaate",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Kopeeriti {{count}} liige",
+    "other": "Kopeeriti {{count}} liiget"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Selles loendis on {{count}} saaja — liiga palju mailto: lingi jaoks. Kasutage selle asemel käsku Kopeeri aadressid.",
+    "other": "Selles loendis on {{count}} saajat — liiga palju mailto: lingi jaoks. Kasutage selle asemel käsku Kopeeri aadressid."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Liiga palju saajaid e-posti kliendi jaoks ({{count}} > {{max}}). Kasutage selle asemel käsku Kopeeri aadressid.",
+    "other": "Liiga palju saajaid e-posti kliendi jaoks ({{count}} > {{max}}). Kasutage selle asemel käsku Kopeeri aadressid."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} minut jäänud",
+    "other": "{{count}} minutit jäänud"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} peret ei õnnestunud geokodeerida",
+    "other": "{{count}} peret ei õnnestunud geokodeerida"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…ja veel {{count}}. Ülejäänute nägemiseks käivitage uuesti.",
+    "other": "…ja veel {{count}}. Ülejäänute nägemiseks käivitage uuesti."
   }
 }

--- a/locale/terms/missing/fi/fi-1.json
+++ b/locale/terms/missing/fi/fi-1.json
@@ -1,52 +1,52 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "Geokoodauksessa tapahtui virhe — yritä myöhemmin uudelleen",
+  "Address is incomplete (missing city, state, and ZIP)": "Osoite on puutteellinen (kaupunki, alue ja postinumero puuttuvat)",
+  "All families already have coordinates.": "Kaikilla perheillä on jo koordinaatit.",
+  "Failed to update coordinates": "Koordinaattien päivittäminen epäonnistui",
+  "Failed to update family coordinates": "Perheen koordinaattien päivittäminen epäonnistui",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Kaikki {{geocoded}} perhettä geokoodattu. Kartta on nyt ajan tasalla.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "{{geocoded}} perhettä geokoodattu. {{failed}} ei voitu ratkaista — katso tiedot alta.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "{{geocoded}}/{{total}} perhettä geokoodattu. {{overflow}} käsittelemättä — suorita uudelleen jatkaaksesi.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Geokoodataan perheitä… tämä voi kestää jopa minuutin. Voit pitää tämän sivun auki.",
+  "Geocoding…": "Geokoodataan…",
+  "No address on file": "Osoitetta ei ole tallennettu",
+  "No match found — check the street address, city, and ZIP": "Osumaa ei löytynyt — tarkista katuosoite, kaupunki ja postinumero",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Päivien määrä, jonka aikana käyttäjien on otettava kaksivaiheinen tunnistautuminen käyttöön sen tultua pakolliseksi. Aseta arvoksi 0 pakottaaksesi sen käyttöön välittömästi (vanha toimintatapa). Aktiivisen siirtymäajan lyhentäminen voi lukita käyttäjät ulos välittömästi.",
+  "Open a family to fix its address, then run this again.": "Avaa perhe korjataksesi sen osoitteen ja suorita tämä sitten uudelleen.",
+  "Set up now": "Ota käyttöön nyt",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Tämä hakee karttakoordinaatit jokaiselle perheelle, jolta ne puuttuvat, käyttäen OpenStreetMapia. Se käsittelee enintään 50 perhettä ajokerralla; täysi erä kestää noin minuutin. Voit pitää tämän sivun auki suorituksen ajan. Jatketaanko?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "Kaksivaiheinen tunnistautuminen on pakollinen. Sinulla on %d päivä aikaa ottaa se käyttöön.",
+    "other": "Kaksivaiheinen tunnistautuminen on pakollinen. Sinulla on %d päivää aikaa ottaa se käyttöön."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Tuntematon perhe",
+  "Update All Coordinates": "Päivitä kaikki koordinaatit",
+  "Update All Family Coordinates": "Päivitä kaikkien perheiden koordinaatit",
+  "Update Coordinates": "Päivitä koordinaatit",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Kopioitiin {{count}} jäsen",
+    "other": "Kopioitiin {{count}} jäsentä"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Tässä listassa on {{count}} vastaanottaja — liikaa mailto:-linkille. Käytä sen sijaan Kopioi osoitteet -toimintoa.",
+    "other": "Tässä listassa on {{count}} vastaanottajaa — liikaa mailto:-linkille. Käytä sen sijaan Kopioi osoitteet -toimintoa."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Liikaa vastaanottajia sähköpostiohjelmalle ({{count}} > {{max}}). Käytä sen sijaan Kopioi osoitteet -toimintoa.",
+    "other": "Liikaa vastaanottajia sähköpostiohjelmalle ({{count}} > {{max}}). Käytä sen sijaan Kopioi osoitteet -toimintoa."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} minuutti jäljellä",
+    "other": "{{count}} minuuttia jäljellä"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} perhe ei voitu geokoodata",
+    "other": "{{count}} perhettä ei voitu geokoodata"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…ja {{count}} muu. Suorita uudelleen nähdäksesi loput.",
+    "other": "…ja {{count}} muuta. Suorita uudelleen nähdäksesi loput."
   }
 }

--- a/locale/terms/missing/fil/fil-1.json
+++ b/locale/terms/missing/fil/fil-1.json
@@ -1,64 +1,64 @@
 {
-  "Access": "",
-  "Self-service": "",
-  "Feature": "",
-  "Check-out": "",
-  "Code": "",
-  "Live Preview": "",
-  "Sell-through": "",
-  "BCC Mode": "",
-  "Data": "",
-  "CSV": "",
-  "N/A": "",
-  "OFX": "",
-  "Preview": "",
-  "Teller": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "Access": "Access",
+  "Self-service": "Self-Service",
+  "Feature": "Tampok",
+  "Check-out": "Check-out",
+  "Code": "Kodigo",
+  "Live Preview": "Live na Preview",
+  "Sell-through": "Rate ng Benta",
+  "BCC Mode": "BCC Mode",
+  "Data": "Data",
+  "CSV": "CSV",
+  "N/A": "N/A",
+  "OFX": "OFX",
+  "Preview": "Preview",
+  "Teller": "Teller",
+  "A geocoding error occurred — try again later": "May naganap na error sa geocoding — subukang muli mamaya",
+  "Address is incomplete (missing city, state, and ZIP)": "Hindi kumpleto ang address (kulang ang lungsod, estado, at ZIP)",
+  "All families already have coordinates.": "Mayroon nang coordinates ang lahat ng pamilya.",
+  "Failed to update coordinates": "Nabigo ang pag-update ng coordinates",
+  "Failed to update family coordinates": "Nabigo ang pag-update ng coordinates ng pamilya",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Na-geocode ang lahat ng {{geocoded}} pamilya. Napapanahon na ang mapa.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Na-geocode ang {{geocoded}} pamilya. Hindi na-resolve ang {{failed}} — tingnan ang detalye sa ibaba.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Na-geocode ang {{geocoded}} sa {{total}} pamilya. Hindi pa naproseso ang {{overflow}} — patakbuhin muli upang magpatuloy.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Ginagawang geocode ang mga pamilya… maaari itong tumagal ng hanggang isang minuto. Puwede mong iwanang bukas ang page na ito.",
+  "Geocoding…": "Ginagawang geocode…",
+  "No address on file": "Walang naka-file na address",
+  "No match found — check the street address, city, and ZIP": "Walang nahanap na tugma — suriin ang address, lungsod, at ZIP",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Bilang ng mga araw na mayroon ang mga user para mag-enroll sa 2FA matapos itong iutos. Itakda sa 0 upang ipatupad kaagad (lumang gawi). Ang pagpapaikli ng aktibong grace period ay maaaring agad na mag-lock-out sa mga user.",
+  "Open a family to fix its address, then run this again.": "Buksan ang isang pamilya upang ayusin ang address nito, pagkatapos ay patakbuhin muli ito.",
+  "Set up now": "I-set up na ngayon",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Hinahanap nito ang mga coordinates sa mapa para sa bawat pamilyang kulang nito, gamit ang OpenStreetMap. Nagpoproseso ito ng hanggang 50 pamilya kada takbo; ang isang buong batch ay tumatagal ng humigit-kumulang isang minuto. Puwede mong iwanang bukas ang page na ito habang tumatakbo ito. Magpatuloy?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "Kinakailangan ang two-factor authentication. Mayroon kang %d araw upang mag-enroll.",
+    "other": "Kinakailangan ang two-factor authentication. Mayroon kang %d araw upang mag-enroll."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Hindi kilalang pamilya",
+  "Update All Coordinates": "I-update ang Lahat ng Coordinates",
+  "Update All Family Coordinates": "I-update ang Lahat ng Coordinates ng Pamilya",
+  "Update Coordinates": "I-update ang Coordinates",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Kinopya ang {{count}} miyembro",
+    "other": "Kinopya ang {{count}} miyembro"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Ang listahang ito ay may {{count}} tatanggap — masyadong marami para sa mailto: link. Gamitin na lang ang Kopyahin ang mga Address.",
+    "other": "Ang listahang ito ay may {{count}} tatanggap — masyadong marami para sa mailto: link. Gamitin na lang ang Kopyahin ang mga Address."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Masyadong maraming tatanggap para sa email client ({{count}} > {{max}}). Gamitin na lang ang Kopyahin ang mga Address.",
+    "other": "Masyadong maraming tatanggap para sa email client ({{count}} > {{max}}). Gamitin na lang ang Kopyahin ang mga Address."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} minuto na lang ang natitira",
+    "other": "{{count}} minuto na lang ang natitira"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "Hindi na-geocode ang {{count}} pamilya",
+    "other": "Hindi na-geocode ang {{count}} pamilya"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…at {{count}} pa. Patakbuhin muli upang makita ang iba.",
+    "other": "…at {{count}} pa. Patakbuhin muli upang makita ang iba."
   }
 }

--- a/locale/terms/missing/fr/fr-1.json
+++ b/locale/terms/missing/fr/fr-1.json
@@ -1,56 +1,56 @@
 {
-  "Code": "",
-  "Signature": "",
-  "Auto": "",
-  "CSV": "",
-  "OFX": "",
-  "Classifications": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "Code": "Code",
+  "Signature": "Signature",
+  "Auto": "Auto",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "Classifications": "Classifications",
+  "A geocoding error occurred — try again later": "Une erreur de géocodage s'est produite — réessayez plus tard",
+  "Address is incomplete (missing city, state, and ZIP)": "L'adresse est incomplète (ville, région et code postal manquants)",
+  "All families already have coordinates.": "Toutes les familles ont déjà des coordonnées.",
+  "Failed to update coordinates": "Échec de la mise à jour des coordonnées",
+  "Failed to update family coordinates": "Échec de la mise à jour des coordonnées de la famille",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Géocodage effectué pour les {{geocoded}} familles. La carte est maintenant à jour.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "{{geocoded}} familles géocodées. {{failed}} n'ont pas pu être résolues — voir les détails ci-dessous.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "{{geocoded}} familles géocodées sur {{total}}. {{overflow}} pas encore traitées — relancez pour continuer.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Géocodage des familles en cours… cela peut prendre jusqu'à une minute. Vous pouvez laisser cette page ouverte.",
+  "Geocoding…": "Géocodage en cours…",
+  "No address on file": "Aucune adresse enregistrée",
+  "No match found — check the street address, city, and ZIP": "Aucune correspondance trouvée — vérifiez l'adresse, la ville et le code postal",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Nombre de jours dont disposent les utilisateurs pour activer l'authentification à deux facteurs après qu'elle devient obligatoire. Réglez sur 0 pour l'imposer immédiatement (comportement hérité). Réduire une période de grâce active peut bloquer immédiatement l'accès des utilisateurs.",
+  "Open a family to fix its address, then run this again.": "Ouvrez une famille pour corriger son adresse, puis relancez cette opération.",
+  "Set up now": "Configurer maintenant",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Cette opération recherche les coordonnées cartographiques pour chaque famille qui n'en a pas, à l'aide d'OpenStreetMap. Elle traite jusqu'à 50 familles par exécution ; un lot complet prend environ une minute. Vous pouvez laisser cette page ouverte pendant l'exécution. Continuer ?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "L'authentification à deux facteurs est requise. Vous avez %d jour pour vous inscrire.",
+    "other": "L'authentification à deux facteurs est requise. Vous avez %d jours pour vous inscrire."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Famille inconnue",
+  "Update All Coordinates": "Mettre à jour toutes les coordonnées",
+  "Update All Family Coordinates": "Mettre à jour les coordonnées de toutes les familles",
+  "Update Coordinates": "Mettre à jour les coordonnées",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} membre copié",
+    "other": "{{count}} membres copiés"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Cette liste contient {{count}} destinataire — trop pour un lien mailto:. Utilisez plutôt Copier les adresses.",
+    "other": "Cette liste contient {{count}} destinataires — trop pour un lien mailto:. Utilisez plutôt Copier les adresses."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Trop de destinataires pour le client de messagerie ({{count}} > {{max}}). Utilisez plutôt Copier les adresses.",
+    "other": "Trop de destinataires pour le client de messagerie ({{count}} > {{max}}). Utilisez plutôt Copier les adresses."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} minute restante",
+    "other": "{{count}} minutes restantes"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} famille n'a pas pu être géocodée",
+    "other": "{{count}} familles n'ont pas pu être géocodées"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…et {{count}} de plus. Relancez pour voir le reste.",
+    "other": "…et {{count}} de plus. Relancez pour voir le reste."
   }
 }

--- a/locale/terms/missing/he/he-1.json
+++ b/locale/terms/missing/he/he-1.json
@@ -1,52 +1,52 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "אירעה שגיאת מיקום גיאוגרפי — נסה שוב מאוחר יותר",
+  "Address is incomplete (missing city, state, and ZIP)": "הכתובת אינה שלמה (חסרים עיר, מדינה ומיקוד)",
+  "All families already have coordinates.": "לכל המשפחות כבר יש קואורדינטות.",
+  "Failed to update coordinates": "עדכון הקואורדינטות נכשל",
+  "Failed to update family coordinates": "עדכון קואורדינטות המשפחה נכשל",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "בוצע מיקום גיאוגרפי לכל {{geocoded}} המשפחות. המפה מעודכנת כעת.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "בוצע מיקום גיאוגרפי ל-{{geocoded}} משפחות. {{failed}} לא ניתן היה לפתור — ראה פרטים למטה.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "בוצע מיקום גיאוגרפי ל-{{geocoded}} מתוך {{total}} משפחות. {{overflow}} טרם עובדו — הרץ שוב כדי להמשיך.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "מבצע מיקום גיאוגרפי למשפחות… פעולה זו עשויה להימשך עד דקה. ניתן להשאיר דף זה פתוח.",
+  "Geocoding…": "מבצע מיקום גיאוגרפי…",
+  "No address on file": "אין כתובת רשומה",
+  "No match found — check the street address, city, and ZIP": "לא נמצאה התאמה — בדוק את הרחוב, העיר והמיקוד",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "מספר הימים העומדים לרשות המשתמשים להירשם לאימות דו-שלבי לאחר שהוא הופך לחובה. הגדר ל-0 כדי לאכוף באופן מיידי (התנהגות ישנה). קיצור תקופת חסד פעילה עלול לנעול משתמשים מחוץ למערכת באופן מיידי.",
+  "Open a family to fix its address, then run this again.": "פתח משפחה כדי לתקן את כתובתה, ולאחר מכן הרץ זאת שוב.",
+  "Set up now": "הגדר כעת",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "פעולה זו מוצאת קואורדינטות מפה עבור כל משפחה שחסרות לה, באמצעות OpenStreetMap. היא מעבדת עד 50 משפחות בכל הרצה; קבוצה מלאה אורכת כדקה אחת. ניתן להשאיר דף זה פתוח בזמן הפעולה. להמשיך?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "נדרש אימות דו-שלבי. יש לך %d יום להירשם.",
+    "other": "נדרש אימות דו-שלבי. יש לך %d ימים להירשם."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "משפחה לא ידועה",
+  "Update All Coordinates": "עדכן את כל הקואורדינטות",
+  "Update All Family Coordinates": "עדכן את כל קואורדינטות המשפחות",
+  "Update Coordinates": "עדכן קואורדינטות",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "הועתק חבר אחד",
+    "other": "הועתקו {{count}} חברים"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "לרשימה זו יש נמען אחד — יותר מדי עבור קישור mailto:. השתמש בהעתקת כתובות במקום זאת.",
+    "other": "לרשימה זו יש {{count}} נמענים — יותר מדי עבור קישור mailto:. השתמש בהעתקת כתובות במקום זאת."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "יותר מדי נמענים עבור לקוח הדוא\"ל ({{count}} > {{max}}). השתמש בהעתקת כתובות במקום זאת.",
+    "other": "יותר מדי נמענים עבור לקוח הדוא\"ל ({{count}} > {{max}}). השתמש בהעתקת כתובות במקום זאת."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "דקה אחת נותרה",
+    "other": "{{count}} דקות נותרו"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "משפחה אחת לא ניתן היה למקם",
+    "other": "{{count}} משפחות לא ניתן היה למקם"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…ועוד אחת. הרץ שוב כדי לראות את השאר.",
+    "other": "…ועוד {{count}}. הרץ שוב כדי לראות את השאר."
   }
 }

--- a/locale/terms/missing/hi/hi-1.json
+++ b/locale/terms/missing/hi/hi-1.json
@@ -1,52 +1,52 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "जियोकोडिंग में त्रुटि हुई — बाद में पुनः प्रयास करें",
+  "Address is incomplete (missing city, state, and ZIP)": "पता अधूरा है (शहर, राज्य और ZIP कोड गायब है)",
+  "All families already have coordinates.": "सभी परिवारों के पास पहले से ही निर्देशांक मौजूद हैं।",
+  "Failed to update coordinates": "निर्देशांक अपडेट करने में विफल",
+  "Failed to update family coordinates": "परिवार के निर्देशांक अपडेट करने में विफल",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "सभी {{geocoded}} परिवारों को जियोकोड किया गया। मानचित्र अब अद्यतित है।",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "{{geocoded}} परिवारों को जियोकोड किया गया। {{failed}} को हल नहीं किया जा सका — नीचे विवरण देखें।",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "{{total}} में से {{geocoded}} परिवारों को जियोकोड किया गया। {{overflow}} अभी संसाधित नहीं हुए हैं — जारी रखने के लिए फिर से चलाएं।",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "परिवारों को जियोकोड किया जा रहा है… इसमें एक मिनट तक का समय लग सकता है। आप इस पेज को खुला रख सकते हैं।",
+  "Geocoding…": "जियोकोडिंग हो रही है…",
+  "No address on file": "कोई पता दर्ज नहीं है",
+  "No match found — check the street address, city, and ZIP": "कोई मिलान नहीं मिला — सड़क का पता, शहर और ZIP कोड जांचें",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "2FA अनिवार्य होने के बाद उपयोगकर्ताओं के पास इसमें नामांकन करने के लिए दिनों की संख्या। तुरंत लागू करने के लिए 0 सेट करें (लीगेसी व्यवहार)। सक्रिय छूट अवधि को छोटा करने से उपयोगकर्ता तुरंत लॉक आउट हो सकते हैं।",
+  "Open a family to fix its address, then run this again.": "पता ठीक करने के लिए परिवार को खोलें, फिर इसे फिर से चलाएं।",
+  "Set up now": "अभी सेट अप करें",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "यह OpenStreetMap का उपयोग करके हर उस परिवार के लिए मानचित्र निर्देशांक ढूंढता है जिनके पास ये नहीं हैं। यह प्रति रन 50 परिवारों तक संसाधित करता है; एक पूर्ण बैच में लगभग एक मिनट लगता है। यह चलते समय आप इस पेज को खुला रख सकते हैं। जारी रखें?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "द्विकारक प्रमाणीकरण (2FA) आवश्यक है। आपके पास नामांकन करने के लिए %d दिन है।",
+    "other": "द्विकारक प्रमाणीकरण (2FA) आवश्यक है। आपके पास नामांकन करने के लिए %d दिन हैं।"
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "अज्ञात परिवार",
+  "Update All Coordinates": "सभी निर्देशांक अपडेट करें",
+  "Update All Family Coordinates": "सभी परिवार के निर्देशांक अपडेट करें",
+  "Update Coordinates": "निर्देशांक अपडेट करें",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} सदस्य कॉपी किया गया",
+    "other": "{{count}} सदस्य कॉपी किए गए"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "इस सूची में {{count}} प्राप्तकर्ता है — यह mailto: लिंक के लिए बहुत अधिक है। इसके बजाय पते कॉपी करें का उपयोग करें।",
+    "other": "इस सूची में {{count}} प्राप्तकर्ता हैं — यह mailto: लिंक के लिए बहुत अधिक है। इसके बजाय पते कॉपी करें का उपयोग करें।"
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "ईमेल क्लाइंट के लिए बहुत अधिक प्राप्तकर्ता ({{count}} > {{max}})। इसके बजाय पते कॉपी करें का उपयोग करें।",
+    "other": "ईमेल क्लाइंट के लिए बहुत अधिक प्राप्तकर्ता ({{count}} > {{max}})। इसके बजाय पते कॉपी करें का उपयोग करें।"
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} मिनट शेष",
+    "other": "{{count}} मिनट शेष"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} परिवार को जियोकोड नहीं किया जा सका",
+    "other": "{{count}} परिवारों को जियोकोड नहीं किया जा सका"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…और {{count}} अधिक। बाकी देखने के लिए फिर से चलाएं।",
+    "other": "…और {{count}} अधिक। बाकी देखने के लिए फिर से चलाएं।"
   }
 }

--- a/locale/terms/missing/hu/hu-1.json
+++ b/locale/terms/missing/hu/hu-1.json
@@ -1,53 +1,53 @@
 {
-  "CSV": "",
-  "N/A": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "N/A": "N/A",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "Geokódolási hiba történt — próbálja újra később",
+  "Address is incomplete (missing city, state, and ZIP)": "A cím hiányos (hiányzik a város, a megye/állam és az irányítószám)",
+  "All families already have coordinates.": "Minden családnak már vannak koordinátái.",
+  "Failed to update coordinates": "Nem sikerült frissíteni a koordinátákat",
+  "Failed to update family coordinates": "Nem sikerült frissíteni a család koordinátáit",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Mind a(z) {{geocoded}} család geokódolása megtörtént. A térkép most már naprakész.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "{{geocoded}} család geokódolása megtörtént. {{failed}} nem volt feloldható — lásd a részleteket lent.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "{{geocoded}} család geokódolása megtörtént a(z) {{total}} közül. {{overflow}} még nincs feldolgozva — a folytatáshoz futtassa újra.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Családok geokódolása… ez akár egy percig is eltarthat. Nyitva tarthatja ezt az oldalt.",
+  "Geocoding…": "Geokódolás…",
+  "No address on file": "Nincs rögzített cím",
+  "No match found — check the street address, city, and ZIP": "Nem található egyezés — ellenőrizze az utca címét, a várost és az irányítószámot",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Azon napok száma, amelyeken belül a felhasználóknak be kell iratkozniuk a kétfaktoros hitelesítésre (2FA), miután az kötelezővé válik. Állítsa 0-ra az azonnali érvényesítéshez (korábbi működés). Egy aktív türelmi időszak lerövidítése azonnal kizárhatja a felhasználókat.",
+  "Open a family to fix its address, then run this again.": "Nyissa meg a családot a cím javításához, majd futtassa újra ezt.",
+  "Set up now": "Beállítás most",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Ez megkeresi a térképkoordinátákat minden olyan családhoz, amelynél hiányoznak, az OpenStreetMap segítségével. Futtatásonként legfeljebb 50 családot dolgoz fel; egy teljes köteg körülbelül egy percet vesz igénybe. Az oldalt nyitva tarthatja futás közben. Folytatja?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "Kétfaktoros hitelesítés szükséges. %d napja van a beiratkozásra.",
+    "other": "Kétfaktoros hitelesítés szükséges. %d napja van a beiratkozásra."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Ismeretlen család",
+  "Update All Coordinates": "Összes koordináta frissítése",
+  "Update All Family Coordinates": "Összes családi koordináta frissítése",
+  "Update Coordinates": "Koordináták frissítése",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} tag másolva",
+    "other": "{{count}} tag másolva"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Ez a lista {{count}} címzettet tartalmaz — ez túl sok egy mailto: linkhez. Használja inkább a Címek másolása funkciót.",
+    "other": "Ez a lista {{count}} címzettet tartalmaz — ez túl sok egy mailto: linkhez. Használja inkább a Címek másolása funkciót."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Túl sok címzett az e-mail kliens számára ({{count}} > {{max}}). Használja inkább a Címek másolása funkciót.",
+    "other": "Túl sok címzett az e-mail kliens számára ({{count}} > {{max}}). Használja inkább a Címek másolása funkciót."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} perc van hátra",
+    "other": "{{count}} perc van hátra"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} családot nem sikerült geokódolni",
+    "other": "{{count}} családot nem sikerült geokódolni"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…és még {{count}}. Futtassa újra a többi megtekintéséhez.",
+    "other": "…és még {{count}}. Futtassa újra a többi megtekintéséhez."
   }
 }

--- a/locale/terms/missing/id/id-1.json
+++ b/locale/terms/missing/id/id-1.json
@@ -1,52 +1,52 @@
 {
-  "Data": "",
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "Data": "Data",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "Terjadi kesalahan geocoding — coba lagi nanti",
+  "Address is incomplete (missing city, state, and ZIP)": "Alamat tidak lengkap (kota, provinsi, dan kode pos tidak ada)",
+  "All families already have coordinates.": "Semua keluarga sudah memiliki koordinat.",
+  "Failed to update coordinates": "Gagal memperbarui koordinat",
+  "Failed to update family coordinates": "Gagal memperbarui koordinat keluarga",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Berhasil melakukan geocoding untuk semua {{geocoded}} keluarga. Peta kini sudah diperbarui.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Berhasil melakukan geocoding untuk {{geocoded}} keluarga. {{failed}} tidak dapat diselesaikan — lihat detail di bawah.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Berhasil melakukan geocoding untuk {{geocoded}} dari {{total}} keluarga. {{overflow}} belum diproses — jalankan lagi untuk melanjutkan.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Sedang melakukan geocoding keluarga… ini dapat memakan waktu hingga satu menit. Anda dapat membiarkan halaman ini tetap terbuka.",
+  "Geocoding…": "Geocoding…",
+  "No address on file": "Tidak ada alamat yang tercatat",
+  "No match found — check the street address, city, and ZIP": "Tidak ditemukan kecocokan — periksa alamat jalan, kota, dan kode pos",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Jumlah hari yang dimiliki pengguna untuk mendaftar 2FA setelah diwajibkan. Atur ke 0 untuk menerapkan segera (perilaku lama). Mempersingkat masa tenggang yang sedang berlaku dapat langsung mengunci pengguna.",
+  "Open a family to fix its address, then run this again.": "Buka data keluarga untuk memperbaiki alamatnya, lalu jalankan ini lagi.",
+  "Set up now": "Atur sekarang",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Ini akan mencari koordinat peta untuk setiap keluarga yang belum memilikinya, menggunakan OpenStreetMap. Proses ini menangani hingga 50 keluarga per jalankan; satu batch penuh memakan waktu sekitar satu menit. Anda dapat membiarkan halaman ini tetap terbuka selama proses berjalan. Lanjutkan?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "other": ""
+    "other": "Autentikasi dua faktor diwajibkan. Anda memiliki %d hari untuk mendaftar."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Keluarga tidak dikenal",
+  "Update All Coordinates": "Perbarui Semua Koordinat",
+  "Update All Family Coordinates": "Perbarui Semua Koordinat Keluarga",
+  "Update Coordinates": "Perbarui Koordinat",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Menyalin {{count}} anggota",
+    "other": "Menyalin {{count}} anggota"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Daftar ini memiliki {{count}} penerima — terlalu banyak untuk tautan mailto:. Gunakan Salin Alamat sebagai gantinya.",
+    "other": "Daftar ini memiliki {{count}} penerima — terlalu banyak untuk tautan mailto:. Gunakan Salin Alamat sebagai gantinya."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Terlalu banyak penerima untuk klien email ({{count}} > {{max}}). Gunakan Salin Alamat sebagai gantinya.",
+    "other": "Terlalu banyak penerima untuk klien email ({{count}} > {{max}}). Gunakan Salin Alamat sebagai gantinya."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} menit tersisa",
+    "other": "{{count}} menit tersisa"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} keluarga tidak dapat di-geocoding",
+    "other": "{{count}} keluarga tidak dapat di-geocoding"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…dan {{count}} lainnya. Jalankan lagi untuk melihat sisanya.",
+    "other": "…dan {{count}} lainnya. Jalankan lagi untuk melihat sisanya."
   }
 }

--- a/locale/terms/missing/it/it-1.json
+++ b/locale/terms/missing/it/it-1.json
@@ -1,54 +1,54 @@
 {
-  "Check-out": "",
-  "Auto": "",
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "Check-out": "Check-out",
+  "Auto": "Automatico",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "Si è verificato un errore di geocodifica — riprova più tardi",
+  "Address is incomplete (missing city, state, and ZIP)": "L'indirizzo è incompleto (mancano città, provincia e CAP)",
+  "All families already have coordinates.": "Tutte le famiglie hanno già le coordinate.",
+  "Failed to update coordinates": "Impossibile aggiornare le coordinate",
+  "Failed to update family coordinates": "Impossibile aggiornare le coordinate della famiglia",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Geocodificate tutte le {{geocoded}} famiglie. La mappa è ora aggiornata.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Geocodificate {{geocoded}} famiglie. {{failed}} non è stato possibile risolverle — vedi i dettagli qui sotto.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Geocodificate {{geocoded}} famiglie su {{total}}. {{overflow}} non ancora elaborate — esegui di nuovo per continuare.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Geocodifica delle famiglie in corso… può richiedere fino a un minuto. Puoi lasciare questa pagina aperta.",
+  "Geocoding…": "Geocodifica in corso…",
+  "No address on file": "Nessun indirizzo registrato",
+  "No match found — check the street address, city, and ZIP": "Nessuna corrispondenza trovata — controlla via, città e CAP",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Numero di giorni a disposizione degli utenti per attivare l'autenticazione a due fattori dopo che è stata resa obbligatoria. Imposta 0 per applicarla immediatamente (comportamento legacy). Ridurre un periodo di tolleranza attivo può bloccare immediatamente l'accesso agli utenti.",
+  "Open a family to fix its address, then run this again.": "Apri una famiglia per correggerne l'indirizzo, quindi esegui di nuovo questa operazione.",
+  "Set up now": "Configura ora",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Questa funzione trova le coordinate sulla mappa per ogni famiglia che ne è priva, utilizzando OpenStreetMap. Elabora fino a 50 famiglie per esecuzione; un lotto completo richiede circa un minuto. Puoi lasciare questa pagina aperta mentre è in esecuzione. Continuare?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "L'autenticazione a due fattori è obbligatoria. Hai %d giorno per attivarla.",
+    "other": "L'autenticazione a due fattori è obbligatoria. Hai %d giorni per attivarla."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Famiglia sconosciuta",
+  "Update All Coordinates": "Aggiorna tutte le coordinate",
+  "Update All Family Coordinates": "Aggiorna le coordinate di tutte le famiglie",
+  "Update Coordinates": "Aggiorna coordinate",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Copiato {{count}} membro",
+    "other": "Copiati {{count}} membri"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Questo elenco ha {{count}} destinatario — troppi per un link mailto:. Usa invece Copia indirizzi.",
+    "other": "Questo elenco ha {{count}} destinatari — troppi per un link mailto:. Usa invece Copia indirizzi."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Troppi destinatari per il client di posta ({{count}} > {{max}}). Usa invece Copia indirizzi.",
+    "other": "Troppi destinatari per il client di posta ({{count}} > {{max}}). Usa invece Copia indirizzi."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} minuto rimanente",
+    "other": "{{count}} minuti rimanenti"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "Non è stato possibile geocodificare {{count}} famiglia",
+    "other": "Non è stato possibile geocodificare {{count}} famiglie"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…e {{count}} altra. Esegui di nuovo per vedere il resto.",
+    "other": "…e {{count}} altre. Esegui di nuovo per vedere il resto."
   }
 }

--- a/locale/terms/missing/ja/ja-1.json
+++ b/locale/terms/missing/ja/ja-1.json
@@ -1,51 +1,51 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "ジオコーディングエラーが発生しました。後でもう一度お試しください",
+  "Address is incomplete (missing city, state, and ZIP)": "住所が不完全です(市区町村、都道府県、郵便番号が不足しています)",
+  "All families already have coordinates.": "すべての家族にはすでに座標が設定されています。",
+  "Failed to update coordinates": "座標の更新に失敗しました",
+  "Failed to update family coordinates": "家族の座標の更新に失敗しました",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "{{geocoded}}件の家族すべてをジオコーディングしました。マップは最新の状態です。",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "{{geocoded}}件の家族をジオコーディングしました。{{failed}}件は解決できませんでした — 詳細は以下をご覧ください。",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "{{total}}件中{{geocoded}}件の家族をジオコーディングしました。{{overflow}}件は未処理です — 続行するにはもう一度実行してください。",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "家族をジオコーディングしています…最大1分かかることがあります。このページを開いたままにしておいてください。",
+  "Geocoding…": "ジオコーディング中…",
+  "No address on file": "登録されている住所がありません",
+  "No match found — check the street address, city, and ZIP": "一致するものが見つかりませんでした — 番地、市区町村、郵便番号を確認してください",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "2要素認証が義務付けられた後、ユーザーが登録するまでの日数。0に設定するとすぐに強制されます(従来の動作)。有効な猶予期間を短縮すると、ユーザーが即座にロックアウトされる可能性があります。",
+  "Open a family to fix its address, then run this again.": "家族を開いて住所を修正してから、もう一度実行してください。",
+  "Set up now": "今すぐ設定",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "OpenStreetMapを使用して、座標が設定されていないすべての家族のマップ座標を検索します。1回の実行で最大50件の家族を処理し、1バッチ全体で約1分かかります。実行中はこのページを開いたままにしておくことができます。続行しますか?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "other": ""
+    "other": "2要素認証が必須です。登録まであと%d日です。"
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "不明な家族",
+  "Update All Coordinates": "すべての座標を更新",
+  "Update All Family Coordinates": "すべての家族の座標を更新",
+  "Update Coordinates": "座標を更新",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}}人のメンバーをコピーしました",
+    "other": "{{count}}人のメンバーをコピーしました"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "この一覧には{{count}}人の受信者がいます — mailto:リンクには多すぎます。代わりに「アドレスをコピー」を使用してください。",
+    "other": "この一覧には{{count}}人の受信者がいます — mailto:リンクには多すぎます。代わりに「アドレスをコピー」を使用してください。"
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "メールクライアントの受信者数が多すぎます({{count}} > {{max}})。代わりに「アドレスをコピー」を使用してください。",
+    "other": "メールクライアントの受信者数が多すぎます({{count}} > {{max}})。代わりに「アドレスをコピー」を使用してください。"
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "残り{{count}}分",
+    "other": "残り{{count}}分"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}}件の家族をジオコーディングできませんでした",
+    "other": "{{count}}件の家族をジオコーディングできませんでした"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…他{{count}}件。残りを見るにはもう一度実行してください。",
+    "other": "…他{{count}}件。残りを見るにはもう一度実行してください。"
   }
 }

--- a/locale/terms/missing/ko/ko-1.json
+++ b/locale/terms/missing/ko/ko-1.json
@@ -1,51 +1,51 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "지오코딩 오류가 발생했습니다 — 나중에 다시 시도하세요",
+  "Address is incomplete (missing city, state, and ZIP)": "주소가 불완전합니다(시/도, 시/군/구, 우편번호 누락)",
+  "All families already have coordinates.": "모든 가족에 이미 좌표가 있습니다.",
+  "Failed to update coordinates": "좌표를 업데이트하지 못했습니다",
+  "Failed to update family coordinates": "가족 좌표를 업데이트하지 못했습니다",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "{{geocoded}}개 가족의 지오코딩을 모두 완료했습니다. 지도가 최신 상태입니다.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "{{geocoded}}개 가족의 지오코딩을 완료했습니다. {{failed}}개는 해결할 수 없습니다 — 아래 세부 정보를 확인하세요.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "전체 {{total}}개 가족 중 {{geocoded}}개의 지오코딩을 완료했습니다. {{overflow}}개는 아직 처리되지 않았습니다 — 계속하려면 다시 실행하세요.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "가족 정보를 지오코딩하는 중입니다… 최대 1분 정도 걸릴 수 있습니다. 이 페이지를 열어 둔 채로 기다리셔도 됩니다.",
+  "Geocoding…": "지오코딩 중…",
+  "No address on file": "등록된 주소가 없습니다",
+  "No match found — check the street address, city, and ZIP": "일치하는 항목을 찾을 수 없습니다 — 도로명 주소, 시/도, 우편번호를 확인하세요",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "2FA(이중 인증)가 의무화된 후 사용자가 등록해야 하는 유예 일수입니다. 즉시 적용하려면 0으로 설정하세요(기존 방식). 활성화된 유예 기간을 단축하면 사용자가 즉시 잠길 수 있습니다.",
+  "Open a family to fix its address, then run this again.": "가족 정보를 열어 주소를 수정한 후 다시 실행하세요.",
+  "Set up now": "지금 설정하기",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "OpenStreetMap을 사용하여 좌표가 없는 모든 가족의 지도 좌표를 찾습니다. 한 번 실행할 때 최대 50개 가족을 처리하며, 전체 배치는 약 1분이 걸립니다. 실행하는 동안 이 페이지를 열어 둔 채로 두셔도 됩니다. 계속하시겠습니까?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "other": ""
+    "other": "이중 인증이 필요합니다. 등록까지 %d일 남았습니다."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "알 수 없는 가족",
+  "Update All Coordinates": "모든 좌표 업데이트",
+  "Update All Family Coordinates": "모든 가족 좌표 업데이트",
+  "Update Coordinates": "좌표 업데이트",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}}명의 회원을 복사했습니다",
+    "other": "{{count}}명의 회원을 복사했습니다"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "이 목록에는 {{count}}명의 수신자가 있습니다 — mailto: 링크로 사용하기에는 너무 많습니다. 대신 주소 복사를 사용하세요.",
+    "other": "이 목록에는 {{count}}명의 수신자가 있습니다 — mailto: 링크로 사용하기에는 너무 많습니다. 대신 주소 복사를 사용하세요."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "이메일 클라이언트에 비해 수신자가 너무 많습니다({{count}} > {{max}}). 대신 주소 복사를 사용하세요.",
+    "other": "이메일 클라이언트에 비해 수신자가 너무 많습니다({{count}} > {{max}}). 대신 주소 복사를 사용하세요."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}}분 남음",
+    "other": "{{count}}분 남음"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}}개 가족을 지오코딩할 수 없습니다",
+    "other": "{{count}}개 가족을 지오코딩할 수 없습니다"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…그리고 {{count}}개 더 있습니다. 나머지를 보려면 다시 실행하세요.",
+    "other": "…그리고 {{count}}개 더 있습니다. 나머지를 보려면 다시 실행하세요."
   }
 }

--- a/locale/terms/missing/ml/ml-1.json
+++ b/locale/terms/missing/ml/ml-1.json
@@ -1,60 +1,60 @@
 {
-  "CSV": "",
+  "CSV": "CSV",
   "Email sent to %d family.": {
-    "one": "%d കുടുംബത്തിലേക്ക് ഇമെയിൽ അയച്ചു.|%d കുടുംബങ്ങളിലേക്ക് ഇമെയിൽ അയച്ചു.|%d കുടുംബങ്ങളിലേക്ക് ഇമെയിൽ അയച്ചു.",
-    "other": ""
+    "one": "%d കുടുംബത്തിന് ഇമെയിൽ അയച്ചു.",
+    "other": "%d കുടുംബങ്ങൾക്ക് ഇമെയിൽ അയച്ചു."
   },
-  "OFX": "",
+  "OFX": "OFX",
   "PDF successfully emailed to %d family.": {
-    "one": "%d കുടുംബത്തിലേക്ക് PDF വിജയകരമായി ഇമെയിൽ ചെയ്തു.|%d കുടുംബങ്ങളിലേക്ക് PDF വിജയകരമായി ഇമെയിൽ ചെയ്തു.|%d കുടുംബങ്ങളിലേക്ക് PDF വിജയകരമായി ഇമെയിൽ ചെയ്തു.",
-    "other": ""
+    "one": "PDF %d കുടുംബത്തിന് വിജയകരമായി ഇമെയിൽ ചെയ്തു.",
+    "other": "PDF %d കുടുംബങ്ങൾക്ക് വിജയകരമായി ഇമെയിൽ ചെയ്തു."
   },
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "A geocoding error occurred — try again later": "ജിയോകോഡിംഗ് പിശക് സംഭവിച്ചു — പിന്നീട് വീണ്ടും ശ്രമിക്കുക",
+  "Address is incomplete (missing city, state, and ZIP)": "വിലാസം അപൂർണ്ണമാണ് (നഗരം, സംസ്ഥാനം, ZIP എന്നിവ ഇല്ല)",
+  "All families already have coordinates.": "എല്ലാ കുടുംബങ്ങൾക്കും ഇതിനകം കോർഡിനേറ്റുകൾ ഉണ്ട്.",
+  "Failed to update coordinates": "കോർഡിനേറ്റുകൾ അപ്ഡേറ്റ് ചെയ്യുന്നതിൽ പരാജയപ്പെട്ടു",
+  "Failed to update family coordinates": "കുടുംബത്തിന്റെ കോർഡിനേറ്റുകൾ അപ്ഡേറ്റ് ചെയ്യുന്നതിൽ പരാജയപ്പെട്ടു",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "എല്ലാ {{geocoded}} കുടുംബങ്ങളും ജിയോകോഡ് ചെയ്തു. മാപ്പ് ഇപ്പോൾ കാലികമാണ്.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "{{geocoded}} കുടുംബങ്ങൾ ജിയോകോഡ് ചെയ്തു. {{failed}} എണ്ണം പരിഹരിക്കാനായില്ല — താഴെയുള്ള വിശദാംശങ്ങൾ കാണുക.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "{{total}} കുടുംബങ്ങളിൽ {{geocoded}} എണ്ണം ജിയോകോഡ് ചെയ്തു. {{overflow}} എണ്ണം ഇനിയും പ്രോസസ്സ് ചെയ്തിട്ടില്ല — തുടരാൻ വീണ്ടും പ്രവർത്തിപ്പിക്കുക.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "കുടുംബങ്ങൾ ജിയോകോഡ് ചെയ്യുന്നു… ഇതിന് ഒരു മിനിറ്റ് വരെ എടുത്തേക്കാം. നിങ്ങൾക്ക് ഈ പേജ് തുറന്നിടാം.",
+  "Geocoding…": "ജിയോകോഡിംഗ്…",
+  "No address on file": "ഫയലിൽ വിലാസം ലഭ്യമല്ല",
+  "No match found — check the street address, city, and ZIP": "പൊരുത്തം കണ്ടെത്തിയില്ല — തെരുവ് വിലാസം, നഗരം, ZIP എന്നിവ പരിശോധിക്കുക",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "2FA നിർബന്ധമാക്കിയ ശേഷം ഉപയോക്താക്കൾക്ക് അതിൽ ചേരാൻ ലഭിക്കുന്ന ദിവസങ്ങളുടെ എണ്ണം. ഉടൻ നടപ്പിലാക്കാൻ (പഴയ രീതി) 0 ആയി സജ്ജമാക്കുക. സജീവമായ ഗ്രേസ് പിരീഡ് കുറയ്ക്കുന്നത് ഉപയോക്താക്കളെ ഉടൻ ലോക്ക് ഔട്ട് ചെയ്തേക്കാം.",
+  "Open a family to fix its address, then run this again.": "വിലാസം ശരിയാക്കാൻ ഒരു കുടുംബം തുറക്കുക, എന്നിട്ട് ഇത് വീണ്ടും പ്രവർത്തിപ്പിക്കുക.",
+  "Set up now": "ഇപ്പോൾ സജ്ജമാക്കുക",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "OpenStreetMap ഉപയോഗിച്ച് കോർഡിനേറ്റുകൾ ഇല്ലാത്ത എല്ലാ കുടുംബങ്ങൾക്കും ഇത് മാപ്പ് കോർഡിനേറ്റുകൾ കണ്ടെത്തുന്നു. ഓരോ പ്രാവശ്യവും ഇത് പരമാവധി 50 കുടുംബങ്ങൾ പ്രോസസ്സ് ചെയ്യുന്നു; ഒരു പൂർണ്ണ ബാച്ചിന് ഏകദേശം ഒരു മിനിറ്റ് എടുക്കും. ഇത് പ്രവർത്തിക്കുമ്പോൾ നിങ്ങൾക്ക് ഈ പേജ് തുറന്നിടാം. തുടരണോ?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "ദ്വിഘടക പ്രാമാണീകരണം ആവശ്യമാണ്. ചേരാൻ നിങ്ങൾക്ക് %d ദിവസം ഉണ്ട്.",
+    "other": "ദ്വിഘടക പ്രാമാണീകരണം ആവശ്യമാണ്. ചേരാൻ നിങ്ങൾക്ക് %d ദിവസങ്ങൾ ഉണ്ട്."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "അജ്ഞാത കുടുംബം",
+  "Update All Coordinates": "എല്ലാ കോർഡിനേറ്റുകളും അപ്ഡേറ്റ് ചെയ്യുക",
+  "Update All Family Coordinates": "എല്ലാ കുടുംബ കോർഡിനേറ്റുകളും അപ്ഡേറ്റ് ചെയ്യുക",
+  "Update Coordinates": "കോർഡിനേറ്റുകൾ അപ്ഡേറ്റ് ചെയ്യുക",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} അംഗത്തെ പകർത്തി",
+    "other": "{{count}} അംഗങ്ങളെ പകർത്തി"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "ഈ പട്ടികയിൽ {{count}} സ്വീകർത്താവ് ഉണ്ട് — mailto: ലിങ്കിന് വളരെ കൂടുതലാണ്. പകരം വിലാസങ്ങൾ പകർത്തുക ഉപയോഗിക്കുക.",
+    "other": "ഈ പട്ടികയിൽ {{count}} സ്വീകർത്താക്കൾ ഉണ്ട് — mailto: ലിങ്കിന് വളരെ കൂടുതലാണ്. പകരം വിലാസങ്ങൾ പകർത്തുക ഉപയോഗിക്കുക."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "ഇമെയിൽ ക്ലയന്റിന് സ്വീകർത്താക്കൾ വളരെ കൂടുതലാണ് ({{count}} > {{max}}). പകരം വിലാസങ്ങൾ പകർത്തുക ഉപയോഗിക്കുക.",
+    "other": "ഇമെയിൽ ക്ലയന്റിന് സ്വീകർത്താക്കൾ വളരെ കൂടുതലാണ് ({{count}} > {{max}}). പകരം വിലാസങ്ങൾ പകർത്തുക ഉപയോഗിക്കുക."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} മിനിറ്റ് ബാക്കി",
+    "other": "{{count}} മിനിറ്റ് ബാക്കി"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} കുടുംബത്തെ ജിയോകോഡ് ചെയ്യാൻ കഴിഞ്ഞില്ല",
+    "other": "{{count}} കുടുംബങ്ങളെ ജിയോകോഡ് ചെയ്യാൻ കഴിഞ്ഞില്ല"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…കൂടാതെ {{count}} എണ്ണം കൂടി. ബാക്കിയുള്ളവ കാണാൻ വീണ്ടും പ്രവർത്തിപ്പിക്കുക.",
+    "other": "…കൂടാതെ {{count}} എണ്ണം കൂടി. ബാക്കിയുള്ളവ കാണാൻ വീണ്ടും പ്രവർത്തിപ്പിക്കുക."
   }
 }

--- a/locale/terms/missing/nb/nb-1.json
+++ b/locale/terms/missing/nb/nb-1.json
@@ -1,62 +1,62 @@
 {
-  "Data": "",
-  "Auto": "",
-  "CSV": "",
+  "Data": "Data",
+  "Auto": "Auto",
+  "CSV": "CSV",
   "Email sent to %d family.": {
-    "one": "E-post sendt til %d familie.|E-post sendt til %d familier.|E-post sendt til %d familier.",
-    "other": ""
+    "one": "E-post sendt til %d familie.",
+    "other": "E-post sendt til %d familier."
   },
-  "OFX": "",
+  "OFX": "OFX",
   "PDF successfully emailed to %d family.": {
-    "one": "PDF ble sendt på e-post til %d familie.|PDF ble sendt på e-post til %d familier.|PDF ble sendt på e-post til %d familier.",
-    "other": ""
+    "one": "PDF sendt på e-post til %d familie.",
+    "other": "PDF sendt på e-post til %d familier."
   },
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "A geocoding error occurred — try again later": "Det oppstod en geokodingsfeil — prøv igjen senere",
+  "Address is incomplete (missing city, state, and ZIP)": "Adressen er ufullstendig (mangler by, fylke og postnummer)",
+  "All families already have coordinates.": "Alle familier har allerede koordinater.",
+  "Failed to update coordinates": "Kunne ikke oppdatere koordinater",
+  "Failed to update family coordinates": "Kunne ikke oppdatere familiekoordinater",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Geokodet alle {{geocoded}} familier. Kartet er nå oppdatert.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Geokodet {{geocoded}} familier. {{failed}} kunne ikke løses — se detaljer nedenfor.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Geokodet {{geocoded}} av {{total}} familier. {{overflow}} er ikke behandlet ennå — kjør igjen for å fortsette.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Geokoder familier … dette kan ta opptil et minutt. Du kan la denne siden være åpen.",
+  "Geocoding…": "Geokoder …",
+  "No address on file": "Ingen adresse registrert",
+  "No match found — check the street address, city, and ZIP": "Ingen treff funnet — sjekk gateadresse, by og postnummer",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Antall dager brukere har til å registrere seg for tofaktorautentisering etter at det er gjort obligatorisk. Sett til 0 for å håndheve umiddelbart (tidligere oppførsel). Å forkorte en aktiv overgangsperiode kan låse brukere ute umiddelbart.",
+  "Open a family to fix its address, then run this again.": "Åpne en familie for å rette adressen, og kjør deretter dette igjen.",
+  "Set up now": "Sett opp nå",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Dette finner kartkoordinater for alle familier som mangler dem, ved hjelp av OpenStreetMap. Det behandler opptil 50 familier per kjøring; en full omgang tar omtrent et minutt. Du kan la denne siden være åpen mens den kjører. Fortsette?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "Tofaktorautentisering er påkrevd. Du har %d dag til å registrere deg.",
+    "other": "Tofaktorautentisering er påkrevd. Du har %d dager til å registrere deg."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Ukjent familie",
+  "Update All Coordinates": "Oppdater alle koordinater",
+  "Update All Family Coordinates": "Oppdater alle familiekoordinater",
+  "Update Coordinates": "Oppdater koordinater",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Kopierte {{count}} medlem",
+    "other": "Kopierte {{count}} medlemmer"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Denne listen har {{count}} mottaker — for mange for en mailto:-lenke. Bruk Kopier adresser i stedet.",
+    "other": "Denne listen har {{count}} mottakere — for mange for en mailto:-lenke. Bruk Kopier adresser i stedet."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "For mange mottakere for e-postklienten ({{count}} > {{max}}). Bruk Kopier adresser i stedet.",
+    "other": "For mange mottakere for e-postklienten ({{count}} > {{max}}). Bruk Kopier adresser i stedet."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} min igjen",
+    "other": "{{count}} min igjen"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} familie kunne ikke geokodes",
+    "other": "{{count}} familier kunne ikke geokodes"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…og {{count}} til. Kjør igjen for å se resten.",
+    "other": "…og {{count}} til. Kjør igjen for å se resten."
   }
 }

--- a/locale/terms/missing/nl/nl-1.json
+++ b/locale/terms/missing/nl/nl-1.json
@@ -1,63 +1,63 @@
 {
-  "Code": "",
-  "Items": "",
-  "Planning": "",
-  "CSV": "",
+  "Code": "Code",
+  "Items": "Items",
+  "Planning": "Planning",
+  "CSV": "CSV",
   "Email sent to %d family.": {
-    "one": "E-mail verzonden naar %d gezin.|E-mail verzonden naar %d gezinnen.|E-mail verzonden naar %d gezinnen.",
-    "other": ""
+    "one": "E-mail verzonden naar %d gezin.",
+    "other": "E-mail verzonden naar %d gezinnen."
   },
-  "OFX": "",
+  "OFX": "OFX",
   "PDF successfully emailed to %d family.": {
-    "one": "PDF succesvol gemaild naar %d gezin.|PDF succesvol gemaild naar %d gezinnen.|PDF succesvol gemaild naar %d gezinnen.",
-    "other": ""
+    "one": "PDF succesvol gemaild naar %d gezin.",
+    "other": "PDF succesvol gemaild naar %d gezinnen."
   },
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "A geocoding error occurred — try again later": "Er is een geocoderingsfout opgetreden — probeer het later opnieuw",
+  "Address is incomplete (missing city, state, and ZIP)": "Adres is onvolledig (plaats, provincie en postcode ontbreken)",
+  "All families already have coordinates.": "Alle gezinnen hebben al coördinaten.",
+  "Failed to update coordinates": "Bijwerken van coördinaten mislukt",
+  "Failed to update family coordinates": "Bijwerken van coördinaten van het gezin mislukt",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Alle {{geocoded}} gezinnen zijn gegeocodeerd. De kaart is nu up-to-date.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "{{geocoded}} gezinnen zijn gegeocodeerd. {{failed}} konden niet worden herleid — zie details hieronder.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "{{geocoded}} van {{total}} gezinnen zijn gegeocodeerd. {{overflow}} nog niet verwerkt — voer opnieuw uit om door te gaan.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Gezinnen worden gegeocodeerd… dit kan tot een minuut duren. U kunt deze pagina open laten staan.",
+  "Geocoding…": "Geocoderen…",
+  "No address on file": "Geen adres bekend",
+  "No match found — check the street address, city, and ZIP": "Geen overeenkomst gevonden — controleer straatnaam, plaats en postcode",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Aantal dagen dat gebruikers hebben om zich in te schrijven voor tweefactorauthenticatie nadat dit verplicht is gesteld. Stel in op 0 om dit onmiddellijk af te dwingen (verouderd gedrag). Het verkorten van een actieve overgangsperiode kan gebruikers onmiddellijk buitensluiten.",
+  "Open a family to fix its address, then run this again.": "Open een gezin om het adres te corrigeren en voer dit daarna opnieuw uit.",
+  "Set up now": "Nu instellen",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Dit zoekt kaartcoördinaten voor elk gezin dat deze mist, met behulp van OpenStreetMap. Er worden maximaal 50 gezinnen per keer verwerkt; een volledige batch duurt ongeveer een minuut. U kunt deze pagina open laten staan terwijl dit wordt uitgevoerd. Doorgaan?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "Tweefactorauthenticatie is verplicht. U heeft %d dag om u in te schrijven.",
+    "other": "Tweefactorauthenticatie is verplicht. U heeft %d dagen om u in te schrijven."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Onbekend gezin",
+  "Update All Coordinates": "Alle coördinaten bijwerken",
+  "Update All Family Coordinates": "Alle gezinscoördinaten bijwerken",
+  "Update Coordinates": "Coördinaten bijwerken",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} lid gekopieerd",
+    "other": "{{count}} leden gekopieerd"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Deze lijst heeft {{count}} ontvanger — te veel voor een mailto:-link. Gebruik in plaats daarvan Adressen kopiëren.",
+    "other": "Deze lijst heeft {{count}} ontvangers — te veel voor een mailto:-link. Gebruik in plaats daarvan Adressen kopiëren."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Te veel ontvangers voor e-mailclient ({{count}} > {{max}}). Gebruik in plaats daarvan Adressen kopiëren.",
+    "other": "Te veel ontvangers voor e-mailclient ({{count}} > {{max}}). Gebruik in plaats daarvan Adressen kopiëren."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} minuut resterend",
+    "other": "{{count}} minuten resterend"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} gezin kon niet worden gegeocodeerd",
+    "other": "{{count}} gezinnen konden niet worden gegeocodeerd"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…en nog {{count}} meer. Voer opnieuw uit om de rest te zien.",
+    "other": "…en nog {{count}} meer. Voer opnieuw uit om de rest te zien."
   }
 }

--- a/locale/terms/missing/pl/pl-1.json
+++ b/locale/terms/missing/pl/pl-1.json
@@ -1,64 +1,64 @@
 {
-  "Auto": "",
-  "CSV": "",
+  "Auto": "Automatyczny",
+  "CSV": "CSV",
   "Email sent to %d family.": {
-    "one": "E-mail wysłany do %d rodziny.|E-mail wysłany do %d rodzin.|E-mail wysłany do %d rodzin.|E-mail wysłany do %d rodzin.|E-mail wysłany do %d rodzin.",
-    "few": "",
-    "other": ""
+    "one": "Wysłano e-mail do %d rodziny.",
+    "few": "Wysłano e-mail do %d rodzin.",
+    "other": "Wysłano e-mail do %d rodzin."
   },
-  "OFX": "",
+  "OFX": "OFX",
   "PDF successfully emailed to %d family.": {
-    "one": "PDF został pomyślnie wysłany e-mailem do %d rodziny.|PDF został pomyślnie wysłany e-mailem do %d rodzin.|PDF został pomyślnie wysłany e-mailem do %d rodzin.|PDF został pomyślnie wysłany e-mailem do %d rodzin.|PDF został pomyślnie wysłany e-mailem do %d rodzin.",
-    "few": "",
-    "other": ""
+    "one": "Plik PDF został wysłany e-mailem do %d rodziny.",
+    "few": "Plik PDF został wysłany e-mailem do %d rodzin.",
+    "other": "Plik PDF został wysłany e-mailem do %d rodzin."
   },
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "A geocoding error occurred — try again later": "Wystąpił błąd geokodowania — spróbuj ponownie później",
+  "Address is incomplete (missing city, state, and ZIP)": "Adres jest niekompletny (brakuje miasta, województwa i kodu pocztowego)",
+  "All families already have coordinates.": "Wszystkie rodziny mają już współrzędne.",
+  "Failed to update coordinates": "Nie udało się zaktualizować współrzędnych",
+  "Failed to update family coordinates": "Nie udało się zaktualizować współrzędnych rodziny",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Zgeokodowano wszystkie {{geocoded}} rodzin. Mapa jest teraz aktualna.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Zgeokodowano {{geocoded}} rodzin. Nie udało się rozpoznać {{failed}} — zobacz szczegóły poniżej.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Zgeokodowano {{geocoded}} z {{total}} rodzin. {{overflow}} jeszcze nie przetworzono — uruchom ponownie, aby kontynuować.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Geokodowanie rodzin… może to potrwać do minuty. Możesz zostawić tę stronę otwartą.",
+  "Geocoding…": "Geokodowanie…",
+  "No address on file": "Brak adresu w kartotece",
+  "No match found — check the street address, city, and ZIP": "Nie znaleziono dopasowania — sprawdź adres, miasto i kod pocztowy",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Liczba dni, jaką użytkownicy mają na włączenie uwierzytelniania dwuskładnikowego (2FA) po jego wprowadzeniu jako obowiązkowego. Ustaw 0, aby wymusić natychmiast (zachowanie zgodne z wcześniejszą wersją). Skrócenie aktywnego okresu karencji może natychmiast zablokować dostęp użytkownikom.",
+  "Open a family to fix its address, then run this again.": "Otwórz rodzinę, aby poprawić jej adres, a następnie uruchom to ponownie.",
+  "Set up now": "Skonfiguruj teraz",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Ta funkcja wyszukuje współrzędne mapy dla każdej rodziny, której ich brakuje, korzystając z OpenStreetMap. Przetwarza do 50 rodzin na jedno uruchomienie; pełna partia trwa około minuty. Możesz zostawić tę stronę otwartą podczas przetwarzania. Kontynuować?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "few": "",
-    "other": ""
+    "one": "Uwierzytelnianie dwuskładnikowe jest wymagane. Masz %d dzień na rejestrację.",
+    "few": "Uwierzytelnianie dwuskładnikowe jest wymagane. Masz %d dni na rejestrację.",
+    "other": "Uwierzytelnianie dwuskładnikowe jest wymagane. Masz %d dni na rejestrację."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Nieznana rodzina",
+  "Update All Coordinates": "Zaktualizuj wszystkie współrzędne",
+  "Update All Family Coordinates": "Zaktualizuj współrzędne wszystkich rodzin",
+  "Update Coordinates": "Zaktualizuj współrzędne",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Skopiowano {{count}} członka",
+    "other": "Skopiowano {{count}} członków"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Ta lista zawiera {{count}} odbiorcę — to zbyt wiele jak na link mailto. Użyj zamiast tego opcji Kopiuj adresy.",
+    "other": "Ta lista zawiera {{count}} odbiorców — to zbyt wiele jak na link mailto. Użyj zamiast tego opcji Kopiuj adresy."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Zbyt wielu odbiorców dla klienta poczty e-mail ({{count}} > {{max}}). Użyj zamiast tego opcji Kopiuj adresy.",
+    "other": "Zbyt wielu odbiorców dla klienta poczty e-mail ({{count}} > {{max}}). Użyj zamiast tego opcji Kopiuj adresy."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "Pozostała {{count}} minuta",
+    "other": "Pozostało {{count}} minut"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "Nie udało się zgeokodować {{count}} rodziny",
+    "other": "Nie udało się zgeokodować {{count}} rodzin"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…i jeszcze {{count}} więcej. Uruchom ponownie, aby zobaczyć resztę.",
+    "other": "…i jeszcze {{count}} więcej. Uruchom ponownie, aby zobaczyć resztę."
   }
 }

--- a/locale/terms/missing/pt-br/pt-br-1.json
+++ b/locale/terms/missing/pt-br/pt-br-1.json
@@ -1,60 +1,60 @@
 {
-  "CSV": "",
+  "CSV": "CSV",
   "Email sent to %d family.": {
-    "one": "E-mail enviado para %d família.|E-mail enviado para %d famílias.|E-mail enviado para %d famílias.",
-    "other": ""
+    "one": "E-mail enviado para %d família.",
+    "other": "E-mail enviado para %d famílias."
   },
-  "OFX": "",
+  "OFX": "OFX",
   "PDF successfully emailed to %d family.": {
-    "one": "PDF enviado com sucesso por e-mail para %d família.|PDF enviado com sucesso por e-mail para %d famílias.|PDF enviado com sucesso por e-mail para %d famílias.",
-    "other": ""
+    "one": "PDF enviado com sucesso por e-mail para %d família.",
+    "other": "PDF enviado com sucesso por e-mail para %d famílias."
   },
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "A geocoding error occurred — try again later": "Ocorreu um erro de geocodificação — tente novamente mais tarde",
+  "Address is incomplete (missing city, state, and ZIP)": "O endereço está incompleto (faltando cidade, estado e CEP)",
+  "All families already have coordinates.": "Todas as famílias já têm coordenadas.",
+  "Failed to update coordinates": "Falha ao atualizar coordenadas",
+  "Failed to update family coordinates": "Falha ao atualizar as coordenadas da família",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Todas as {{geocoded}} famílias foram geocodificadas. O mapa está atualizado agora.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "{{geocoded}} famílias foram geocodificadas. {{failed}} não puderam ser resolvidas — veja os detalhes abaixo.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "{{geocoded}} de {{total}} famílias foram geocodificadas. {{overflow}} ainda não foram processadas — execute novamente para continuar.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Geocodificando famílias… isso pode levar até um minuto. Você pode manter esta página aberta.",
+  "Geocoding…": "Geocodificando…",
+  "No address on file": "Nenhum endereço registrado",
+  "No match found — check the street address, city, and ZIP": "Nenhuma correspondência encontrada — verifique o endereço, a cidade e o CEP",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Número de dias que os usuários têm para se cadastrar na autenticação de dois fatores (2FA) depois que ela se tornar obrigatória. Defina como 0 para aplicar imediatamente (comportamento legado). Reduzir um período de carência ativo pode bloquear o acesso dos usuários imediatamente.",
+  "Open a family to fix its address, then run this again.": "Abra uma família para corrigir seu endereço e execute isso novamente.",
+  "Set up now": "Configurar agora",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Isso encontra coordenadas no mapa para cada família que ainda não as possui, usando o OpenStreetMap. Ele processa até 50 famílias por execução; um lote completo leva cerca de um minuto. Você pode manter esta página aberta enquanto ele é executado. Continuar?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "A autenticação de dois fatores é obrigatória. Você tem %d dia para se cadastrar.",
+    "other": "A autenticação de dois fatores é obrigatória. Você tem %d dias para se cadastrar."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Família desconhecida",
+  "Update All Coordinates": "Atualizar Todas as Coordenadas",
+  "Update All Family Coordinates": "Atualizar Todas as Coordenadas das Famílias",
+  "Update Coordinates": "Atualizar Coordenadas",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} membro copiado",
+    "other": "{{count}} membros copiados"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Esta lista tem {{count}} destinatário — muitos para um link mailto:. Use Copiar Endereços em vez disso.",
+    "other": "Esta lista tem {{count}} destinatários — muitos para um link mailto:. Use Copiar Endereços em vez disso."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Muitos destinatários para o cliente de e-mail ({{count}} > {{max}}). Use Copiar Endereços em vez disso.",
+    "other": "Muitos destinatários para o cliente de e-mail ({{count}} > {{max}}). Use Copiar Endereços em vez disso."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} minuto restante",
+    "other": "{{count}} minutos restantes"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} família não pôde ser geocodificada",
+    "other": "{{count}} famílias não puderam ser geocodificadas"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…e mais {{count}}. Execute novamente para ver o restante.",
+    "other": "…e mais {{count}}. Execute novamente para ver o restante."
   }
 }

--- a/locale/terms/missing/pt/pt-1.json
+++ b/locale/terms/missing/pt/pt-1.json
@@ -1,60 +1,60 @@
 {
-  "CSV": "",
+  "CSV": "CSV",
   "Email sent to %d family.": {
-    "one": "E-mail enviado para %d família.|E-mail enviado para %d famílias.|E-mail enviado para %d famílias.",
-    "other": ""
+    "one": "E-mail enviado para %d família.",
+    "other": "E-mail enviado para %d famílias."
   },
-  "OFX": "",
+  "OFX": "OFX",
   "PDF successfully emailed to %d family.": {
-    "one": "PDF enviado com sucesso por e-mail para %d família.|PDF enviado com sucesso por e-mail para %d famílias.|PDF enviado com sucesso por e-mail para %d famílias.",
-    "other": ""
+    "one": "PDF enviado com sucesso por e-mail para %d família.",
+    "other": "PDF enviado com sucesso por e-mail para %d famílias."
   },
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "A geocoding error occurred — try again later": "Ocorreu um erro de geocodificação — tente novamente mais tarde",
+  "Address is incomplete (missing city, state, and ZIP)": "O endereço está incompleto (falta cidade, distrito e código postal)",
+  "All families already have coordinates.": "Todas as famílias já têm coordenadas.",
+  "Failed to update coordinates": "Falha ao atualizar as coordenadas",
+  "Failed to update family coordinates": "Falha ao atualizar as coordenadas da família",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Foram geocodificadas todas as {{geocoded}} famílias. O mapa está agora atualizado.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Foram geocodificadas {{geocoded}} famílias. {{failed}} não puderam ser resolvidas — veja os detalhes abaixo.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Foram geocodificadas {{geocoded}} de {{total}} famílias. {{overflow}} ainda não foram processadas — execute novamente para continuar.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "A geocodificar as famílias… isto pode demorar até um minuto. Pode manter esta página aberta.",
+  "Geocoding…": "A geocodificar…",
+  "No address on file": "Nenhum endereço registado",
+  "No match found — check the street address, city, and ZIP": "Nenhuma correspondência encontrada — verifique a morada, a cidade e o código postal",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Número de dias que os utilizadores têm para ativar a autenticação de dois fatores depois de esta se tornar obrigatória. Defina como 0 para aplicar imediatamente (comportamento legado). Reduzir um período de tolerância ativo pode bloquear imediatamente o acesso dos utilizadores.",
+  "Open a family to fix its address, then run this again.": "Abra uma família para corrigir a sua morada e execute novamente.",
+  "Set up now": "Configurar agora",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Isto encontra as coordenadas do mapa para todas as famílias que não as têm, utilizando o OpenStreetMap. Processa até 50 famílias por execução; um lote completo demora cerca de um minuto. Pode manter esta página aberta enquanto é executado. Continuar?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "A autenticação de dois fatores é obrigatória. Tem %d dia para se registar.",
+    "other": "A autenticação de dois fatores é obrigatória. Tem %d dias para se registar."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Família desconhecida",
+  "Update All Coordinates": "Atualizar Todas as Coordenadas",
+  "Update All Family Coordinates": "Atualizar Todas as Coordenadas das Famílias",
+  "Update Coordinates": "Atualizar Coordenadas",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} membro copiado",
+    "other": "{{count}} membros copiados"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Esta lista tem {{count}} destinatário — demasiados para um link mailto:. Utilize antes Copiar Endereços.",
+    "other": "Esta lista tem {{count}} destinatários — demasiados para um link mailto:. Utilize antes Copiar Endereços."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Demasiados destinatários para o cliente de e-mail ({{count}} > {{max}}). Utilize antes Copiar Endereços.",
+    "other": "Demasiados destinatários para o cliente de e-mail ({{count}} > {{max}}). Utilize antes Copiar Endereços."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "resta {{count}} minuto",
+    "other": "restam {{count}} minutos"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} família não pôde ser geocodificada",
+    "other": "{{count}} famílias não puderam ser geocodificadas"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…e mais {{count}}. Execute novamente para ver o resto.",
+    "other": "…e mais {{count}}. Execute novamente para ver o resto."
   }
 }

--- a/locale/terms/missing/ro/ro-1.json
+++ b/locale/terms/missing/ro/ro-1.json
@@ -1,68 +1,68 @@
 {
-  "Important": "",
-  "Major": "",
-  "Catalog": "",
-  "Auto": "",
-  "CSV": "",
+  "Important": "Important",
+  "Major": "Major",
+  "Catalog": "Catalog",
+  "Auto": "Automat",
+  "CSV": "CSV",
   "Email sent to %d family.": {
-    "one": "E-mail trimis către %d familie.|E-mail trimis către %d familii.|E-mail trimis către %d de familii.|E-mail trimis către %d familii.|E-mail trimis către %d de familii.",
-    "few": "",
-    "other": ""
+    "one": "E-mail trimis către %d familie.",
+    "few": "E-mail trimis către %d familii.",
+    "other": "E-mail trimis către %d de familii."
   },
-  "N/A": "",
-  "OFX": "",
+  "N/A": "N/A",
+  "OFX": "OFX",
   "PDF successfully emailed to %d family.": {
-    "one": "PDF trimis cu succes prin e-mail către %d familie.|PDF trimis cu succes prin e-mail către %d familii.|PDF trimis cu succes prin e-mail către %d de familii.|PDF trimis cu succes prin e-mail către %d familii.|PDF trimis cu succes prin e-mail către %d de familii.",
-    "few": "",
-    "other": ""
+    "one": "PDF trimis cu succes prin e-mail către %d familie.",
+    "few": "PDF trimis cu succes prin e-mail către %d familii.",
+    "other": "PDF trimis cu succes prin e-mail către %d de familii."
   },
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "A geocoding error occurred — try again later": "A apărut o eroare de geocodare — încercați din nou mai târziu",
+  "Address is incomplete (missing city, state, and ZIP)": "Adresa este incompletă (lipsesc orașul, județul și codul poștal)",
+  "All families already have coordinates.": "Toate familiile au deja coordonate.",
+  "Failed to update coordinates": "Actualizarea coordonatelor a eșuat",
+  "Failed to update family coordinates": "Actualizarea coordonatelor familiei a eșuat",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Au fost geocodate toate cele {{geocoded}} familii. Harta este acum actualizată.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Au fost geocodate {{geocoded}} familii. {{failed}} nu au putut fi rezolvate — vedeți detaliile de mai jos.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Au fost geocodate {{geocoded}} din {{total}} familii. {{overflow}} nu au fost încă procesate — rulați din nou pentru a continua.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Se geocodează familiile… acest lucru poate dura până la un minut. Puteți lăsa această pagină deschisă.",
+  "Geocoding…": "Se geocodează…",
+  "No address on file": "Nicio adresă înregistrată",
+  "No match found — check the street address, city, and ZIP": "Nu s-a găsit nicio corespondență — verificați strada, orașul și codul poștal",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Numărul de zile pe care utilizatorii le au la dispoziție pentru a activa autentificarea în doi factori (2FA) după ce aceasta devine obligatorie. Setați la 0 pentru a o impune imediat (comportament vechi). Scurtarea unei perioade de grație active poate bloca imediat accesul utilizatorilor.",
+  "Open a family to fix its address, then run this again.": "Deschideți o familie pentru a-i corecta adresa, apoi rulați din nou.",
+  "Set up now": "Configurați acum",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Aceasta găsește coordonatele pe hartă pentru fiecare familie căreia îi lipsesc, folosind OpenStreetMap. Procesează până la 50 de familii pe rulare; un lot complet durează aproximativ un minut. Puteți lăsa această pagină deschisă în timp ce rulează. Continuați?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "few": "",
-    "other": ""
+    "one": "Autentificarea în doi factori este obligatorie. Aveți %d zi pentru a vă înscrie.",
+    "few": "Autentificarea în doi factori este obligatorie. Aveți %d zile pentru a vă înscrie.",
+    "other": "Autentificarea în doi factori este obligatorie. Aveți %d de zile pentru a vă înscrie."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Familie necunoscută",
+  "Update All Coordinates": "Actualizează toate coordonatele",
+  "Update All Family Coordinates": "Actualizează toate coordonatele familiilor",
+  "Update Coordinates": "Actualizează coordonatele",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "S-a copiat {{count}} membru",
+    "other": "S-au copiat {{count}} membri"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Această listă are {{count}} destinatar — prea mult pentru un link mailto. Utilizați în schimb Copiere adrese.",
+    "other": "Această listă are {{count}} destinatari — prea mulți pentru un link mailto. Utilizați în schimb Copiere adrese."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Prea mulți destinatari pentru clientul de e-mail ({{count}} > {{max}}). Utilizați în schimb Copiere adrese.",
+    "other": "Prea mulți destinatari pentru clientul de e-mail ({{count}} > {{max}}). Utilizați în schimb Copiere adrese."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} minut rămas",
+    "other": "{{count}} minute rămase"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} familie nu a putut fi geocodată",
+    "other": "{{count}} familii nu au putut fi geocodate"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…și încă {{count}}. Rulați din nou pentru a vedea restul.",
+    "other": "…și încă {{count}}. Rulați din nou pentru a vedea restul."
   }
 }

--- a/locale/terms/missing/ru/ru-1.json
+++ b/locale/terms/missing/ru/ru-1.json
@@ -1,66 +1,66 @@
 {
-  "CSV": "",
+  "CSV": "CSV",
   "Email sent to %d family.": {
-    "one": "Письмо отправлено %d семье.|Письмо отправлено %d семьям.|Письмо отправлено %d семьям.|Письмо отправлено %d семьи.|Письмо отправлено %d семьям.|Письмо отправлено %d семьям.|Письмо отправлено %d семьи.",
-    "few": "",
-    "many": "",
-    "other": ""
+    "one": "Письмо отправлено %d семье.",
+    "few": "Письмо отправлено %d семьям.",
+    "many": "Письмо отправлено %d семьям.",
+    "other": "Письмо отправлено %d семьи."
   },
-  "OFX": "",
+  "OFX": "OFX",
   "PDF successfully emailed to %d family.": {
-    "one": "PDF успешно отправлен %d семье.|PDF успешно отправлен %d семьям.|PDF успешно отправлен %d семьям.|PDF успешно отправлен %d семьи.|PDF успешно отправлен %d семьям.|PDF успешно отправлен %d семьям.|PDF успешно отправлен %d семьи.",
-    "few": "",
-    "many": "",
-    "other": ""
+    "one": "PDF-файл успешно отправлен %d семье.",
+    "few": "PDF-файл успешно отправлен %d семьям.",
+    "many": "PDF-файл успешно отправлен %d семьям.",
+    "other": "PDF-файл успешно отправлен %d семьи."
   },
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "A geocoding error occurred — try again later": "Произошла ошибка геокодирования — попробуйте позже",
+  "Address is incomplete (missing city, state, and ZIP)": "Адрес указан не полностью (отсутствует город, штат/область или почтовый индекс)",
+  "All families already have coordinates.": "У всех семей уже есть координаты.",
+  "Failed to update coordinates": "Не удалось обновить координаты",
+  "Failed to update family coordinates": "Не удалось обновить координаты семьи",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Геокодированы все семьи ({{geocoded}}). Карта обновлена.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Геокодировано семей: {{geocoded}}. Не удалось определить координаты для {{failed}} — подробности ниже.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Геокодировано {{geocoded}} из {{total}} семей. {{overflow}} ещё не обработано — запустите снова, чтобы продолжить.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Геокодирование семей… это может занять до минуты. Вы можете оставить страницу открытой.",
+  "Geocoding…": "Геокодирование…",
+  "No address on file": "Адрес не указан",
+  "No match found — check the street address, city, and ZIP": "Совпадений не найдено — проверьте улицу, город и почтовый индекс",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Количество дней, в течение которых пользователи должны настроить двухфакторную аутентификацию после того, как она станет обязательной. Установите 0, чтобы применить требование немедленно (прежнее поведение). Сокращение уже действующего льготного периода может немедленно заблокировать доступ пользователям.",
+  "Open a family to fix its address, then run this again.": "Откройте карточку семьи, чтобы исправить адрес, а затем запустите это снова.",
+  "Set up now": "Настроить сейчас",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Эта функция находит координаты на карте для всех семей, у которых они отсутствуют, используя OpenStreetMap. За один запуск обрабатывается до 50 семей; полный пакет занимает около минуты. Вы можете оставить страницу открытой во время выполнения. Продолжить?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "few": "",
-    "many": "",
-    "other": ""
+    "one": "Требуется двухфакторная аутентификация. У вас есть %d день на настройку.",
+    "few": "Требуется двухфакторная аутентификация. У вас есть %d дня на настройку.",
+    "many": "Требуется двухфакторная аутентификация. У вас есть %d дней на настройку.",
+    "other": "Требуется двухфакторная аутентификация. У вас есть %d дня на настройку."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Неизвестная семья",
+  "Update All Coordinates": "Обновить все координаты",
+  "Update All Family Coordinates": "Обновить координаты всех семей",
+  "Update Coordinates": "Обновить координаты",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Скопирован {{count}} участник",
+    "other": "Скопировано {{count}} участников"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "В этом списке {{count}} получатель — слишком много для ссылки mailto:. Используйте вместо этого «Копировать адреса».",
+    "other": "В этом списке {{count}} получателей — слишком много для ссылки mailto:. Используйте вместо этого «Копировать адреса»."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Слишком много получателей для почтового клиента ({{count}} > {{max}}). Используйте вместо этого «Копировать адреса».",
+    "other": "Слишком много получателей для почтового клиента ({{count}} > {{max}}). Используйте вместо этого «Копировать адреса»."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "Осталась {{count}} минута",
+    "other": "Осталось {{count}} минут"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "Не удалось геокодировать {{count}} семью",
+    "other": "Не удалось геокодировать {{count}} семей"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…и ещё {{count}}. Запустите снова, чтобы увидеть остальное.",
+    "other": "…и ещё {{count}}. Запустите снова, чтобы увидеть остальное."
   }
 }

--- a/locale/terms/missing/sk/sk-1.json
+++ b/locale/terms/missing/sk/sk-1.json
@@ -1,66 +1,66 @@
 {
-  "CSV": "",
+  "CSV": "CSV",
   "Email sent to %d family.": {
-    "one": "E-mail odoslaný %d rodine.|E-mail odoslaný %d rodinám.|E-mail odoslaný %d rodinám.|E-mail odoslaný %d rodinám.|E-mail odoslaný %d rodinám.|E-mail odoslaný %d rodinám.|E-mail odoslaný %d rodinám.",
-    "few": "",
-    "many": "",
-    "other": ""
+    "one": "E-mail bol odoslaný pre %d rodinu.",
+    "few": "E-mail bol odoslaný pre %d rodiny.",
+    "many": "E-mail bol odoslaný pre %d rodiny.",
+    "other": "E-mail bol odoslaný pre %d rodín."
   },
-  "OFX": "",
+  "OFX": "OFX",
   "PDF successfully emailed to %d family.": {
-    "one": "PDF úspešne odoslané %d rodine.|PDF úspešne odoslané %d rodinám.|PDF úspešne odoslané %d rodinám.|PDF úspešne odoslané %d rodinám.|PDF úspešne odoslané %d rodinám.|PDF úspešne odoslané %d rodinám.|PDF úspešne odoslané %d rodinám.",
-    "few": "",
-    "many": "",
-    "other": ""
+    "one": "PDF bolo úspešne odoslané e-mailom pre %d rodinu.",
+    "few": "PDF bolo úspešne odoslané e-mailom pre %d rodiny.",
+    "many": "PDF bolo úspešne odoslané e-mailom pre %d rodiny.",
+    "other": "PDF bolo úspešne odoslané e-mailom pre %d rodín."
   },
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "A geocoding error occurred — try again later": "Vyskytla sa chyba geokódovania — skúste to znova neskôr",
+  "Address is incomplete (missing city, state, and ZIP)": "Adresa je neúplná (chýba mesto, štát a PSČ)",
+  "All families already have coordinates.": "Všetky rodiny už majú súradnice.",
+  "Failed to update coordinates": "Nepodarilo sa aktualizovať súradnice",
+  "Failed to update family coordinates": "Nepodarilo sa aktualizovať súradnice rodiny",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Geokódovanie dokončené pre všetkých {{geocoded}} rodín. Mapa je teraz aktuálna.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Geokódovaných bolo {{geocoded}} rodín. {{failed}} sa nepodarilo vyriešiť — pozrite podrobnosti nižšie.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Geokódovaných bolo {{geocoded}} z {{total}} rodín. {{overflow}} ešte nebolo spracovaných — spustite znova pre pokračovanie.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Geokódovanie rodín… môže to trvať až minútu. Túto stránku môžete nechať otvorenú.",
+  "Geocoding…": "Geokódovanie…",
+  "No address on file": "Žiadna adresa v evidencii",
+  "No match found — check the street address, city, and ZIP": "Nenašla sa žiadna zhoda — skontrolujte ulicu, mesto a PSČ",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Počet dní, ktoré majú používatelia na zapojenie dvojfaktorového overenia (2FA) po jeho nariadení. Nastavením na 0 sa vynúti okamžite (pôvodné správanie). Skrátenie aktívnej ochrannej lehoty môže používateľov okamžite uzamknúť.",
+  "Open a family to fix its address, then run this again.": "Otvorte rodinu, opravte jej adresu a potom spustite toto znova.",
+  "Set up now": "Nastaviť teraz",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Toto nájde súradnice na mape pre každú rodinu, ktorej chýbajú, pomocou OpenStreetMap. Spracuje až 50 rodín na jeden beh; celá dávka trvá približne minútu. Túto stránku môžete nechať otvorenú počas behu. Pokračovať?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "few": "",
-    "many": "",
-    "other": ""
+    "one": "Vyžaduje sa dvojfaktorové overenie. Na zapojenie máte %d deň.",
+    "few": "Vyžaduje sa dvojfaktorové overenie. Na zapojenie máte %d dni.",
+    "many": "Vyžaduje sa dvojfaktorové overenie. Na zapojenie máte %d dňa.",
+    "other": "Vyžaduje sa dvojfaktorové overenie. Na zapojenie máte %d dní."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Neznáma rodina",
+  "Update All Coordinates": "Aktualizovať všetky súradnice",
+  "Update All Family Coordinates": "Aktualizovať súradnice všetkých rodín",
+  "Update Coordinates": "Aktualizovať súradnice",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Skopírovaný {{count}} člen",
+    "other": "Skopírovaných {{count}} členov"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Tento zoznam obsahuje {{count}} príjemcu — príliš veľa pre odkaz mailto:. Namiesto toho použite Kopírovať adresy.",
+    "other": "Tento zoznam obsahuje {{count}} príjemcov — príliš veľa pre odkaz mailto:. Namiesto toho použite Kopírovať adresy."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Príliš veľa príjemcov pre e-mailového klienta ({{count}} > {{max}}). Namiesto toho použite Kopírovať adresy.",
+    "other": "Príliš veľa príjemcov pre e-mailového klienta ({{count}} > {{max}}). Namiesto toho použite Kopírovať adresy."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "Zostáva {{count}} min",
+    "other": "Zostáva {{count}} min"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "Nepodarilo sa geokódovať {{count}} rodinu",
+    "other": "Nepodarilo sa geokódovať {{count}} rodín"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…a {{count}} ďalšia. Spustite znova, ak chcete vidieť zvyšok.",
+    "other": "…a {{count}} ďalších. Spustite znova, ak chcete vidieť zvyšok."
   }
 }

--- a/locale/terms/missing/sq/sq-1.json
+++ b/locale/terms/missing/sq/sq-1.json
@@ -1,61 +1,61 @@
 {
-  "CSV": "",
+  "CSV": "CSV",
   "Email sent to %d family.": {
-    "one": "Email-i u dërgua tek %d familje.|Email-i u dërgua tek %d familje.|Email-i u dërgua tek %d familje.",
-    "other": ""
+    "one": "Email-i u dërgua te %d familje.",
+    "other": "Email-i u dërgua te %d familje."
   },
-  "N/A": "",
-  "OFX": "",
+  "N/A": "N/A",
+  "OFX": "OFX",
   "PDF successfully emailed to %d family.": {
-    "one": "PDF-i u dërgua me sukses me email tek %d familje.|PDF-i u dërgua me sukses me email tek %d familje.|PDF-i u dërgua me sukses me email tek %d familje.",
-    "other": ""
+    "one": "PDF-ja u dërgua me sukses te %d familje.",
+    "other": "PDF-ja u dërgua me sukses te %d familje."
   },
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "A geocoding error occurred — try again later": "Ndodhi një gabim gjatë gjeokodimit — provoni përsëri më vonë",
+  "Address is incomplete (missing city, state, and ZIP)": "Adresa është e paplotë (mungon qyteti, shteti dhe kodi postar)",
+  "All families already have coordinates.": "Të gjitha familjet kanë tashmë koordinata.",
+  "Failed to update coordinates": "Dështoi përditësimi i koordinatave",
+  "Failed to update family coordinates": "Dështoi përditësimi i koordinatave të familjes",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "U gjeokoduan të gjitha {{geocoded}} familjet. Harta tani është e përditësuar.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "U gjeokoduan {{geocoded}} familje. {{failed}} nuk u zgjidhën dot — shihni detajet më poshtë.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "U gjeokoduan {{geocoded}} nga {{total}} familje. {{overflow}} ende nuk janë përpunuar — ekzekutojeni përsëri për të vazhduar.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Duke gjeokoduar familjet… kjo mund të zgjasë deri në një minutë. Mund ta mbani këtë faqe hapur.",
+  "Geocoding…": "Duke gjeokoduar…",
+  "No address on file": "Nuk ka adresë të regjistruar",
+  "No match found — check the street address, city, and ZIP": "Nuk u gjet asnjë përputhje — kontrolloni adresën e rrugës, qytetin dhe kodin postar",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Numri i ditëve që kanë përdoruesit për t'u regjistruar në 2FA pasi bëhet i detyrueshëm. Vendoseni në 0 për ta zbatuar menjëherë (sjellje e vjetër). Shkurtimi i një periudhe hiri aktive mund t'i bllokojë përdoruesit menjëherë jashtë sistemit.",
+  "Open a family to fix its address, then run this again.": "Hapni një familje për të korrigjuar adresën e saj, më pas ekzekutojeni këtë përsëri.",
+  "Set up now": "Konfiguro tani",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Kjo gjen koordinatat e hartës për çdo familje që i mungojnë, duke përdorur OpenStreetMap. Përpunon deri në 50 familje për ekzekutim; një grup i plotë zgjat rreth një minutë. Mund ta mbani këtë faqe hapur ndërsa ekzekutohet. Të vazhdohet?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "Kërkohet vërtetimi dyfaktorësh. Keni %d ditë për t'u regjistruar.",
+    "other": "Kërkohet vërtetimi dyfaktorësh. Keni %d ditë për t'u regjistruar."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Familje e panjohur",
+  "Update All Coordinates": "Përditëso të Gjitha Koordinatat",
+  "Update All Family Coordinates": "Përditëso të Gjitha Koordinatat e Familjeve",
+  "Update Coordinates": "Përditëso Koordinatat",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "U kopjua {{count}} anëtar",
+    "other": "U kopjuan {{count}} anëtarë"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Kjo listë ka {{count}} marrës — shumë për një lidhje mailto:. Përdorni Kopjo Adresat në vend të kësaj.",
+    "other": "Kjo listë ka {{count}} marrës — shumë për një lidhje mailto:. Përdorni Kopjo Adresat në vend të kësaj."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Shumë marrës për klientin e email-it ({{count}} > {{max}}). Përdorni Kopjo Adresat në vend të kësaj.",
+    "other": "Shumë marrës për klientin e email-it ({{count}} > {{max}}). Përdorni Kopjo Adresat në vend të kësaj."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} minutë e mbetur",
+    "other": "{{count}} minuta të mbetura"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} familje nuk u gjeokodua dot",
+    "other": "{{count}} familje nuk u gjeokoduan dot"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…dhe {{count}} tjetër. Ekzekutojeni përsëri për të parë pjesën tjetër.",
+    "other": "…dhe {{count}} të tjera. Ekzekutojeni përsëri për të parë pjesën tjetër."
   }
 }

--- a/locale/terms/missing/sv/sv-1.json
+++ b/locale/terms/missing/sv/sv-1.json
@@ -1,62 +1,62 @@
 {
-  "Data": "",
-  "Auto": "",
-  "CSV": "",
+  "Data": "Data",
+  "Auto": "Auto",
+  "CSV": "CSV",
   "Email sent to %d family.": {
-    "one": "E-post skickad till %d familj.|E-post skickad till %d familjer.|E-post skickad till %d familjer.",
-    "other": ""
+    "one": "E-post skickad till %d familj.",
+    "other": "E-post skickad till %d familjer."
   },
-  "OFX": "",
+  "OFX": "OFX",
   "PDF successfully emailed to %d family.": {
-    "one": "PDF har skickats via e-post till %d familj.|PDF har skickats via e-post till %d familjer.|PDF har skickats via e-post till %d familjer.",
-    "other": ""
+    "one": "PDF skickades via e-post till %d familj.",
+    "other": "PDF skickades via e-post till %d familjer."
   },
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "A geocoding error occurred — try again later": "Ett geokodningsfel uppstod — försök igen senare",
+  "Address is incomplete (missing city, state, and ZIP)": "Adressen är ofullständig (saknar stad, delstat och postnummer)",
+  "All families already have coordinates.": "Alla familjer har redan koordinater.",
+  "Failed to update coordinates": "Det gick inte att uppdatera koordinaterna",
+  "Failed to update family coordinates": "Det gick inte att uppdatera familjens koordinater",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Geokodade alla {{geocoded}} familjer. Kartan är nu uppdaterad.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Geokodade {{geocoded}} familjer. {{failed}} kunde inte lösas — se detaljer nedan.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Geokodade {{geocoded}} av {{total}} familjer. {{overflow}} har inte bearbetats än — kör igen för att fortsätta.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Geokodar familjer… detta kan ta upp till en minut. Du kan låta sidan vara öppen.",
+  "Geocoding…": "Geokodar…",
+  "No address on file": "Ingen adress registrerad",
+  "No match found — check the street address, city, and ZIP": "Ingen träff hittades — kontrollera gatuadress, stad och postnummer",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Antal dagar användare har på sig att registrera tvåfaktorsautentisering (2FA) efter att det blivit obligatoriskt. Ange 0 för att verkställa omedelbart (äldre beteende). Att förkorta en aktiv respittid kan låsa ute användare omedelbart.",
+  "Open a family to fix its address, then run this again.": "Öppna en familj för att åtgärda dess adress och kör sedan detta igen.",
+  "Set up now": "Konfigurera nu",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Detta hittar kartkoordinater för alla familjer som saknar dem, med hjälp av OpenStreetMap. Det bearbetar upp till 50 familjer per körning; en full batch tar cirka en minut. Du kan låta sidan vara öppen medan den körs. Fortsätta?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "Tvåfaktorsautentisering krävs. Du har %d dag på dig att registrera dig.",
+    "other": "Tvåfaktorsautentisering krävs. Du har %d dagar på dig att registrera dig."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Okänd familj",
+  "Update All Coordinates": "Uppdatera alla koordinater",
+  "Update All Family Coordinates": "Uppdatera alla familjekoordinater",
+  "Update Coordinates": "Uppdatera koordinater",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Kopierade {{count}} medlem",
+    "other": "Kopierade {{count}} medlemmar"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Listan har {{count}} mottagare — för många för en mailto:-länk. Använd Kopiera adresser istället.",
+    "other": "Listan har {{count}} mottagare — för många för en mailto:-länk. Använd Kopiera adresser istället."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "För många mottagare för e-postklienten ({{count}} > {{max}}). Använd Kopiera adresser istället.",
+    "other": "För många mottagare för e-postklienten ({{count}} > {{max}}). Använd Kopiera adresser istället."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} minut kvar",
+    "other": "{{count}} minuter kvar"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} familj kunde inte geokodas",
+    "other": "{{count}} familjer kunde inte geokodas"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…och {{count}} till. Kör igen för att se resten.",
+    "other": "…och {{count}} till. Kör igen för att se resten."
   }
 }

--- a/locale/terms/missing/sw/sw-1.json
+++ b/locale/terms/missing/sw/sw-1.json
@@ -1,61 +1,61 @@
 {
-  "Data": "",
-  "CSV": "",
+  "Data": "Data",
+  "CSV": "CSV",
   "Email sent to %d family.": {
-    "one": "Barua pepe imetumwa kwa familia %d.|Barua pepe zimetumwa kwa familia %d.|Barua pepe zimetumwa kwa familia %d.",
-    "other": ""
+    "one": "Barua pepe imetumwa kwa familia %d.",
+    "other": "Barua pepe zimetumwa kwa familia %d."
   },
-  "OFX": "",
+  "OFX": "OFX",
   "PDF successfully emailed to %d family.": {
-    "one": "PDF imetumwa kwa mafanikio kwa familia %d.|PDF zimetumwa kwa mafanikio kwa familia %d.|PDF zimetumwa kwa mafanikio kwa familia %d.",
-    "other": ""
+    "one": "PDF imetumwa kwa mafanikio kwa barua pepe kwa familia %d.",
+    "other": "PDF zimetumwa kwa mafanikio kwa barua pepe kwa familia %d."
   },
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "A geocoding error occurred — try again later": "Hitilafu ya kutafuta kuratibu za ramani imetokea — jaribu tena baadaye",
+  "Address is incomplete (missing city, state, and ZIP)": "Anwani haijakamilika (jiji, jimbo, na msimbo wa posta havipo)",
+  "All families already have coordinates.": "Familia zote tayari zina kuratibu.",
+  "Failed to update coordinates": "Imeshindwa kusasisha kuratibu",
+  "Failed to update family coordinates": "Imeshindwa kusasisha kuratibu za familia",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Familia zote {{geocoded}} zimepatiwa kuratibu. Ramani sasa imesasishwa.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Familia {{geocoded}} zimepatiwa kuratibu. {{failed}} hazikuweza kutatuliwa — angalia maelezo hapa chini.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Familia {{geocoded}} kati ya {{total}} zimepatiwa kuratibu. {{overflow}} bado hazijachakatwa — endesha tena ili kuendelea.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Inatafuta kuratibu za familia… hii inaweza kuchukua hadi dakika moja. Unaweza kuacha ukurasa huu wazi.",
+  "Geocoding…": "Inatafuta kuratibu…",
+  "No address on file": "Hakuna anwani iliyohifadhiwa",
+  "No match found — check the street address, city, and ZIP": "Hakuna kinachofanana kilichopatikana — angalia anwani ya mtaa, jiji, na msimbo wa posta",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Idadi ya siku watumiaji walizonazo kujiandikisha kwa uthibitishaji wa hatua mbili (2FA) baada ya kuwa ni lazima. Weka 0 kutekeleza mara moja (tabia ya zamani). Kupunguza muda wa neema unaoendelea kunaweza kuwafungia watumiaji nje mara moja.",
+  "Open a family to fix its address, then run this again.": "Fungua familia ili kurekebisha anwani yake, kisha endesha hii tena.",
+  "Set up now": "Sanidi sasa",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Hii hutafuta kuratibu za ramani kwa kila familia isiyokuwa nazo, kwa kutumia OpenStreetMap. Huchakata familia hadi 50 kwa kila kuendesha; kundi kamili huchukua takriban dakika moja. Unaweza kuacha ukurasa huu wazi wakati inaendelea. Endelea?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "Uthibitishaji wa hatua mbili unahitajika. Una siku %d ya kujiandikisha.",
+    "other": "Uthibitishaji wa hatua mbili unahitajika. Una siku %d za kujiandikisha."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Familia isiyojulikana",
+  "Update All Coordinates": "Sasisha Kuratibu Zote",
+  "Update All Family Coordinates": "Sasisha Kuratibu Zote za Familia",
+  "Update Coordinates": "Sasisha Kuratibu",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Mwanachama {{count}} amenakiliwa",
+    "other": "Wanachama {{count}} wamenakiliwa"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Orodha hii ina mpokeaji {{count}} — ni wengi mno kwa kiungo cha mailto:. Tumia Nakili Anwani badala yake.",
+    "other": "Orodha hii ina wapokeaji {{count}} — ni wengi mno kwa kiungo cha mailto:. Tumia Nakili Anwani badala yake."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Wapokeaji ni wengi mno kwa mteja wa barua pepe ({{count}} > {{max}}). Tumia Nakili Anwani badala yake.",
+    "other": "Wapokeaji ni wengi mno kwa mteja wa barua pepe ({{count}} > {{max}}). Tumia Nakili Anwani badala yake."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "Dakika {{count}} iliyobaki",
+    "other": "Dakika {{count}} zilizobaki"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "Familia {{count}} haikuweza kupatiwa kuratibu",
+    "other": "Familia {{count}} hazikuweza kupatiwa kuratibu"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…na {{count}} zaidi. Endesha tena kuona zilizobaki.",
+    "other": "…na {{count}} zaidi. Endesha tena kuona zilizobaki."
   }
 }

--- a/locale/terms/missing/ta/ta-1.json
+++ b/locale/terms/missing/ta/ta-1.json
@@ -1,36 +1,36 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "புவிக்குறியீட்டில் பிழை ஏற்பட்டது — பின்னர் மீண்டும் முயற்சிக்கவும்",
+  "Address is incomplete (missing city, state, and ZIP)": "முகவரி முழுமையடையவில்லை (நகரம், மாநிலம் மற்றும் அஞ்சல் குறியீடு இல்லை)",
+  "All families already have coordinates.": "அனைத்து குடும்பங்களுக்கும் ஏற்கனவே ஆயத்தொலைவுகள் உள்ளன.",
+  "Failed to update coordinates": "ஆயத்தொலைவுகளைப் புதுப்பிக்க முடியவில்லை",
+  "Failed to update family coordinates": "குடும்ப ஆயத்தொலைவுகளைப் புதுப்பிக்க முடியவில்லை",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "அனைத்து {{geocoded}} குடும்பங்களும் புவிக்குறியிடப்பட்டன. வரைபடம் இப்போது புதுப்பித்த நிலையில் உள்ளது.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "{{geocoded}} குடும்பங்கள் புவிக்குறியிடப்பட்டன. {{failed}} தீர்க்க முடியவில்லை — கீழே உள்ள விவரங்களைப் பார்க்கவும்.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "{{total}} குடும்பங்களில் {{geocoded}} புவிக்குறியிடப்பட்டன. {{overflow}} இன்னும் செயலாக்கப்படவில்லை — தொடர மீண்டும் இயக்கவும்.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "குடும்பங்களை புவிக்குறியிடுகிறது… இதற்கு ஒரு நிமிடம் வரை ஆகலாம். இந்தப் பக்கத்தைத் திறந்தே வைத்திருக்கலாம்.",
+  "Geocoding…": "புவிக்குறியிடுகிறது…",
+  "No address on file": "பதிவில் முகவரி இல்லை",
+  "No match found — check the street address, city, and ZIP": "பொருத்தம் எதுவும் கிடைக்கவில்லை — தெரு முகவரி, நகரம் மற்றும் அஞ்சல் குறியீட்டைச் சரிபார்க்கவும்",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "2FA கட்டாயமாக்கப்பட்ட பிறகு பயனர்கள் அதில் பதிவு செய்ய வேண்டிய நாட்களின் எண்ணிக்கை. உடனடியாக அமல்படுத்த 0 எனச் அமைக்கவும் (பழைய நடத்தை). செயலிலுள்ள சலுகைக் காலத்தைக் குறைப்பது பயனர்களை உடனடியாகத் தடுக்கக்கூடும்.",
+  "Open a family to fix its address, then run this again.": "முகவரியைச் சரிசெய்ய ஒரு குடும்பத்தைத் திறந்து, பின்னர் இதை மீண்டும் இயக்கவும்.",
+  "Set up now": "இப்போது அமைக்கவும்",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "இது OpenStreetMap-ஐப் பயன்படுத்தி, ஆயத்தொலைவுகள் இல்லாத ஒவ்வொரு குடும்பத்திற்கும் வரைபட ஆயத்தொலைவுகளைக் கண்டறியும். ஒரு இயக்கத்திற்கு 50 குடும்பங்கள் வரை செயலாக்கப்படும்; ஒரு முழுத் தொகுதிக்கு சுமார் ஒரு நிமிடம் ஆகும். இது இயங்கும்போது இந்தப் பக்கத்தைத் திறந்தே வைத்திருக்கலாம். தொடரவா?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "இரு-காரணி அங்கீகாரம் தேவை. பதிவு செய்ய உங்களுக்கு %d நாள் உள்ளது.",
+    "other": "இரு-காரணி அங்கீகாரம் தேவை. பதிவு செய்ய உங்களுக்கு %d நாட்கள் உள்ளன."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "தெரியாத குடும்பம்",
+  "Update All Coordinates": "அனைத்து ஆயத்தொலைவுகளையும் புதுப்பிக்கவும்",
+  "Update All Family Coordinates": "அனைத்து குடும்ப ஆயத்தொலைவுகளையும் புதுப்பிக்கவும்",
+  "Update Coordinates": "ஆயத்தொலைவுகளைப் புதுப்பிக்கவும்",
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} குடும்பத்தை புவிக்குறியிட முடியவில்லை",
+    "other": "{{count}} குடும்பங்களை புவிக்குறியிட முடியவில்லை"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…மற்றும் {{count}} மேலும். மீதமுள்ளதைப் பார்க்க மீண்டும் இயக்கவும்.",
+    "other": "…மற்றும் {{count}} மேலும். மீதமுள்ளதைப் பார்க்க மீண்டும் இயக்கவும்."
   }
 }

--- a/locale/terms/missing/te/te-1.json
+++ b/locale/terms/missing/te/te-1.json
@@ -1,60 +1,60 @@
 {
-  "CSV": "",
+  "CSV": "CSV",
   "Email sent to %d family.": {
-    "one": "%d కుటుంబానికి ఇమెయిల్ పంపబడింది.|%d కుటుంబాలకు ఇమెయిల్ పంపబడింది.|%d కుటుంబాలకు ఇమెయిల్ పంపబడింది.",
-    "other": ""
+    "one": "%d కుటుంబానికి ఇమెయిల్ పంపబడింది.",
+    "other": "%d కుటుంబాలకు ఇమెయిల్ పంపబడింది."
   },
-  "OFX": "",
+  "OFX": "OFX",
   "PDF successfully emailed to %d family.": {
-    "one": "%d కుటుంబానికి PDF విజయవంతంగా ఇమెయిల్ చేయబడింది.|%d కుటుంబాలకు PDF విజయవంతంగా ఇమెయిల్ చేయబడింది.|%d కుటుంబాలకు PDF విజయవంతంగా ఇమెయిల్ చేయబడింది.",
-    "other": ""
+    "one": "%d కుటుంబానికి PDF విజయవంతంగా ఇమెయిల్ చేయబడింది.",
+    "other": "%d కుటుంబాలకు PDF విజయవంతంగా ఇమెయిల్ చేయబడింది."
   },
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "A geocoding error occurred — try again later": "జియోకోడింగ్ లోపం సంభవించింది — దయచేసి తర్వాత మళ్ళీ ప్రయత్నించండి",
+  "Address is incomplete (missing city, state, and ZIP)": "చిరునామా అసంపూర్ణంగా ఉంది (నగరం, రాష్ట్రం మరియు పిన్ కోడ్ లేవు)",
+  "All families already have coordinates.": "అన్ని కుటుంబాలకు ఇప్పటికే కోఆర్డినేట్‌లు ఉన్నాయి.",
+  "Failed to update coordinates": "కోఆర్డినేట్‌లను నవీకరించడంలో విఫలమైంది",
+  "Failed to update family coordinates": "కుటుంబ కోఆర్డినేట్‌లను నవీకరించడంలో విఫలమైంది",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "మొత్తం {{geocoded}} కుటుంబాలను జియోకోడ్ చేసారు. మ్యాప్ ఇప్పుడు తాజాగా ఉంది.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "{{geocoded}} కుటుంబాలను జియోకోడ్ చేసారు. {{failed}} పరిష్కరించలేకపోయాము — దిగువ వివరాలు చూడండి.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "{{total}} కుటుంబాలలో {{geocoded}} జియోకోడ్ చేసారు. {{overflow}} ఇంకా ప్రాసెస్ చేయలేదు — కొనసాగించడానికి మళ్ళీ అమలు చేయండి.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "కుటుంబాలను జియోకోడింగ్ చేస్తోంది… దీనికి ఒక నిమిషం వరకు పట్టవచ్చు. మీరు ఈ పేజీని తెరిచి ఉంచవచ్చు.",
+  "Geocoding…": "జియోకోడింగ్…",
+  "No address on file": "ఫైల్‌లో చిరునామా లేదు",
+  "No match found — check the street address, city, and ZIP": "సరిపోలిక కనుగొనబడలేదు — వీధి చిరునామా, నగరం మరియు పిన్ కోడ్‌ని తనిఖీ చేయండి",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "2FA తప్పనిసరి చేసిన తర్వాత వినియోగదారులు నమోదు చేసుకోవడానికి ఉన్న రోజుల సంఖ్య. వెంటనే అమలు చేయడానికి (లెగసీ ప్రవర్తన) దీన్ని 0కి సెట్ చేయండి. యాక్టివ్ గ్రేస్ పీరియడ్‌ను తగ్గించడం వల్ల వినియోగదారులు వెంటనే లాక్ అవ్వవచ్చు.",
+  "Open a family to fix its address, then run this again.": "దాని చిరునామాను సరిచేయడానికి ఒక కుటుంబాన్ని తెరవండి, ఆపై దీన్ని మళ్ళీ అమలు చేయండి.",
+  "Set up now": "ఇప్పుడే సెటప్ చేయండి",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "ఇది OpenStreetMap ఉపయోగించి, కోఆర్డినేట్‌లు లేని ప్రతి కుటుంబానికి మ్యాప్ కోఆర్డినేట్‌లను కనుగొంటుంది. ఇది ఒక్కో రన్‌కు 50 కుటుంబాల వరకు ప్రాసెస్ చేస్తుంది; పూర్తి బ్యాచ్‌కు దాదాపు ఒక నిమిషం పడుతుంది. ఇది నడుస్తున్నప్పుడు మీరు ఈ పేజీని తెరిచి ఉంచవచ్చు. కొనసాగించాలా?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "రెండు-కారకాల ప్రామాణీకరణ అవసరం. నమోదు చేసుకోవడానికి మీకు %d రోజు ఉంది.",
+    "other": "రెండు-కారకాల ప్రామాణీకరణ అవసరం. నమోదు చేసుకోవడానికి మీకు %d రోజులు ఉన్నాయి."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "తెలియని కుటుంబం",
+  "Update All Coordinates": "అన్ని కోఆర్డినేట్‌లను నవీకరించండి",
+  "Update All Family Coordinates": "అన్ని కుటుంబ కోఆర్డినేట్‌లను నవీకరించండి",
+  "Update Coordinates": "కోఆర్డినేట్‌లను నవీకరించండి",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} సభ్యుడిని కాపీ చేసారు",
+    "other": "{{count}} మంది సభ్యులను కాపీ చేసారు"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "ఈ జాబితాలో {{count}} గ్రహీత ఉన్నారు — mailto: లింక్‌కు చాలా ఎక్కువ. బదులుగా చిరునామాలను కాపీ చేయండి ఉపయోగించండి.",
+    "other": "ఈ జాబితాలో {{count}} మంది గ్రహీతలు ఉన్నారు — mailto: లింక్‌కు చాలా ఎక్కువ. బదులుగా చిరునామాలను కాపీ చేయండి ఉపయోగించండి."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "ఇమెయిల్ క్లయింట్‌కు గ్రహీతలు చాలా ఎక్కువ ({{count}} > {{max}}). బదులుగా చిరునామాలను కాపీ చేయండి ఉపయోగించండి.",
+    "other": "ఇమెయిల్ క్లయింట్‌కు గ్రహీతలు చాలా ఎక్కువ ({{count}} > {{max}}). బదులుగా చిరునామాలను కాపీ చేయండి ఉపయోగించండి."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} నిమిషం మిగిలి ఉంది",
+    "other": "{{count}} నిమిషాలు మిగిలి ఉన్నాయి"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} కుటుంబాన్ని జియోకోడ్ చేయలేకపోయాము",
+    "other": "{{count}} కుటుంబాలను జియోకోడ్ చేయలేకపోయాము"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…మరియు {{count}} మరొకటి. మిగిలినవి చూడడానికి మళ్ళీ అమలు చేయండి.",
+    "other": "…మరియు {{count}} మరిన్ని. మిగిలినవి చూడడానికి మళ్ళీ అమలు చేయండి."
   }
 }

--- a/locale/terms/missing/th/th-1.json
+++ b/locale/terms/missing/th/th-1.json
@@ -1,51 +1,51 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "เกิดข้อผิดพลาดในการระบุพิกัดทางภูมิศาสตร์ — โปรดลองอีกครั้งในภายหลัง",
+  "Address is incomplete (missing city, state, and ZIP)": "ที่อยู่ไม่สมบูรณ์ (ไม่มีเมือง รัฐ และรหัสไปรษณีย์)",
+  "All families already have coordinates.": "ทุกครอบครัวมีพิกัดแล้ว",
+  "Failed to update coordinates": "ไม่สามารถอัปเดตพิกัดได้",
+  "Failed to update family coordinates": "ไม่สามารถอัปเดตพิกัดของครอบครัวได้",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "ระบุพิกัดครอบครัวทั้งหมด {{geocoded}} ครอบครัวแล้ว แผนที่เป็นข้อมูลล่าสุดแล้ว",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "ระบุพิกัดครอบครัวแล้ว {{geocoded}} ครอบครัว ไม่สามารถระบุได้ {{failed}} ครอบครัว — ดูรายละเอียดด้านล่าง",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "ระบุพิกัดแล้ว {{geocoded}} จาก {{total}} ครอบครัว ยังไม่ได้ประมวลผล {{overflow}} ครอบครัว — เรียกใช้อีกครั้งเพื่อดำเนินการต่อ",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "กำลังระบุพิกัดครอบครัว… อาจใช้เวลาถึงหนึ่งนาที คุณสามารถเปิดหน้านี้ค้างไว้ได้",
+  "Geocoding…": "กำลังระบุพิกัด…",
+  "No address on file": "ไม่มีที่อยู่ในระบบ",
+  "No match found — check the street address, city, and ZIP": "ไม่พบข้อมูลที่ตรงกัน — โปรดตรวจสอบที่อยู่ถนน เมือง และรหัสไปรษณีย์",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "จำนวนวันที่ผู้ใช้มีในการลงทะเบียนยืนยันตัวตนสองขั้นตอน (2FA) หลังจากมีการบังคับใช้ ตั้งค่าเป็น 0 เพื่อบังคับใช้ทันที (พฤติกรรมแบบเดิม) การลดระยะเวลาผ่อนผันที่ใช้งานอยู่อาจทำให้ผู้ใช้ถูกล็อกออกทันที",
+  "Open a family to fix its address, then run this again.": "เปิดข้อมูลครอบครัวเพื่อแก้ไขที่อยู่ แล้วเรียกใช้อีกครั้ง",
+  "Set up now": "ตั้งค่าตอนนี้",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "ฟีเจอร์นี้จะค้นหาพิกัดแผนที่สำหรับทุกครอบครัวที่ยังไม่มีพิกัด โดยใช้ OpenStreetMap ในแต่ละครั้งจะประมวลผลได้สูงสุด 50 ครอบครัว ซึ่งใช้เวลาประมาณหนึ่งนาทีต่อชุด คุณสามารถเปิดหน้านี้ค้างไว้ระหว่างดำเนินการได้ ต้องการดำเนินการต่อหรือไม่?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "other": ""
+    "other": "จำเป็นต้องใช้การยืนยันตัวตนสองขั้นตอน คุณมีเวลา %d วันในการลงทะเบียน"
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "ครอบครัวที่ไม่รู้จัก",
+  "Update All Coordinates": "อัปเดตพิกัดทั้งหมด",
+  "Update All Family Coordinates": "อัปเดตพิกัดครอบครัวทั้งหมด",
+  "Update Coordinates": "อัปเดตพิกัด",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "คัดลอกสมาชิก {{count}} คนแล้ว",
+    "other": "คัดลอกสมาชิก {{count}} คนแล้ว"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "รายการนี้มีผู้รับ {{count}} คน — มากเกินไปสำหรับลิงก์ mailto: โปรดใช้ปุ่มคัดลอกที่อยู่แทน",
+    "other": "รายการนี้มีผู้รับ {{count}} คน — มากเกินไปสำหรับลิงก์ mailto: โปรดใช้ปุ่มคัดลอกที่อยู่แทน"
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "มีผู้รับมากเกินไปสำหรับโปรแกรมอีเมล ({{count}} > {{max}}) โปรดใช้ปุ่มคัดลอกที่อยู่แทน",
+    "other": "มีผู้รับมากเกินไปสำหรับโปรแกรมอีเมล ({{count}} > {{max}}) โปรดใช้ปุ่มคัดลอกที่อยู่แทน"
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "เหลืออีก {{count}} นาที",
+    "other": "เหลืออีก {{count}} นาที"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "ไม่สามารถระบุพิกัดครอบครัวได้ {{count}} ครอบครัว",
+    "other": "ไม่สามารถระบุพิกัดครอบครัวได้ {{count}} ครอบครัว"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…และอีก {{count}} รายการ เรียกใช้อีกครั้งเพื่อดูส่วนที่เหลือ",
+    "other": "…และอีก {{count}} รายการ เรียกใช้อีกครั้งเพื่อดูส่วนที่เหลือ"
   }
 }

--- a/locale/terms/missing/tr/tr-1.json
+++ b/locale/terms/missing/tr/tr-1.json
@@ -1,60 +1,60 @@
 {
-  "CSV": "",
+  "CSV": "CSV",
   "Email sent to %d family.": {
-    "one": "%d aileye e-posta gönderildi.|%d aileye e-posta gönderildi.|%d aileye e-posta gönderildi.",
-    "other": ""
+    "one": "%d aileye e-posta gönderildi.",
+    "other": "%d aileye e-posta gönderildi."
   },
-  "OFX": "",
+  "OFX": "OFX",
   "PDF successfully emailed to %d family.": {
-    "one": "PDF başarıyla %d aileye e-posta ile gönderildi.|PDF başarıyla %d aileye e-posta ile gönderildi.|PDF başarıyla %d aileye e-posta ile gönderildi.",
-    "other": ""
+    "one": "%d aileye PDF başarıyla e-postayla gönderildi.",
+    "other": "%d aileye PDF başarıyla e-postayla gönderildi."
   },
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "A geocoding error occurred — try again later": "Bir coğrafi kodlama hatası oluştu — lütfen daha sonra tekrar deneyin",
+  "Address is incomplete (missing city, state, and ZIP)": "Adres eksik (şehir, eyalet ve posta kodu eksik)",
+  "All families already have coordinates.": "Tüm ailelerin zaten koordinatları var.",
+  "Failed to update coordinates": "Koordinatlar güncellenemedi",
+  "Failed to update family coordinates": "Aile koordinatları güncellenemedi",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "{{geocoded}} ailenin tümü coğrafi olarak kodlandı. Harita artık güncel.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "{{geocoded}} aile coğrafi olarak kodlandı. {{failed}} tanesi çözümlenemedi — ayrıntılar için aşağıya bakın.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "{{total}} aileden {{geocoded}} tanesi coğrafi olarak kodlandı. {{overflow}} tanesi henüz işlenmedi — devam etmek için tekrar çalıştırın.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Aileler coğrafi olarak kodlanıyor… bu işlem bir dakikaya kadar sürebilir. Bu sayfayı açık tutabilirsiniz.",
+  "Geocoding…": "Coğrafi kodlama…",
+  "No address on file": "Kayıtlı adres yok",
+  "No match found — check the street address, city, and ZIP": "Eşleşme bulunamadı — sokak adresini, şehri ve posta kodunu kontrol edin",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Kullanıcıların, iki faktörlü kimlik doğrulama zorunlu kılındıktan sonra kaydolmaları için sahip oldukları gün sayısı. Hemen zorunlu kılmak için 0 olarak ayarlayın (eski davranış). Etkin bir tolerans süresini kısaltmak, kullanıcıların hemen dışarıda kalmasına neden olabilir.",
+  "Open a family to fix its address, then run this again.": "Adresini düzeltmek için bir aileyi açın, ardından bunu tekrar çalıştırın.",
+  "Set up now": "Şimdi kur",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Bu, koordinatları eksik olan her aile için OpenStreetMap kullanarak harita koordinatlarını bulur. Her çalıştırmada en fazla 50 aile işlenir; tam bir grup yaklaşık bir dakika sürer. Çalışırken bu sayfayı açık tutabilirsiniz. Devam edilsin mi?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "other": ""
+    "one": "İki faktörlü kimlik doğrulama zorunludur. Kaydolmak için %d gününüz var.",
+    "other": "İki faktörlü kimlik doğrulama zorunludur. Kaydolmak için %d gününüz var."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Bilinmeyen aile",
+  "Update All Coordinates": "Tüm Koordinatları Güncelle",
+  "Update All Family Coordinates": "Tüm Aile Koordinatlarını Güncelle",
+  "Update Coordinates": "Koordinatları Güncelle",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} üye kopyalandı",
+    "other": "{{count}} üye kopyalandı"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Bu listede {{count}} alıcı var — bir mailto: bağlantısı için çok fazla. Bunun yerine Adresleri Kopyala seçeneğini kullanın.",
+    "other": "Bu listede {{count}} alıcı var — bir mailto: bağlantısı için çok fazla. Bunun yerine Adresleri Kopyala seçeneğini kullanın."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "E-posta istemcisi için çok fazla alıcı ({{count}} > {{max}}). Bunun yerine Adresleri Kopyala seçeneğini kullanın.",
+    "other": "E-posta istemcisi için çok fazla alıcı ({{count}} > {{max}}). Bunun yerine Adresleri Kopyala seçeneğini kullanın."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} dakika kaldı",
+    "other": "{{count}} dakika kaldı"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} aile coğrafi olarak kodlanamadı",
+    "other": "{{count}} aile coğrafi olarak kodlanamadı"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…ve {{count}} tane daha. Kalanını görmek için tekrar çalıştırın.",
+    "other": "…ve {{count}} tane daha. Kalanını görmek için tekrar çalıştırın."
   }
 }

--- a/locale/terms/missing/uk/uk-1.json
+++ b/locale/terms/missing/uk/uk-1.json
@@ -1,66 +1,66 @@
 {
-  "CSV": "",
+  "CSV": "CSV",
   "Email sent to %d family.": {
-    "one": "Електронний лист надіслано %d родині.|Електронний лист надіслано %d родинам.|Електронний лист надіслано %d родинам.|Електронний лист надіслано %d родини.|Електронний лист надіслано %d родинам.|Електронний лист надіслано %d родинам.|Електронний лист надіслано %d родини.",
-    "few": "",
-    "many": "",
-    "other": ""
+    "one": "Електронний лист надіслано %d сім'ї.",
+    "few": "Електронний лист надіслано %d сім'ям.",
+    "many": "Електронний лист надіслано %d сім'ям.",
+    "other": "Електронний лист надіслано %d сім'ї."
   },
-  "OFX": "",
+  "OFX": "OFX",
   "PDF successfully emailed to %d family.": {
-    "one": "PDF успішно надіслано %d родині.|PDF успішно надіслано %d родинам.|PDF успішно надіслано %d родинам.|PDF успішно надіслано %d родини.|PDF успішно надіслано %d родинам.|PDF успішно надіслано %d родинам.|PDF успішно надіслано %d родини.",
-    "few": "",
-    "many": "",
-    "other": ""
+    "one": "PDF успішно надіслано електронною поштою %d сім'ї.",
+    "few": "PDF успішно надіслано електронною поштою %d сім'ям.",
+    "many": "PDF успішно надіслано електронною поштою %d сім'ям.",
+    "other": "PDF успішно надіслано електронною поштою %d сім'ї."
   },
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "A geocoding error occurred — try again later": "Сталася помилка геокодування — спробуйте пізніше",
+  "Address is incomplete (missing city, state, and ZIP)": "Адреса неповна (відсутні місто, область та поштовий індекс)",
+  "All families already have coordinates.": "Усі сім'ї вже мають координати.",
+  "Failed to update coordinates": "Не вдалося оновити координати",
+  "Failed to update family coordinates": "Не вдалося оновити координати сім'ї",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Геокодовано всі {{geocoded}} сімей. Карта тепер актуальна.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Геокодовано {{geocoded}} сімей. {{failed}} не вдалося визначити — див. деталі нижче.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Геокодовано {{geocoded}} із {{total}} сімей. {{overflow}} ще не оброблено — запустіть знову, щоб продовжити.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Геокодування сімей… це може зайняти до хвилини. Ви можете залишити цю сторінку відкритою.",
+  "Geocoding…": "Геокодування…",
+  "No address on file": "Немає адреси в записі",
+  "No match found — check the street address, city, and ZIP": "Збігів не знайдено — перевірте вулицю, місто та поштовий індекс",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Кількість днів, які мають користувачі для реєстрації у двофакторній автентифікації після її запровадження. Встановіть 0, щоб застосувати негайно (застаріла поведінка). Скорочення активного пільгового періоду може негайно заблокувати доступ користувачам.",
+  "Open a family to fix its address, then run this again.": "Відкрийте сім'ю, щоб виправити її адресу, а потім запустіть це знову.",
+  "Set up now": "Налаштувати зараз",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Це знаходить координати на карті для кожної сім'ї, якій їх бракує, використовуючи OpenStreetMap. За один запуск обробляється до 50 сімей; повна партія займає близько хвилини. Ви можете залишити цю сторінку відкритою під час виконання. Продовжити?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "one": "",
-    "few": "",
-    "many": "",
-    "other": ""
+    "one": "Потрібна двофакторна автентифікація. У вас є %d день на реєстрацію.",
+    "few": "Потрібна двофакторна автентифікація. У вас є %d дні на реєстрацію.",
+    "many": "Потрібна двофакторна автентифікація. У вас є %d днів на реєстрацію.",
+    "other": "Потрібна двофакторна автентифікація. У вас є %d дня на реєстрацію."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Невідома сім'я",
+  "Update All Coordinates": "Оновити всі координати",
+  "Update All Family Coordinates": "Оновити координати всіх сімей",
+  "Update Coordinates": "Оновити координати",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Скопійовано {{count}} учасника",
+    "other": "Скопійовано {{count}} учасників"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Цей список містить {{count}} отримувача — забагато для посилання mailto:. Використайте замість цього «Копіювати адреси».",
+    "other": "Цей список містить {{count}} отримувачів — забагато для посилання mailto:. Використайте замість цього «Копіювати адреси»."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Забагато отримувачів для поштового клієнта ({{count}} > {{max}}). Використайте замість цього «Копіювати адреси».",
+    "other": "Забагато отримувачів для поштового клієнта ({{count}} > {{max}}). Використайте замість цього «Копіювати адреси»."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "Залишилася {{count}} хвилина",
+    "other": "Залишилося {{count}} хвилин"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} сім'ю не вдалося геокодувати",
+    "other": "{{count}} сімей не вдалося геокодувати"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…і ще {{count}}. Запустіть знову, щоб побачити решту.",
+    "other": "…і ще {{count}}. Запустіть знову, щоб побачити решту."
   }
 }

--- a/locale/terms/missing/vi/vi-1.json
+++ b/locale/terms/missing/vi/vi-1.json
@@ -1,51 +1,51 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "Đã xảy ra lỗi định vị địa lý — vui lòng thử lại sau",
+  "Address is incomplete (missing city, state, and ZIP)": "Địa chỉ không đầy đủ (thiếu thành phố, tỉnh/bang và mã ZIP)",
+  "All families already have coordinates.": "Tất cả các gia đình đều đã có tọa độ.",
+  "Failed to update coordinates": "Không thể cập nhật tọa độ",
+  "Failed to update family coordinates": "Không thể cập nhật tọa độ gia đình",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "Đã định vị địa lý cho tất cả {{geocoded}} gia đình. Bản đồ hiện đã được cập nhật.",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "Đã định vị địa lý cho {{geocoded}} gia đình. {{failed}} không thể xác định được — xem chi tiết bên dưới.",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "Đã định vị địa lý {{geocoded}} trong số {{total}} gia đình. {{overflow}} chưa được xử lý — chạy lại để tiếp tục.",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "Đang định vị địa lý cho các gia đình… quá trình này có thể mất đến một phút. Bạn có thể để trang này mở.",
+  "Geocoding…": "Đang định vị địa lý…",
+  "No address on file": "Không có địa chỉ được lưu",
+  "No match found — check the street address, city, and ZIP": "Không tìm thấy kết quả phù hợp — hãy kiểm tra địa chỉ đường, thành phố và mã ZIP",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "Số ngày người dùng có để đăng ký xác thực hai yếu tố (2FA) sau khi bắt buộc áp dụng. Đặt thành 0 để bắt buộc ngay lập tức (hành vi cũ). Rút ngắn thời gian ân hạn đang áp dụng có thể khiến người dùng bị khóa ngay lập tức.",
+  "Open a family to fix its address, then run this again.": "Mở một gia đình để sửa địa chỉ, sau đó chạy lại thao tác này.",
+  "Set up now": "Thiết lập ngay",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "Thao tác này tìm tọa độ bản đồ cho mọi gia đình còn thiếu, sử dụng OpenStreetMap. Nó xử lý tối đa 50 gia đình mỗi lần chạy; một đợt đầy đủ mất khoảng một phút. Bạn có thể để trang này mở trong khi chạy. Tiếp tục?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "other": ""
+    "other": "Yêu cầu xác thực hai yếu tố. Bạn có %d ngày để đăng ký."
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "Gia đình không xác định",
+  "Update All Coordinates": "Cập nhật tất cả tọa độ",
+  "Update All Family Coordinates": "Cập nhật tất cả tọa độ gia đình",
+  "Update Coordinates": "Cập nhật tọa độ",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "Đã sao chép {{count}} thành viên",
+    "other": "Đã sao chép {{count}} thành viên"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Danh sách này có {{count}} người nhận — quá nhiều để dùng liên kết mailto:. Hãy dùng Sao chép địa chỉ thay thế.",
+    "other": "Danh sách này có {{count}} người nhận — quá nhiều để dùng liên kết mailto:. Hãy dùng Sao chép địa chỉ thay thế."
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "Quá nhiều người nhận cho ứng dụng email ({{count}} > {{max}}). Hãy dùng Sao chép địa chỉ thay thế.",
+    "other": "Quá nhiều người nhận cho ứng dụng email ({{count}} > {{max}}). Hãy dùng Sao chép địa chỉ thay thế."
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "Còn {{count}} phút",
+    "other": "Còn {{count}} phút"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} gia đình không thể được định vị địa lý",
+    "other": "{{count}} gia đình không thể được định vị địa lý"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "…và {{count}} gia đình khác. Chạy lại để xem phần còn lại.",
+    "other": "…và {{count}} gia đình khác. Chạy lại để xem phần còn lại."
   }
 }

--- a/locale/terms/missing/zh-CN/zh-CN-1.json
+++ b/locale/terms/missing/zh-CN/zh-CN-1.json
@@ -1,51 +1,45 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "发生地理编码错误 — 请稍后重试",
+  "Address is incomplete (missing city, state, and ZIP)": "地址不完整(缺少城市、州/省和邮政编码)",
+  "All families already have coordinates.": "所有家庭都已具有坐标。",
+  "Failed to update coordinates": "更新坐标失败",
+  "Failed to update family coordinates": "更新家庭坐标失败",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "已为全部 {{geocoded}} 个家庭完成地理编码。地图现已更新。",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "已为 {{geocoded}} 个家庭完成地理编码。{{failed}} 个未能解析 — 详情见下文。",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "已为 {{total}} 个家庭中的 {{geocoded}} 个完成地理编码。{{overflow}} 个尚未处理 — 请再次运行以继续。",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "正在对家庭进行地理编码……这可能需要长达一分钟。您可以让此页面保持打开状态。",
+  "Geocoding…": "正在进行地理编码……",
+  "No address on file": "没有存档地址",
+  "No match found — check the street address, city, and ZIP": "未找到匹配项 — 请检查街道地址、城市和邮政编码",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "强制启用双重验证(2FA)后,用户可用于注册的天数。设为 0 表示立即强制执行(旧版行为)。缩短正在生效的宽限期可能会立即导致用户被锁定。",
+  "Open a family to fix its address, then run this again.": "打开一个家庭以修正其地址,然后再次运行此操作。",
+  "Set up now": "立即设置",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "此操作使用 OpenStreetMap 为每个缺少地图坐标的家庭查找坐标。每次运行最多处理 50 个家庭;完成一整批大约需要一分钟。运行期间您可以让此页面保持打开状态。是否继续?",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "other": ""
+    "other": "需要进行双重验证。您还有 %d 天可以完成注册。"
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "未知家庭",
+  "Update All Coordinates": "更新所有坐标",
+  "Update All Family Coordinates": "更新所有家庭坐标",
+  "Update Coordinates": "更新坐标",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "other": "已复制 {{count}} 位成员"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "other": "此列表有 {{count}} 位收件人 — 对于 mailto: 链接来说太多了。请改用“复制地址”。"
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "other": "收件人数量超过邮件客户端限制({{count}} > {{max}})。请改用“复制地址”。"
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "other": "剩余 {{count}} 分钟"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "other": "有 {{count}} 个家庭无法进行地理编码"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "other": "……以及另外 {{count}} 个。请再次运行以查看其余内容。"
   }
 }

--- a/locale/terms/missing/zh-TW/zh-TW-1.json
+++ b/locale/terms/missing/zh-TW/zh-TW-1.json
@@ -1,51 +1,51 @@
 {
-  "CSV": "",
-  "OFX": "",
-  "A geocoding error occurred — try again later": "",
-  "Address is incomplete (missing city, state, and ZIP)": "",
-  "All families already have coordinates.": "",
-  "Failed to update coordinates": "",
-  "Failed to update family coordinates": "",
-  "Geocoded all {{geocoded}} families. The map is now up to date.": "",
-  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "",
-  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "",
-  "Geocoding families… this can take up to a minute. You can keep this page open.": "",
-  "Geocoding…": "",
-  "No address on file": "",
-  "No match found — check the street address, city, and ZIP": "",
-  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "",
-  "Open a family to fix its address, then run this again.": "",
-  "Set up now": "",
-  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "",
+  "CSV": "CSV",
+  "OFX": "OFX",
+  "A geocoding error occurred — try again later": "發生地理編碼錯誤，請稍後再試",
+  "Address is incomplete (missing city, state, and ZIP)": "地址不完整（缺少城市、州/省和郵遞區號）",
+  "All families already have coordinates.": "所有家庭都已有座標。",
+  "Failed to update coordinates": "更新座標失敗",
+  "Failed to update family coordinates": "更新家庭座標失敗",
+  "Geocoded all {{geocoded}} families. The map is now up to date.": "已為全部 {{geocoded}} 個家庭完成地理編碼。地圖現已更新。",
+  "Geocoded {{geocoded}} families. {{failed}} could not be resolved — see details below.": "已為 {{geocoded}} 個家庭完成地理編碼。{{failed}} 個無法解析 — 詳見下方說明。",
+  "Geocoded {{geocoded}} of {{total}} families. {{overflow}} not yet processed — run again to continue.": "已為 {{total}} 個家庭中的 {{geocoded}} 個完成地理編碼。尚有 {{overflow}} 個未處理 — 請再次執行以繼續。",
+  "Geocoding families… this can take up to a minute. You can keep this page open.": "正在為家庭進行地理編碼……這可能需要長達一分鐘。您可以保持此頁面開啟。",
+  "Geocoding…": "地理編碼中……",
+  "No address on file": "沒有存檔地址",
+  "No match found — check the street address, city, and ZIP": "找不到相符結果 — 請檢查街道地址、城市和郵遞區號",
+  "Number of days users have to enroll in 2FA after it is mandated. Set to 0 to enforce immediately (legacy behavior). Shortening an active grace period may lock users out immediately.": "強制啟用雙因素驗證（2FA）後，使用者可用來註冊的天數。設為 0 表示立即強制執行（舊有行為）。縮短正在進行中的寬限期可能導致使用者立即被鎖定。",
+  "Open a family to fix its address, then run this again.": "開啟該家庭以修正其地址，然後再次執行此操作。",
+  "Set up now": "立即設定",
+  "This finds map coordinates for every family that is missing them, using OpenStreetMap. It processes up to 50 families per run; a full batch takes about a minute. You can keep this page open while it runs. Continue?": "此功能會使用 OpenStreetMap 為每個缺少座標的家庭尋找地圖座標。每次執行最多處理 50 個家庭，完整一批約需一分鐘。執行期間您可以保持此頁面開啟。是否繼續？",
   "Two-factor authentication is required. You have %d day to enroll.": {
-    "other": ""
+    "other": "需要雙因素驗證。您還有 %d 天可以完成註冊。"
   },
-  "Unknown family": "",
-  "Update All Coordinates": "",
-  "Update All Family Coordinates": "",
-  "Update Coordinates": "",
+  "Unknown family": "未知家庭",
+  "Update All Coordinates": "更新所有座標",
+  "Update All Family Coordinates": "更新所有家庭座標",
+  "Update Coordinates": "更新座標",
   "Copied {{count}} members": {
-    "one": "",
-    "other": ""
+    "one": "已複製 {{count}} 位成員",
+    "other": "已複製 {{count}} 位成員"
   },
   "This list has {{count}} recipients — too many for a mailto: link. Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "此名單有 {{count}} 位收件者 — 對 mailto: 連結而言太多了。請改用「複製地址」。",
+    "other": "此名單有 {{count}} 位收件者 — 對 mailto: 連結而言太多了。請改用「複製地址」。"
   },
   "Too many recipients for email client ({{count}} > {{max}}). Use Copy Addresses instead.": {
-    "one": "",
-    "other": ""
+    "one": "收件者數量對電子郵件客戶端而言過多（{{count}} > {{max}}）。請改用「複製地址」。",
+    "other": "收件者數量對電子郵件客戶端而言過多（{{count}} > {{max}}）。請改用「複製地址」。"
   },
   "{{count}} min left": {
-    "one": "",
-    "other": ""
+    "one": "剩餘 {{count}} 分鐘",
+    "other": "剩餘 {{count}} 分鐘"
   },
   "{{count}} families could not be geocoded": {
-    "one": "",
-    "other": ""
+    "one": "{{count}} 個家庭無法完成地理編碼",
+    "other": "{{count}} 個家庭無法完成地理編碼"
   },
   "…and {{count}} more. Run again to see the rest.": {
-    "one": "",
-    "other": ""
+    "one": "……還有 {{count}} 個。再次執行以查看其餘項目。",
+    "other": "……還有 {{count}} 個。再次執行以查看其餘項目。"
   }
 }


### PR DESCRIPTION
Automated locale translation for ChurchCRM 7.7.0.

## Translation Summary
- Group A (Latin America & Iberia): es, es-MX, pt-br, pt, es-AR ✅
- Group B (Romance & Europe): es-CO, es-SV, fr, it, ro ✅
- Group C (Eastern Europe): ru, uk, pl, cs, hu ✅
- Group D (Northern Europe): de, nl, sv, nb, fi, et ✅
- Group E (Asia Pacific): fil, ko, id, vi, zh-CN ✅
- Group F (More Asia): zh-TW, hi, ja, ta, te ✅
- Group G (Africa & Other): sw, am, af, sq, ml ✅
- Group H (Completion): ar, el, he, th, sk, tr ✅

41 locales, ~1,220 terms translated by parallel church-domain-aware sub-agent translators, applied via `locale/scripts/locale-translate.js --apply`, one commit per locale.

Note: `hr` (Croatian, 29 terms) was not part of the assigned locale groups for this run and remains untranslated — a follow-up run can pick it up.

## Next Steps
1. Review and merge
2. Run: `npm run locale:upload:missing -- --yes`