### PR TITLE
Add issue #9705: Volunteer v2 core domain model and database migrations

### DIFF
--- a/.agents/skills/churchcrm/cypress-testing.md
+++ b/.agents/skills/churchcrm/cypress-testing.md
@@ -2341,7 +2341,7 @@ cy.dbQuery("INSERT INTO volunteer_ministry_vmin (vmin_Name, vmin_Active, vmin_Cr
 // result.rows is the OkPacket for an INSERT — result.rows.insertId is the new id.
 ```
 
-Connection is `127.0.0.1` plus `DATABASE_PORT`, `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_DATABASE` from the environment, defaulting to `docker/.env`. An isolated stack on another port needs `DATABASE_PORT` exported for the Cypress process, not just for `docker compose`.
+Connection is `127.0.0.1` plus `DATABASE_PORT`, `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_DATABASE` from the environment, defaulting to `docker/.env`. An isolated stack on another port needs `DATABASE_PORT` exported for the Cypress process, not just for `docker compose` — and so does CI's `ci-subdir` stack, whose database is on 3307 (`DATABASE_SUBDIR_PORT`); both workflows export `DATABASE_PORT: "3307"` on the subdir Cypress step for that reason.
 
 ### `on('task', ...)` Replaces, It Does Not Merge
 

--- a/.agents/skills/churchcrm/cypress-testing.md
+++ b/.agents/skills/churchcrm/cypress-testing.md
@@ -2326,3 +2326,33 @@ cy.get("select#State").next(".ts-wrapper").find(".ts-dropdown .option")
 ```
 
 Assert the **count**, not just that the dropdown opened — a rendered count of exactly 50 is the signature of the `maxOptions` cap (see the frontend-development skill). Derive `expected` from the API the select is populated from (`/api/public/data/countries`) rather than hardcoding it, so the test does not go stale when the data changes.
+
+## Database Assertions via the `db:query` Node Task <!-- learned: 2026-09-12 -->
+
+Some guarantees have no HTTP surface — UNIQUE keys, foreign keys and their `ON DELETE` rules, enum domains. A spec cannot open a MySQL socket itself, so `cypress/configs/_shared.ts` exports `dbTasks`, a `db:query` node-event task built on the existing `mysql2` devDependency, wrapped as `cy.dbQuery(sql, params)`.
+
+It **returns** driver errors instead of throwing, because asserting that a write is *refused* is usually the point:
+
+```js
+cy.dbQuery("INSERT INTO volunteer_ministry_vmin (vmin_Name, vmin_Active, vmin_CreatedDate) VALUES ('dup', 1, NOW())")
+  .then((result) => {
+      expect(result.error.code).to.equal("ER_DUP_ENTRY");
+  });
+// result.rows is the OkPacket for an INSERT — result.rows.insertId is the new id.
+```
+
+Connection is `127.0.0.1` plus `DATABASE_PORT`, `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_DATABASE` from the environment, defaulting to `docker/.env`. An isolated stack on another port needs `DATABASE_PORT` exported for the Cypress process, not just for `docker compose`.
+
+### `on('task', ...)` Replaces, It Does Not Merge
+
+Calling `on('task', {...})` a second time **overwrites** the first registration. Every task must go into one object:
+
+```js
+on('task', { ...verifyDownloadTasks, ...dbTasks });
+```
+
+Related trap: `docker.config.ts`, `docker-ui.config.ts` and `docker-admin.config.ts` each define their **own** `setupNodeEvents` and do **not** call `setupCommonNodeEvents` from `_shared.ts` (only `base.config.ts` and `locale.config.ts` do). Adding a task to `_shared.ts` alone leaves it undefined for `npm run test:api` — wire it into the config the spec actually runs under as well.
+
+### Strict Mode Decides Whether a Bad Enum Errors or Truncates
+
+The Docker test database is MariaDB with `sql_mode = STRICT_TRANS_TABLES,...`, so writing a value outside an `enum(...)` is an error, not a silent `''`. Read `@@sql_mode` in the spec and branch rather than hardcoding the expectation — the same spec must survive a server without strict mode.

--- a/.agents/skills/churchcrm/db-schema-migration.md
+++ b/.agents/skills/churchcrm/db-schema-migration.md
@@ -152,3 +152,25 @@ MySQL `utf8` / `utf8mb3` is 3-byte max and silently fails on emoji and other 4-b
 -- ✅ Upgrading existing tables
 ALTER TABLE `note_nte` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 ```
+
+### The Schema Has No Foreign Keys Yet — New Tables Are the First <!-- learned: 2026-09-12 -->
+
+`SELECT COUNT(*) FROM information_schema.REFERENTIAL_CONSTRAINTS WHERE CONSTRAINT_SCHEMA = DATABASE()` returns **0** on a stock install: `orm/schema.xml` declares `<foreign-key>` elements, but `Install.sql` and `cypress/data/seed.sql` contain no `FOREIGN KEY` clause at all, so nothing is enforced at the database level. Consequences when you add a table that *does* declare them (the `volunteer_*` tables in #9705 are the first):
+
+- The constraints are real, so `ON DELETE CASCADE` / `SET NULL` / `RESTRICT` actually fire, and an orphan insert is rejected with `ER_NO_REFERENCED_ROW_2`. That is worth having, but it is new behaviour for this codebase — do not assume existing code is prepared for a `RESTRICT`.
+- `<foreign-key onDelete="cascade|setnull|restrict">` is supported by Propel and was previously unused anywhere in `schema.xml`.
+- **The clauses must be written into `Install.sql` and `seed.sql` by hand**, exactly as in the upgrade script. Mirroring only the columns leaves a fresh install and the Cypress database without the constraints the upgrade path has, and no tooling compares the three files.
+- MariaDB needs an index on every foreign-key column; declare one explicitly (or make the column the leftmost part of a composite key) or the server invents an auto-named one that breaks an `_idx` / `_uidx` naming check.
+- Order matters inside one script: create the parent table before anything references it.
+
+### `npm run build:orm` Works Again <!-- learned: 2026-09-12 -->
+
+`package.json` now runs `cd src/ && composer run orm-gen`; the old broken `./vendor/bin/propel build --config-dir=propel` invocation is gone (#9722). Copy the config first — `orm/propel.php` is gitignored and absent from a fresh checkout:
+
+```bash
+cp orm/propel.php.dist orm/propel.php
+npm run build:orm
+npm run build:php:validate:orm
+```
+
+`src/ChurchCRM/model/ChurchCRM/Base/` and `Map/` are gitignored, so nothing from the regeneration is committed — only the hand-written subclasses. Note that `scripts/validate-orm-base-classes.js` passes silently when `Base/` is absent, so run `composer install` before trusting it.

--- a/.github/workflows/build-test-nightly.yml
+++ b/.github/workflows/build-test-nightly.yml
@@ -340,6 +340,9 @@ jobs:
       run: npx cypress run --config-file "${{ matrix.test-type.config }}" --spec "${{ matrix.test-type.spec }}" --headless --browser electron --reporter junit --reporter-options mochaFile=cypress/reports/junit-php8.5-subdir-${{ matrix.test-type.name }}-[suiteName]-[hash].xml
       env:
         CYPRESS_BASE_URL: http://127.0.0.1:8080/churchcrm/
+        # The ci-subdir database is published on DATABASE_SUBDIR_PORT (3307,
+        # docker-compose.parallel.yaml); the db:query Cypress task reads this.
+        DATABASE_PORT: "3307"
         SPLIT: ${{ matrix.shard-total || '' }}
         SPLIT_INDEX: ${{ matrix.split-index }}
 

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -412,6 +412,9 @@ jobs:
       run: npx cypress run --config-file "${{ matrix.test-type.config }}" --spec "${{ matrix.test-type.spec }}" --headless --browser electron --reporter junit --reporter-options mochaFile=cypress/reports/junit-php${{ matrix.php-version }}-subdir-${{ matrix.test-type.name }}-[suiteName]-[hash].xml
       env:
         CYPRESS_BASE_URL: http://127.0.0.1:8080/churchcrm/
+        # The ci-subdir database is published on DATABASE_SUBDIR_PORT (3307,
+        # docker-compose.parallel.yaml); the db:query Cypress task reads this.
+        DATABASE_PORT: "3307"
         SPLIT: ${{ matrix.shard-total || '' }}
         SPLIT_INDEX: ${{ matrix.split-index }}
 

--- a/cypress/configs/_shared.ts
+++ b/cypress/configs/_shared.ts
@@ -20,6 +20,10 @@ export const dbTasks = {
   async 'db:query'({ sql, params }: { sql: string; params?: unknown[] }) {
     const mysql = require('mysql2/promise');
 
+    // A connection failure (DB down, wrong port or credentials) deliberately
+    // THROWS rather than being returned as data: it is an infrastructure fault
+    // that must fail the run loudly, not something a spec should assert on.
+    // Only driver errors from the statement itself are returned below.
     const connection = await mysql.createConnection({
       host: process.env.DATABASE_HOST || '127.0.0.1',
       port: Number(process.env.DATABASE_PORT || 3306),
@@ -44,7 +48,13 @@ export const dbTasks = {
         }
       };
     } finally {
-      await connection.end();
+      // A rejected await inside finally would replace the value returned
+      // above, so never let end() reject; destroy() cannot.
+      try {
+        await connection.end();
+      } catch {
+        connection.destroy();
+      }
     }
   }
 };

--- a/cypress/configs/_shared.ts
+++ b/cypress/configs/_shared.ts
@@ -24,9 +24,15 @@ export const dbTasks = {
     // THROWS rather than being returned as data: it is an infrastructure fault
     // that must fail the run loudly, not something a spec should assert on.
     // Only driver errors from the statement itself are returned below.
+    //
+    // The port must match the stack the specs run against: 3306 for the
+    // default and ci-root stacks, DATABASE_SUBDIR_PORT (3307) for ci-subdir —
+    // the workflows export DATABASE_PORT accordingly, and an isolated local
+    // stack on another port must export it too.
+    const port = Number(process.env.DATABASE_PORT || 3306);
     const connection = await mysql.createConnection({
       host: process.env.DATABASE_HOST || '127.0.0.1',
-      port: Number(process.env.DATABASE_PORT || 3306),
+      port,
       user: process.env.MYSQL_USER || 'churchcrm',
       password: process.env.MYSQL_PASSWORD || 'changeme',
       database: process.env.MYSQL_DATABASE || 'churchcrm',

--- a/cypress/configs/_shared.ts
+++ b/cypress/configs/_shared.ts
@@ -1,4 +1,54 @@
 // Shared node event setup used by multiple Cypress configs
+
+/**
+ * Node-side database tasks.
+ *
+ * Cypress runs specs in a browser, so a spec cannot open a MySQL socket itself.
+ * Schema-level guarantees — UNIQUE keys, foreign keys and their ON DELETE
+ * rules, enum domains — have no HTTP surface to assert against, so #9705 (the
+ * Volunteer v2 schema) needs a way to talk to the database directly.
+ *
+ * `mysql2` is already a devDependency (it is pulled in by the tooling), so this
+ * adds no dependency. The task deliberately **returns** driver errors instead of
+ * throwing: a rejected task fails the whole test, and asserting that a write is
+ * rejected (ER_DUP_ENTRY, ER_NO_REFERENCED_ROW_2, ...) is the entire point.
+ *
+ * Connection defaults mirror docker/.env, which CI exports as real environment
+ * variables; DATABASE_PORT lets an isolated stack publish MySQL on another port.
+ */
+export const dbTasks = {
+  async 'db:query'({ sql, params }: { sql: string; params?: unknown[] }) {
+    const mysql = require('mysql2/promise');
+
+    const connection = await mysql.createConnection({
+      host: process.env.DATABASE_HOST || '127.0.0.1',
+      port: Number(process.env.DATABASE_PORT || 3306),
+      user: process.env.MYSQL_USER || 'churchcrm',
+      password: process.env.MYSQL_PASSWORD || 'changeme',
+      database: process.env.MYSQL_DATABASE || 'churchcrm',
+      multipleStatements: false,
+      dateStrings: true
+    });
+
+    try {
+      const [rows] = await connection.query(sql, params || []);
+      return { rows, error: null };
+    } catch (err: any) {
+      return {
+        rows: null,
+        error: {
+          code: err.code || null,
+          errno: err.errno || null,
+          sqlState: err.sqlState || null,
+          message: err.message || String(err)
+        }
+      };
+    } finally {
+      await connection.end();
+    }
+  }
+};
+
 export function setupCommonNodeEvents(on: any, config: any) {
   // cypress-terminal-report logs printer for CI debugging
   try {
@@ -16,13 +66,19 @@ export function setupCommonNodeEvents(on: any, config: any) {
     // ignore optional logging integration errors in local environments
   }
 
+  // Every task must be registered in a single on('task', ...) call — a second
+  // registration replaces the first rather than merging with it.
+  const tasks: Record<string, any> = { ...dbTasks };
+
   // Register download verification tasks if available
   try {
     const { verifyDownloadTasks } = require('cy-verify-downloads');
-    on('task', verifyDownloadTasks);
+    Object.assign(tasks, verifyDownloadTasks);
   } catch (err) {
     // optional dependency may be missing in some environments
   }
+
+  on('task', tasks);
 
   // Common browser launch options
   on('before:browser:launch', (browser: any, launchOptions: any) => {

--- a/cypress/configs/docker.config.ts
+++ b/cypress/configs/docker.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'cypress'
 import { verifyDownloadTasks } from 'cy-verify-downloads';
 
 import base from './base.config'
+import { dbTasks } from './_shared'
 export default defineConfig({
   chromeWebSecurity: false,
   video: false,
@@ -69,7 +70,10 @@ export default defineConfig({
         printLogsToConsole: 'onFail',
         printLogsToFile: 'always'
       });
-      on('task', verifyDownloadTasks);
+      // One registration only — a second on('task', ...) replaces the first.
+      // dbTasks adds db:query, the direct-MySQL task the Volunteer v2 schema
+      // specs use to assert constraints that have no HTTP surface (#9705).
+      on('task', { ...verifyDownloadTasks, ...dbTasks });
       on('before:browser:launch', (browser, launchOptions) => {
         if (browser.name === 'chrome') {
           launchOptions.args.push('--disable-dev-shm-usage');

--- a/cypress/data/seed.sql
+++ b/cypress/data/seed.sql
@@ -2152,6 +2152,401 @@ CREATE TABLE `pledge_denominations_pdem` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
+--
+-- Table structure for table `volunteer_ministry_vmin`
+-- Volunteer Management v2 (#9705); mirrors src/mysql/install/Install.sql
+--
+
+DROP TABLE IF EXISTS `volunteer_ministry_vmin`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `volunteer_ministry_vmin` (
+  `vmin_ID`               int(11)               NOT NULL AUTO_INCREMENT,
+  `vmin_Name`             varchar(100)          NOT NULL,
+  `vmin_Description`      varchar(255)                   DEFAULT NULL,
+  `vmin_Active`           tinyint(1) unsigned   NOT NULL DEFAULT 1,
+  `vmin_CreatedDate`      datetime              NOT NULL,
+  `vmin_CreatedBy_per_ID` mediumint(9) unsigned          DEFAULT NULL,
+  PRIMARY KEY (`vmin_ID`),
+  UNIQUE KEY `vmin_name_uidx`  (`vmin_Name`),
+  KEY `vmin_active_idx`        (`vmin_Active`),
+  KEY `vmin_created_by_idx`    (`vmin_CreatedBy_per_ID`),
+  CONSTRAINT `fk_vmin_created_by` FOREIGN KEY (`vmin_CreatedBy_per_ID`)
+      REFERENCES `person_per` (`per_ID`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `volunteer_team_vtem`
+-- Volunteer Management v2 (#9705); mirrors src/mysql/install/Install.sql
+--
+
+DROP TABLE IF EXISTS `volunteer_team_vtem`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `volunteer_team_vtem` (
+  `vtem_ID`          int(11)             NOT NULL AUTO_INCREMENT,
+  `vtem_vmin_ID`     int(11)             NOT NULL,
+  `vtem_Name`        varchar(100)        NOT NULL,
+  `vtem_Description` varchar(255)                 DEFAULT NULL,
+  `vtem_Active`      tinyint(1) unsigned NOT NULL DEFAULT 1,
+  PRIMARY KEY (`vtem_ID`),
+  UNIQUE KEY `vtem_ministry_name_uidx` (`vtem_vmin_ID`, `vtem_Name`),
+  KEY `vtem_ministry_idx`              (`vtem_vmin_ID`),
+  CONSTRAINT `fk_vtem_ministry` FOREIGN KEY (`vtem_vmin_ID`)
+      REFERENCES `volunteer_ministry_vmin` (`vmin_ID`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `volunteer_pool_vpol`
+-- Volunteer Management v2 (#9705); mirrors src/mysql/install/Install.sql
+--
+
+DROP TABLE IF EXISTS `volunteer_pool_vpol`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `volunteer_pool_vpol` (
+  `vpol_ID`        int(11)                     NOT NULL AUTO_INCREMENT,
+  `vpol_OwnerType` enum('ministry','team')     NOT NULL,
+  `vpol_OwnerId`   int(11)                     NOT NULL,
+  `vpol_grp_ID`    mediumint(8) unsigned       NOT NULL,
+  `vpol_Label`     varchar(100)                         DEFAULT NULL,
+  PRIMARY KEY (`vpol_ID`),
+  UNIQUE KEY `vpol_owner_group_uidx` (`vpol_OwnerType`, `vpol_OwnerId`, `vpol_grp_ID`),
+  KEY `vpol_group_idx`               (`vpol_grp_ID`),
+  CONSTRAINT `fk_vpol_group` FOREIGN KEY (`vpol_grp_ID`)
+      REFERENCES `group_grp` (`grp_ID`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `volunteer_position_vpos`
+-- Volunteer Management v2 (#9705); mirrors src/mysql/install/Install.sql
+--
+
+DROP TABLE IF EXISTS `volunteer_position_vpos`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `volunteer_position_vpos` (
+  `vpos_ID`          int(11)             NOT NULL AUTO_INCREMENT,
+  `vpos_vmin_ID`     int(11)             NOT NULL,
+  `vpos_vtem_ID`     int(11)                      DEFAULT NULL,
+  `vpos_Name`        varchar(100)        NOT NULL,
+  `vpos_Description` varchar(255)                 DEFAULT NULL,
+  `vpos_Active`      tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `vpos_Order`       int(11)             NOT NULL DEFAULT 0,
+  PRIMARY KEY (`vpos_ID`),
+  UNIQUE KEY `vpos_ministry_team_name_uidx` (`vpos_vmin_ID`, `vpos_vtem_ID`, `vpos_Name`),
+  KEY `vpos_ministry_active_idx`            (`vpos_vmin_ID`, `vpos_Active`),
+  KEY `vpos_team_idx`                       (`vpos_vtem_ID`),
+  CONSTRAINT `fk_vpos_ministry` FOREIGN KEY (`vpos_vmin_ID`)
+      REFERENCES `volunteer_ministry_vmin` (`vmin_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vpos_team` FOREIGN KEY (`vpos_vtem_ID`)
+      REFERENCES `volunteer_team_vtem` (`vtem_ID`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `volunteer_qualification_vqal`
+-- Volunteer Management v2 (#9705); mirrors src/mysql/install/Install.sql
+--
+
+DROP TABLE IF EXISTS `volunteer_qualification_vqal`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `volunteer_qualification_vqal` (
+  `vqal_ID`               int(11)               NOT NULL AUTO_INCREMENT,
+  `vqal_per_ID`           mediumint(9) unsigned NOT NULL,
+  `vqal_vpos_ID`          int(11)               NOT NULL,
+  `vqal_Active`           tinyint(1) unsigned   NOT NULL DEFAULT 1,
+  `vqal_GrantedDate`      datetime              NOT NULL,
+  `vqal_GrantedBy_per_ID` mediumint(9) unsigned          DEFAULT NULL,
+  `vqal_Notes`            varchar(255)                   DEFAULT NULL,
+  PRIMARY KEY (`vqal_ID`),
+  UNIQUE KEY `vqal_person_position_uidx` (`vqal_per_ID`, `vqal_vpos_ID`),
+  KEY `vqal_position_active_idx`         (`vqal_vpos_ID`, `vqal_Active`),
+  KEY `vqal_person_idx`                  (`vqal_per_ID`),
+  KEY `vqal_granted_by_idx`              (`vqal_GrantedBy_per_ID`),
+  CONSTRAINT `fk_vqal_person` FOREIGN KEY (`vqal_per_ID`)
+      REFERENCES `person_per` (`per_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vqal_position` FOREIGN KEY (`vqal_vpos_ID`)
+      REFERENCES `volunteer_position_vpos` (`vpos_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vqal_granted_by` FOREIGN KEY (`vqal_GrantedBy_per_ID`)
+      REFERENCES `person_per` (`per_ID`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `volunteer_schedule_vsch`
+-- Volunteer Management v2 (#9705); mirrors src/mysql/install/Install.sql
+--
+
+DROP TABLE IF EXISTS `volunteer_schedule_vsch`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `volunteer_schedule_vsch` (
+  `vsch_ID`                int(11)                                        NOT NULL AUTO_INCREMENT,
+  `vsch_vmin_ID`           int(11)                                        NOT NULL,
+  `vsch_vtem_ID`           int(11)                                                 DEFAULT NULL,
+  `vsch_Name`              varchar(100)                                   NOT NULL,
+  `vsch_LinkMode`          enum('event_type','standalone')                NOT NULL,
+  `vsch_event_type_id`     int(11)                                                 DEFAULT NULL,
+  `vsch_TitleFilter`       varchar(255)                                            DEFAULT NULL,
+  `vsch_RecurType`         enum('none','weekly','monthly','yearly')       NOT NULL DEFAULT 'none',
+  `vsch_RecurDOW`          enum('Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday') DEFAULT NULL,
+  `vsch_RecurDOM`          tinyint(3)                                              DEFAULT NULL,
+  `vsch_StartTime`         time                                                    DEFAULT NULL,
+  `vsch_EndTime`           time                                                    DEFAULT NULL,
+  `vsch_WindowStart`       date                                           NOT NULL,
+  `vsch_WindowEnd`         date                                                    DEFAULT NULL,
+  `vsch_GenerateAheadDays` int(11)                                        NOT NULL DEFAULT 56,
+  `vsch_Active`            tinyint(1) unsigned                            NOT NULL DEFAULT 1,
+  PRIMARY KEY (`vsch_ID`),
+  KEY `vsch_ministry_idx`      (`vsch_vmin_ID`),
+  KEY `vsch_team_idx`          (`vsch_vtem_ID`),
+  KEY `vsch_type_idx`          (`vsch_event_type_id`),
+  KEY `vsch_active_window_idx` (`vsch_Active`, `vsch_WindowStart`),
+  CONSTRAINT `fk_vsch_ministry` FOREIGN KEY (`vsch_vmin_ID`)
+      REFERENCES `volunteer_ministry_vmin` (`vmin_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vsch_team` FOREIGN KEY (`vsch_vtem_ID`)
+      REFERENCES `volunteer_team_vtem` (`vtem_ID`) ON DELETE SET NULL,
+  CONSTRAINT `fk_vsch_event_type` FOREIGN KEY (`vsch_event_type_id`)
+      REFERENCES `event_types` (`type_id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `volunteer_occurrence_vocc`
+-- Volunteer Management v2 (#9705); mirrors src/mysql/install/Install.sql
+--
+
+DROP TABLE IF EXISTS `volunteer_occurrence_vocc`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `volunteer_occurrence_vocc` (
+  `vocc_ID`             int(11)                          NOT NULL AUTO_INCREMENT,
+  `vocc_vsch_ID`        int(11)                          NOT NULL,
+  `vocc_event_id`       int(11)                                   DEFAULT NULL,
+  `vocc_OccurrenceDate` date                             NOT NULL,
+  `vocc_StartDateTime`  datetime                                  DEFAULT NULL,
+  `vocc_EndDateTime`    datetime                                  DEFAULT NULL,
+  `vocc_Status`         enum('scheduled','cancelled')    NOT NULL DEFAULT 'scheduled',
+  `vocc_Notes`          varchar(255)                              DEFAULT NULL,
+  `vocc_GeneratedDate`  datetime                         NOT NULL,
+  PRIMARY KEY (`vocc_ID`),
+  UNIQUE KEY `vocc_schedule_event_uidx` (`vocc_vsch_ID`, `vocc_event_id`),
+  UNIQUE KEY `vocc_schedule_start_uidx` (`vocc_vsch_ID`, `vocc_StartDateTime`),
+  KEY `vocc_date_idx`  (`vocc_OccurrenceDate`),
+  KEY `vocc_event_idx` (`vocc_event_id`),
+  CONSTRAINT `fk_vocc_schedule` FOREIGN KEY (`vocc_vsch_ID`)
+      REFERENCES `volunteer_schedule_vsch` (`vsch_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vocc_event` FOREIGN KEY (`vocc_event_id`)
+      REFERENCES `events_event` (`event_id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `volunteer_requirement_vreq`
+-- Volunteer Management v2 (#9705); mirrors src/mysql/install/Install.sql
+--
+
+DROP TABLE IF EXISTS `volunteer_requirement_vreq`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `volunteer_requirement_vreq` (
+  `vreq_ID`       int(11)      NOT NULL AUTO_INCREMENT,
+  `vreq_vsch_ID`  int(11)               DEFAULT NULL,
+  `vreq_vocc_ID`  int(11)               DEFAULT NULL,
+  `vreq_vpos_ID`  int(11)      NOT NULL,
+  `vreq_MinCount` int(11)      NOT NULL DEFAULT 1,
+  `vreq_MaxCount` int(11)               DEFAULT NULL,
+  `vreq_Notes`    varchar(255)          DEFAULT NULL,
+  PRIMARY KEY (`vreq_ID`),
+  UNIQUE KEY `vreq_schedule_position_uidx`   (`vreq_vsch_ID`, `vreq_vpos_ID`),
+  UNIQUE KEY `vreq_occurrence_position_uidx` (`vreq_vocc_ID`, `vreq_vpos_ID`),
+  KEY `vreq_position_idx`                    (`vreq_vpos_ID`),
+  CONSTRAINT `fk_vreq_schedule` FOREIGN KEY (`vreq_vsch_ID`)
+      REFERENCES `volunteer_schedule_vsch` (`vsch_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vreq_occurrence` FOREIGN KEY (`vreq_vocc_ID`)
+      REFERENCES `volunteer_occurrence_vocc` (`vocc_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vreq_position` FOREIGN KEY (`vreq_vpos_ID`)
+      REFERENCES `volunteer_position_vpos` (`vpos_ID`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `volunteer_assignment_vasg`
+-- Volunteer Management v2 (#9705); mirrors src/mysql/install/Install.sql
+--
+
+DROP TABLE IF EXISTS `volunteer_assignment_vasg`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `volunteer_assignment_vasg` (
+  `vasg_ID`                int(11)               NOT NULL AUTO_INCREMENT,
+  `vasg_vocc_ID`           int(11)               NOT NULL,
+  `vasg_vpos_ID`           int(11)               NOT NULL,
+  `vasg_per_ID`            mediumint(9) unsigned NOT NULL,
+  `vasg_vreq_ID`           int(11)                        DEFAULT NULL,
+  `vasg_Status`            enum('pending','accepted','declined','cancelled','substituted','completed')
+                                                 NOT NULL DEFAULT 'pending',
+  `vasg_Source`            enum('coordinator','self_signup','substitute')
+                                                 NOT NULL DEFAULT 'coordinator',
+  `vasg_AssignedDate`      datetime              NOT NULL,
+  `vasg_AssignedBy_per_ID` mediumint(9) unsigned          DEFAULT NULL,
+  `vasg_RespondedDate`     datetime                       DEFAULT NULL,
+  `vasg_Replaces_vasg_ID`  int(11)                        DEFAULT NULL,
+  `vasg_Notes`             varchar(255)                   DEFAULT NULL,
+  PRIMARY KEY (`vasg_ID`),
+  UNIQUE KEY `vasg_occ_pos_per_uidx` (`vasg_vocc_ID`, `vasg_vpos_ID`, `vasg_per_ID`),
+  KEY `vasg_occurrence_idx`     (`vasg_vocc_ID`, `vasg_Status`),
+  KEY `vasg_person_status_idx`  (`vasg_per_ID`, `vasg_Status`),
+  KEY `vasg_position_idx`       (`vasg_vpos_ID`),
+  KEY `vasg_requirement_idx`    (`vasg_vreq_ID`),
+  KEY `vasg_assigned_by_idx`    (`vasg_AssignedBy_per_ID`),
+  KEY `vasg_replaces_idx`       (`vasg_Replaces_vasg_ID`),
+  CONSTRAINT `fk_vasg_occurrence` FOREIGN KEY (`vasg_vocc_ID`)
+      REFERENCES `volunteer_occurrence_vocc` (`vocc_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vasg_position` FOREIGN KEY (`vasg_vpos_ID`)
+      REFERENCES `volunteer_position_vpos` (`vpos_ID`) ON DELETE RESTRICT,
+  CONSTRAINT `fk_vasg_person` FOREIGN KEY (`vasg_per_ID`)
+      REFERENCES `person_per` (`per_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vasg_requirement` FOREIGN KEY (`vasg_vreq_ID`)
+      REFERENCES `volunteer_requirement_vreq` (`vreq_ID`) ON DELETE SET NULL,
+  CONSTRAINT `fk_vasg_assigned_by` FOREIGN KEY (`vasg_AssignedBy_per_ID`)
+      REFERENCES `person_per` (`per_ID`) ON DELETE SET NULL,
+  CONSTRAINT `fk_vasg_replaces` FOREIGN KEY (`vasg_Replaces_vasg_ID`)
+      REFERENCES `volunteer_assignment_vasg` (`vasg_ID`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `volunteer_response_vrsp`
+-- Volunteer Management v2 (#9705); mirrors src/mysql/install/Install.sql
+--
+
+DROP TABLE IF EXISTS `volunteer_response_vrsp`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `volunteer_response_vrsp` (
+  `vrsp_ID`           int(11)               NOT NULL AUTO_INCREMENT,
+  `vrsp_vasg_ID`      int(11)               NOT NULL,
+  `vrsp_per_ID`       mediumint(9) unsigned NOT NULL,
+  `vrsp_Response`     enum('accepted','declined','cancelled','substitute_proposed','substitute_approved','substitute_rejected','substitute_withdrawn')
+                                            NOT NULL,
+  `vrsp_ResponseDate` datetime              NOT NULL,
+  `vrsp_Channel`      enum('web','coordinator') NOT NULL DEFAULT 'web',
+  `vrsp_Comment`      varchar(255)                   DEFAULT NULL,
+  PRIMARY KEY (`vrsp_ID`),
+  KEY `vrsp_assignment_idx` (`vrsp_vasg_ID`, `vrsp_ResponseDate`),
+  KEY `vrsp_person_idx`     (`vrsp_per_ID`),
+  CONSTRAINT `fk_vrsp_assignment` FOREIGN KEY (`vrsp_vasg_ID`)
+      REFERENCES `volunteer_assignment_vasg` (`vasg_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vrsp_person` FOREIGN KEY (`vrsp_per_ID`)
+      REFERENCES `person_per` (`per_ID`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `volunteer_swap_vswp`
+-- Volunteer Management v2 (#9705); mirrors src/mysql/install/Install.sql
+--
+
+DROP TABLE IF EXISTS `volunteer_swap_vswp`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `volunteer_swap_vswp` (
+  `vswp_ID`               int(11)               NOT NULL AUTO_INCREMENT,
+  `vswp_vasg_ID`          int(11)               NOT NULL,
+  `vswp_ProposedBy_per_ID` mediumint(9) unsigned NOT NULL,
+  `vswp_Proposed_per_ID`  mediumint(9) unsigned NOT NULL,
+  `vswp_Status`           enum('proposed','approved','rejected','withdrawn') NOT NULL DEFAULT 'proposed',
+  `vswp_ProposedDate`     datetime              NOT NULL,
+  `vswp_DecidedDate`      datetime                       DEFAULT NULL,
+  `vswp_DecidedBy_per_ID` mediumint(9) unsigned          DEFAULT NULL,
+  `vswp_Comment`          varchar(255)                   DEFAULT NULL,
+  PRIMARY KEY (`vswp_ID`),
+  KEY `vswp_assignment_status_idx` (`vswp_vasg_ID`, `vswp_Status`),
+  KEY `vswp_proposed_person_idx`   (`vswp_Proposed_per_ID`),
+  KEY `vswp_proposed_by_idx`       (`vswp_ProposedBy_per_ID`),
+  KEY `vswp_decided_by_idx`        (`vswp_DecidedBy_per_ID`),
+  CONSTRAINT `fk_vswp_assignment` FOREIGN KEY (`vswp_vasg_ID`)
+      REFERENCES `volunteer_assignment_vasg` (`vasg_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vswp_proposed_by` FOREIGN KEY (`vswp_ProposedBy_per_ID`)
+      REFERENCES `person_per` (`per_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vswp_proposed_person` FOREIGN KEY (`vswp_Proposed_per_ID`)
+      REFERENCES `person_per` (`per_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vswp_decided_by` FOREIGN KEY (`vswp_DecidedBy_per_ID`)
+      REFERENCES `person_per` (`per_ID`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `volunteer_notification_vntf`
+-- Volunteer Management v2 (#9705); mirrors src/mysql/install/Install.sql
+--
+
+DROP TABLE IF EXISTS `volunteer_notification_vntf`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `volunteer_notification_vntf` (
+  `vntf_ID`              int(11)               NOT NULL AUTO_INCREMENT,
+  `vntf_Type`            enum('assignment','reminder','decline_alert','gap_alert','signup_confirm','swap_proposed','swap_resolved')
+                                               NOT NULL,
+  `vntf_Channel`         enum('email')         NOT NULL DEFAULT 'email',
+  `vntf_per_ID`          mediumint(9) unsigned NOT NULL,
+  `vntf_vasg_ID`         int(11)                        DEFAULT NULL,
+  `vntf_vocc_ID`         int(11)                        DEFAULT NULL,
+  `vntf_DedupeKey`       varchar(190)          NOT NULL,
+  `vntf_ScheduledFor`    datetime              NOT NULL,
+  `vntf_Status`          enum('pending','sent','failed','skipped') NOT NULL DEFAULT 'pending',
+  `vntf_Attempts`        int(11)               NOT NULL DEFAULT 0,
+  `vntf_LastAttemptDate` datetime                       DEFAULT NULL,
+  `vntf_SentDate`        datetime                       DEFAULT NULL,
+  `vntf_LastError`       varchar(255)                   DEFAULT NULL,
+  PRIMARY KEY (`vntf_ID`),
+  UNIQUE KEY `vntf_dedupe_uidx` (`vntf_DedupeKey`),
+  KEY `vntf_due_idx`            (`vntf_Status`, `vntf_ScheduledFor`),
+  KEY `vntf_assignment_idx`     (`vntf_vasg_ID`),
+  KEY `vntf_person_idx`         (`vntf_per_ID`),
+  KEY `vntf_occurrence_idx`     (`vntf_vocc_ID`),
+  CONSTRAINT `fk_vntf_person` FOREIGN KEY (`vntf_per_ID`)
+      REFERENCES `person_per` (`per_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vntf_assignment` FOREIGN KEY (`vntf_vasg_ID`)
+      REFERENCES `volunteer_assignment_vasg` (`vasg_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vntf_occurrence` FOREIGN KEY (`vntf_vocc_ID`)
+      REFERENCES `volunteer_occurrence_vocc` (`vocc_ID`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `volunteer_scope_vscp`
+-- Volunteer Management v2 (#9705); mirrors src/mysql/install/Install.sql
+--
+
+DROP TABLE IF EXISTS `volunteer_scope_vscp`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `volunteer_scope_vscp` (
+  `vscp_ID`               int(11)                 NOT NULL AUTO_INCREMENT,
+  `vscp_per_ID`           mediumint(9) unsigned   NOT NULL,
+  `vscp_ScopeType`        enum('ministry','team') NOT NULL,
+  `vscp_ScopeId`          int(11)                 NOT NULL,
+  `vscp_GrantedDate`      datetime                NOT NULL,
+  `vscp_GrantedBy_per_ID` mediumint(9) unsigned            DEFAULT NULL,
+  PRIMARY KEY (`vscp_ID`),
+  UNIQUE KEY `vscp_person_scope_uidx` (`vscp_per_ID`, `vscp_ScopeType`, `vscp_ScopeId`),
+  KEY `vscp_person_idx`               (`vscp_per_ID`),
+  KEY `vscp_scope_idx`                (`vscp_ScopeType`, `vscp_ScopeId`),
+  KEY `vscp_granted_by_idx`           (`vscp_GrantedBy_per_ID`),
+  CONSTRAINT `fk_vscp_person` FOREIGN KEY (`vscp_per_ID`)
+      REFERENCES `person_per` (`per_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vscp_granted_by` FOREIGN KEY (`vscp_GrantedBy_per_ID`)
+      REFERENCES `person_per` (`per_ID`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 /*!40101 SET AUTOCOMMIT=@OLD_AUTOCOMMIT */;
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;

--- a/cypress/data/seed.sql
+++ b/cypress/data/seed.sql
@@ -2343,6 +2343,12 @@ CREATE TABLE `volunteer_occurrence_vocc` (
       REFERENCES `volunteer_schedule_vsch` (`vsch_ID`) ON DELETE CASCADE,
   CONSTRAINT `fk_vocc_event` FOREIGN KEY (`vocc_event_id`)
       REFERENCES `events_event` (`event_id`) ON DELETE SET NULL
+  -- No CHECK "standalone rows must have a start time": once fk_vocc_event has
+  -- SET NULL a deleted event, a formerly linked row legitimately has neither an
+  -- event nor a start time (its date lives in vocc_OccurrenceDate), and MariaDB
+  -- refuses a CHECK on a column an FK action can change anyway. The generator
+  -- (VolunteerScheduleService, #9708) always sets vocc_StartDateTime for
+  -- standalone schedules; vocc_schedule_start_uidx deduplicates those rows.
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -2371,7 +2377,12 @@ CREATE TABLE `volunteer_requirement_vreq` (
   CONSTRAINT `fk_vreq_occurrence` FOREIGN KEY (`vreq_vocc_ID`)
       REFERENCES `volunteer_occurrence_vocc` (`vocc_ID`) ON DELETE CASCADE,
   CONSTRAINT `fk_vreq_position` FOREIGN KEY (`vreq_vpos_ID`)
-      REFERENCES `volunteer_position_vpos` (`vpos_ID`) ON DELETE CASCADE
+      REFERENCES `volunteer_position_vpos` (`vpos_ID`) ON DELETE CASCADE,
+  -- Exactly one parent: a template requirement belongs to a schedule, an
+  -- override to an occurrence, never both and never neither. Enforced on
+  -- MariaDB 10.2.1+ / MySQL 8.0.16+; parsed and ignored by MySQL 5.7.
+  CONSTRAINT `vreq_one_parent_chk`
+      CHECK ((`vreq_vsch_ID` IS NULL) <> (`vreq_vocc_ID` IS NULL))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/cypress/e2e/api/private/standard/private.volunteer.setup.spec.js
+++ b/cypress/e2e/api/private/standard/private.volunteer.setup.spec.js
@@ -1,0 +1,1280 @@
+/// <reference types="cypress" />
+
+/**
+ * Volunteer v2 — core domain schema (#9705, epic #9701)
+ *
+ * #9705 ships tables, not endpoints: the V2 API arrives with #9706/#9707, so
+ * there is nothing to exercise over HTTP yet. What the issue actually promises
+ * is a set of database guarantees — "duplicate assignments are prevented",
+ * "open gaps can be derived without duplicating assignment truth", "the
+ * migration does not modify V1 volunteer data" — and every one of those lives
+ * in a UNIQUE key, a foreign key, an ON DELETE rule or an enum domain.
+ *
+ * So this spec asserts them where they live, through the node-side `db:query`
+ * task (`cy.dbQuery`, cypress/configs/_shared.ts). #9707 extends this same file
+ * with the setup endpoints once they exist.
+ *
+ * Fixture data is the §2.17 worked example from the design document
+ * (.agents/skills/churchcrm/volunteer-v2-design.md): UC1 Coffee Bar and UC2
+ * Sunday Worship, including the two cases the schema is deliberately shaped
+ * around — one person holding several qualifications in one team, and one
+ * person serving two different positions on a single occurrence (I7 / D16).
+ *
+ * Cleanup runs in `before` as well as `after`: an `after` hook does not run
+ * when a test crashes the runner, so the next run must not inherit rows.
+ */
+
+// FK-safe delete order: children before the rows they reference.
+const V2_TABLES_CHILD_FIRST = [
+    "volunteer_notification_vntf",
+    "volunteer_swap_vswp",
+    "volunteer_response_vrsp",
+    "volunteer_assignment_vasg",
+    "volunteer_requirement_vreq",
+    "volunteer_occurrence_vocc",
+    "volunteer_schedule_vsch",
+    "volunteer_qualification_vqal",
+    "volunteer_position_vpos",
+    "volunteer_pool_vpol",
+    "volunteer_scope_vscp",
+    "volunteer_team_vtem",
+    "volunteer_ministry_vmin",
+];
+
+// Every V2 table and the exact column set it must expose (design §2.3–§2.15).
+const EXPECTED_COLUMNS = {
+    volunteer_ministry_vmin: [
+        "vmin_ID",
+        "vmin_Name",
+        "vmin_Description",
+        "vmin_Active",
+        "vmin_CreatedDate",
+        "vmin_CreatedBy_per_ID",
+    ],
+    volunteer_team_vtem: [
+        "vtem_ID",
+        "vtem_vmin_ID",
+        "vtem_Name",
+        "vtem_Description",
+        "vtem_Active",
+    ],
+    volunteer_pool_vpol: [
+        "vpol_ID",
+        "vpol_OwnerType",
+        "vpol_OwnerId",
+        "vpol_grp_ID",
+        "vpol_Label",
+    ],
+    volunteer_position_vpos: [
+        "vpos_ID",
+        "vpos_vmin_ID",
+        "vpos_vtem_ID",
+        "vpos_Name",
+        "vpos_Description",
+        "vpos_Active",
+        "vpos_Order",
+    ],
+    volunteer_qualification_vqal: [
+        "vqal_ID",
+        "vqal_per_ID",
+        "vqal_vpos_ID",
+        "vqal_Active",
+        "vqal_GrantedDate",
+        "vqal_GrantedBy_per_ID",
+        "vqal_Notes",
+    ],
+    volunteer_schedule_vsch: [
+        "vsch_ID",
+        "vsch_vmin_ID",
+        "vsch_vtem_ID",
+        "vsch_Name",
+        "vsch_LinkMode",
+        "vsch_event_type_id",
+        "vsch_TitleFilter",
+        "vsch_RecurType",
+        "vsch_RecurDOW",
+        "vsch_RecurDOM",
+        "vsch_StartTime",
+        "vsch_EndTime",
+        "vsch_WindowStart",
+        "vsch_WindowEnd",
+        "vsch_GenerateAheadDays",
+        "vsch_Active",
+    ],
+    volunteer_occurrence_vocc: [
+        "vocc_ID",
+        "vocc_vsch_ID",
+        "vocc_event_id",
+        "vocc_OccurrenceDate",
+        "vocc_StartDateTime",
+        "vocc_EndDateTime",
+        "vocc_Status",
+        "vocc_Notes",
+        "vocc_GeneratedDate",
+    ],
+    volunteer_requirement_vreq: [
+        "vreq_ID",
+        "vreq_vsch_ID",
+        "vreq_vocc_ID",
+        "vreq_vpos_ID",
+        "vreq_MinCount",
+        "vreq_MaxCount",
+        "vreq_Notes",
+    ],
+    volunteer_assignment_vasg: [
+        "vasg_ID",
+        "vasg_vocc_ID",
+        "vasg_vpos_ID",
+        "vasg_per_ID",
+        "vasg_vreq_ID",
+        "vasg_Status",
+        "vasg_Source",
+        "vasg_AssignedDate",
+        "vasg_AssignedBy_per_ID",
+        "vasg_RespondedDate",
+        "vasg_Replaces_vasg_ID",
+        "vasg_Notes",
+    ],
+    volunteer_response_vrsp: [
+        "vrsp_ID",
+        "vrsp_vasg_ID",
+        "vrsp_per_ID",
+        "vrsp_Response",
+        "vrsp_ResponseDate",
+        "vrsp_Channel",
+        "vrsp_Comment",
+    ],
+    volunteer_swap_vswp: [
+        "vswp_ID",
+        "vswp_vasg_ID",
+        "vswp_ProposedBy_per_ID",
+        "vswp_Proposed_per_ID",
+        "vswp_Status",
+        "vswp_ProposedDate",
+        "vswp_DecidedDate",
+        "vswp_DecidedBy_per_ID",
+        "vswp_Comment",
+    ],
+    volunteer_notification_vntf: [
+        "vntf_ID",
+        "vntf_Type",
+        "vntf_Channel",
+        "vntf_per_ID",
+        "vntf_vasg_ID",
+        "vntf_vocc_ID",
+        "vntf_DedupeKey",
+        "vntf_ScheduledFor",
+        "vntf_Status",
+        "vntf_Attempts",
+        "vntf_LastAttemptDate",
+        "vntf_SentDate",
+        "vntf_LastError",
+    ],
+    volunteer_scope_vscp: [
+        "vscp_ID",
+        "vscp_per_ID",
+        "vscp_ScopeType",
+        "vscp_ScopeId",
+        "vscp_GrantedDate",
+        "vscp_GrantedBy_per_ID",
+    ],
+};
+
+const V2_TABLES = Object.keys(EXPECTED_COLUMNS);
+
+// The ON DELETE rules the design specifies, keyed by "table.column".
+const EXPECTED_DELETE_RULES = {
+    "volunteer_ministry_vmin.vmin_CreatedBy_per_ID": "SET NULL",
+    "volunteer_team_vtem.vtem_vmin_ID": "CASCADE",
+    "volunteer_pool_vpol.vpol_grp_ID": "CASCADE",
+    "volunteer_position_vpos.vpos_vmin_ID": "CASCADE",
+    "volunteer_position_vpos.vpos_vtem_ID": "SET NULL",
+    "volunteer_qualification_vqal.vqal_per_ID": "CASCADE",
+    "volunteer_qualification_vqal.vqal_vpos_ID": "CASCADE",
+    "volunteer_qualification_vqal.vqal_GrantedBy_per_ID": "SET NULL",
+    "volunteer_schedule_vsch.vsch_vmin_ID": "CASCADE",
+    "volunteer_schedule_vsch.vsch_vtem_ID": "SET NULL",
+    "volunteer_schedule_vsch.vsch_event_type_id": "SET NULL",
+    "volunteer_occurrence_vocc.vocc_vsch_ID": "CASCADE",
+    "volunteer_occurrence_vocc.vocc_event_id": "SET NULL",
+    "volunteer_requirement_vreq.vreq_vsch_ID": "CASCADE",
+    "volunteer_requirement_vreq.vreq_vocc_ID": "CASCADE",
+    "volunteer_requirement_vreq.vreq_vpos_ID": "CASCADE",
+    "volunteer_assignment_vasg.vasg_vocc_ID": "CASCADE",
+    "volunteer_assignment_vasg.vasg_vpos_ID": "RESTRICT",
+    "volunteer_assignment_vasg.vasg_per_ID": "CASCADE",
+    "volunteer_assignment_vasg.vasg_vreq_ID": "SET NULL",
+    "volunteer_assignment_vasg.vasg_AssignedBy_per_ID": "SET NULL",
+    "volunteer_assignment_vasg.vasg_Replaces_vasg_ID": "SET NULL",
+    "volunteer_response_vrsp.vrsp_vasg_ID": "CASCADE",
+    "volunteer_response_vrsp.vrsp_per_ID": "CASCADE",
+    "volunteer_swap_vswp.vswp_vasg_ID": "CASCADE",
+    "volunteer_swap_vswp.vswp_ProposedBy_per_ID": "CASCADE",
+    "volunteer_swap_vswp.vswp_Proposed_per_ID": "CASCADE",
+    "volunteer_swap_vswp.vswp_DecidedBy_per_ID": "SET NULL",
+    "volunteer_notification_vntf.vntf_per_ID": "CASCADE",
+    "volunteer_notification_vntf.vntf_vasg_ID": "CASCADE",
+    "volunteer_notification_vntf.vntf_vocc_ID": "CASCADE",
+    "volunteer_scope_vscp.vscp_per_ID": "CASCADE",
+    "volunteer_scope_vscp.vscp_GrantedBy_per_ID": "SET NULL",
+};
+
+// Seeded fixtures reused rather than recreated (design §6.4).
+const PERSON_ADMIN = 1;
+const PERSON_TONY = 3;
+const PERSON_AMANDA = 99;
+const PERSON_LENA = 100;
+const GROUP_ANGELS = 1;
+const GROUP_WORSHIP = 10;
+const EVENT_TYPE_CHURCH_SERVICE = 1;
+const EVENT_SUNDAY_SCHOOL = 1;
+
+const DUP_ENTRY = "ER_DUP_ENTRY";
+const NO_REFERENCED_ROW = ["ER_NO_REFERENCED_ROW", "ER_NO_REFERENCED_ROW_2"];
+const ROW_IS_REFERENCED = ["ER_ROW_IS_REFERENCED", "ER_ROW_IS_REFERENCED_2"];
+
+/** Run SQL and fail the test if the database rejected it. */
+function dbOk(sql, params = []) {
+    return cy.dbQuery(sql, params).then((result) => {
+        if (result.error !== null) {
+            throw new Error(
+                `Unexpected SQL failure.\n  SQL: ${sql}\n  ${result.error.code}: ${result.error.message}`,
+            );
+        }
+        return result.rows;
+    });
+}
+
+/** Run SQL that must be rejected, and hand the driver error to the caller. */
+function dbRejects(sql, params = []) {
+    return cy.dbQuery(sql, params).then((result) => {
+        expect(
+            result.error,
+            `the database was expected to reject: ${sql}`,
+        ).to.not.equal(null);
+        return result.error;
+    });
+}
+
+/** INSERT and return the generated id. */
+function insertReturningId(sql, params = []) {
+    return dbOk(sql, params).then((rows) => rows.insertId);
+}
+
+/** Delete every V2 row, children first. Tolerant: used before the schema exists. */
+function cleanupV2Rows() {
+    V2_TABLES_CHILD_FIRST.forEach((table) => {
+        cy.dbQuery(`DELETE FROM \`${table}\``);
+    });
+}
+
+function countRows(table) {
+    return cy
+        .dbQuery(`SELECT COUNT(*) AS c FROM \`${table}\``)
+        .then((result) => (result.error === null ? result.rows[0].c : -1));
+}
+
+describe("API Private Volunteer v2 core schema", () => {
+    // D7: the V1 tables must be untouched by anything in this issue.
+    const v1CountsBefore = {};
+    let sqlMode = "";
+
+    before(() => {
+        cy.dbQuery("SELECT @@sql_mode AS mode").then((result) => {
+            sqlMode = result.error === null ? result.rows[0].mode : "";
+        });
+        countRows("volunteeropportunity_vol").then((c) => {
+            v1CountsBefore.volunteeropportunity_vol = c;
+        });
+        countRows("person2volunteeropp_p2vo").then((c) => {
+            v1CountsBefore.person2volunteeropp_p2vo = c;
+        });
+        cleanupV2Rows();
+    });
+
+    after(() => {
+        cleanupV2Rows();
+    });
+
+    describe("Schema shape", () => {
+        it("creates all 13 volunteer_* tables as InnoDB / utf8mb4", () => {
+            const placeholders = V2_TABLES.map(() => "?").join(", ");
+            dbOk(
+                `SELECT TABLE_NAME, ENGINE, TABLE_COLLATION
+                   FROM information_schema.TABLES
+                  WHERE TABLE_SCHEMA = DATABASE()
+                    AND TABLE_NAME IN (${placeholders})`,
+                V2_TABLES,
+            ).then((rows) => {
+                const found = new Map(rows.map((r) => [r.TABLE_NAME, r]));
+                V2_TABLES.forEach((table) => {
+                    expect(found.has(table), `${table} exists`).to.equal(true);
+                    expect(found.get(table).ENGINE, `${table} engine`).to.equal(
+                        "InnoDB",
+                    );
+                    expect(
+                        found.get(table).TABLE_COLLATION,
+                        `${table} collation`,
+                    ).to.match(/^utf8mb4_/);
+                });
+                expect(rows).to.have.length(13);
+            });
+        });
+
+        it("declares exactly the documented columns on every table", () => {
+            V2_TABLES.forEach((table) => {
+                dbOk(
+                    `SELECT COLUMN_NAME
+                       FROM information_schema.COLUMNS
+                      WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?`,
+                    [table],
+                ).then((rows) => {
+                    const actual = rows.map((r) => r.COLUMN_NAME).sort();
+                    const expected = [...EXPECTED_COLUMNS[table]].sort();
+                    expect(actual, `columns of ${table}`).to.deep.equal(
+                        expected,
+                    );
+                });
+            });
+        });
+
+        it("names every primary key column <prefix>_ID and adds no redundant UNIQUE on it", () => {
+            const placeholders = V2_TABLES.map(() => "?").join(", ");
+            dbOk(
+                `SELECT TABLE_NAME, COLUMN_NAME
+                   FROM information_schema.STATISTICS
+                  WHERE TABLE_SCHEMA = DATABASE()
+                    AND INDEX_NAME = 'PRIMARY'
+                    AND TABLE_NAME IN (${placeholders})`,
+                V2_TABLES,
+            ).then((rows) => {
+                expect(rows, "one single-column PK per table").to.have.length(
+                    13,
+                );
+                rows.forEach((row) => {
+                    expect(row.COLUMN_NAME, `PK of ${row.TABLE_NAME}`).to.match(
+                        /^v[a-z]{3}_ID$/,
+                    );
+                });
+            });
+
+            // §2.0: "Redundant UNIQUE(pk) — never." Any other unique index that
+            // covers exactly the primary key column is that anti-pattern.
+            dbOk(
+                `SELECT TABLE_NAME, INDEX_NAME, COUNT(*) AS cols,
+                        MIN(COLUMN_NAME) AS col
+                   FROM information_schema.STATISTICS
+                  WHERE TABLE_SCHEMA = DATABASE()
+                    AND NON_UNIQUE = 0
+                    AND INDEX_NAME <> 'PRIMARY'
+                    AND TABLE_NAME IN (${placeholders})
+                  GROUP BY TABLE_NAME, INDEX_NAME
+                 HAVING cols = 1 AND col LIKE '%\\_ID'`,
+                V2_TABLES,
+            ).then((rows) => {
+                const offenders = rows
+                    .filter((r) => /^v[a-z]{3}_ID$/.test(r.col))
+                    .map((r) => `${r.TABLE_NAME}.${r.INDEX_NAME}`);
+                expect(offenders, "redundant UNIQUE on a PK").to.deep.equal([]);
+            });
+        });
+
+        it("names indexes with the _idx / _uidx convention", () => {
+            const placeholders = V2_TABLES.map(() => "?").join(", ");
+            dbOk(
+                `SELECT DISTINCT TABLE_NAME, INDEX_NAME, NON_UNIQUE
+                   FROM information_schema.STATISTICS
+                  WHERE TABLE_SCHEMA = DATABASE()
+                    AND INDEX_NAME <> 'PRIMARY'
+                    AND TABLE_NAME IN (${placeholders})`,
+                V2_TABLES,
+            ).then((rows) => {
+                rows.forEach((row) => {
+                    const suffix =
+                        Number(row.NON_UNIQUE) === 0 ? "_uidx" : "_idx";
+                    expect(
+                        row.INDEX_NAME.endsWith(suffix),
+                        `${row.TABLE_NAME}.${row.INDEX_NAME} should end in ${suffix}`,
+                    ).to.equal(true);
+                });
+            });
+        });
+
+        it("declares the documented ON DELETE rule on every foreign key", () => {
+            const placeholders = V2_TABLES.map(() => "?").join(", ");
+            dbOk(
+                `SELECT k.TABLE_NAME, k.COLUMN_NAME, k.REFERENCED_TABLE_NAME,
+                        k.REFERENCED_COLUMN_NAME, r.DELETE_RULE
+                   FROM information_schema.KEY_COLUMN_USAGE k
+                   JOIN information_schema.REFERENTIAL_CONSTRAINTS r
+                     ON r.CONSTRAINT_SCHEMA = k.CONSTRAINT_SCHEMA
+                    AND r.CONSTRAINT_NAME   = k.CONSTRAINT_NAME
+                  WHERE k.TABLE_SCHEMA = DATABASE()
+                    AND k.REFERENCED_TABLE_NAME IS NOT NULL
+                    AND k.TABLE_NAME IN (${placeholders})`,
+                V2_TABLES,
+            ).then((rows) => {
+                const actual = {};
+                rows.forEach((row) => {
+                    actual[`${row.TABLE_NAME}.${row.COLUMN_NAME}`] =
+                        row.DELETE_RULE;
+                });
+                Object.entries(EXPECTED_DELETE_RULES).forEach(
+                    ([key, rule]) => {
+                        expect(actual[key], `ON DELETE of ${key}`).to.equal(
+                            rule,
+                        );
+                    },
+                );
+                expect(
+                    Object.keys(actual).sort(),
+                    "the full foreign-key set",
+                ).to.deep.equal(Object.keys(EXPECTED_DELETE_RULES).sort());
+            });
+        });
+
+        it("leaves the two polymorphic columns without a foreign key, by design", () => {
+            // §2.0: vscp_ScopeId and vpol_OwnerId point at either a ministry or
+            // a team, so no single FK target exists — the same limitation
+            // record2property_r2p lives with. Integrity is a service concern.
+            dbOk(
+                `SELECT COUNT(*) AS c
+                   FROM information_schema.KEY_COLUMN_USAGE
+                  WHERE TABLE_SCHEMA = DATABASE()
+                    AND REFERENCED_TABLE_NAME IS NOT NULL
+                    AND (
+                          (TABLE_NAME = 'volunteer_scope_vscp' AND COLUMN_NAME = 'vscp_ScopeId')
+                       OR (TABLE_NAME = 'volunteer_pool_vpol'  AND COLUMN_NAME = 'vpol_OwnerId')
+                    )`,
+            ).then((rows) => {
+                expect(Number(rows[0].c)).to.equal(0);
+            });
+        });
+
+        it("matches foreign key column types to the parent column", () => {
+            // F6/§2.0: existing tables disagree with their parents
+            // (person2group2role_p2g2r is mediumint(8) against a mediumint(9)
+            // parent). V2 matches the parent instead.
+            dbOk(
+                `SELECT TABLE_NAME, COLUMN_NAME, COLUMN_TYPE
+                   FROM information_schema.COLUMNS
+                  WHERE TABLE_SCHEMA = DATABASE()
+                    AND (
+                        (TABLE_NAME = 'person_per' AND COLUMN_NAME = 'per_ID')
+                     OR (TABLE_NAME = 'group_grp'  AND COLUMN_NAME = 'grp_ID')
+                     OR (TABLE_NAME = 'volunteer_assignment_vasg' AND COLUMN_NAME = 'vasg_per_ID')
+                     OR (TABLE_NAME = 'volunteer_qualification_vqal' AND COLUMN_NAME = 'vqal_per_ID')
+                     OR (TABLE_NAME = 'volunteer_scope_vscp' AND COLUMN_NAME = 'vscp_per_ID')
+                     OR (TABLE_NAME = 'volunteer_pool_vpol' AND COLUMN_NAME = 'vpol_grp_ID')
+                    )`,
+            ).then((rows) => {
+                const byKey = {};
+                rows.forEach((r) => {
+                    byKey[`${r.TABLE_NAME}.${r.COLUMN_NAME}`] = r.COLUMN_TYPE;
+                });
+                const personType = byKey["person_per.per_ID"];
+                const groupType = byKey["group_grp.grp_ID"];
+                [
+                    "volunteer_assignment_vasg.vasg_per_ID",
+                    "volunteer_qualification_vqal.vqal_per_ID",
+                    "volunteer_scope_vscp.vscp_per_ID",
+                ].forEach((key) => {
+                    expect(byKey[key], `${key} matches person_per.per_ID`).to.equal(
+                        personType,
+                    );
+                });
+                expect(
+                    byKey["volunteer_pool_vpol.vpol_grp_ID"],
+                    "vpol_grp_ID matches group_grp.grp_ID",
+                ).to.equal(groupType);
+            });
+        });
+    });
+
+    describe("Constraints", () => {
+        // Ids of the §2.17 fixture rows, filled in by the before hook.
+        const f = {};
+
+        before(() => {
+            cleanupV2Rows();
+
+            // --- UC1 Coffee Bar -------------------------------------------
+            insertReturningId(
+                `INSERT INTO volunteer_ministry_vmin
+                    (vmin_Name, vmin_Description, vmin_Active, vmin_CreatedDate, vmin_CreatedBy_per_ID)
+                 VALUES ('Cypress Coffee Bar', 'UC1', 1, NOW(), ?)`,
+                [PERSON_ADMIN],
+            ).then((id) => {
+                f.ministryCoffee = id;
+            });
+
+            cy.then(() =>
+                insertReturningId(
+                    `INSERT INTO volunteer_team_vtem
+                        (vtem_vmin_ID, vtem_Name, vtem_Active)
+                     VALUES (?, 'Coffee Bar Team', 1)`,
+                    [f.ministryCoffee],
+                ).then((id) => {
+                    f.teamCoffee = id;
+                }),
+            );
+
+            cy.then(() =>
+                insertReturningId(
+                    `INSERT INTO volunteer_pool_vpol
+                        (vpol_OwnerType, vpol_OwnerId, vpol_grp_ID, vpol_Label)
+                     VALUES ('team', ?, ?, 'Cypress pool')`,
+                    [f.teamCoffee, GROUP_ANGELS],
+                ).then((id) => {
+                    f.poolCoffee = id;
+                }),
+            );
+
+            cy.then(() =>
+                insertReturningId(
+                    `INSERT INTO volunteer_position_vpos
+                        (vpos_vmin_ID, vpos_vtem_ID, vpos_Name, vpos_Active, vpos_Order)
+                     VALUES (?, ?, 'Espresso', 1, 3)`,
+                    [f.ministryCoffee, f.teamCoffee],
+                ).then((id) => {
+                    f.posEspresso = id;
+                }),
+            );
+
+            cy.then(() =>
+                insertReturningId(
+                    `INSERT INTO volunteer_position_vpos
+                        (vpos_vmin_ID, vpos_vtem_ID, vpos_Name, vpos_Active, vpos_Order)
+                     VALUES (?, ?, 'Milk Station', 1, 4)`,
+                    [f.ministryCoffee, f.teamCoffee],
+                ).then((id) => {
+                    f.posMilk = id;
+                }),
+            );
+
+            // Tony holds two qualifications in the same team (§2.7, D16).
+            cy.then(() =>
+                insertReturningId(
+                    `INSERT INTO volunteer_qualification_vqal
+                        (vqal_per_ID, vqal_vpos_ID, vqal_Active, vqal_GrantedDate, vqal_GrantedBy_per_ID)
+                     VALUES (?, ?, 1, NOW(), ?)`,
+                    [PERSON_TONY, f.posEspresso, PERSON_ADMIN],
+                ).then((id) => {
+                    f.qualTonyEspresso = id;
+                }),
+            );
+            cy.then(() =>
+                dbOk(
+                    `INSERT INTO volunteer_qualification_vqal
+                        (vqal_per_ID, vqal_vpos_ID, vqal_Active, vqal_GrantedDate)
+                     VALUES (?, ?, 1, NOW())`,
+                    [PERSON_TONY, f.posMilk],
+                ),
+            );
+
+            cy.then(() =>
+                insertReturningId(
+                    `INSERT INTO volunteer_schedule_vsch
+                        (vsch_vmin_ID, vsch_vtem_ID, vsch_Name, vsch_LinkMode, vsch_event_type_id,
+                         vsch_RecurType, vsch_WindowStart, vsch_GenerateAheadDays, vsch_Active)
+                     VALUES (?, ?, 'Coffee Bar — Sunday', 'event_type', ?, 'none', '2026-09-13', 56, 1)`,
+                    [f.ministryCoffee, f.teamCoffee, EVENT_TYPE_CHURCH_SERVICE],
+                ).then((id) => {
+                    f.schedCoffee = id;
+                }),
+            );
+
+            cy.then(() =>
+                insertReturningId(
+                    `INSERT INTO volunteer_requirement_vreq
+                        (vreq_vsch_ID, vreq_vpos_ID, vreq_MinCount, vreq_MaxCount)
+                     VALUES (?, ?, 1, 1)`,
+                    [f.schedCoffee, f.posEspresso],
+                ).then((id) => {
+                    f.reqEspresso = id;
+                }),
+            );
+
+            cy.then(() =>
+                insertReturningId(
+                    `INSERT INTO volunteer_occurrence_vocc
+                        (vocc_vsch_ID, vocc_event_id, vocc_OccurrenceDate, vocc_Status, vocc_GeneratedDate)
+                     VALUES (?, ?, '2026-09-13', 'scheduled', NOW())`,
+                    [f.schedCoffee, EVENT_SUNDAY_SCHOOL],
+                ).then((id) => {
+                    f.occCoffee = id;
+                }),
+            );
+
+            cy.then(() =>
+                insertReturningId(
+                    `INSERT INTO volunteer_assignment_vasg
+                        (vasg_vocc_ID, vasg_vpos_ID, vasg_per_ID, vasg_vreq_ID,
+                         vasg_Status, vasg_Source, vasg_AssignedDate, vasg_AssignedBy_per_ID)
+                     VALUES (?, ?, ?, ?, 'pending', 'coordinator', NOW(), ?)`,
+                    [
+                        f.occCoffee,
+                        f.posEspresso,
+                        PERSON_TONY,
+                        f.reqEspresso,
+                        PERSON_ADMIN,
+                    ],
+                ).then((id) => {
+                    f.asgTonyEspresso = id;
+                }),
+            );
+
+            // --- UC2 Sunday Worship ---------------------------------------
+            cy.then(() =>
+                insertReturningId(
+                    `INSERT INTO volunteer_ministry_vmin
+                        (vmin_Name, vmin_Active, vmin_CreatedDate)
+                     VALUES ('Cypress Worship', 1, NOW())`,
+                ).then((id) => {
+                    f.ministryWorship = id;
+                }),
+            );
+            cy.then(() =>
+                insertReturningId(
+                    `INSERT INTO volunteer_team_vtem (vtem_vmin_ID, vtem_Name, vtem_Active)
+                     VALUES (?, 'Worship Team', 1)`,
+                    [f.ministryWorship],
+                ).then((id) => {
+                    f.teamWorship = id;
+                }),
+            );
+            cy.then(() =>
+                dbOk(
+                    `INSERT INTO volunteer_pool_vpol (vpol_OwnerType, vpol_OwnerId, vpol_grp_ID)
+                     VALUES ('team', ?, ?)`,
+                    [f.teamWorship, GROUP_WORSHIP],
+                ),
+            );
+            cy.then(() =>
+                insertReturningId(
+                    `INSERT INTO volunteer_position_vpos
+                        (vpos_vmin_ID, vpos_vtem_ID, vpos_Name, vpos_Active, vpos_Order)
+                     VALUES (?, ?, 'Communion Leader', 1, 2)`,
+                    [f.ministryWorship, f.teamWorship],
+                ).then((id) => {
+                    f.posCommunion = id;
+                }),
+            );
+            cy.then(() =>
+                insertReturningId(
+                    `INSERT INTO volunteer_position_vpos
+                        (vpos_vmin_ID, vpos_vtem_ID, vpos_Name, vpos_Active, vpos_Order)
+                     VALUES (?, ?, 'Closing Prayer', 1, 4)`,
+                    [f.ministryWorship, f.teamWorship],
+                ).then((id) => {
+                    f.posClosing = id;
+                }),
+            );
+            cy.then(() =>
+                dbOk(
+                    `INSERT INTO volunteer_qualification_vqal
+                        (vqal_per_ID, vqal_vpos_ID, vqal_Active, vqal_GrantedDate)
+                     VALUES (?, ?, 1, NOW()), (?, ?, 1, NOW())`,
+                    [
+                        PERSON_AMANDA,
+                        f.posCommunion,
+                        PERSON_AMANDA,
+                        f.posClosing,
+                    ],
+                ),
+            );
+            cy.then(() =>
+                insertReturningId(
+                    `INSERT INTO volunteer_schedule_vsch
+                        (vsch_vmin_ID, vsch_vtem_ID, vsch_Name, vsch_LinkMode, vsch_event_type_id,
+                         vsch_RecurType, vsch_WindowStart, vsch_Active)
+                     VALUES (?, ?, 'Sunday Morning Worship', 'event_type', ?, 'none', '2026-09-13', 1)`,
+                    [
+                        f.ministryWorship,
+                        f.teamWorship,
+                        EVENT_TYPE_CHURCH_SERVICE,
+                    ],
+                ).then((id) => {
+                    f.schedWorship = id;
+                }),
+            );
+            // UC3: a second schedule's occurrence points at the SAME event row.
+            cy.then(() =>
+                insertReturningId(
+                    `INSERT INTO volunteer_occurrence_vocc
+                        (vocc_vsch_ID, vocc_event_id, vocc_OccurrenceDate, vocc_Status, vocc_GeneratedDate)
+                     VALUES (?, ?, '2026-09-13', 'scheduled', NOW())`,
+                    [f.schedWorship, EVENT_SUNDAY_SCHOOL],
+                ).then((id) => {
+                    f.occWorship = id;
+                }),
+            );
+            // I7 / D16: Amanda serves two different positions on one occurrence.
+            cy.then(() =>
+                insertReturningId(
+                    `INSERT INTO volunteer_assignment_vasg
+                        (vasg_vocc_ID, vasg_vpos_ID, vasg_per_ID, vasg_Status, vasg_Source, vasg_AssignedDate)
+                     VALUES (?, ?, ?, 'accepted', 'coordinator', NOW())`,
+                    [f.occWorship, f.posCommunion, PERSON_AMANDA],
+                ).then((id) => {
+                    f.asgAmandaCommunion = id;
+                }),
+            );
+            cy.then(() =>
+                insertReturningId(
+                    `INSERT INTO volunteer_assignment_vasg
+                        (vasg_vocc_ID, vasg_vpos_ID, vasg_per_ID, vasg_Status, vasg_Source, vasg_AssignedDate)
+                     VALUES (?, ?, ?, 'accepted', 'coordinator', NOW())`,
+                    [f.occWorship, f.posClosing, PERSON_AMANDA],
+                ).then((id) => {
+                    f.asgAmandaClosing = id;
+                }),
+            );
+            cy.then(() =>
+                dbOk(
+                    `INSERT INTO volunteer_response_vrsp
+                        (vrsp_vasg_ID, vrsp_per_ID, vrsp_Response, vrsp_ResponseDate, vrsp_Channel)
+                     VALUES (?, ?, 'accepted', NOW(), 'web')`,
+                    [f.asgAmandaCommunion, PERSON_AMANDA],
+                ),
+            );
+            cy.then(() =>
+                dbOk(
+                    `INSERT INTO volunteer_swap_vswp
+                        (vswp_vasg_ID, vswp_ProposedBy_per_ID, vswp_Proposed_per_ID,
+                         vswp_Status, vswp_ProposedDate)
+                     VALUES (?, ?, ?, 'proposed', NOW())`,
+                    [f.asgAmandaCommunion, PERSON_AMANDA, PERSON_LENA],
+                ),
+            );
+            cy.then(() =>
+                dbOk(
+                    `INSERT INTO volunteer_notification_vntf
+                        (vntf_Type, vntf_Channel, vntf_per_ID, vntf_vasg_ID,
+                         vntf_DedupeKey, vntf_ScheduledFor, vntf_Status)
+                     VALUES ('assignment', 'email', ?, ?, ?, NOW(), 'pending')`,
+                    [
+                        PERSON_AMANDA,
+                        f.asgAmandaCommunion,
+                        `assignment:${f.asgAmandaCommunion}:${PERSON_AMANDA}`,
+                    ],
+                ),
+            );
+            cy.then(() =>
+                dbOk(
+                    `INSERT INTO volunteer_scope_vscp
+                        (vscp_per_ID, vscp_ScopeType, vscp_ScopeId, vscp_GrantedDate, vscp_GrantedBy_per_ID)
+                     VALUES (?, 'ministry', ?, NOW(), ?)`,
+                    [PERSON_TONY, f.ministryCoffee, PERSON_ADMIN],
+                ),
+            );
+        });
+
+        describe("Unique keys", () => {
+            it("rejects a duplicate ministry name (vmin_name_uidx)", () => {
+                dbRejects(
+                    `INSERT INTO volunteer_ministry_vmin (vmin_Name, vmin_Active, vmin_CreatedDate)
+                     VALUES ('Cypress Coffee Bar', 1, NOW())`,
+                ).then((err) => {
+                    expect(err.code).to.equal(DUP_ENTRY);
+                });
+            });
+
+            it("rejects a duplicate team name inside one ministry (vtem_ministry_name_uidx)", () => {
+                dbRejects(
+                    `INSERT INTO volunteer_team_vtem (vtem_vmin_ID, vtem_Name, vtem_Active)
+                     VALUES (?, 'Coffee Bar Team', 1)`,
+                    [f.ministryCoffee],
+                ).then((err) => {
+                    expect(err.code).to.equal(DUP_ENTRY);
+                });
+
+                // The same team name under a different ministry is fine.
+                dbOk(
+                    `INSERT INTO volunteer_team_vtem (vtem_vmin_ID, vtem_Name, vtem_Active)
+                     VALUES (?, 'Coffee Bar Team', 1)`,
+                    [f.ministryWorship],
+                ).then((rows) => {
+                    cy.dbQuery(`DELETE FROM volunteer_team_vtem WHERE vtem_ID = ?`, [
+                        rows.insertId,
+                    ]);
+                });
+            });
+
+            it("rejects the same group linked twice to one owner (vpol_owner_group_uidx)", () => {
+                dbRejects(
+                    `INSERT INTO volunteer_pool_vpol (vpol_OwnerType, vpol_OwnerId, vpol_grp_ID)
+                     VALUES ('team', ?, ?)`,
+                    [f.teamCoffee, GROUP_ANGELS],
+                ).then((err) => {
+                    expect(err.code).to.equal(DUP_ENTRY);
+                });
+            });
+
+            it("rejects a duplicate position name in one ministry+team (vpos_ministry_team_name_uidx)", () => {
+                dbRejects(
+                    `INSERT INTO volunteer_position_vpos
+                        (vpos_vmin_ID, vpos_vtem_ID, vpos_Name, vpos_Active, vpos_Order)
+                     VALUES (?, ?, 'Espresso', 1, 9)`,
+                    [f.ministryCoffee, f.teamCoffee],
+                ).then((err) => {
+                    expect(err.code).to.equal(DUP_ENTRY);
+                });
+            });
+
+            it("does NOT catch two ministry-wide positions of the same name — the documented NULL trap", () => {
+                // §2.6: MySQL treats NULLs as distinct inside a UNIQUE index, so
+                // two vpos_vtem_ID IS NULL rows with the same name are accepted.
+                // VolunteerSetupService::createPosition() is what returns 409.
+                // This test pins the behaviour so nobody "fixes" it with a
+                // NOT NULL DEFAULT 0 sentinel, which would break the FK.
+                const ids = [];
+                dbOk(
+                    `INSERT INTO volunteer_position_vpos
+                        (vpos_vmin_ID, vpos_vtem_ID, vpos_Name, vpos_Active, vpos_Order)
+                     VALUES (?, NULL, 'Ministry Wide', 1, 0)`,
+                    [f.ministryCoffee],
+                ).then((rows) => ids.push(rows.insertId));
+                dbOk(
+                    `INSERT INTO volunteer_position_vpos
+                        (vpos_vmin_ID, vpos_vtem_ID, vpos_Name, vpos_Active, vpos_Order)
+                     VALUES (?, NULL, 'Ministry Wide', 1, 0)`,
+                    [f.ministryCoffee],
+                ).then((rows) => {
+                    ids.push(rows.insertId);
+                    expect(ids, "both inserts accepted").to.have.length(2);
+                    cy.dbQuery(
+                        `DELETE FROM volunteer_position_vpos WHERE vpos_ID IN (?, ?)`,
+                        ids,
+                    );
+                });
+            });
+
+            it("rejects a duplicate person+position qualification (vqal_person_position_uidx)", () => {
+                dbRejects(
+                    `INSERT INTO volunteer_qualification_vqal
+                        (vqal_per_ID, vqal_vpos_ID, vqal_Active, vqal_GrantedDate)
+                     VALUES (?, ?, 1, NOW())`,
+                    [PERSON_TONY, f.posEspresso],
+                ).then((err) => {
+                    expect(err.code).to.equal(DUP_ENTRY);
+                });
+            });
+
+            it("allows one person to hold several qualifications (§2.7, D16)", () => {
+                dbOk(
+                    `SELECT COUNT(*) AS c FROM volunteer_qualification_vqal WHERE vqal_per_ID = ?`,
+                    [PERSON_TONY],
+                ).then((rows) => {
+                    expect(Number(rows[0].c)).to.equal(2);
+                });
+            });
+
+            it("rejects a second occurrence for the same schedule+event (vocc_schedule_event_uidx)", () => {
+                dbRejects(
+                    `INSERT INTO volunteer_occurrence_vocc
+                        (vocc_vsch_ID, vocc_event_id, vocc_OccurrenceDate, vocc_Status, vocc_GeneratedDate)
+                     VALUES (?, ?, '2026-09-13', 'scheduled', NOW())`,
+                    [f.schedCoffee, EVENT_SUNDAY_SCHOOL],
+                ).then((err) => {
+                    expect(err.code).to.equal(DUP_ENTRY);
+                });
+            });
+
+            it("allows two schedules to share one event row (UC3)", () => {
+                dbOk(
+                    `SELECT COUNT(*) AS c FROM volunteer_occurrence_vocc WHERE vocc_event_id = ?`,
+                    [EVENT_SUNDAY_SCHOOL],
+                ).then((rows) => {
+                    expect(Number(rows[0].c)).to.equal(2);
+                });
+            });
+
+            it("rejects a duplicate requirement for one schedule+position (vreq_schedule_position_uidx)", () => {
+                dbRejects(
+                    `INSERT INTO volunteer_requirement_vreq
+                        (vreq_vsch_ID, vreq_vpos_ID, vreq_MinCount)
+                     VALUES (?, ?, 2)`,
+                    [f.schedCoffee, f.posEspresso],
+                ).then((err) => {
+                    expect(err.code).to.equal(DUP_ENTRY);
+                });
+            });
+
+            it("rejects the same person twice on one position of an occurrence (I1, vasg_occ_pos_per_uidx)", () => {
+                dbRejects(
+                    `INSERT INTO volunteer_assignment_vasg
+                        (vasg_vocc_ID, vasg_vpos_ID, vasg_per_ID, vasg_Status, vasg_Source, vasg_AssignedDate)
+                     VALUES (?, ?, ?, 'pending', 'coordinator', NOW())`,
+                    [f.occWorship, f.posCommunion, PERSON_AMANDA],
+                ).then((err) => {
+                    expect(err.code).to.equal(DUP_ENTRY);
+                });
+            });
+
+            it("allows the same person on TWO positions of one occurrence (I7 / D16)", () => {
+                // The key is (occurrence, position, person) — deliberately not
+                // (occurrence, person). Do not tighten it.
+                dbOk(
+                    `SELECT COUNT(*) AS c FROM volunteer_assignment_vasg
+                      WHERE vasg_vocc_ID = ? AND vasg_per_ID = ?`,
+                    [f.occWorship, PERSON_AMANDA],
+                ).then((rows) => {
+                    expect(Number(rows[0].c)).to.equal(2);
+                });
+            });
+
+            it("rejects a duplicate notification dedupe key (vntf_dedupe_uidx)", () => {
+                dbRejects(
+                    `INSERT INTO volunteer_notification_vntf
+                        (vntf_Type, vntf_Channel, vntf_per_ID, vntf_vasg_ID,
+                         vntf_DedupeKey, vntf_ScheduledFor, vntf_Status)
+                     VALUES ('assignment', 'email', ?, ?, ?, NOW(), 'pending')`,
+                    [
+                        PERSON_AMANDA,
+                        f.asgAmandaCommunion,
+                        `assignment:${f.asgAmandaCommunion}:${PERSON_AMANDA}`,
+                    ],
+                ).then((err) => {
+                    expect(err.code).to.equal(DUP_ENTRY);
+                });
+            });
+
+            it("rejects a duplicate scope grant (vscp_person_scope_uidx)", () => {
+                dbRejects(
+                    `INSERT INTO volunteer_scope_vscp
+                        (vscp_per_ID, vscp_ScopeType, vscp_ScopeId, vscp_GrantedDate)
+                     VALUES (?, 'ministry', ?, NOW())`,
+                    [PERSON_TONY, f.ministryCoffee],
+                ).then((err) => {
+                    expect(err.code).to.equal(DUP_ENTRY);
+                });
+            });
+        });
+
+        describe("Foreign keys", () => {
+            it("rejects a team whose ministry does not exist", () => {
+                dbRejects(
+                    `INSERT INTO volunteer_team_vtem (vtem_vmin_ID, vtem_Name, vtem_Active)
+                     VALUES (999999, 'Orphan Team', 1)`,
+                ).then((err) => {
+                    expect(NO_REFERENCED_ROW).to.include(err.code);
+                });
+            });
+
+            it("rejects a qualification for a person who does not exist", () => {
+                dbRejects(
+                    `INSERT INTO volunteer_qualification_vqal
+                        (vqal_per_ID, vqal_vpos_ID, vqal_Active, vqal_GrantedDate)
+                     VALUES (999999, ?, 1, NOW())`,
+                    [f.posEspresso],
+                ).then((err) => {
+                    expect(NO_REFERENCED_ROW).to.include(err.code);
+                });
+            });
+
+            it("rejects an assignment on an occurrence that does not exist", () => {
+                dbRejects(
+                    `INSERT INTO volunteer_assignment_vasg
+                        (vasg_vocc_ID, vasg_vpos_ID, vasg_per_ID, vasg_Status, vasg_Source, vasg_AssignedDate)
+                     VALUES (999999, ?, ?, 'pending', 'coordinator', NOW())`,
+                    [f.posEspresso, PERSON_TONY],
+                ).then((err) => {
+                    expect(NO_REFERENCED_ROW).to.include(err.code);
+                });
+            });
+
+            it("rejects a pool linked to a group that does not exist", () => {
+                dbRejects(
+                    `INSERT INTO volunteer_pool_vpol (vpol_OwnerType, vpol_OwnerId, vpol_grp_ID)
+                     VALUES ('ministry', ?, 9999)`,
+                    [f.ministryCoffee],
+                ).then((err) => {
+                    expect(NO_REFERENCED_ROW).to.include(err.code);
+                });
+            });
+
+            it("accepts a polymorphic owner id that points at nothing — service-enforced, by design", () => {
+                dbOk(
+                    `INSERT INTO volunteer_pool_vpol (vpol_OwnerType, vpol_OwnerId, vpol_grp_ID)
+                     VALUES ('ministry', 999999, ?)`,
+                    [GROUP_ANGELS],
+                ).then((rows) => {
+                    cy.dbQuery(
+                        `DELETE FROM volunteer_pool_vpol WHERE vpol_ID = ?`,
+                        [rows.insertId],
+                    );
+                });
+            });
+        });
+
+        describe("ON DELETE behaviour", () => {
+            it("cascades assignments when an occurrence is deleted", () => {
+                let occId;
+                let asgId;
+                insertReturningId(
+                    `INSERT INTO volunteer_occurrence_vocc
+                        (vocc_vsch_ID, vocc_OccurrenceDate, vocc_StartDateTime, vocc_Status, vocc_GeneratedDate)
+                     VALUES (?, '2026-10-04', '2026-10-04 10:30:00', 'scheduled', NOW())`,
+                    [f.schedCoffee],
+                )
+                    .then((id) => {
+                        occId = id;
+                        return insertReturningId(
+                            `INSERT INTO volunteer_assignment_vasg
+                                (vasg_vocc_ID, vasg_vpos_ID, vasg_per_ID, vasg_Status, vasg_Source, vasg_AssignedDate)
+                             VALUES (?, ?, ?, 'pending', 'coordinator', NOW())`,
+                            [occId, f.posMilk, PERSON_TONY],
+                        );
+                    })
+                    .then((id) => {
+                        asgId = id;
+                        return dbOk(
+                            `DELETE FROM volunteer_occurrence_vocc WHERE vocc_ID = ?`,
+                            [occId],
+                        );
+                    })
+                    .then(() =>
+                        dbOk(
+                            `SELECT COUNT(*) AS c FROM volunteer_assignment_vasg WHERE vasg_ID = ?`,
+                            [asgId],
+                        ),
+                    )
+                    .then((rows) => {
+                        expect(Number(rows[0].c), "assignment cascaded").to.equal(0);
+                    });
+            });
+
+            it("refuses to delete a position that still has assignments (RESTRICT, §2.6)", () => {
+                dbRejects(
+                    `DELETE FROM volunteer_position_vpos WHERE vpos_ID = ?`,
+                    [f.posEspresso],
+                ).then((err) => {
+                    expect(ROW_IS_REFERENCED).to.include(err.code);
+                });
+            });
+
+            it("nulls vasg_Replaces_vasg_ID when the replaced assignment is deleted", () => {
+                let originalId;
+                let substituteId;
+                insertReturningId(
+                    `INSERT INTO volunteer_assignment_vasg
+                        (vasg_vocc_ID, vasg_vpos_ID, vasg_per_ID, vasg_Status, vasg_Source, vasg_AssignedDate)
+                     VALUES (?, ?, ?, 'substituted', 'coordinator', NOW())`,
+                    [f.occCoffee, f.posMilk, PERSON_TONY],
+                )
+                    .then((id) => {
+                        originalId = id;
+                        return insertReturningId(
+                            `INSERT INTO volunteer_assignment_vasg
+                                (vasg_vocc_ID, vasg_vpos_ID, vasg_per_ID, vasg_Status, vasg_Source,
+                                 vasg_AssignedDate, vasg_Replaces_vasg_ID)
+                             VALUES (?, ?, ?, 'accepted', 'substitute', NOW(), ?)`,
+                            [f.occCoffee, f.posMilk, PERSON_LENA, originalId],
+                        );
+                    })
+                    .then((id) => {
+                        substituteId = id;
+                        return dbOk(
+                            `DELETE FROM volunteer_assignment_vasg WHERE vasg_ID = ?`,
+                            [originalId],
+                        );
+                    })
+                    .then(() =>
+                        dbOk(
+                            `SELECT vasg_Replaces_vasg_ID AS replaces
+                               FROM volunteer_assignment_vasg WHERE vasg_ID = ?`,
+                            [substituteId],
+                        ),
+                    )
+                    .then((rows) => {
+                        expect(rows[0].replaces, "self-FK set to NULL").to.equal(
+                            null,
+                        );
+                        cy.dbQuery(
+                            `DELETE FROM volunteer_assignment_vasg WHERE vasg_ID = ?`,
+                            [substituteId],
+                        );
+                    });
+            });
+
+            it("cascades qualifications, assignments and scopes when a person is deleted", () => {
+                let personId;
+                insertReturningId(
+                    `INSERT INTO person_per (per_FirstName, per_LastName, per_DateEntered)
+                     VALUES ('Cypress', 'V2 Cascade', NOW())`,
+                )
+                    .then((id) => {
+                        personId = id;
+                        return dbOk(
+                            `INSERT INTO volunteer_qualification_vqal
+                                (vqal_per_ID, vqal_vpos_ID, vqal_Active, vqal_GrantedDate)
+                             VALUES (?, ?, 1, NOW())`,
+                            [personId, f.posMilk],
+                        );
+                    })
+                    .then(() =>
+                        dbOk(
+                            `INSERT INTO volunteer_assignment_vasg
+                                (vasg_vocc_ID, vasg_vpos_ID, vasg_per_ID, vasg_Status, vasg_Source, vasg_AssignedDate)
+                             VALUES (?, ?, ?, 'pending', 'coordinator', NOW())`,
+                            [f.occCoffee, f.posMilk, personId],
+                        ),
+                    )
+                    .then(() =>
+                        dbOk(
+                            `INSERT INTO volunteer_scope_vscp
+                                (vscp_per_ID, vscp_ScopeType, vscp_ScopeId, vscp_GrantedDate)
+                             VALUES (?, 'team', ?, NOW())`,
+                            [personId, f.teamCoffee],
+                        ),
+                    )
+                    .then(() =>
+                        dbOk(`DELETE FROM person_per WHERE per_ID = ?`, [
+                            personId,
+                        ]),
+                    )
+                    .then(() =>
+                        dbOk(
+                            `SELECT
+                                (SELECT COUNT(*) FROM volunteer_qualification_vqal WHERE vqal_per_ID = ?) AS quals,
+                                (SELECT COUNT(*) FROM volunteer_assignment_vasg  WHERE vasg_per_ID = ?) AS asgs,
+                                (SELECT COUNT(*) FROM volunteer_scope_vscp       WHERE vscp_per_ID = ?) AS scopes`,
+                            [personId, personId, personId],
+                        ),
+                    )
+                    .then((rows) => {
+                        expect(Number(rows[0].quals), "qualifications").to.equal(0);
+                        expect(Number(rows[0].asgs), "assignments").to.equal(0);
+                        expect(Number(rows[0].scopes), "scopes").to.equal(0);
+                    });
+            });
+
+            it("nulls the granter instead of deleting the grant (SET NULL)", () => {
+                let personId;
+                let qualId;
+                insertReturningId(
+                    `INSERT INTO person_per (per_FirstName, per_LastName, per_DateEntered)
+                     VALUES ('Cypress', 'V2 Granter', NOW())`,
+                )
+                    .then((id) => {
+                        personId = id;
+                        return insertReturningId(
+                            `INSERT INTO volunteer_qualification_vqal
+                                (vqal_per_ID, vqal_vpos_ID, vqal_Active, vqal_GrantedDate, vqal_GrantedBy_per_ID)
+                             VALUES (?, ?, 1, NOW(), ?)`,
+                            [PERSON_LENA, f.posMilk, personId],
+                        );
+                    })
+                    .then((id) => {
+                        qualId = id;
+                        return dbOk(`DELETE FROM person_per WHERE per_ID = ?`, [
+                            personId,
+                        ]);
+                    })
+                    .then(() =>
+                        dbOk(
+                            `SELECT vqal_GrantedBy_per_ID AS granter
+                               FROM volunteer_qualification_vqal WHERE vqal_ID = ?`,
+                            [qualId],
+                        ),
+                    )
+                    .then((rows) => {
+                        expect(rows, "the grant survives").to.have.length(1);
+                        expect(rows[0].granter).to.equal(null);
+                        cy.dbQuery(
+                            `DELETE FROM volunteer_qualification_vqal WHERE vqal_ID = ?`,
+                            [qualId],
+                        );
+                    });
+            });
+        });
+
+        describe("Enum domains", () => {
+            const enumCases = [
+                [
+                    "volunteer_assignment_vasg.vasg_Status",
+                    `INSERT INTO volunteer_assignment_vasg
+                        (vasg_vocc_ID, vasg_vpos_ID, vasg_per_ID, vasg_Status, vasg_Source, vasg_AssignedDate)
+                     VALUES (?, ?, ?, 'not_a_status', 'coordinator', NOW())`,
+                    () => [f.occCoffee, f.posMilk, PERSON_LENA],
+                ],
+                [
+                    "volunteer_response_vrsp.vrsp_Response",
+                    `INSERT INTO volunteer_response_vrsp
+                        (vrsp_vasg_ID, vrsp_per_ID, vrsp_Response, vrsp_ResponseDate, vrsp_Channel)
+                     VALUES (?, ?, 'not_a_response', NOW(), 'web')`,
+                    () => [f.asgAmandaCommunion, PERSON_AMANDA],
+                ],
+                [
+                    "volunteer_scope_vscp.vscp_ScopeType",
+                    `INSERT INTO volunteer_scope_vscp
+                        (vscp_per_ID, vscp_ScopeType, vscp_ScopeId, vscp_GrantedDate)
+                     VALUES (?, 'diocese', ?, NOW())`,
+                    () => [PERSON_LENA, f.ministryCoffee],
+                ],
+                [
+                    "volunteer_notification_vntf.vntf_Type",
+                    `INSERT INTO volunteer_notification_vntf
+                        (vntf_Type, vntf_Channel, vntf_per_ID, vntf_DedupeKey, vntf_ScheduledFor, vntf_Status)
+                     VALUES ('carrier_pigeon', 'email', ?, 'cypress:enum:probe', NOW(), 'pending')`,
+                    () => [PERSON_LENA],
+                ],
+            ];
+
+            enumCases.forEach(([label, sql, params]) => {
+                it(`rejects an unknown value for ${label}`, () => {
+                    // The test database runs MariaDB with STRICT_TRANS_TABLES,
+                    // so an out-of-domain enum value is an error (ER_*_DATA_*).
+                    // Without strict mode MySQL would silently store '' instead,
+                    // so assert whichever this server actually does.
+                    const strict = /STRICT_(TRANS|ALL)_TABLES/.test(sqlMode);
+                    if (strict) {
+                        dbRejects(sql, params()).then((err) => {
+                            expect(
+                                err.message,
+                                `${label} rejected in strict mode`,
+                            ).to.match(/truncated|incorrect|invalid/i);
+                        });
+                    } else {
+                        dbOk(sql, params()).then((rows) => {
+                            cy.log(
+                                `sql_mode is not strict (${sqlMode}) — value was truncated, not rejected`,
+                            );
+                            expect(rows.affectedRows).to.equal(1);
+                        });
+                    }
+                });
+            });
+
+            it("accepts substitute_withdrawn as a response value (§2.12, §2.13)", () => {
+                dbOk(
+                    `INSERT INTO volunteer_response_vrsp
+                        (vrsp_vasg_ID, vrsp_per_ID, vrsp_Response, vrsp_ResponseDate, vrsp_Channel)
+                     VALUES (?, ?, 'substitute_withdrawn', NOW(), 'web')`,
+                    [f.asgAmandaCommunion, PERSON_AMANDA],
+                ).then((rows) => {
+                    cy.dbQuery(
+                        `DELETE FROM volunteer_response_vrsp WHERE vrsp_ID = ?`,
+                        [rows.insertId],
+                    );
+                });
+            });
+        });
+    });
+
+    describe("V1 volunteer data (D7)", () => {
+        it("leaves volunteeropportunity_vol and person2volunteeropp_p2vo untouched", () => {
+            countRows("volunteeropportunity_vol").then((c) => {
+                expect(c, "volunteeropportunity_vol row count").to.equal(
+                    v1CountsBefore.volunteeropportunity_vol,
+                );
+            });
+            countRows("person2volunteeropp_p2vo").then((c) => {
+                expect(c, "person2volunteeropp_p2vo row count").to.equal(
+                    v1CountsBefore.person2volunteeropp_p2vo,
+                );
+            });
+        });
+    });
+});

--- a/cypress/e2e/api/private/standard/private.volunteer.setup.spec.js
+++ b/cypress/e2e/api/private/standard/private.volunteer.setup.spec.js
@@ -890,6 +890,51 @@ describe("API Private Volunteer v2 core schema", () => {
                 });
             });
 
+            // CHECK constraints (MariaDB 10.2.1+ / MySQL 8.0.16+ enforce them; the
+            // CI databases are MariaDB 10.11 and mysql:latest). Error codes differ:
+            // MariaDB 4025 ER_CONSTRAINT_FAILED, MySQL 3819 ER_CHECK_CONSTRAINT_VIOLATED.
+            const CHECK_ERRNOS = [4025, 3819];
+
+            it("accepts a formerly linked occurrence left with no event and no start time (fk_vocc_event SET NULL)", () => {
+                // Why there is deliberately no CHECK on vocc_StartDateTime: see the
+                // comment in the migration. The standalone dedupe key still applies
+                // to rows the generator creates with a start time.
+                dbOk(
+                    `INSERT INTO volunteer_occurrence_vocc
+                        (vocc_vsch_ID, vocc_event_id, vocc_OccurrenceDate, vocc_StartDateTime, vocc_Status, vocc_GeneratedDate)
+                     VALUES (?, NULL, '2026-09-20', NULL, 'scheduled', NOW())`,
+                    [f.schedCoffee],
+                ).then((res) => {
+                    expect(res.insertId).to.be.greaterThan(0);
+                    return dbOk(`DELETE FROM volunteer_occurrence_vocc WHERE vocc_ID = ?`, [res.insertId]);
+                });
+            });
+
+            it("rejects a requirement with neither a schedule nor an occurrence (vreq_one_parent_chk)", () => {
+                dbRejects(
+                    `INSERT INTO volunteer_requirement_vreq
+                        (vreq_vsch_ID, vreq_vocc_ID, vreq_vpos_ID, vreq_MinCount)
+                     VALUES (NULL, NULL, ?, 1)`,
+                    [f.posEspresso],
+                ).then((err) => {
+                    expect(err.errno).to.be.oneOf(CHECK_ERRNOS);
+                });
+            });
+
+            it("rejects a requirement that names both a schedule and an occurrence (vreq_one_parent_chk)", () => {
+                dbOk(`SELECT vocc_ID FROM volunteer_occurrence_vocc WHERE vocc_vsch_ID = ? LIMIT 1`, [f.schedCoffee]).then((rows) => {
+                    expect(rows.length).to.equal(1);
+                    dbRejects(
+                        `INSERT INTO volunteer_requirement_vreq
+                            (vreq_vsch_ID, vreq_vocc_ID, vreq_vpos_ID, vreq_MinCount)
+                         VALUES (?, ?, ?, 1)`,
+                        [f.schedCoffee, rows[0].vocc_ID, f.posEspresso],
+                    ).then((err) => {
+                        expect(err.errno).to.be.oneOf(CHECK_ERRNOS);
+                    });
+                });
+            });
+
             it("rejects a duplicate requirement for one schedule+position (vreq_schedule_position_uidx)", () => {
                 dbRejects(
                     `INSERT INTO volunteer_requirement_vreq

--- a/cypress/support/api-commands.js
+++ b/cypress/support/api-commands.js
@@ -267,3 +267,15 @@ Cypress.Commands.add(
         });
     },
 );
+
+// -- Direct database access (node-side `db:query` task) --
+//
+// Schema-level guarantees — UNIQUE keys, foreign keys and their ON DELETE
+// rules, enum domains — have no HTTP surface, so the Volunteer v2 schema specs
+// assert them against the database itself (#9705). The task resolves with
+// `{ rows, error }` rather than rejecting, so a spec can assert that a write
+// was refused (ER_DUP_ENTRY, ER_NO_REFERENCED_ROW_2, ...) without failing the
+// test run.
+Cypress.Commands.add("dbQuery", (sql, params = []) => {
+    return cy.task("db:query", { sql, params }, { log: false });
+});

--- a/cypress/support/commands.d.ts
+++ b/cypress/support/commands.d.ts
@@ -463,6 +463,29 @@ declare namespace Cypress {
      */
     waitForLocales(timeout?: number): Chainable<void>;
 
+    // ---------------------------------------------------------------
+    // Database commands (cypress/support/api-commands.js)
+    // ---------------------------------------------------------------
+
+    /**
+     * Run a SQL statement against the test database through the node-side
+     * `db:query` task (mysql2). Used to assert schema guarantees that have no
+     * HTTP surface — UNIQUE keys, foreign keys, ON DELETE rules, enum domains.
+     *
+     * Resolves with `{ rows, error }`: driver errors are RETURNED, not thrown,
+     * so a spec can assert that a write was rejected.
+     *
+     * @param sql - SQL statement, with `?` placeholders for params
+     * @param params - Values bound to the `?` placeholders
+     */
+    dbQuery(
+      sql: string,
+      params?: unknown[]
+    ): Chainable<{
+      rows: any;
+      error: { code: string; errno: number; sqlState: string; message: string } | null;
+    }>;
+
     /**
      * Wait for a Notyf notification with specific text
      * Ensures locales are loaded first (for i18next translations) and verifies notification content

--- a/orm/schema.xml
+++ b/orm/schema.xml
@@ -1246,6 +1246,8 @@
         </vendor>
     </table>
 
+    <!-- The SQL files also add CHECK vreq_one_parent_chk: exactly one of vreq_vsch_ID / vreq_vocc_ID is set.
+         Propel cannot express CHECK constraints, so it lives in SQL only. -->
     <table name="volunteer_requirement_vreq" idMethod="native" phpName="VolunteerRequirement"
            description="Volunteer v2: how many people in which position an occurrence needs. Exactly one of the schedule (template) and occurrence (override) columns is set">
         <column name="vreq_ID" phpName="Id" type="INTEGER" primaryKey="true" autoIncrement="true" required="true"/>

--- a/orm/schema.xml
+++ b/orm/schema.xml
@@ -962,4 +962,582 @@
         </vendor>
     </table>
 
+    <!-- ===================================================================
+         Volunteer Management v2 (#9705, epic #9701)
+
+         Thirteen tables covering ministry, team, pool, position,
+         qualification, schedule, occurrence, staffing requirement,
+         assignment, response, swap, notification outbox and scope.
+
+         Conventions (design .agents/skills/churchcrm/volunteer-v2-design.md
+         §2.0): InnoDB, utf8mb4 in SQL, `<prefix>_ID` primary keys named
+         phpName="Id", enums as CHAR + sqlType, BOOLEAN as tinyint(1)
+         unsigned, index names `_idx` / `_uidx`, and foreign-key column types
+         matched to the PARENT column rather than to the inconsistent widths
+         used by person2group2role_p2g2r / event_audience.
+
+         Two columns are deliberately polymorphic and therefore carry no
+         foreign key: volunteer_pool_vpol.vpol_OwnerId and
+         volunteer_scope_vscp.vscp_ScopeId. Referential integrity for those
+         is a service concern, as it already is for record2property_r2p.
+         =================================================================== -->
+
+    <table name="volunteer_ministry_vmin" idMethod="native" phpName="VolunteerMinistry"
+           description="Volunteer v2: an organizational area (Coffee Bar, Worship, Children's Ministry) that owns teams, positions, schedules and coordinator scope">
+        <column name="vmin_ID" phpName="Id" type="INTEGER" primaryKey="true" autoIncrement="true" required="true"/>
+        <column name="vmin_Name" phpName="Name" type="VARCHAR" size="100" required="true"/>
+        <column name="vmin_Description" phpName="Description" type="VARCHAR" size="255"/>
+        <column name="vmin_Active" phpName="Active" type="BOOLEAN" size="1" sqlType="tinyint(1) unsigned"
+                required="true" defaultValue="1"
+                description="Deactivate rather than delete once occurrences exist"/>
+        <column name="vmin_CreatedDate" phpName="CreatedDate" type="TIMESTAMP" required="true"
+                description="Naive wall-clock in sTimeZone"/>
+        <column name="vmin_CreatedBy_per_ID" phpName="CreatedByPersonId" type="SMALLINT" size="9"
+                sqlType="mediumint(9) unsigned"/>
+        <foreign-key foreignTable="person_per" name="VolunteerMinistryCreatedBy" phpName="CreatedByPerson"
+                     refPhpName="CreatedVolunteerMinistry" onDelete="setnull">
+            <reference local="vmin_CreatedBy_per_ID" foreign="per_ID"/>
+        </foreign-key>
+        <unique name="vmin_name_uidx">
+            <unique-column name="vmin_Name"/>
+        </unique>
+        <index name="vmin_active_idx">
+            <index-column name="vmin_Active"/>
+        </index>
+        <index name="vmin_created_by_idx">
+            <index-column name="vmin_CreatedBy_per_ID"/>
+        </index>
+        <vendor type="mysql">
+            <parameter name="Engine" value="InnoDB"/>
+        </vendor>
+    </table>
+
+    <table name="volunteer_team_vtem" idMethod="native" phpName="VolunteerTeam"
+           description="Volunteer v2: an operational team inside a ministry; the finest authorization scope. Exactly one level - ministries are never nested">
+        <column name="vtem_ID" phpName="Id" type="INTEGER" primaryKey="true" autoIncrement="true" required="true"/>
+        <column name="vtem_vmin_ID" phpName="MinistryId" type="INTEGER" required="true"/>
+        <column name="vtem_Name" phpName="Name" type="VARCHAR" size="100" required="true"/>
+        <column name="vtem_Description" phpName="Description" type="VARCHAR" size="255"/>
+        <column name="vtem_Active" phpName="Active" type="BOOLEAN" size="1" sqlType="tinyint(1) unsigned"
+                required="true" defaultValue="1"/>
+        <foreign-key foreignTable="volunteer_ministry_vmin" name="VolunteerTeamMinistry" phpName="Ministry"
+                     refPhpName="VolunteerTeam" onDelete="cascade">
+            <reference local="vtem_vmin_ID" foreign="vmin_ID"/>
+        </foreign-key>
+        <unique name="vtem_ministry_name_uidx">
+            <unique-column name="vtem_vmin_ID"/>
+            <unique-column name="vtem_Name"/>
+        </unique>
+        <index name="vtem_ministry_idx">
+            <index-column name="vtem_vmin_ID"/>
+        </index>
+        <vendor type="mysql">
+            <parameter name="Engine" value="InnoDB"/>
+        </vendor>
+    </table>
+
+    <table name="volunteer_pool_vpol" idMethod="native" phpName="VolunteerPool"
+           description="Volunteer v2: links a ministry or team to an existing ChurchCRM group that acts as its volunteer pool. Stores no people - the group is the roster">
+        <column name="vpol_ID" phpName="Id" type="INTEGER" primaryKey="true" autoIncrement="true" required="true"/>
+        <column name="vpol_OwnerType" phpName="OwnerType" type="CHAR" sqlType="enum('ministry','team')"
+                required="true" description="Which table vpol_OwnerId points at"/>
+        <column name="vpol_OwnerId" phpName="OwnerId" type="INTEGER" required="true"
+                description="vmin_ID or vtem_ID. Polymorphic, so no database foreign key is possible - integrity is enforced in the service layer"/>
+        <column name="vpol_grp_ID" phpName="GroupId" type="SMALLINT" size="8" sqlType="mediumint(8) unsigned"
+                required="true"/>
+        <column name="vpol_Label" phpName="Label" type="VARCHAR" size="100"
+                description="Optional coordinator label, e.g. &quot;Sunday A team&quot;"/>
+        <foreign-key foreignTable="group_grp" name="VolunteerPoolGroup" phpName="Group"
+                     refPhpName="VolunteerPool" onDelete="cascade">
+            <reference local="vpol_grp_ID" foreign="grp_ID"/>
+        </foreign-key>
+        <unique name="vpol_owner_group_uidx">
+            <unique-column name="vpol_OwnerType"/>
+            <unique-column name="vpol_OwnerId"/>
+            <unique-column name="vpol_grp_ID"/>
+        </unique>
+        <index name="vpol_group_idx">
+            <index-column name="vpol_grp_ID"/>
+        </index>
+        <vendor type="mysql">
+            <parameter name="Engine" value="InnoDB"/>
+        </vendor>
+    </table>
+
+    <table name="volunteer_position_vpos" idMethod="native" phpName="VolunteerPosition"
+           description="Volunteer v2: a role a volunteer can serve in (Espresso, Song Leader, Nursery Teacher). Owned by a ministry, optionally narrowed to a team">
+        <column name="vpos_ID" phpName="Id" type="INTEGER" primaryKey="true" autoIncrement="true" required="true"/>
+        <column name="vpos_vmin_ID" phpName="MinistryId" type="INTEGER" required="true"/>
+        <column name="vpos_vtem_ID" phpName="TeamId" type="INTEGER"
+                description="NULL means the position is ministry-wide"/>
+        <column name="vpos_Name" phpName="Name" type="VARCHAR" size="100" required="true"/>
+        <column name="vpos_Description" phpName="Description" type="VARCHAR" size="255"
+                description="Operational requirements for the position, as prose"/>
+        <column name="vpos_Active" phpName="Active" type="BOOLEAN" size="1" sqlType="tinyint(1) unsigned"
+                required="true" defaultValue="1"
+                description="Deactivate rather than delete once assignments exist, so history survives"/>
+        <column name="vpos_Order" phpName="Order" type="INTEGER" required="true" defaultValue="0"
+                description="Display order within the ministry"/>
+        <foreign-key foreignTable="volunteer_ministry_vmin" name="VolunteerPositionMinistry" phpName="Ministry"
+                     refPhpName="VolunteerPosition" onDelete="cascade">
+            <reference local="vpos_vmin_ID" foreign="vmin_ID"/>
+        </foreign-key>
+        <foreign-key foreignTable="volunteer_team_vtem" name="VolunteerPositionTeam" phpName="Team"
+                     refPhpName="VolunteerPosition" onDelete="setnull">
+            <reference local="vpos_vtem_ID" foreign="vtem_ID"/>
+        </foreign-key>
+        <unique name="vpos_ministry_team_name_uidx">
+            <unique-column name="vpos_vmin_ID"/>
+            <unique-column name="vpos_vtem_ID"/>
+            <unique-column name="vpos_Name"/>
+        </unique>
+        <index name="vpos_ministry_active_idx">
+            <index-column name="vpos_vmin_ID"/>
+            <index-column name="vpos_Active"/>
+        </index>
+        <index name="vpos_team_idx">
+            <index-column name="vpos_vtem_ID"/>
+        </index>
+        <vendor type="mysql">
+            <parameter name="Engine" value="InnoDB"/>
+        </vendor>
+    </table>
+
+    <table name="volunteer_qualification_vqal" idMethod="native" phpName="VolunteerQualification"
+           description="Volunteer v2: person-to-position eligibility, many to many. Deliberately not a group role - person2group2role_p2g2r permits only one role per person per group">
+        <column name="vqal_ID" phpName="Id" type="INTEGER" primaryKey="true" autoIncrement="true" required="true"/>
+        <column name="vqal_per_ID" phpName="PersonId" type="SMALLINT" size="9" sqlType="mediumint(9) unsigned"
+                required="true"/>
+        <column name="vqal_vpos_ID" phpName="PositionId" type="INTEGER" required="true"/>
+        <column name="vqal_Active" phpName="Active" type="BOOLEAN" size="1" sqlType="tinyint(1) unsigned"
+                required="true" defaultValue="1"
+                description="Revocation is deactivation, never deletion, so historical assignments stay readable"/>
+        <column name="vqal_GrantedDate" phpName="GrantedDate" type="TIMESTAMP" required="true"/>
+        <column name="vqal_GrantedBy_per_ID" phpName="GrantedByPersonId" type="SMALLINT" size="9"
+                sqlType="mediumint(9) unsigned"/>
+        <column name="vqal_Notes" phpName="Notes" type="VARCHAR" size="255"/>
+        <foreign-key foreignTable="person_per" name="VolunteerQualificationPerson" phpName="Person"
+                     refPhpName="VolunteerQualification" onDelete="cascade">
+            <reference local="vqal_per_ID" foreign="per_ID"/>
+        </foreign-key>
+        <foreign-key foreignTable="volunteer_position_vpos" name="VolunteerQualificationPosition" phpName="Position"
+                     refPhpName="VolunteerQualification" onDelete="cascade">
+            <reference local="vqal_vpos_ID" foreign="vpos_ID"/>
+        </foreign-key>
+        <foreign-key foreignTable="person_per" name="VolunteerQualificationGrantedBy" phpName="GrantedByPerson"
+                     refPhpName="GrantedVolunteerQualification" onDelete="setnull">
+            <reference local="vqal_GrantedBy_per_ID" foreign="per_ID"/>
+        </foreign-key>
+        <unique name="vqal_person_position_uidx">
+            <unique-column name="vqal_per_ID"/>
+            <unique-column name="vqal_vpos_ID"/>
+        </unique>
+        <index name="vqal_position_active_idx">
+            <index-column name="vqal_vpos_ID"/>
+            <index-column name="vqal_Active"/>
+        </index>
+        <index name="vqal_person_idx">
+            <index-column name="vqal_per_ID"/>
+        </index>
+        <index name="vqal_granted_by_idx">
+            <index-column name="vqal_GrantedBy_per_ID"/>
+        </index>
+        <vendor type="mysql">
+            <parameter name="Engine" value="InnoDB"/>
+        </vendor>
+    </table>
+
+    <table name="volunteer_schedule_vsch" idMethod="native" phpName="VolunteerSchedule"
+           description="Volunteer v2: the recurring series V2 owns. Either linked to a ChurchCRM event type, in which case the event occurrences are authoritative, or standalone, in which case V2 generates its own dates">
+        <column name="vsch_ID" phpName="Id" type="INTEGER" primaryKey="true" autoIncrement="true" required="true"/>
+        <column name="vsch_vmin_ID" phpName="MinistryId" type="INTEGER" required="true"/>
+        <column name="vsch_vtem_ID" phpName="TeamId" type="INTEGER"/>
+        <column name="vsch_Name" phpName="Name" type="VARCHAR" size="100" required="true"/>
+        <column name="vsch_LinkMode" phpName="LinkMode" type="CHAR" sqlType="enum('event_type','standalone')"
+                required="true"/>
+        <column name="vsch_event_type_id" phpName="EventTypeId" type="INTEGER"
+                description="Required when LinkMode is event_type"/>
+        <column name="vsch_TitleFilter" phpName="TitleFilter" type="VARCHAR" size="255"
+                description="Optional LIKE narrowing when one event type carries several distinct services"/>
+        <column name="vsch_RecurType" phpName="RecurType" type="CHAR"
+                sqlType="enum('none','weekly','monthly','yearly')" required="true" defaultValue="none"
+                description="Standalone schedules only; a linked schedule never carries its own recurrence"/>
+        <column name="vsch_RecurDOW" phpName="RecurDow" type="CHAR"
+                sqlType="enum('Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday')"/>
+        <column name="vsch_RecurDOM" phpName="RecurDom" type="TINYINT" size="3"/>
+        <column name="vsch_StartTime" phpName="StartTime" type="TIME"/>
+        <column name="vsch_EndTime" phpName="EndTime" type="TIME"/>
+        <column name="vsch_WindowStart" phpName="WindowStart" type="DATE" required="true"
+                description="No occurrence is ever generated before this date"/>
+        <column name="vsch_WindowEnd" phpName="WindowEnd" type="DATE" description="NULL means open ended"/>
+        <column name="vsch_GenerateAheadDays" phpName="GenerateAheadDays" type="INTEGER" required="true"
+                defaultValue="56" description="How far ahead a generation run materialises occurrences"/>
+        <column name="vsch_Active" phpName="Active" type="BOOLEAN" size="1" sqlType="tinyint(1) unsigned"
+                required="true" defaultValue="1"/>
+        <foreign-key foreignTable="volunteer_ministry_vmin" name="VolunteerScheduleMinistry" phpName="Ministry"
+                     refPhpName="VolunteerSchedule" onDelete="cascade">
+            <reference local="vsch_vmin_ID" foreign="vmin_ID"/>
+        </foreign-key>
+        <foreign-key foreignTable="volunteer_team_vtem" name="VolunteerScheduleTeam" phpName="Team"
+                     refPhpName="VolunteerSchedule" onDelete="setnull">
+            <reference local="vsch_vtem_ID" foreign="vtem_ID"/>
+        </foreign-key>
+        <foreign-key foreignTable="event_types" name="VolunteerScheduleEventType" phpName="EventType"
+                     refPhpName="VolunteerSchedule" onDelete="setnull">
+            <reference local="vsch_event_type_id" foreign="type_id"/>
+        </foreign-key>
+        <index name="vsch_ministry_idx">
+            <index-column name="vsch_vmin_ID"/>
+        </index>
+        <index name="vsch_team_idx">
+            <index-column name="vsch_vtem_ID"/>
+        </index>
+        <index name="vsch_type_idx">
+            <index-column name="vsch_event_type_id"/>
+        </index>
+        <index name="vsch_active_window_idx">
+            <index-column name="vsch_Active"/>
+            <index-column name="vsch_WindowStart"/>
+        </index>
+        <vendor type="mysql">
+            <parameter name="Engine" value="InnoDB"/>
+        </vendor>
+    </table>
+
+    <table name="volunteer_occurrence_vocc" idMethod="native" phpName="VolunteerOccurrence"
+           description="Volunteer v2: one concrete opportunity to serve. When linked to an event the start and end times are read lazily from events_event and are NULL here; several occurrences from different schedules may point at the same event">
+        <column name="vocc_ID" phpName="Id" type="INTEGER" primaryKey="true" autoIncrement="true" required="true"/>
+        <column name="vocc_vsch_ID" phpName="ScheduleId" type="INTEGER" required="true"/>
+        <column name="vocc_event_id" phpName="EventId" type="INTEGER"
+                description="When set, events_event is authoritative for date and time"/>
+        <column name="vocc_OccurrenceDate" phpName="OccurrenceDate" type="DATE" required="true"
+                description="Sort and range-filter key. Non-authoritative when the occurrence is linked to an event"/>
+        <column name="vocc_StartDateTime" phpName="StartDateTime" type="TIMESTAMP"
+                description="Standalone occurrences only; naive wall-clock in sTimeZone"/>
+        <column name="vocc_EndDateTime" phpName="EndDateTime" type="TIMESTAMP"/>
+        <column name="vocc_Status" phpName="Status" type="CHAR" sqlType="enum('scheduled','cancelled')"
+                required="true" defaultValue="scheduled"/>
+        <column name="vocc_Notes" phpName="Notes" type="VARCHAR" size="255"/>
+        <column name="vocc_GeneratedDate" phpName="GeneratedDate" type="TIMESTAMP" required="true"/>
+        <foreign-key foreignTable="volunteer_schedule_vsch" name="VolunteerOccurrenceSchedule" phpName="Schedule"
+                     refPhpName="VolunteerOccurrence" onDelete="cascade">
+            <reference local="vocc_vsch_ID" foreign="vsch_ID"/>
+        </foreign-key>
+        <foreign-key foreignTable="events_event" name="VolunteerOccurrenceEvent" phpName="Event"
+                     refPhpName="VolunteerOccurrence" onDelete="setnull">
+            <reference local="vocc_event_id" foreign="event_id"/>
+        </foreign-key>
+        <unique name="vocc_schedule_event_uidx">
+            <unique-column name="vocc_vsch_ID"/>
+            <unique-column name="vocc_event_id"/>
+        </unique>
+        <unique name="vocc_schedule_start_uidx">
+            <unique-column name="vocc_vsch_ID"/>
+            <unique-column name="vocc_StartDateTime"/>
+        </unique>
+        <index name="vocc_date_idx">
+            <index-column name="vocc_OccurrenceDate"/>
+        </index>
+        <index name="vocc_event_idx">
+            <index-column name="vocc_event_id"/>
+        </index>
+        <vendor type="mysql">
+            <parameter name="Engine" value="InnoDB"/>
+        </vendor>
+    </table>
+
+    <table name="volunteer_requirement_vreq" idMethod="native" phpName="VolunteerRequirement"
+           description="Volunteer v2: how many people in which position an occurrence needs. Exactly one of the schedule (template) and occurrence (override) columns is set">
+        <column name="vreq_ID" phpName="Id" type="INTEGER" primaryKey="true" autoIncrement="true" required="true"/>
+        <column name="vreq_vsch_ID" phpName="ScheduleId" type="INTEGER" description="Template level"/>
+        <column name="vreq_vocc_ID" phpName="OccurrenceId" type="INTEGER" description="Per-occurrence override"/>
+        <column name="vreq_vpos_ID" phpName="PositionId" type="INTEGER" required="true"/>
+        <column name="vreq_MinCount" phpName="MinCount" type="INTEGER" required="true" defaultValue="1"
+                description="The number below which a gap exists"/>
+        <column name="vreq_MaxCount" phpName="MaxCount" type="INTEGER"
+                description="NULL means the same as MinCount. Capacity ceiling for self-signup"/>
+        <column name="vreq_Notes" phpName="Notes" type="VARCHAR" size="255"/>
+        <foreign-key foreignTable="volunteer_schedule_vsch" name="VolunteerRequirementSchedule" phpName="Schedule"
+                     refPhpName="VolunteerRequirement" onDelete="cascade">
+            <reference local="vreq_vsch_ID" foreign="vsch_ID"/>
+        </foreign-key>
+        <foreign-key foreignTable="volunteer_occurrence_vocc" name="VolunteerRequirementOccurrence" phpName="Occurrence"
+                     refPhpName="VolunteerRequirement" onDelete="cascade">
+            <reference local="vreq_vocc_ID" foreign="vocc_ID"/>
+        </foreign-key>
+        <foreign-key foreignTable="volunteer_position_vpos" name="VolunteerRequirementPosition" phpName="Position"
+                     refPhpName="VolunteerRequirement" onDelete="cascade">
+            <reference local="vreq_vpos_ID" foreign="vpos_ID"/>
+        </foreign-key>
+        <unique name="vreq_schedule_position_uidx">
+            <unique-column name="vreq_vsch_ID"/>
+            <unique-column name="vreq_vpos_ID"/>
+        </unique>
+        <unique name="vreq_occurrence_position_uidx">
+            <unique-column name="vreq_vocc_ID"/>
+            <unique-column name="vreq_vpos_ID"/>
+        </unique>
+        <index name="vreq_position_idx">
+            <index-column name="vreq_vpos_ID"/>
+        </index>
+        <vendor type="mysql">
+            <parameter name="Engine" value="InnoDB"/>
+        </vendor>
+    </table>
+
+    <table name="volunteer_assignment_vasg" idMethod="native" phpName="VolunteerAssignment"
+           description="Volunteer v2: a person serving a position on an occurrence, with an explicit lifecycle. One row per person per position per occurrence - the same person may hold two different positions on one occurrence">
+        <column name="vasg_ID" phpName="Id" type="INTEGER" primaryKey="true" autoIncrement="true" required="true"/>
+        <column name="vasg_vocc_ID" phpName="OccurrenceId" type="INTEGER" required="true"/>
+        <column name="vasg_vpos_ID" phpName="PositionId" type="INTEGER" required="true"/>
+        <column name="vasg_per_ID" phpName="PersonId" type="SMALLINT" size="9" sqlType="mediumint(9) unsigned"
+                required="true"/>
+        <column name="vasg_vreq_ID" phpName="RequirementId" type="INTEGER"
+                description="Which requirement this fills. Nullable so an assignment survives a requirement being restructured"/>
+        <column name="vasg_Status" phpName="Status" type="CHAR"
+                sqlType="enum('pending','accepted','declined','cancelled','substituted','completed')"
+                required="true" defaultValue="pending"/>
+        <column name="vasg_Source" phpName="Source" type="CHAR"
+                sqlType="enum('coordinator','self_signup','substitute')" required="true" defaultValue="coordinator"/>
+        <column name="vasg_AssignedDate" phpName="AssignedDate" type="TIMESTAMP" required="true"/>
+        <column name="vasg_AssignedBy_per_ID" phpName="AssignedByPersonId" type="SMALLINT" size="9"
+                sqlType="mediumint(9) unsigned" description="NULL for self-signup"/>
+        <column name="vasg_RespondedDate" phpName="RespondedDate" type="TIMESTAMP"
+                description="Denormalised from the latest response row"/>
+        <column name="vasg_Replaces_vasg_ID" phpName="ReplacesAssignmentId" type="INTEGER"
+                description="Links a substitute back to the assignment it replaced"/>
+        <column name="vasg_Notes" phpName="Notes" type="VARCHAR" size="255"/>
+        <foreign-key foreignTable="volunteer_occurrence_vocc" name="VolunteerAssignmentOccurrence" phpName="Occurrence"
+                     refPhpName="VolunteerAssignment" onDelete="cascade">
+            <reference local="vasg_vocc_ID" foreign="vocc_ID"/>
+        </foreign-key>
+        <foreign-key foreignTable="volunteer_position_vpos" name="VolunteerAssignmentPosition" phpName="Position"
+                     refPhpName="VolunteerAssignment" onDelete="restrict">
+            <reference local="vasg_vpos_ID" foreign="vpos_ID"/>
+        </foreign-key>
+        <foreign-key foreignTable="person_per" name="VolunteerAssignmentPerson" phpName="Person"
+                     refPhpName="VolunteerAssignment" onDelete="cascade">
+            <reference local="vasg_per_ID" foreign="per_ID"/>
+        </foreign-key>
+        <foreign-key foreignTable="volunteer_requirement_vreq" name="VolunteerAssignmentRequirement" phpName="Requirement"
+                     refPhpName="VolunteerAssignment" onDelete="setnull">
+            <reference local="vasg_vreq_ID" foreign="vreq_ID"/>
+        </foreign-key>
+        <foreign-key foreignTable="person_per" name="VolunteerAssignmentAssignedBy" phpName="AssignedByPerson"
+                     refPhpName="AssignedVolunteerAssignment" onDelete="setnull">
+            <reference local="vasg_AssignedBy_per_ID" foreign="per_ID"/>
+        </foreign-key>
+        <foreign-key foreignTable="volunteer_assignment_vasg" name="VolunteerAssignmentReplaces"
+                     phpName="ReplacedAssignment" refPhpName="ReplacementAssignment" onDelete="setnull">
+            <reference local="vasg_Replaces_vasg_ID" foreign="vasg_ID"/>
+        </foreign-key>
+        <unique name="vasg_occ_pos_per_uidx">
+            <unique-column name="vasg_vocc_ID"/>
+            <unique-column name="vasg_vpos_ID"/>
+            <unique-column name="vasg_per_ID"/>
+        </unique>
+        <index name="vasg_occurrence_idx">
+            <index-column name="vasg_vocc_ID"/>
+            <index-column name="vasg_Status"/>
+        </index>
+        <index name="vasg_person_status_idx">
+            <index-column name="vasg_per_ID"/>
+            <index-column name="vasg_Status"/>
+        </index>
+        <index name="vasg_position_idx">
+            <index-column name="vasg_vpos_ID"/>
+        </index>
+        <index name="vasg_requirement_idx">
+            <index-column name="vasg_vreq_ID"/>
+        </index>
+        <index name="vasg_assigned_by_idx">
+            <index-column name="vasg_AssignedBy_per_ID"/>
+        </index>
+        <index name="vasg_replaces_idx">
+            <index-column name="vasg_Replaces_vasg_ID"/>
+        </index>
+        <vendor type="mysql">
+            <parameter name="Engine" value="InnoDB"/>
+        </vendor>
+    </table>
+
+    <table name="volunteer_response_vrsp" idMethod="native" phpName="VolunteerResponse"
+           description="Volunteer v2: append-only history of every response to an assignment. Rows are never updated or deleted; vasg_Status is the denormalised current state">
+        <column name="vrsp_ID" phpName="Id" type="INTEGER" primaryKey="true" autoIncrement="true" required="true"/>
+        <column name="vrsp_vasg_ID" phpName="AssignmentId" type="INTEGER" required="true"/>
+        <column name="vrsp_per_ID" phpName="PersonId" type="SMALLINT" size="9" sqlType="mediumint(9) unsigned"
+                required="true" description="Who responded - the volunteer, or a coordinator acting on their behalf"/>
+        <column name="vrsp_Response" phpName="Response" type="CHAR"
+                sqlType="enum('accepted','declined','cancelled','substitute_proposed','substitute_approved','substitute_rejected','substitute_withdrawn')"
+                required="true"/>
+        <column name="vrsp_ResponseDate" phpName="ResponseDate" type="TIMESTAMP" required="true"/>
+        <column name="vrsp_Channel" phpName="Channel" type="CHAR" sqlType="enum('web','coordinator')"
+                required="true" defaultValue="web"/>
+        <column name="vrsp_Comment" phpName="Comment" type="VARCHAR" size="255"/>
+        <foreign-key foreignTable="volunteer_assignment_vasg" name="VolunteerResponseAssignment" phpName="Assignment"
+                     refPhpName="VolunteerResponse" onDelete="cascade">
+            <reference local="vrsp_vasg_ID" foreign="vasg_ID"/>
+        </foreign-key>
+        <foreign-key foreignTable="person_per" name="VolunteerResponsePerson" phpName="Person"
+                     refPhpName="VolunteerResponse" onDelete="cascade">
+            <reference local="vrsp_per_ID" foreign="per_ID"/>
+        </foreign-key>
+        <index name="vrsp_assignment_idx">
+            <index-column name="vrsp_vasg_ID"/>
+            <index-column name="vrsp_ResponseDate"/>
+        </index>
+        <index name="vrsp_person_idx">
+            <index-column name="vrsp_per_ID"/>
+        </index>
+        <vendor type="mysql">
+            <parameter name="Engine" value="InnoDB"/>
+        </vendor>
+    </table>
+
+    <table name="volunteer_swap_vswp" idMethod="native" phpName="VolunteerSwap"
+           description="Volunteer v2: a volunteer proposes a named substitute who has already agreed; a coordinator approves or rejects. Approval never edits the original assignment beyond its status, so the audit trail survives">
+        <column name="vswp_ID" phpName="Id" type="INTEGER" primaryKey="true" autoIncrement="true" required="true"/>
+        <column name="vswp_vasg_ID" phpName="AssignmentId" type="INTEGER" required="true"
+                description="The original assignment being handed over"/>
+        <column name="vswp_ProposedBy_per_ID" phpName="ProposedByPersonId" type="SMALLINT" size="9"
+                sqlType="mediumint(9) unsigned" required="true"/>
+        <column name="vswp_Proposed_per_ID" phpName="ProposedPersonId" type="SMALLINT" size="9"
+                sqlType="mediumint(9) unsigned" required="true" description="The substitute"/>
+        <column name="vswp_Status" phpName="Status" type="CHAR"
+                sqlType="enum('proposed','approved','rejected','withdrawn')" required="true" defaultValue="proposed"/>
+        <column name="vswp_ProposedDate" phpName="ProposedDate" type="TIMESTAMP" required="true"/>
+        <column name="vswp_DecidedDate" phpName="DecidedDate" type="TIMESTAMP"/>
+        <column name="vswp_DecidedBy_per_ID" phpName="DecidedByPersonId" type="SMALLINT" size="9"
+                sqlType="mediumint(9) unsigned"/>
+        <column name="vswp_Comment" phpName="Comment" type="VARCHAR" size="255"/>
+        <foreign-key foreignTable="volunteer_assignment_vasg" name="VolunteerSwapAssignment" phpName="Assignment"
+                     refPhpName="VolunteerSwap" onDelete="cascade">
+            <reference local="vswp_vasg_ID" foreign="vasg_ID"/>
+        </foreign-key>
+        <foreign-key foreignTable="person_per" name="VolunteerSwapProposedBy" phpName="ProposedByPerson"
+                     refPhpName="ProposedVolunteerSwap" onDelete="cascade">
+            <reference local="vswp_ProposedBy_per_ID" foreign="per_ID"/>
+        </foreign-key>
+        <foreign-key foreignTable="person_per" name="VolunteerSwapProposedPerson" phpName="ProposedPerson"
+                     refPhpName="SubstituteVolunteerSwap" onDelete="cascade">
+            <reference local="vswp_Proposed_per_ID" foreign="per_ID"/>
+        </foreign-key>
+        <foreign-key foreignTable="person_per" name="VolunteerSwapDecidedBy" phpName="DecidedByPerson"
+                     refPhpName="DecidedVolunteerSwap" onDelete="setnull">
+            <reference local="vswp_DecidedBy_per_ID" foreign="per_ID"/>
+        </foreign-key>
+        <index name="vswp_assignment_status_idx">
+            <index-column name="vswp_vasg_ID"/>
+            <index-column name="vswp_Status"/>
+        </index>
+        <index name="vswp_proposed_person_idx">
+            <index-column name="vswp_Proposed_per_ID"/>
+        </index>
+        <index name="vswp_proposed_by_idx">
+            <index-column name="vswp_ProposedBy_per_ID"/>
+        </index>
+        <index name="vswp_decided_by_idx">
+            <index-column name="vswp_DecidedBy_per_ID"/>
+        </index>
+        <vendor type="mysql">
+            <parameter name="Engine" value="InnoDB"/>
+        </vendor>
+    </table>
+
+    <table name="volunteer_notification_vntf" idMethod="native" phpName="VolunteerNotification"
+           description="Volunteer v2: the notification outbox. Idempotent enqueue keyed by vntf_DedupeKey, a due time, and a retry-safe send log drained by the background timer jobs">
+        <column name="vntf_ID" phpName="Id" type="INTEGER" primaryKey="true" autoIncrement="true" required="true"/>
+        <column name="vntf_Type" phpName="Type" type="CHAR"
+                sqlType="enum('assignment','reminder','decline_alert','gap_alert','signup_confirm','swap_proposed','swap_resolved')"
+                required="true"/>
+        <column name="vntf_Channel" phpName="Channel" type="CHAR" sqlType="enum('email')" required="true"
+                defaultValue="email" description="The delivery extension point; email is the only channel in the first release"/>
+        <column name="vntf_per_ID" phpName="PersonId" type="SMALLINT" size="9" sqlType="mediumint(9) unsigned"
+                required="true" description="Recipient"/>
+        <column name="vntf_vasg_ID" phpName="AssignmentId" type="INTEGER"/>
+        <column name="vntf_vocc_ID" phpName="OccurrenceId" type="INTEGER"
+                description="Used by gap_alert, which is not assignment scoped"/>
+        <column name="vntf_DedupeKey" phpName="DedupeKey" type="VARCHAR" size="190" required="true"
+                description="190 rather than 255 to stay inside the InnoDB index prefix limit for utf8mb4"/>
+        <column name="vntf_ScheduledFor" phpName="ScheduledFor" type="TIMESTAMP" required="true"
+                description="Naive wall-clock in sTimeZone; now() for immediate messages"/>
+        <column name="vntf_Status" phpName="Status" type="CHAR"
+                sqlType="enum('pending','sent','failed','skipped')" required="true" defaultValue="pending"/>
+        <column name="vntf_Attempts" phpName="Attempts" type="INTEGER" required="true" defaultValue="0"/>
+        <column name="vntf_LastAttemptDate" phpName="LastAttemptDate" type="TIMESTAMP"/>
+        <column name="vntf_SentDate" phpName="SentDate" type="TIMESTAMP"/>
+        <column name="vntf_LastError" phpName="LastError" type="VARCHAR" size="255"/>
+        <foreign-key foreignTable="person_per" name="VolunteerNotificationPerson" phpName="Person"
+                     refPhpName="VolunteerNotification" onDelete="cascade">
+            <reference local="vntf_per_ID" foreign="per_ID"/>
+        </foreign-key>
+        <foreign-key foreignTable="volunteer_assignment_vasg" name="VolunteerNotificationAssignment" phpName="Assignment"
+                     refPhpName="VolunteerNotification" onDelete="cascade">
+            <reference local="vntf_vasg_ID" foreign="vasg_ID"/>
+        </foreign-key>
+        <foreign-key foreignTable="volunteer_occurrence_vocc" name="VolunteerNotificationOccurrence" phpName="Occurrence"
+                     refPhpName="VolunteerNotification" onDelete="cascade">
+            <reference local="vntf_vocc_ID" foreign="vocc_ID"/>
+        </foreign-key>
+        <unique name="vntf_dedupe_uidx">
+            <unique-column name="vntf_DedupeKey"/>
+        </unique>
+        <index name="vntf_due_idx">
+            <index-column name="vntf_Status"/>
+            <index-column name="vntf_ScheduledFor"/>
+        </index>
+        <index name="vntf_assignment_idx">
+            <index-column name="vntf_vasg_ID"/>
+        </index>
+        <index name="vntf_person_idx">
+            <index-column name="vntf_per_ID"/>
+        </index>
+        <index name="vntf_occurrence_idx">
+            <index-column name="vntf_vocc_ID"/>
+        </index>
+        <vendor type="mysql">
+            <parameter name="Engine" value="InnoDB"/>
+        </vendor>
+    </table>
+
+    <table name="volunteer_scope_vscp" idMethod="native" phpName="VolunteerScope"
+           description="Volunteer v2: persists that a person coordinates a ministry or leads a team. Keyed on the person, not the user, so a scope may be granted before the person has a login">
+        <column name="vscp_ID" phpName="Id" type="INTEGER" primaryKey="true" autoIncrement="true" required="true"/>
+        <column name="vscp_per_ID" phpName="PersonId" type="SMALLINT" size="9" sqlType="mediumint(9) unsigned"
+                required="true"/>
+        <column name="vscp_ScopeType" phpName="ScopeType" type="CHAR" sqlType="enum('ministry','team')"
+                required="true"/>
+        <column name="vscp_ScopeId" phpName="ScopeId" type="INTEGER" required="true"
+                description="vmin_ID or vtem_ID. Polymorphic, so no database foreign key is possible - integrity is enforced in the authorization service"/>
+        <column name="vscp_GrantedDate" phpName="GrantedDate" type="TIMESTAMP" required="true"/>
+        <column name="vscp_GrantedBy_per_ID" phpName="GrantedByPersonId" type="SMALLINT" size="9"
+                sqlType="mediumint(9) unsigned"/>
+        <foreign-key foreignTable="person_per" name="VolunteerScopePerson" phpName="Person"
+                     refPhpName="VolunteerScope" onDelete="cascade">
+            <reference local="vscp_per_ID" foreign="per_ID"/>
+        </foreign-key>
+        <foreign-key foreignTable="person_per" name="VolunteerScopeGrantedBy" phpName="GrantedByPerson"
+                     refPhpName="GrantedVolunteerScope" onDelete="setnull">
+            <reference local="vscp_GrantedBy_per_ID" foreign="per_ID"/>
+        </foreign-key>
+        <unique name="vscp_person_scope_uidx">
+            <unique-column name="vscp_per_ID"/>
+            <unique-column name="vscp_ScopeType"/>
+            <unique-column name="vscp_ScopeId"/>
+        </unique>
+        <index name="vscp_person_idx">
+            <index-column name="vscp_per_ID"/>
+        </index>
+        <index name="vscp_scope_idx">
+            <index-column name="vscp_ScopeType"/>
+            <index-column name="vscp_ScopeId"/>
+        </index>
+        <index name="vscp_granted_by_idx">
+            <index-column name="vscp_GrantedBy_per_ID"/>
+        </index>
+        <vendor type="mysql">
+            <parameter name="Engine" value="InnoDB"/>
+        </vendor>
+    </table>
+
 </database>

--- a/src/ChurchCRM/model/ChurchCRM/VolunteerAssignment.php
+++ b/src/ChurchCRM/model/ChurchCRM/VolunteerAssignment.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace ChurchCRM\model\ChurchCRM;
+
+use ChurchCRM\model\ChurchCRM\Base\VolunteerAssignment as BaseVolunteerAssignment;
+
+/**
+ * Skeleton subclass for representing a row from the 'volunteer_assignment_vasg' table.
+ *
+ * Volunteer Management v2 (#9705). A person serving a position on an occurrence, with an explicit lifecycle.
+ *
+ * Deliberately holds no business logic and no pre* authorization hooks: the
+ * Group and Person2group2roleP2g2r models gate saves through AuthService, which
+ * reads $_SESSION flags an API-key caller never sets, so a non-admin coordinator
+ * could not save through the ORM at all. V2 authorizes in middleware and
+ * services instead (#9706).
+ */
+class VolunteerAssignment extends BaseVolunteerAssignment
+{
+    // Lifecycle: pending -> accepted|declined|cancelled;
+    // accepted -> substituted|completed|declined. The terminal states are
+    // declined, cancelled, substituted and completed. Only VolunteerAssignmentService
+    // (#9709) may move a row between them.
+    public const STATUS_PENDING = 'pending';
+    public const STATUS_ACCEPTED = 'accepted';
+    public const STATUS_DECLINED = 'declined';
+    public const STATUS_CANCELLED = 'cancelled';
+    public const STATUS_SUBSTITUTED = 'substituted';
+    public const STATUS_COMPLETED = 'completed';
+
+    /**
+     * Every legal value of vasg_Status.
+     *
+     * @return string[]
+     */
+    public static function allStatuses(): array
+    {
+        return [
+            self::STATUS_PENDING,
+            self::STATUS_ACCEPTED,
+            self::STATUS_DECLINED,
+            self::STATUS_CANCELLED,
+            self::STATUS_SUBSTITUTED,
+            self::STATUS_COMPLETED,
+        ];
+    }
+
+    // Only pending and accepted rows count as live when a gap is derived.
+    public const SOURCE_COORDINATOR = 'coordinator';
+    public const SOURCE_SELF_SIGNUP = 'self_signup';
+    public const SOURCE_SUBSTITUTE = 'substitute';
+
+    /**
+     * Every legal value of vasg_Source.
+     *
+     * @return string[]
+     */
+    public static function allSources(): array
+    {
+        return [
+            self::SOURCE_COORDINATOR,
+            self::SOURCE_SELF_SIGNUP,
+            self::SOURCE_SUBSTITUTE,
+        ];
+    }
+}

--- a/src/ChurchCRM/model/ChurchCRM/VolunteerAssignmentQuery.php
+++ b/src/ChurchCRM/model/ChurchCRM/VolunteerAssignmentQuery.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace ChurchCRM\model\ChurchCRM;
+
+use ChurchCRM\model\ChurchCRM\Base\VolunteerAssignmentQuery as BaseVolunteerAssignmentQuery;
+
+/**
+ * Skeleton subclass for performing query and update operations on the 'volunteer_assignment_vasg' table.
+ *
+ * Volunteer Management v2 (#9705).
+ */
+class VolunteerAssignmentQuery extends BaseVolunteerAssignmentQuery
+{
+}

--- a/src/ChurchCRM/model/ChurchCRM/VolunteerMinistry.php
+++ b/src/ChurchCRM/model/ChurchCRM/VolunteerMinistry.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace ChurchCRM\model\ChurchCRM;
+
+use ChurchCRM\model\ChurchCRM\Base\VolunteerMinistry as BaseVolunteerMinistry;
+
+/**
+ * Skeleton subclass for representing a row from the 'volunteer_ministry_vmin' table.
+ *
+ * Volunteer Management v2 (#9705). An organizational area that owns teams, positions, schedules and coordinator scope.
+ *
+ * Deliberately holds no business logic and no pre* authorization hooks: the
+ * Group and Person2group2roleP2g2r models gate saves through AuthService, which
+ * reads $_SESSION flags an API-key caller never sets, so a non-admin coordinator
+ * could not save through the ORM at all. V2 authorizes in middleware and
+ * services instead (#9706).
+ */
+class VolunteerMinistry extends BaseVolunteerMinistry
+{
+}

--- a/src/ChurchCRM/model/ChurchCRM/VolunteerMinistryQuery.php
+++ b/src/ChurchCRM/model/ChurchCRM/VolunteerMinistryQuery.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace ChurchCRM\model\ChurchCRM;
+
+use ChurchCRM\model\ChurchCRM\Base\VolunteerMinistryQuery as BaseVolunteerMinistryQuery;
+
+/**
+ * Skeleton subclass for performing query and update operations on the 'volunteer_ministry_vmin' table.
+ *
+ * Volunteer Management v2 (#9705).
+ */
+class VolunteerMinistryQuery extends BaseVolunteerMinistryQuery
+{
+}

--- a/src/ChurchCRM/model/ChurchCRM/VolunteerNotification.php
+++ b/src/ChurchCRM/model/ChurchCRM/VolunteerNotification.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace ChurchCRM\model\ChurchCRM;
+
+use ChurchCRM\model\ChurchCRM\Base\VolunteerNotification as BaseVolunteerNotification;
+
+/**
+ * Skeleton subclass for representing a row from the 'volunteer_notification_vntf' table.
+ *
+ * Volunteer Management v2 (#9705). The notification outbox: idempotent enqueue, a due time and a retry-safe send log.
+ *
+ * Deliberately holds no business logic and no pre* authorization hooks: the
+ * Group and Person2group2roleP2g2r models gate saves through AuthService, which
+ * reads $_SESSION flags an API-key caller never sets, so a non-admin coordinator
+ * could not save through the ORM at all. V2 authorizes in middleware and
+ * services instead (#9706).
+ */
+class VolunteerNotification extends BaseVolunteerNotification
+{
+    // Each type maps to one email template.
+    public const TYPE_ASSIGNMENT = 'assignment';
+    public const TYPE_REMINDER = 'reminder';
+    public const TYPE_DECLINE_ALERT = 'decline_alert';
+    public const TYPE_GAP_ALERT = 'gap_alert';
+    public const TYPE_SIGNUP_CONFIRM = 'signup_confirm';
+    public const TYPE_SWAP_PROPOSED = 'swap_proposed';
+    public const TYPE_SWAP_RESOLVED = 'swap_resolved';
+
+    /**
+     * Every legal value of vntf_Type.
+     *
+     * @return string[]
+     */
+    public static function allTypes(): array
+    {
+        return [
+            self::TYPE_ASSIGNMENT,
+            self::TYPE_REMINDER,
+            self::TYPE_DECLINE_ALERT,
+            self::TYPE_GAP_ALERT,
+            self::TYPE_SIGNUP_CONFIRM,
+            self::TYPE_SWAP_PROPOSED,
+            self::TYPE_SWAP_RESOLVED,
+        ];
+    }
+
+    // 'failed' means the drain gave up after the retry limit, never 'will retry';
+    // 'skipped' means delivery was deliberately not attempted.
+    public const STATUS_PENDING = 'pending';
+    public const STATUS_SENT = 'sent';
+    public const STATUS_FAILED = 'failed';
+    public const STATUS_SKIPPED = 'skipped';
+
+    /**
+     * Every legal value of vntf_Status.
+     *
+     * @return string[]
+     */
+    public static function allStatuses(): array
+    {
+        return [
+            self::STATUS_PENDING,
+            self::STATUS_SENT,
+            self::STATUS_FAILED,
+            self::STATUS_SKIPPED,
+        ];
+    }
+
+    // The delivery extension point; email is the only channel in the first release.
+    public const CHANNEL_EMAIL = 'email';
+
+    /**
+     * Every legal value of vntf_Channel.
+     *
+     * @return string[]
+     */
+    public static function allChannels(): array
+    {
+        return [
+            self::CHANNEL_EMAIL,
+        ];
+    }
+}

--- a/src/ChurchCRM/model/ChurchCRM/VolunteerNotificationQuery.php
+++ b/src/ChurchCRM/model/ChurchCRM/VolunteerNotificationQuery.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace ChurchCRM\model\ChurchCRM;
+
+use ChurchCRM\model\ChurchCRM\Base\VolunteerNotificationQuery as BaseVolunteerNotificationQuery;
+
+/**
+ * Skeleton subclass for performing query and update operations on the 'volunteer_notification_vntf' table.
+ *
+ * Volunteer Management v2 (#9705).
+ */
+class VolunteerNotificationQuery extends BaseVolunteerNotificationQuery
+{
+}

--- a/src/ChurchCRM/model/ChurchCRM/VolunteerOccurrence.php
+++ b/src/ChurchCRM/model/ChurchCRM/VolunteerOccurrence.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ChurchCRM\model\ChurchCRM;
+
+use ChurchCRM\model\ChurchCRM\Base\VolunteerOccurrence as BaseVolunteerOccurrence;
+
+/**
+ * Skeleton subclass for representing a row from the 'volunteer_occurrence_vocc' table.
+ *
+ * Volunteer Management v2 (#9705). One concrete opportunity to serve; the row assignments hang off.
+ *
+ * Deliberately holds no business logic and no pre* authorization hooks: the
+ * Group and Person2group2roleP2g2r models gate saves through AuthService, which
+ * reads $_SESSION flags an API-key caller never sets, so a non-admin coordinator
+ * could not save through the ORM at all. V2 authorizes in middleware and
+ * services instead (#9706).
+ */
+class VolunteerOccurrence extends BaseVolunteerOccurrence
+{
+    // A coordinator may cancel a single occurrence without touching the schedule.
+    public const STATUS_SCHEDULED = 'scheduled';
+    public const STATUS_CANCELLED = 'cancelled';
+
+    /**
+     * Every legal value of vocc_Status.
+     *
+     * @return string[]
+     */
+    public static function allStatuses(): array
+    {
+        return [
+            self::STATUS_SCHEDULED,
+            self::STATUS_CANCELLED,
+        ];
+    }
+}

--- a/src/ChurchCRM/model/ChurchCRM/VolunteerOccurrenceQuery.php
+++ b/src/ChurchCRM/model/ChurchCRM/VolunteerOccurrenceQuery.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace ChurchCRM\model\ChurchCRM;
+
+use ChurchCRM\model\ChurchCRM\Base\VolunteerOccurrenceQuery as BaseVolunteerOccurrenceQuery;
+
+/**
+ * Skeleton subclass for performing query and update operations on the 'volunteer_occurrence_vocc' table.
+ *
+ * Volunteer Management v2 (#9705).
+ */
+class VolunteerOccurrenceQuery extends BaseVolunteerOccurrenceQuery
+{
+}

--- a/src/ChurchCRM/model/ChurchCRM/VolunteerPool.php
+++ b/src/ChurchCRM/model/ChurchCRM/VolunteerPool.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ChurchCRM\model\ChurchCRM;
+
+use ChurchCRM\model\ChurchCRM\Base\VolunteerPool as BaseVolunteerPool;
+
+/**
+ * Skeleton subclass for representing a row from the 'volunteer_pool_vpol' table.
+ *
+ * Volunteer Management v2 (#9705). Links a ministry or team to an existing group that acts as its volunteer pool.
+ *
+ * Deliberately holds no business logic and no pre* authorization hooks: the
+ * Group and Person2group2roleP2g2r models gate saves through AuthService, which
+ * reads $_SESSION flags an API-key caller never sets, so a non-admin coordinator
+ * could not save through the ORM at all. V2 authorizes in middleware and
+ * services instead (#9706).
+ */
+class VolunteerPool extends BaseVolunteerPool
+{
+    // The owner of a pool is polymorphic, so vpol_OwnerId carries no foreign
+    // key; VolunteerSetupService resolves it against one of these two tables.
+    public const OWNER_TYPE_MINISTRY = 'ministry';
+    public const OWNER_TYPE_TEAM = 'team';
+
+    /**
+     * Every legal value of vpol_OwnerType.
+     *
+     * @return string[]
+     */
+    public static function allOwnerTypes(): array
+    {
+        return [
+            self::OWNER_TYPE_MINISTRY,
+            self::OWNER_TYPE_TEAM,
+        ];
+    }
+}

--- a/src/ChurchCRM/model/ChurchCRM/VolunteerPoolQuery.php
+++ b/src/ChurchCRM/model/ChurchCRM/VolunteerPoolQuery.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace ChurchCRM\model\ChurchCRM;
+
+use ChurchCRM\model\ChurchCRM\Base\VolunteerPoolQuery as BaseVolunteerPoolQuery;
+
+/**
+ * Skeleton subclass for performing query and update operations on the 'volunteer_pool_vpol' table.
+ *
+ * Volunteer Management v2 (#9705).
+ */
+class VolunteerPoolQuery extends BaseVolunteerPoolQuery
+{
+}

--- a/src/ChurchCRM/model/ChurchCRM/VolunteerPosition.php
+++ b/src/ChurchCRM/model/ChurchCRM/VolunteerPosition.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace ChurchCRM\model\ChurchCRM;
+
+use ChurchCRM\model\ChurchCRM\Base\VolunteerPosition as BaseVolunteerPosition;
+
+/**
+ * Skeleton subclass for representing a row from the 'volunteer_position_vpos' table.
+ *
+ * Volunteer Management v2 (#9705). A role a volunteer can serve in, owned by a ministry and optionally narrowed to a team.
+ *
+ * Deliberately holds no business logic and no pre* authorization hooks: the
+ * Group and Person2group2roleP2g2r models gate saves through AuthService, which
+ * reads $_SESSION flags an API-key caller never sets, so a non-admin coordinator
+ * could not save through the ORM at all. V2 authorizes in middleware and
+ * services instead (#9706).
+ */
+class VolunteerPosition extends BaseVolunteerPosition
+{
+}

--- a/src/ChurchCRM/model/ChurchCRM/VolunteerPositionQuery.php
+++ b/src/ChurchCRM/model/ChurchCRM/VolunteerPositionQuery.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace ChurchCRM\model\ChurchCRM;
+
+use ChurchCRM\model\ChurchCRM\Base\VolunteerPositionQuery as BaseVolunteerPositionQuery;
+
+/**
+ * Skeleton subclass for performing query and update operations on the 'volunteer_position_vpos' table.
+ *
+ * Volunteer Management v2 (#9705).
+ */
+class VolunteerPositionQuery extends BaseVolunteerPositionQuery
+{
+}

--- a/src/ChurchCRM/model/ChurchCRM/VolunteerQualification.php
+++ b/src/ChurchCRM/model/ChurchCRM/VolunteerQualification.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace ChurchCRM\model\ChurchCRM;
+
+use ChurchCRM\model\ChurchCRM\Base\VolunteerQualification as BaseVolunteerQualification;
+
+/**
+ * Skeleton subclass for representing a row from the 'volunteer_qualification_vqal' table.
+ *
+ * Volunteer Management v2 (#9705). Person-to-position eligibility, many to many. Revocation is deactivation, never deletion.
+ *
+ * Deliberately holds no business logic and no pre* authorization hooks: the
+ * Group and Person2group2roleP2g2r models gate saves through AuthService, which
+ * reads $_SESSION flags an API-key caller never sets, so a non-admin coordinator
+ * could not save through the ORM at all. V2 authorizes in middleware and
+ * services instead (#9706).
+ */
+class VolunteerQualification extends BaseVolunteerQualification
+{
+}

--- a/src/ChurchCRM/model/ChurchCRM/VolunteerQualificationQuery.php
+++ b/src/ChurchCRM/model/ChurchCRM/VolunteerQualificationQuery.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace ChurchCRM\model\ChurchCRM;
+
+use ChurchCRM\model\ChurchCRM\Base\VolunteerQualificationQuery as BaseVolunteerQualificationQuery;
+
+/**
+ * Skeleton subclass for performing query and update operations on the 'volunteer_qualification_vqal' table.
+ *
+ * Volunteer Management v2 (#9705).
+ */
+class VolunteerQualificationQuery extends BaseVolunteerQualificationQuery
+{
+}

--- a/src/ChurchCRM/model/ChurchCRM/VolunteerRequirement.php
+++ b/src/ChurchCRM/model/ChurchCRM/VolunteerRequirement.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace ChurchCRM\model\ChurchCRM;
+
+use ChurchCRM\model\ChurchCRM\Base\VolunteerRequirement as BaseVolunteerRequirement;
+
+/**
+ * Skeleton subclass for representing a row from the 'volunteer_requirement_vreq' table.
+ *
+ * Volunteer Management v2 (#9705). How many people in which position an occurrence needs, at schedule or occurrence level.
+ *
+ * Deliberately holds no business logic and no pre* authorization hooks: the
+ * Group and Person2group2roleP2g2r models gate saves through AuthService, which
+ * reads $_SESSION flags an API-key caller never sets, so a non-admin coordinator
+ * could not save through the ORM at all. V2 authorizes in middleware and
+ * services instead (#9706).
+ */
+class VolunteerRequirement extends BaseVolunteerRequirement
+{
+}

--- a/src/ChurchCRM/model/ChurchCRM/VolunteerRequirementQuery.php
+++ b/src/ChurchCRM/model/ChurchCRM/VolunteerRequirementQuery.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace ChurchCRM\model\ChurchCRM;
+
+use ChurchCRM\model\ChurchCRM\Base\VolunteerRequirementQuery as BaseVolunteerRequirementQuery;
+
+/**
+ * Skeleton subclass for performing query and update operations on the 'volunteer_requirement_vreq' table.
+ *
+ * Volunteer Management v2 (#9705).
+ */
+class VolunteerRequirementQuery extends BaseVolunteerRequirementQuery
+{
+}

--- a/src/ChurchCRM/model/ChurchCRM/VolunteerResponse.php
+++ b/src/ChurchCRM/model/ChurchCRM/VolunteerResponse.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace ChurchCRM\model\ChurchCRM;
+
+use ChurchCRM\model\ChurchCRM\Base\VolunteerResponse as BaseVolunteerResponse;
+
+/**
+ * Skeleton subclass for representing a row from the 'volunteer_response_vrsp' table.
+ *
+ * Volunteer Management v2 (#9705). Append-only history of every response to an assignment. Rows are never updated or deleted.
+ *
+ * Deliberately holds no business logic and no pre* authorization hooks: the
+ * Group and Person2group2roleP2g2r models gate saves through AuthService, which
+ * reads $_SESSION flags an API-key caller never sets, so a non-admin coordinator
+ * could not save through the ORM at all. V2 authorizes in middleware and
+ * services instead (#9706).
+ */
+class VolunteerResponse extends BaseVolunteerResponse
+{
+    // One value per swap outcome, so every swap state transition leaves a row.
+    public const RESPONSE_ACCEPTED = 'accepted';
+    public const RESPONSE_DECLINED = 'declined';
+    public const RESPONSE_CANCELLED = 'cancelled';
+    public const RESPONSE_SUBSTITUTE_PROPOSED = 'substitute_proposed';
+    public const RESPONSE_SUBSTITUTE_APPROVED = 'substitute_approved';
+    public const RESPONSE_SUBSTITUTE_REJECTED = 'substitute_rejected';
+    public const RESPONSE_SUBSTITUTE_WITHDRAWN = 'substitute_withdrawn';
+
+    /**
+     * Every legal value of vrsp_Response.
+     *
+     * @return string[]
+     */
+    public static function allResponses(): array
+    {
+        return [
+            self::RESPONSE_ACCEPTED,
+            self::RESPONSE_DECLINED,
+            self::RESPONSE_CANCELLED,
+            self::RESPONSE_SUBSTITUTE_PROPOSED,
+            self::RESPONSE_SUBSTITUTE_APPROVED,
+            self::RESPONSE_SUBSTITUTE_REJECTED,
+            self::RESPONSE_SUBSTITUTE_WITHDRAWN,
+        ];
+    }
+
+    // 'email_token' is reserved for the future tokenized-link extension and is
+    // deliberately not part of the enum yet.
+    public const CHANNEL_WEB = 'web';
+    public const CHANNEL_COORDINATOR = 'coordinator';
+
+    /**
+     * Every legal value of vrsp_Channel.
+     *
+     * @return string[]
+     */
+    public static function allChannels(): array
+    {
+        return [
+            self::CHANNEL_WEB,
+            self::CHANNEL_COORDINATOR,
+        ];
+    }
+}

--- a/src/ChurchCRM/model/ChurchCRM/VolunteerResponseQuery.php
+++ b/src/ChurchCRM/model/ChurchCRM/VolunteerResponseQuery.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace ChurchCRM\model\ChurchCRM;
+
+use ChurchCRM\model\ChurchCRM\Base\VolunteerResponseQuery as BaseVolunteerResponseQuery;
+
+/**
+ * Skeleton subclass for performing query and update operations on the 'volunteer_response_vrsp' table.
+ *
+ * Volunteer Management v2 (#9705).
+ */
+class VolunteerResponseQuery extends BaseVolunteerResponseQuery
+{
+}

--- a/src/ChurchCRM/model/ChurchCRM/VolunteerSchedule.php
+++ b/src/ChurchCRM/model/ChurchCRM/VolunteerSchedule.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace ChurchCRM\model\ChurchCRM;
+
+use ChurchCRM\model\ChurchCRM\Base\VolunteerSchedule as BaseVolunteerSchedule;
+
+/**
+ * Skeleton subclass for representing a row from the 'volunteer_schedule_vsch' table.
+ *
+ * Volunteer Management v2 (#9705). The recurring series V2 owns: either linked to an event type or standalone.
+ *
+ * Deliberately holds no business logic and no pre* authorization hooks: the
+ * Group and Person2group2roleP2g2r models gate saves through AuthService, which
+ * reads $_SESSION flags an API-key caller never sets, so a non-admin coordinator
+ * could not save through the ORM at all. V2 authorizes in middleware and
+ * services instead (#9706).
+ */
+class VolunteerSchedule extends BaseVolunteerSchedule
+{
+    // A linked schedule never carries its own recurrence - the event
+    // occurrences are authoritative. Only standalone schedules recur here.
+    public const LINK_MODE_EVENT_TYPE = 'event_type';
+    public const LINK_MODE_STANDALONE = 'standalone';
+
+    /**
+     * Every legal value of vsch_LinkMode.
+     *
+     * @return string[]
+     */
+    public static function allLinkModes(): array
+    {
+        return [
+            self::LINK_MODE_EVENT_TYPE,
+            self::LINK_MODE_STANDALONE,
+        ];
+    }
+
+    public const RECUR_NONE = 'none';
+    public const RECUR_WEEKLY = 'weekly';
+    public const RECUR_MONTHLY = 'monthly';
+    public const RECUR_YEARLY = 'yearly';
+
+    /**
+     * Every legal value of vsch_RecurType.
+     *
+     * @return string[]
+     */
+    public static function allRecurTypes(): array
+    {
+        return [
+            self::RECUR_NONE,
+            self::RECUR_WEEKLY,
+            self::RECUR_MONTHLY,
+            self::RECUR_YEARLY,
+        ];
+    }
+
+    // Same value domain as event_types.type_defrecurDOW.
+    public const DOW_SUNDAY = 'Sunday';
+    public const DOW_MONDAY = 'Monday';
+    public const DOW_TUESDAY = 'Tuesday';
+    public const DOW_WEDNESDAY = 'Wednesday';
+    public const DOW_THURSDAY = 'Thursday';
+    public const DOW_FRIDAY = 'Friday';
+    public const DOW_SATURDAY = 'Saturday';
+
+    /**
+     * Every legal value of vsch_RecurDOW.
+     *
+     * @return string[]
+     */
+    public static function allRecurDows(): array
+    {
+        return [
+            self::DOW_SUNDAY,
+            self::DOW_MONDAY,
+            self::DOW_TUESDAY,
+            self::DOW_WEDNESDAY,
+            self::DOW_THURSDAY,
+            self::DOW_FRIDAY,
+            self::DOW_SATURDAY,
+        ];
+    }
+}

--- a/src/ChurchCRM/model/ChurchCRM/VolunteerScheduleQuery.php
+++ b/src/ChurchCRM/model/ChurchCRM/VolunteerScheduleQuery.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace ChurchCRM\model\ChurchCRM;
+
+use ChurchCRM\model\ChurchCRM\Base\VolunteerScheduleQuery as BaseVolunteerScheduleQuery;
+
+/**
+ * Skeleton subclass for performing query and update operations on the 'volunteer_schedule_vsch' table.
+ *
+ * Volunteer Management v2 (#9705).
+ */
+class VolunteerScheduleQuery extends BaseVolunteerScheduleQuery
+{
+}

--- a/src/ChurchCRM/model/ChurchCRM/VolunteerScope.php
+++ b/src/ChurchCRM/model/ChurchCRM/VolunteerScope.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ChurchCRM\model\ChurchCRM;
+
+use ChurchCRM\model\ChurchCRM\Base\VolunteerScope as BaseVolunteerScope;
+
+/**
+ * Skeleton subclass for representing a row from the 'volunteer_scope_vscp' table.
+ *
+ * Volunteer Management v2 (#9705). Persists that a person coordinates a ministry or leads a team.
+ *
+ * Deliberately holds no business logic and no pre* authorization hooks: the
+ * Group and Person2group2roleP2g2r models gate saves through AuthService, which
+ * reads $_SESSION flags an API-key caller never sets, so a non-admin coordinator
+ * could not save through the ORM at all. V2 authorizes in middleware and
+ * services instead (#9706).
+ */
+class VolunteerScope extends BaseVolunteerScope
+{
+    // vscp_ScopeId is polymorphic and therefore carries no foreign key;
+    // VolunteerAuthorizationService resolves it against one of these two tables.
+    public const TYPE_MINISTRY = 'ministry';
+    public const TYPE_TEAM = 'team';
+
+    /**
+     * Every legal value of vscp_ScopeType.
+     *
+     * @return string[]
+     */
+    public static function allScopeTypes(): array
+    {
+        return [
+            self::TYPE_MINISTRY,
+            self::TYPE_TEAM,
+        ];
+    }
+}

--- a/src/ChurchCRM/model/ChurchCRM/VolunteerScopeQuery.php
+++ b/src/ChurchCRM/model/ChurchCRM/VolunteerScopeQuery.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace ChurchCRM\model\ChurchCRM;
+
+use ChurchCRM\model\ChurchCRM\Base\VolunteerScopeQuery as BaseVolunteerScopeQuery;
+
+/**
+ * Skeleton subclass for performing query and update operations on the 'volunteer_scope_vscp' table.
+ *
+ * Volunteer Management v2 (#9705).
+ */
+class VolunteerScopeQuery extends BaseVolunteerScopeQuery
+{
+}

--- a/src/ChurchCRM/model/ChurchCRM/VolunteerSwap.php
+++ b/src/ChurchCRM/model/ChurchCRM/VolunteerSwap.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace ChurchCRM\model\ChurchCRM;
+
+use ChurchCRM\model\ChurchCRM\Base\VolunteerSwap as BaseVolunteerSwap;
+
+/**
+ * Skeleton subclass for representing a row from the 'volunteer_swap_vswp' table.
+ *
+ * Volunteer Management v2 (#9705). A proposed substitute who has already agreed, plus the coordinator decision.
+ *
+ * Deliberately holds no business logic and no pre* authorization hooks: the
+ * Group and Person2group2roleP2g2r models gate saves through AuthService, which
+ * reads $_SESSION flags an API-key caller never sets, so a non-admin coordinator
+ * could not save through the ORM at all. V2 authorizes in middleware and
+ * services instead (#9706).
+ */
+class VolunteerSwap extends BaseVolunteerSwap
+{
+    // proposed -> approved | rejected | withdrawn, all terminal. Withdrawn is
+    // reachable only by the proposer and leaves the original assignment accepted.
+    public const STATUS_PROPOSED = 'proposed';
+    public const STATUS_APPROVED = 'approved';
+    public const STATUS_REJECTED = 'rejected';
+    public const STATUS_WITHDRAWN = 'withdrawn';
+
+    /**
+     * Every legal value of vswp_Status.
+     *
+     * @return string[]
+     */
+    public static function allStatuses(): array
+    {
+        return [
+            self::STATUS_PROPOSED,
+            self::STATUS_APPROVED,
+            self::STATUS_REJECTED,
+            self::STATUS_WITHDRAWN,
+        ];
+    }
+}

--- a/src/ChurchCRM/model/ChurchCRM/VolunteerSwapQuery.php
+++ b/src/ChurchCRM/model/ChurchCRM/VolunteerSwapQuery.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace ChurchCRM\model\ChurchCRM;
+
+use ChurchCRM\model\ChurchCRM\Base\VolunteerSwapQuery as BaseVolunteerSwapQuery;
+
+/**
+ * Skeleton subclass for performing query and update operations on the 'volunteer_swap_vswp' table.
+ *
+ * Volunteer Management v2 (#9705).
+ */
+class VolunteerSwapQuery extends BaseVolunteerSwapQuery
+{
+}

--- a/src/ChurchCRM/model/ChurchCRM/VolunteerTeam.php
+++ b/src/ChurchCRM/model/ChurchCRM/VolunteerTeam.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace ChurchCRM\model\ChurchCRM;
+
+use ChurchCRM\model\ChurchCRM\Base\VolunteerTeam as BaseVolunteerTeam;
+
+/**
+ * Skeleton subclass for representing a row from the 'volunteer_team_vtem' table.
+ *
+ * Volunteer Management v2 (#9705). An operational team inside a ministry. Exactly one level - ministries are never nested.
+ *
+ * Deliberately holds no business logic and no pre* authorization hooks: the
+ * Group and Person2group2roleP2g2r models gate saves through AuthService, which
+ * reads $_SESSION flags an API-key caller never sets, so a non-admin coordinator
+ * could not save through the ORM at all. V2 authorizes in middleware and
+ * services instead (#9706).
+ */
+class VolunteerTeam extends BaseVolunteerTeam
+{
+}

--- a/src/ChurchCRM/model/ChurchCRM/VolunteerTeamQuery.php
+++ b/src/ChurchCRM/model/ChurchCRM/VolunteerTeamQuery.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace ChurchCRM\model\ChurchCRM;
+
+use ChurchCRM\model\ChurchCRM\Base\VolunteerTeamQuery as BaseVolunteerTeamQuery;
+
+/**
+ * Skeleton subclass for performing query and update operations on the 'volunteer_team_vtem' table.
+ *
+ * Volunteer Management v2 (#9705).
+ */
+class VolunteerTeamQuery extends BaseVolunteerTeamQuery
+{
+}

--- a/src/mysql/install/Install.sql
+++ b/src/mysql/install/Install.sql
@@ -1112,7 +1112,7 @@ CREATE TABLE `pledge_denominations_pdem` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 --
--- Volunteer Management v2 (#9705) - mirrors src/mysql/upgrade/7.7.0-volunteer-v2-schema.sql
+-- Volunteer Management v2 (#9705) - mirrors src/mysql/upgrade/7.8.0-volunteer-v2-schema.sql
 -- Ordered so that every foreign-key target already exists.
 --
 

--- a/src/mysql/install/Install.sql
+++ b/src/mysql/install/Install.sql
@@ -1273,6 +1273,12 @@ CREATE TABLE `volunteer_occurrence_vocc` (
       REFERENCES `volunteer_schedule_vsch` (`vsch_ID`) ON DELETE CASCADE,
   CONSTRAINT `fk_vocc_event` FOREIGN KEY (`vocc_event_id`)
       REFERENCES `events_event` (`event_id`) ON DELETE SET NULL
+  -- No CHECK "standalone rows must have a start time": once fk_vocc_event has
+  -- SET NULL a deleted event, a formerly linked row legitimately has neither an
+  -- event nor a start time (its date lives in vocc_OccurrenceDate), and MariaDB
+  -- refuses a CHECK on a column an FK action can change anyway. The generator
+  -- (VolunteerScheduleService, #9708) always sets vocc_StartDateTime for
+  -- standalone schedules; vocc_schedule_start_uidx deduplicates those rows.
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 --
@@ -1296,7 +1302,12 @@ CREATE TABLE `volunteer_requirement_vreq` (
   CONSTRAINT `fk_vreq_occurrence` FOREIGN KEY (`vreq_vocc_ID`)
       REFERENCES `volunteer_occurrence_vocc` (`vocc_ID`) ON DELETE CASCADE,
   CONSTRAINT `fk_vreq_position` FOREIGN KEY (`vreq_vpos_ID`)
-      REFERENCES `volunteer_position_vpos` (`vpos_ID`) ON DELETE CASCADE
+      REFERENCES `volunteer_position_vpos` (`vpos_ID`) ON DELETE CASCADE,
+  -- Exactly one parent: a template requirement belongs to a schedule, an
+  -- override to an occurrence, never both and never neither. Enforced on
+  -- MariaDB 10.2.1+ / MySQL 8.0.16+; parsed and ignored by MySQL 5.7.
+  CONSTRAINT `vreq_one_parent_chk`
+      CHECK ((`vreq_vsch_ID` IS NULL) <> (`vreq_vocc_ID` IS NULL))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 --

--- a/src/mysql/install/Install.sql
+++ b/src/mysql/install/Install.sql
@@ -1111,4 +1111,339 @@ CREATE TABLE `pledge_denominations_pdem` (
   UNIQUE KEY `pdem_groupkey_denom_uidx` (`pdem_plg_GroupKey`, `pdem_denominationID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+--
+-- Volunteer Management v2 (#9705) - mirrors src/mysql/upgrade/7.7.0-volunteer-v2-schema.sql
+-- Ordered so that every foreign-key target already exists.
+--
+
+--
+-- Table structure for table `volunteer_ministry_vmin`
+--
+
+CREATE TABLE `volunteer_ministry_vmin` (
+  `vmin_ID`               int(11)               NOT NULL AUTO_INCREMENT,
+  `vmin_Name`             varchar(100)          NOT NULL,
+  `vmin_Description`      varchar(255)                   DEFAULT NULL,
+  `vmin_Active`           tinyint(1) unsigned   NOT NULL DEFAULT 1,
+  `vmin_CreatedDate`      datetime              NOT NULL,
+  `vmin_CreatedBy_per_ID` mediumint(9) unsigned          DEFAULT NULL,
+  PRIMARY KEY (`vmin_ID`),
+  UNIQUE KEY `vmin_name_uidx`  (`vmin_Name`),
+  KEY `vmin_active_idx`        (`vmin_Active`),
+  KEY `vmin_created_by_idx`    (`vmin_CreatedBy_per_ID`),
+  CONSTRAINT `fk_vmin_created_by` FOREIGN KEY (`vmin_CreatedBy_per_ID`)
+      REFERENCES `person_per` (`per_ID`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+--
+-- Table structure for table `volunteer_team_vtem`
+--
+
+CREATE TABLE `volunteer_team_vtem` (
+  `vtem_ID`          int(11)             NOT NULL AUTO_INCREMENT,
+  `vtem_vmin_ID`     int(11)             NOT NULL,
+  `vtem_Name`        varchar(100)        NOT NULL,
+  `vtem_Description` varchar(255)                 DEFAULT NULL,
+  `vtem_Active`      tinyint(1) unsigned NOT NULL DEFAULT 1,
+  PRIMARY KEY (`vtem_ID`),
+  UNIQUE KEY `vtem_ministry_name_uidx` (`vtem_vmin_ID`, `vtem_Name`),
+  KEY `vtem_ministry_idx`              (`vtem_vmin_ID`),
+  CONSTRAINT `fk_vtem_ministry` FOREIGN KEY (`vtem_vmin_ID`)
+      REFERENCES `volunteer_ministry_vmin` (`vmin_ID`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+--
+-- Table structure for table `volunteer_pool_vpol`
+--
+
+CREATE TABLE `volunteer_pool_vpol` (
+  `vpol_ID`        int(11)                     NOT NULL AUTO_INCREMENT,
+  `vpol_OwnerType` enum('ministry','team')     NOT NULL,
+  `vpol_OwnerId`   int(11)                     NOT NULL,
+  `vpol_grp_ID`    mediumint(8) unsigned       NOT NULL,
+  `vpol_Label`     varchar(100)                         DEFAULT NULL,
+  PRIMARY KEY (`vpol_ID`),
+  UNIQUE KEY `vpol_owner_group_uidx` (`vpol_OwnerType`, `vpol_OwnerId`, `vpol_grp_ID`),
+  KEY `vpol_group_idx`               (`vpol_grp_ID`),
+  CONSTRAINT `fk_vpol_group` FOREIGN KEY (`vpol_grp_ID`)
+      REFERENCES `group_grp` (`grp_ID`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+--
+-- Table structure for table `volunteer_position_vpos`
+--
+
+CREATE TABLE `volunteer_position_vpos` (
+  `vpos_ID`          int(11)             NOT NULL AUTO_INCREMENT,
+  `vpos_vmin_ID`     int(11)             NOT NULL,
+  `vpos_vtem_ID`     int(11)                      DEFAULT NULL,
+  `vpos_Name`        varchar(100)        NOT NULL,
+  `vpos_Description` varchar(255)                 DEFAULT NULL,
+  `vpos_Active`      tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `vpos_Order`       int(11)             NOT NULL DEFAULT 0,
+  PRIMARY KEY (`vpos_ID`),
+  UNIQUE KEY `vpos_ministry_team_name_uidx` (`vpos_vmin_ID`, `vpos_vtem_ID`, `vpos_Name`),
+  KEY `vpos_ministry_active_idx`            (`vpos_vmin_ID`, `vpos_Active`),
+  KEY `vpos_team_idx`                       (`vpos_vtem_ID`),
+  CONSTRAINT `fk_vpos_ministry` FOREIGN KEY (`vpos_vmin_ID`)
+      REFERENCES `volunteer_ministry_vmin` (`vmin_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vpos_team` FOREIGN KEY (`vpos_vtem_ID`)
+      REFERENCES `volunteer_team_vtem` (`vtem_ID`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+--
+-- Table structure for table `volunteer_qualification_vqal`
+--
+
+CREATE TABLE `volunteer_qualification_vqal` (
+  `vqal_ID`               int(11)               NOT NULL AUTO_INCREMENT,
+  `vqal_per_ID`           mediumint(9) unsigned NOT NULL,
+  `vqal_vpos_ID`          int(11)               NOT NULL,
+  `vqal_Active`           tinyint(1) unsigned   NOT NULL DEFAULT 1,
+  `vqal_GrantedDate`      datetime              NOT NULL,
+  `vqal_GrantedBy_per_ID` mediumint(9) unsigned          DEFAULT NULL,
+  `vqal_Notes`            varchar(255)                   DEFAULT NULL,
+  PRIMARY KEY (`vqal_ID`),
+  UNIQUE KEY `vqal_person_position_uidx` (`vqal_per_ID`, `vqal_vpos_ID`),
+  KEY `vqal_position_active_idx`         (`vqal_vpos_ID`, `vqal_Active`),
+  KEY `vqal_person_idx`                  (`vqal_per_ID`),
+  KEY `vqal_granted_by_idx`              (`vqal_GrantedBy_per_ID`),
+  CONSTRAINT `fk_vqal_person` FOREIGN KEY (`vqal_per_ID`)
+      REFERENCES `person_per` (`per_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vqal_position` FOREIGN KEY (`vqal_vpos_ID`)
+      REFERENCES `volunteer_position_vpos` (`vpos_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vqal_granted_by` FOREIGN KEY (`vqal_GrantedBy_per_ID`)
+      REFERENCES `person_per` (`per_ID`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+--
+-- Table structure for table `volunteer_schedule_vsch`
+--
+
+CREATE TABLE `volunteer_schedule_vsch` (
+  `vsch_ID`                int(11)                                        NOT NULL AUTO_INCREMENT,
+  `vsch_vmin_ID`           int(11)                                        NOT NULL,
+  `vsch_vtem_ID`           int(11)                                                 DEFAULT NULL,
+  `vsch_Name`              varchar(100)                                   NOT NULL,
+  `vsch_LinkMode`          enum('event_type','standalone')                NOT NULL,
+  `vsch_event_type_id`     int(11)                                                 DEFAULT NULL,
+  `vsch_TitleFilter`       varchar(255)                                            DEFAULT NULL,
+  `vsch_RecurType`         enum('none','weekly','monthly','yearly')       NOT NULL DEFAULT 'none',
+  `vsch_RecurDOW`          enum('Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday') DEFAULT NULL,
+  `vsch_RecurDOM`          tinyint(3)                                              DEFAULT NULL,
+  `vsch_StartTime`         time                                                    DEFAULT NULL,
+  `vsch_EndTime`           time                                                    DEFAULT NULL,
+  `vsch_WindowStart`       date                                           NOT NULL,
+  `vsch_WindowEnd`         date                                                    DEFAULT NULL,
+  `vsch_GenerateAheadDays` int(11)                                        NOT NULL DEFAULT 56,
+  `vsch_Active`            tinyint(1) unsigned                            NOT NULL DEFAULT 1,
+  PRIMARY KEY (`vsch_ID`),
+  KEY `vsch_ministry_idx`      (`vsch_vmin_ID`),
+  KEY `vsch_team_idx`          (`vsch_vtem_ID`),
+  KEY `vsch_type_idx`          (`vsch_event_type_id`),
+  KEY `vsch_active_window_idx` (`vsch_Active`, `vsch_WindowStart`),
+  CONSTRAINT `fk_vsch_ministry` FOREIGN KEY (`vsch_vmin_ID`)
+      REFERENCES `volunteer_ministry_vmin` (`vmin_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vsch_team` FOREIGN KEY (`vsch_vtem_ID`)
+      REFERENCES `volunteer_team_vtem` (`vtem_ID`) ON DELETE SET NULL,
+  CONSTRAINT `fk_vsch_event_type` FOREIGN KEY (`vsch_event_type_id`)
+      REFERENCES `event_types` (`type_id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+--
+-- Table structure for table `volunteer_occurrence_vocc`
+--
+
+CREATE TABLE `volunteer_occurrence_vocc` (
+  `vocc_ID`             int(11)                          NOT NULL AUTO_INCREMENT,
+  `vocc_vsch_ID`        int(11)                          NOT NULL,
+  `vocc_event_id`       int(11)                                   DEFAULT NULL,
+  `vocc_OccurrenceDate` date                             NOT NULL,
+  `vocc_StartDateTime`  datetime                                  DEFAULT NULL,
+  `vocc_EndDateTime`    datetime                                  DEFAULT NULL,
+  `vocc_Status`         enum('scheduled','cancelled')    NOT NULL DEFAULT 'scheduled',
+  `vocc_Notes`          varchar(255)                              DEFAULT NULL,
+  `vocc_GeneratedDate`  datetime                         NOT NULL,
+  PRIMARY KEY (`vocc_ID`),
+  UNIQUE KEY `vocc_schedule_event_uidx` (`vocc_vsch_ID`, `vocc_event_id`),
+  UNIQUE KEY `vocc_schedule_start_uidx` (`vocc_vsch_ID`, `vocc_StartDateTime`),
+  KEY `vocc_date_idx`  (`vocc_OccurrenceDate`),
+  KEY `vocc_event_idx` (`vocc_event_id`),
+  CONSTRAINT `fk_vocc_schedule` FOREIGN KEY (`vocc_vsch_ID`)
+      REFERENCES `volunteer_schedule_vsch` (`vsch_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vocc_event` FOREIGN KEY (`vocc_event_id`)
+      REFERENCES `events_event` (`event_id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+--
+-- Table structure for table `volunteer_requirement_vreq`
+--
+
+CREATE TABLE `volunteer_requirement_vreq` (
+  `vreq_ID`       int(11)      NOT NULL AUTO_INCREMENT,
+  `vreq_vsch_ID`  int(11)               DEFAULT NULL,
+  `vreq_vocc_ID`  int(11)               DEFAULT NULL,
+  `vreq_vpos_ID`  int(11)      NOT NULL,
+  `vreq_MinCount` int(11)      NOT NULL DEFAULT 1,
+  `vreq_MaxCount` int(11)               DEFAULT NULL,
+  `vreq_Notes`    varchar(255)          DEFAULT NULL,
+  PRIMARY KEY (`vreq_ID`),
+  UNIQUE KEY `vreq_schedule_position_uidx`   (`vreq_vsch_ID`, `vreq_vpos_ID`),
+  UNIQUE KEY `vreq_occurrence_position_uidx` (`vreq_vocc_ID`, `vreq_vpos_ID`),
+  KEY `vreq_position_idx`                    (`vreq_vpos_ID`),
+  CONSTRAINT `fk_vreq_schedule` FOREIGN KEY (`vreq_vsch_ID`)
+      REFERENCES `volunteer_schedule_vsch` (`vsch_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vreq_occurrence` FOREIGN KEY (`vreq_vocc_ID`)
+      REFERENCES `volunteer_occurrence_vocc` (`vocc_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vreq_position` FOREIGN KEY (`vreq_vpos_ID`)
+      REFERENCES `volunteer_position_vpos` (`vpos_ID`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+--
+-- Table structure for table `volunteer_assignment_vasg`
+--
+
+CREATE TABLE `volunteer_assignment_vasg` (
+  `vasg_ID`                int(11)               NOT NULL AUTO_INCREMENT,
+  `vasg_vocc_ID`           int(11)               NOT NULL,
+  `vasg_vpos_ID`           int(11)               NOT NULL,
+  `vasg_per_ID`            mediumint(9) unsigned NOT NULL,
+  `vasg_vreq_ID`           int(11)                        DEFAULT NULL,
+  `vasg_Status`            enum('pending','accepted','declined','cancelled','substituted','completed')
+                                                 NOT NULL DEFAULT 'pending',
+  `vasg_Source`            enum('coordinator','self_signup','substitute')
+                                                 NOT NULL DEFAULT 'coordinator',
+  `vasg_AssignedDate`      datetime              NOT NULL,
+  `vasg_AssignedBy_per_ID` mediumint(9) unsigned          DEFAULT NULL,
+  `vasg_RespondedDate`     datetime                       DEFAULT NULL,
+  `vasg_Replaces_vasg_ID`  int(11)                        DEFAULT NULL,
+  `vasg_Notes`             varchar(255)                   DEFAULT NULL,
+  PRIMARY KEY (`vasg_ID`),
+  UNIQUE KEY `vasg_occ_pos_per_uidx` (`vasg_vocc_ID`, `vasg_vpos_ID`, `vasg_per_ID`),
+  KEY `vasg_occurrence_idx`     (`vasg_vocc_ID`, `vasg_Status`),
+  KEY `vasg_person_status_idx`  (`vasg_per_ID`, `vasg_Status`),
+  KEY `vasg_position_idx`       (`vasg_vpos_ID`),
+  KEY `vasg_requirement_idx`    (`vasg_vreq_ID`),
+  KEY `vasg_assigned_by_idx`    (`vasg_AssignedBy_per_ID`),
+  KEY `vasg_replaces_idx`       (`vasg_Replaces_vasg_ID`),
+  CONSTRAINT `fk_vasg_occurrence` FOREIGN KEY (`vasg_vocc_ID`)
+      REFERENCES `volunteer_occurrence_vocc` (`vocc_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vasg_position` FOREIGN KEY (`vasg_vpos_ID`)
+      REFERENCES `volunteer_position_vpos` (`vpos_ID`) ON DELETE RESTRICT,
+  CONSTRAINT `fk_vasg_person` FOREIGN KEY (`vasg_per_ID`)
+      REFERENCES `person_per` (`per_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vasg_requirement` FOREIGN KEY (`vasg_vreq_ID`)
+      REFERENCES `volunteer_requirement_vreq` (`vreq_ID`) ON DELETE SET NULL,
+  CONSTRAINT `fk_vasg_assigned_by` FOREIGN KEY (`vasg_AssignedBy_per_ID`)
+      REFERENCES `person_per` (`per_ID`) ON DELETE SET NULL,
+  CONSTRAINT `fk_vasg_replaces` FOREIGN KEY (`vasg_Replaces_vasg_ID`)
+      REFERENCES `volunteer_assignment_vasg` (`vasg_ID`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+--
+-- Table structure for table `volunteer_response_vrsp`
+--
+
+CREATE TABLE `volunteer_response_vrsp` (
+  `vrsp_ID`           int(11)               NOT NULL AUTO_INCREMENT,
+  `vrsp_vasg_ID`      int(11)               NOT NULL,
+  `vrsp_per_ID`       mediumint(9) unsigned NOT NULL,
+  `vrsp_Response`     enum('accepted','declined','cancelled','substitute_proposed','substitute_approved','substitute_rejected','substitute_withdrawn')
+                                            NOT NULL,
+  `vrsp_ResponseDate` datetime              NOT NULL,
+  `vrsp_Channel`      enum('web','coordinator') NOT NULL DEFAULT 'web',
+  `vrsp_Comment`      varchar(255)                   DEFAULT NULL,
+  PRIMARY KEY (`vrsp_ID`),
+  KEY `vrsp_assignment_idx` (`vrsp_vasg_ID`, `vrsp_ResponseDate`),
+  KEY `vrsp_person_idx`     (`vrsp_per_ID`),
+  CONSTRAINT `fk_vrsp_assignment` FOREIGN KEY (`vrsp_vasg_ID`)
+      REFERENCES `volunteer_assignment_vasg` (`vasg_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vrsp_person` FOREIGN KEY (`vrsp_per_ID`)
+      REFERENCES `person_per` (`per_ID`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+--
+-- Table structure for table `volunteer_swap_vswp`
+--
+
+CREATE TABLE `volunteer_swap_vswp` (
+  `vswp_ID`               int(11)               NOT NULL AUTO_INCREMENT,
+  `vswp_vasg_ID`          int(11)               NOT NULL,
+  `vswp_ProposedBy_per_ID` mediumint(9) unsigned NOT NULL,
+  `vswp_Proposed_per_ID`  mediumint(9) unsigned NOT NULL,
+  `vswp_Status`           enum('proposed','approved','rejected','withdrawn') NOT NULL DEFAULT 'proposed',
+  `vswp_ProposedDate`     datetime              NOT NULL,
+  `vswp_DecidedDate`      datetime                       DEFAULT NULL,
+  `vswp_DecidedBy_per_ID` mediumint(9) unsigned          DEFAULT NULL,
+  `vswp_Comment`          varchar(255)                   DEFAULT NULL,
+  PRIMARY KEY (`vswp_ID`),
+  KEY `vswp_assignment_status_idx` (`vswp_vasg_ID`, `vswp_Status`),
+  KEY `vswp_proposed_person_idx`   (`vswp_Proposed_per_ID`),
+  KEY `vswp_proposed_by_idx`       (`vswp_ProposedBy_per_ID`),
+  KEY `vswp_decided_by_idx`        (`vswp_DecidedBy_per_ID`),
+  CONSTRAINT `fk_vswp_assignment` FOREIGN KEY (`vswp_vasg_ID`)
+      REFERENCES `volunteer_assignment_vasg` (`vasg_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vswp_proposed_by` FOREIGN KEY (`vswp_ProposedBy_per_ID`)
+      REFERENCES `person_per` (`per_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vswp_proposed_person` FOREIGN KEY (`vswp_Proposed_per_ID`)
+      REFERENCES `person_per` (`per_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vswp_decided_by` FOREIGN KEY (`vswp_DecidedBy_per_ID`)
+      REFERENCES `person_per` (`per_ID`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+--
+-- Table structure for table `volunteer_notification_vntf`
+--
+
+CREATE TABLE `volunteer_notification_vntf` (
+  `vntf_ID`              int(11)               NOT NULL AUTO_INCREMENT,
+  `vntf_Type`            enum('assignment','reminder','decline_alert','gap_alert','signup_confirm','swap_proposed','swap_resolved')
+                                               NOT NULL,
+  `vntf_Channel`         enum('email')         NOT NULL DEFAULT 'email',
+  `vntf_per_ID`          mediumint(9) unsigned NOT NULL,
+  `vntf_vasg_ID`         int(11)                        DEFAULT NULL,
+  `vntf_vocc_ID`         int(11)                        DEFAULT NULL,
+  `vntf_DedupeKey`       varchar(190)          NOT NULL,
+  `vntf_ScheduledFor`    datetime              NOT NULL,
+  `vntf_Status`          enum('pending','sent','failed','skipped') NOT NULL DEFAULT 'pending',
+  `vntf_Attempts`        int(11)               NOT NULL DEFAULT 0,
+  `vntf_LastAttemptDate` datetime                       DEFAULT NULL,
+  `vntf_SentDate`        datetime                       DEFAULT NULL,
+  `vntf_LastError`       varchar(255)                   DEFAULT NULL,
+  PRIMARY KEY (`vntf_ID`),
+  UNIQUE KEY `vntf_dedupe_uidx` (`vntf_DedupeKey`),
+  KEY `vntf_due_idx`            (`vntf_Status`, `vntf_ScheduledFor`),
+  KEY `vntf_assignment_idx`     (`vntf_vasg_ID`),
+  KEY `vntf_person_idx`         (`vntf_per_ID`),
+  KEY `vntf_occurrence_idx`     (`vntf_vocc_ID`),
+  CONSTRAINT `fk_vntf_person` FOREIGN KEY (`vntf_per_ID`)
+      REFERENCES `person_per` (`per_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vntf_assignment` FOREIGN KEY (`vntf_vasg_ID`)
+      REFERENCES `volunteer_assignment_vasg` (`vasg_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vntf_occurrence` FOREIGN KEY (`vntf_vocc_ID`)
+      REFERENCES `volunteer_occurrence_vocc` (`vocc_ID`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+--
+-- Table structure for table `volunteer_scope_vscp`
+--
+
+CREATE TABLE `volunteer_scope_vscp` (
+  `vscp_ID`               int(11)                 NOT NULL AUTO_INCREMENT,
+  `vscp_per_ID`           mediumint(9) unsigned   NOT NULL,
+  `vscp_ScopeType`        enum('ministry','team') NOT NULL,
+  `vscp_ScopeId`          int(11)                 NOT NULL,
+  `vscp_GrantedDate`      datetime                NOT NULL,
+  `vscp_GrantedBy_per_ID` mediumint(9) unsigned            DEFAULT NULL,
+  PRIMARY KEY (`vscp_ID`),
+  UNIQUE KEY `vscp_person_scope_uidx` (`vscp_per_ID`, `vscp_ScopeType`, `vscp_ScopeId`),
+  KEY `vscp_person_idx`               (`vscp_per_ID`),
+  KEY `vscp_scope_idx`                (`vscp_ScopeType`, `vscp_ScopeId`),
+  KEY `vscp_granted_by_idx`           (`vscp_GrantedBy_per_ID`),
+  CONSTRAINT `fk_vscp_person` FOREIGN KEY (`vscp_per_ID`)
+      REFERENCES `person_per` (`per_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vscp_granted_by` FOREIGN KEY (`vscp_GrantedBy_per_ID`)
+      REFERENCES `person_per` (`per_ID`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
 update version_ver set ver_update_end = now();

--- a/src/mysql/upgrade.json
+++ b/src/mysql/upgrade.json
@@ -1,81 +1,36 @@
 {
   "consolidated-pre-6.0.0": {
-    "versions": [
-      "1.2.14",
-      "1.3.0",
-      "1.3.1",
-      "1.3.2"
-    ],
-    "scripts": [
-      "/mysql/upgrade/pre-6.0.0-consolidated.sql",
-      "/mysql/upgrade/2.9.0-InnoDB.php"
-    ],
+    "versions": ["1.2.14", "1.3.0", "1.3.1", "1.3.2"],
+    "scripts": ["/mysql/upgrade/pre-6.0.0-consolidated.sql", "/mysql/upgrade/2.9.0-InnoDB.php"],
     "dbVersion": "6.0.0"
   },
   "pre-6.2.0": {
-    "versions": [
-      "6.0.0",
-      "6.0.1",
-      "6.0.2",
-      "6.1.0"
-    ],
-    "scripts": [
-      "/mysql/upgrade/6.2.0.sql"
-    ],
+    "versions": ["6.0.0", "6.0.1", "6.0.2", "6.1.0"],
+    "scripts": ["/mysql/upgrade/6.2.0.sql"],
     "dbVersion": "6.2.0"
   },
   "pre-6.3.0": {
-    "versions": [
-      "6.2.0"
-    ],
-    "scripts": [
-      "/mysql/upgrade/6.3.0.sql"
-    ],
+    "versions": ["6.2.0"],
+    "scripts": ["/mysql/upgrade/6.3.0.sql"],
     "dbVersion": "6.3.0"
   },
   "pre-6.5.0": {
-    "versions": [
-      "6.3.0",
-      "6.4.0"
-    ],
-    "scripts": [
-      "/mysql/upgrade/6.5.0.sql"
-    ],
+    "versions": ["6.3.0", "6.4.0"],
+    "scripts": ["/mysql/upgrade/6.5.0.sql"],
     "dbVersion": "6.5.0"
   },
   "pre-6.6.0": {
-    "versions": [
-      "6.5.0",
-      "6.5.1",
-      "6.5.2",
-      "6.5.3",
-      "6.5.4"
-    ],
-    "scripts": [
-      "/mysql/upgrade/6.6.0.php",
-      "/mysql/upgrade/6.6.0.sql"
-    ],
+    "versions": ["6.5.0", "6.5.1", "6.5.2", "6.5.3", "6.5.4"],
+    "scripts": ["/mysql/upgrade/6.6.0.php", "/mysql/upgrade/6.6.0.sql"],
     "dbVersion": "6.6.0"
   },
   "pre-6.7.0": {
-    "versions": [
-      "6.6.0",
-      "6.6.1"
-    ],
-    "scripts": [
-      "/mysql/upgrade/6.7.0.sql"
-    ],
+    "versions": ["6.6.0", "6.6.1"],
+    "scripts": ["/mysql/upgrade/6.7.0.sql"],
     "dbVersion": "6.7.0"
   },
   "pre-7.0.0": {
-    "versions": [
-      "6.7.0",
-      "6.7.1",
-      "6.7.2",
-      "6.7.3",
-      "6.8.0",
-      "6.8.1"
-    ],
+    "versions": ["6.7.0", "6.7.1", "6.7.2", "6.7.3", "6.8.0", "6.8.1"],
     "scripts": [
       "/mysql/upgrade/6.8.0.sql",
       "/mysql/upgrade/7.0.0-remove-bing-maps.sql",
@@ -84,68 +39,32 @@
     "dbVersion": "7.0.0"
   },
   "pre-7.0.2": {
-    "versions": [
-      "7.0.0",
-      "7.0.1"
-    ],
-    "scripts": [
-      "/mysql/upgrade/7.0.2-2fa.sql"
-    ],
+    "versions": ["7.0.0", "7.0.1"],
+    "scripts": ["/mysql/upgrade/7.0.2-2fa.sql"],
     "dbVersion": "7.0.2"
   },
   "pre-7.1.0": {
-    "versions": [
-      "7.0.2",
-      "7.0.3",
-      "7.0.4",
-      "7.0.5"
-    ],
-    "scripts": [
-      "/mysql/upgrade/7.1.0-config.sql"
-    ],
+    "versions": ["7.0.2", "7.0.3", "7.0.4", "7.0.5"],
+    "scripts": ["/mysql/upgrade/7.1.0-config.sql"],
     "dbVersion": "7.1.0"
   },
   "pre-7.2.0": {
-    "versions": [
-      "7.1.0",
-      "7.1.1",
-      "7.1.2"
-    ],
-    "scripts": [
-      "/mysql/upgrade/7.2.0.sql"
-    ],
+    "versions": ["7.1.0", "7.1.1", "7.1.2"],
+    "scripts": ["/mysql/upgrade/7.2.0.sql"],
     "dbVersion": "7.2.0"
   },
   "pre-7.3.1": {
-    "versions": [
-      "7.2.0",
-      "7.2.1",
-      "7.2.2",
-      "7.2.3",
-      "7.3.0"
-    ],
-    "scripts": [
-      "/mysql/upgrade/7.3.1-cleanup.sql"
-    ],
+    "versions": ["7.2.0", "7.2.1", "7.2.2", "7.2.3", "7.3.0"],
+    "scripts": ["/mysql/upgrade/7.3.1-cleanup.sql"],
     "dbVersion": "7.3.1"
   },
   "pre-7.4.1": {
-    "versions": [
-      "7.3.1",
-      "7.3.2",
-      "7.3.3",
-      "7.4.0"
-    ],
-    "scripts": [
-      "/mysql/upgrade/7.4.2-editself-exclusive.sql"
-    ],
+    "versions": ["7.3.1", "7.3.2", "7.3.3", "7.4.0"],
+    "scripts": ["/mysql/upgrade/7.4.2-editself-exclusive.sql"],
     "dbVersion": "7.4.1"
   },
   "pre-7.4.3": {
-    "versions": [
-      "7.4.1",
-      "7.4.2"
-    ],
+    "versions": ["7.4.1", "7.4.2"],
     "scripts": [
       "/mysql/upgrade/7.4.3-manage-fundraisers.sql",
       "/mysql/upgrade/7.4.3-remove-directory-csv-permissions.sql"
@@ -153,27 +72,17 @@
     "dbVersion": "7.4.3"
   },
   "pre-7.5.0": {
-    "versions": [
-      "7.4.3"
-    ],
-    "scripts": [
-      "/mysql/upgrade/7.5.0-fundraiser-fields.sql"
-    ],
+    "versions": ["7.4.3"],
+    "scripts": ["/mysql/upgrade/7.5.0-fundraiser-fields.sql"],
     "dbVersion": "7.5.0"
   },
   "pre-7.5.1": {
-    "versions": [
-      "7.5.0"
-    ],
-    "scripts": [
-      "/mysql/upgrade/7.5.1-remove-sMailtoDelimiter.sql"
-    ],
+    "versions": ["7.5.0"],
+    "scripts": ["/mysql/upgrade/7.5.1-remove-sMailtoDelimiter.sql"],
     "dbVersion": "7.5.1"
   },
   "pre-7.6.0": {
-    "versions": [
-      "7.5.1"
-    ],
+    "versions": ["7.5.1"],
     "scripts": [
       "/mysql/upgrade/7.6.0-remove-orphaned-query-parameters.sql",
       "/mysql/upgrade/7.6.0-remove-legacy-custom-search-query.sql"
@@ -181,37 +90,22 @@
     "dbVersion": "7.6.0"
   },
   "pre-7.6.1": {
-    "versions": [
-      "7.6.0"
-    ],
-    "scripts": [
-      "/mysql/upgrade/7.6.1-add-anniversary-queries.sql"
-    ],
+    "versions": ["7.6.0"],
+    "scripts": ["/mysql/upgrade/7.6.1-add-anniversary-queries.sql"],
     "dbVersion": "7.6.1"
   },
   "pre-7.6.2": {
-    "versions": [
-      "7.6.1"
-    ],
-    "scripts": [
-      "/mysql/upgrade/7.6.2-add-missing-fk-indexes.sql"
-    ],
+    "versions": ["7.6.1"],
+    "scripts": ["/mysql/upgrade/7.6.2-add-missing-fk-indexes.sql"],
     "dbVersion": "7.6.2"
   },
   "pre-7.6.4": {
-    "versions": [
-      "7.6.2",
-      "7.6.3"
-    ],
-    "scripts": [
-      "/mysql/upgrade/7.6.4-pledge-denominations.sql"
-    ],
+    "versions": ["7.6.2", "7.6.3"],
+    "scripts": ["/mysql/upgrade/7.6.4-pledge-denominations.sql"],
     "dbVersion": "7.6.4"
   },
   "current": {
-    "versions": [
-      "7.6.4"
-    ],
+    "versions": ["7.6.4"],
     "scripts": [
       "/mysql/upgrade/7.7.0-2fa-grace-period.sql",
       "/mysql/upgrade/7.7.0-add-person-deceased-date.sql",

--- a/src/mysql/upgrade.json
+++ b/src/mysql/upgrade.json
@@ -1,36 +1,81 @@
 {
   "consolidated-pre-6.0.0": {
-    "versions": ["1.2.14", "1.3.0", "1.3.1", "1.3.2"],
-    "scripts": ["/mysql/upgrade/pre-6.0.0-consolidated.sql", "/mysql/upgrade/2.9.0-InnoDB.php"],
+    "versions": [
+      "1.2.14",
+      "1.3.0",
+      "1.3.1",
+      "1.3.2"
+    ],
+    "scripts": [
+      "/mysql/upgrade/pre-6.0.0-consolidated.sql",
+      "/mysql/upgrade/2.9.0-InnoDB.php"
+    ],
     "dbVersion": "6.0.0"
   },
   "pre-6.2.0": {
-    "versions": ["6.0.0", "6.0.1", "6.0.2", "6.1.0"],
-    "scripts": ["/mysql/upgrade/6.2.0.sql"],
+    "versions": [
+      "6.0.0",
+      "6.0.1",
+      "6.0.2",
+      "6.1.0"
+    ],
+    "scripts": [
+      "/mysql/upgrade/6.2.0.sql"
+    ],
     "dbVersion": "6.2.0"
   },
   "pre-6.3.0": {
-    "versions": ["6.2.0"],
-    "scripts": ["/mysql/upgrade/6.3.0.sql"],
+    "versions": [
+      "6.2.0"
+    ],
+    "scripts": [
+      "/mysql/upgrade/6.3.0.sql"
+    ],
     "dbVersion": "6.3.0"
   },
   "pre-6.5.0": {
-    "versions": ["6.3.0", "6.4.0"],
-    "scripts": ["/mysql/upgrade/6.5.0.sql"],
+    "versions": [
+      "6.3.0",
+      "6.4.0"
+    ],
+    "scripts": [
+      "/mysql/upgrade/6.5.0.sql"
+    ],
     "dbVersion": "6.5.0"
   },
   "pre-6.6.0": {
-    "versions": ["6.5.0", "6.5.1", "6.5.2", "6.5.3", "6.5.4"],
-    "scripts": ["/mysql/upgrade/6.6.0.php", "/mysql/upgrade/6.6.0.sql"],
+    "versions": [
+      "6.5.0",
+      "6.5.1",
+      "6.5.2",
+      "6.5.3",
+      "6.5.4"
+    ],
+    "scripts": [
+      "/mysql/upgrade/6.6.0.php",
+      "/mysql/upgrade/6.6.0.sql"
+    ],
     "dbVersion": "6.6.0"
   },
   "pre-6.7.0": {
-    "versions": ["6.6.0", "6.6.1"],
-    "scripts": ["/mysql/upgrade/6.7.0.sql"],
+    "versions": [
+      "6.6.0",
+      "6.6.1"
+    ],
+    "scripts": [
+      "/mysql/upgrade/6.7.0.sql"
+    ],
     "dbVersion": "6.7.0"
   },
   "pre-7.0.0": {
-    "versions": ["6.7.0", "6.7.1", "6.7.2", "6.7.3", "6.8.0", "6.8.1"],
+    "versions": [
+      "6.7.0",
+      "6.7.1",
+      "6.7.2",
+      "6.7.3",
+      "6.8.0",
+      "6.8.1"
+    ],
     "scripts": [
       "/mysql/upgrade/6.8.0.sql",
       "/mysql/upgrade/7.0.0-remove-bing-maps.sql",
@@ -39,32 +84,68 @@
     "dbVersion": "7.0.0"
   },
   "pre-7.0.2": {
-    "versions": ["7.0.0", "7.0.1"],
-    "scripts": ["/mysql/upgrade/7.0.2-2fa.sql"],
+    "versions": [
+      "7.0.0",
+      "7.0.1"
+    ],
+    "scripts": [
+      "/mysql/upgrade/7.0.2-2fa.sql"
+    ],
     "dbVersion": "7.0.2"
   },
   "pre-7.1.0": {
-    "versions": ["7.0.2", "7.0.3", "7.0.4", "7.0.5"],
-    "scripts": ["/mysql/upgrade/7.1.0-config.sql"],
+    "versions": [
+      "7.0.2",
+      "7.0.3",
+      "7.0.4",
+      "7.0.5"
+    ],
+    "scripts": [
+      "/mysql/upgrade/7.1.0-config.sql"
+    ],
     "dbVersion": "7.1.0"
   },
   "pre-7.2.0": {
-    "versions": ["7.1.0", "7.1.1", "7.1.2"],
-    "scripts": ["/mysql/upgrade/7.2.0.sql"],
+    "versions": [
+      "7.1.0",
+      "7.1.1",
+      "7.1.2"
+    ],
+    "scripts": [
+      "/mysql/upgrade/7.2.0.sql"
+    ],
     "dbVersion": "7.2.0"
   },
   "pre-7.3.1": {
-    "versions": ["7.2.0", "7.2.1", "7.2.2", "7.2.3", "7.3.0"],
-    "scripts": ["/mysql/upgrade/7.3.1-cleanup.sql"],
+    "versions": [
+      "7.2.0",
+      "7.2.1",
+      "7.2.2",
+      "7.2.3",
+      "7.3.0"
+    ],
+    "scripts": [
+      "/mysql/upgrade/7.3.1-cleanup.sql"
+    ],
     "dbVersion": "7.3.1"
   },
   "pre-7.4.1": {
-    "versions": ["7.3.1", "7.3.2", "7.3.3", "7.4.0"],
-    "scripts": ["/mysql/upgrade/7.4.2-editself-exclusive.sql"],
+    "versions": [
+      "7.3.1",
+      "7.3.2",
+      "7.3.3",
+      "7.4.0"
+    ],
+    "scripts": [
+      "/mysql/upgrade/7.4.2-editself-exclusive.sql"
+    ],
     "dbVersion": "7.4.1"
   },
   "pre-7.4.3": {
-    "versions": ["7.4.1", "7.4.2"],
+    "versions": [
+      "7.4.1",
+      "7.4.2"
+    ],
     "scripts": [
       "/mysql/upgrade/7.4.3-manage-fundraisers.sql",
       "/mysql/upgrade/7.4.3-remove-directory-csv-permissions.sql"
@@ -72,17 +153,27 @@
     "dbVersion": "7.4.3"
   },
   "pre-7.5.0": {
-    "versions": ["7.4.3"],
-    "scripts": ["/mysql/upgrade/7.5.0-fundraiser-fields.sql"],
+    "versions": [
+      "7.4.3"
+    ],
+    "scripts": [
+      "/mysql/upgrade/7.5.0-fundraiser-fields.sql"
+    ],
     "dbVersion": "7.5.0"
   },
   "pre-7.5.1": {
-    "versions": ["7.5.0"],
-    "scripts": ["/mysql/upgrade/7.5.1-remove-sMailtoDelimiter.sql"],
+    "versions": [
+      "7.5.0"
+    ],
+    "scripts": [
+      "/mysql/upgrade/7.5.1-remove-sMailtoDelimiter.sql"
+    ],
     "dbVersion": "7.5.1"
   },
   "pre-7.6.0": {
-    "versions": ["7.5.1"],
+    "versions": [
+      "7.5.1"
+    ],
     "scripts": [
       "/mysql/upgrade/7.6.0-remove-orphaned-query-parameters.sql",
       "/mysql/upgrade/7.6.0-remove-legacy-custom-search-query.sql"
@@ -90,28 +181,42 @@
     "dbVersion": "7.6.0"
   },
   "pre-7.6.1": {
-    "versions": ["7.6.0"],
-    "scripts": ["/mysql/upgrade/7.6.1-add-anniversary-queries.sql"],
+    "versions": [
+      "7.6.0"
+    ],
+    "scripts": [
+      "/mysql/upgrade/7.6.1-add-anniversary-queries.sql"
+    ],
     "dbVersion": "7.6.1"
   },
   "pre-7.6.2": {
-    "versions": ["7.6.1"],
-    "scripts": ["/mysql/upgrade/7.6.2-add-missing-fk-indexes.sql"],
+    "versions": [
+      "7.6.1"
+    ],
+    "scripts": [
+      "/mysql/upgrade/7.6.2-add-missing-fk-indexes.sql"
+    ],
     "dbVersion": "7.6.2"
   },
   "pre-7.6.4": {
-    "versions": ["7.6.2", "7.6.3"],
-    "scripts": ["/mysql/upgrade/7.6.4-pledge-denominations.sql"],
+    "versions": [
+      "7.6.2",
+      "7.6.3"
+    ],
+    "scripts": [
+      "/mysql/upgrade/7.6.4-pledge-denominations.sql"
+    ],
     "dbVersion": "7.6.4"
   },
   "current": {
-    "versions": ["7.6.4"],
+    "versions": [
+      "7.6.4"
+    ],
     "scripts": [
       "/mysql/upgrade/7.7.0-2fa-grace-period.sql",
       "/mysql/upgrade/7.7.0-add-person-deceased-date.sql",
       "/mysql/upgrade/7.7.0-add-person-datedeactivated.sql",
-      "/mysql/upgrade/7.7.0-events-utf8mb4.sql",
-      "/mysql/upgrade/7.7.0-volunteer-v2-schema.sql"
+      "/mysql/upgrade/7.7.0-events-utf8mb4.sql"
     ],
     "dbVersion": "7.7.0"
   }

--- a/src/mysql/upgrade.json
+++ b/src/mysql/upgrade.json
@@ -110,7 +110,8 @@
       "/mysql/upgrade/7.7.0-2fa-grace-period.sql",
       "/mysql/upgrade/7.7.0-add-person-deceased-date.sql",
       "/mysql/upgrade/7.7.0-add-person-datedeactivated.sql",
-      "/mysql/upgrade/7.7.0-events-utf8mb4.sql"
+      "/mysql/upgrade/7.7.0-events-utf8mb4.sql",
+      "/mysql/upgrade/7.7.0-volunteer-v2-schema.sql"
     ],
     "dbVersion": "7.7.0"
   }

--- a/src/mysql/upgrade/7.7.0-volunteer-v2-schema.sql
+++ b/src/mysql/upgrade/7.7.0-volunteer-v2-schema.sql
@@ -1,0 +1,355 @@
+-- ChurchCRM 7.7.0 — Volunteer Management v2 core domain model
+-- Implements #9705 (epic #9701); design: .agents/skills/churchcrm/volunteer-v2-design.md §2
+--
+-- Why these tables exist at all, in one line each (the long form, with the
+-- evidence that reuse was insufficient, is design §8.1):
+--
+--   ministry / team      "Ministry" exists today only as group-type list option
+--                        list_lst (3,1) — there is no entity for five tables and
+--                        a core column to reference, and putting ministry
+--                        identity on group_grp would hide it behind the
+--                        bManageGroups model hooks and GroupQuery::preSelect().
+--   pool                 The group↔owner link has nowhere to live; event_audience
+--                        is documented as an advertising audience, not ownership.
+--   position             Nothing in core models "a role a volunteer can serve in".
+--   qualification        Person↔position many-to-many is structurally impossible
+--                        on person2group2role_p2g2r: its primary key is
+--                        (person, group), i.e. one role per person per group.
+--   schedule/occurrence  There is no event series identifier anywhere in core —
+--                        "repeat" bulk-inserts N unlinked events_event rows — so
+--                        V2 must own the series, and an occurrence row is what
+--                        lets several ministries staff one event independently.
+--   requirement          "This occurrence needs 2–3 espresso people" has no home;
+--                        eventcounts_evtcnt is a per-type head count with no
+--                        position concept and no foreign key.
+--   assignment/response  person + position + occurrence + lifecycle does not
+--                        exist; event_attend is (event, person) presence only.
+--   swap                 No proposal/approval workflow exists in the codebase.
+--   notification         There is no queue, outbox or send log in the schema; the
+--                        only idempotency marker in the messaging stack is one
+--                        config_cfg string with a check-then-set race.
+--   scope                No table persists a user→object scope; every existing
+--                        gate is a global boolean on user_usr.
+--
+-- Deliberately NOT here:
+--   * Open Gap is derived (requirement minus live assignments), never stored — a
+--     persisted gap is a cache that disagrees with the assignments the first time
+--     a decline is processed outside the happy path.
+--   * events_event.event_ministry_id ships with #9713 and user_usr.usr_VolunteerManager
+--     with #9706, each in its own migration appended after this one.
+--   * The V1 tables (volunteeropportunity_vol, person2volunteeropp_p2vo) are not
+--     read, written, altered or dropped here. V1 data is #9702's concern.
+--
+-- CREATE TABLE IF NOT EXISTS throughout, so re-running the script is a no-op.
+-- Tables are ordered so that every foreign-key target already exists.
+--
+-- volunteer_pool_vpol.vpol_OwnerId and volunteer_scope_vscp.vscp_ScopeId are
+-- polymorphic (ministry or team) and therefore carry no foreign key — the same
+-- limitation record2property_r2p lives with. The service layer enforces those.
+
+CREATE TABLE IF NOT EXISTS `volunteer_ministry_vmin` (
+  `vmin_ID`               int(11)               NOT NULL AUTO_INCREMENT,
+  `vmin_Name`             varchar(100)          NOT NULL,
+  `vmin_Description`      varchar(255)                   DEFAULT NULL,
+  `vmin_Active`           tinyint(1) unsigned   NOT NULL DEFAULT 1,
+  `vmin_CreatedDate`      datetime              NOT NULL,
+  `vmin_CreatedBy_per_ID` mediumint(9) unsigned          DEFAULT NULL,
+  PRIMARY KEY (`vmin_ID`),
+  UNIQUE KEY `vmin_name_uidx`  (`vmin_Name`),
+  KEY `vmin_active_idx`        (`vmin_Active`),
+  KEY `vmin_created_by_idx`    (`vmin_CreatedBy_per_ID`),
+  CONSTRAINT `fk_vmin_created_by` FOREIGN KEY (`vmin_CreatedBy_per_ID`)
+      REFERENCES `person_per` (`per_ID`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `volunteer_team_vtem` (
+  `vtem_ID`          int(11)             NOT NULL AUTO_INCREMENT,
+  `vtem_vmin_ID`     int(11)             NOT NULL,
+  `vtem_Name`        varchar(100)        NOT NULL,
+  `vtem_Description` varchar(255)                 DEFAULT NULL,
+  `vtem_Active`      tinyint(1) unsigned NOT NULL DEFAULT 1,
+  PRIMARY KEY (`vtem_ID`),
+  UNIQUE KEY `vtem_ministry_name_uidx` (`vtem_vmin_ID`, `vtem_Name`),
+  KEY `vtem_ministry_idx`              (`vtem_vmin_ID`),
+  CONSTRAINT `fk_vtem_ministry` FOREIGN KEY (`vtem_vmin_ID`)
+      REFERENCES `volunteer_ministry_vmin` (`vmin_ID`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `volunteer_pool_vpol` (
+  `vpol_ID`        int(11)                     NOT NULL AUTO_INCREMENT,
+  `vpol_OwnerType` enum('ministry','team')     NOT NULL,
+  `vpol_OwnerId`   int(11)                     NOT NULL,
+  `vpol_grp_ID`    mediumint(8) unsigned       NOT NULL,
+  `vpol_Label`     varchar(100)                         DEFAULT NULL,
+  PRIMARY KEY (`vpol_ID`),
+  UNIQUE KEY `vpol_owner_group_uidx` (`vpol_OwnerType`, `vpol_OwnerId`, `vpol_grp_ID`),
+  KEY `vpol_group_idx`               (`vpol_grp_ID`),
+  CONSTRAINT `fk_vpol_group` FOREIGN KEY (`vpol_grp_ID`)
+      REFERENCES `group_grp` (`grp_ID`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `volunteer_position_vpos` (
+  `vpos_ID`          int(11)             NOT NULL AUTO_INCREMENT,
+  `vpos_vmin_ID`     int(11)             NOT NULL,
+  `vpos_vtem_ID`     int(11)                      DEFAULT NULL,
+  `vpos_Name`        varchar(100)        NOT NULL,
+  `vpos_Description` varchar(255)                 DEFAULT NULL,
+  `vpos_Active`      tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `vpos_Order`       int(11)             NOT NULL DEFAULT 0,
+  PRIMARY KEY (`vpos_ID`),
+  -- MySQL treats NULLs as distinct inside a UNIQUE index, so this does not stop
+  -- two ministry-wide (vpos_vtem_ID IS NULL) positions sharing a name. That is
+  -- deliberate: VolunteerSetupService::createPosition() does the case-insensitive
+  -- check and the API returns 409. Do not "fix" it with a NOT NULL DEFAULT 0
+  -- sentinel — that is the event_types.type_grpid anti-pattern and it breaks the FK.
+  UNIQUE KEY `vpos_ministry_team_name_uidx` (`vpos_vmin_ID`, `vpos_vtem_ID`, `vpos_Name`),
+  KEY `vpos_ministry_active_idx`            (`vpos_vmin_ID`, `vpos_Active`),
+  KEY `vpos_team_idx`                       (`vpos_vtem_ID`),
+  CONSTRAINT `fk_vpos_ministry` FOREIGN KEY (`vpos_vmin_ID`)
+      REFERENCES `volunteer_ministry_vmin` (`vmin_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vpos_team` FOREIGN KEY (`vpos_vtem_ID`)
+      REFERENCES `volunteer_team_vtem` (`vtem_ID`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `volunteer_qualification_vqal` (
+  `vqal_ID`               int(11)               NOT NULL AUTO_INCREMENT,
+  `vqal_per_ID`           mediumint(9) unsigned NOT NULL,
+  `vqal_vpos_ID`          int(11)               NOT NULL,
+  `vqal_Active`           tinyint(1) unsigned   NOT NULL DEFAULT 1,
+  `vqal_GrantedDate`      datetime              NOT NULL,
+  `vqal_GrantedBy_per_ID` mediumint(9) unsigned          DEFAULT NULL,
+  `vqal_Notes`            varchar(255)                   DEFAULT NULL,
+  PRIMARY KEY (`vqal_ID`),
+  -- One row per person per position — NOT one per person per team or ministry.
+  -- This is what lets a volunteer hold several qualifications at once, which
+  -- person2group2role_p2g2r structurally cannot express.
+  UNIQUE KEY `vqal_person_position_uidx` (`vqal_per_ID`, `vqal_vpos_ID`),
+  KEY `vqal_position_active_idx`         (`vqal_vpos_ID`, `vqal_Active`),
+  KEY `vqal_person_idx`                  (`vqal_per_ID`),
+  KEY `vqal_granted_by_idx`              (`vqal_GrantedBy_per_ID`),
+  CONSTRAINT `fk_vqal_person` FOREIGN KEY (`vqal_per_ID`)
+      REFERENCES `person_per` (`per_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vqal_position` FOREIGN KEY (`vqal_vpos_ID`)
+      REFERENCES `volunteer_position_vpos` (`vpos_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vqal_granted_by` FOREIGN KEY (`vqal_GrantedBy_per_ID`)
+      REFERENCES `person_per` (`per_ID`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `volunteer_schedule_vsch` (
+  `vsch_ID`                int(11)                                        NOT NULL AUTO_INCREMENT,
+  `vsch_vmin_ID`           int(11)                                        NOT NULL,
+  `vsch_vtem_ID`           int(11)                                                 DEFAULT NULL,
+  `vsch_Name`              varchar(100)                                   NOT NULL,
+  `vsch_LinkMode`          enum('event_type','standalone')                NOT NULL,
+  `vsch_event_type_id`     int(11)                                                 DEFAULT NULL,
+  `vsch_TitleFilter`       varchar(255)                                            DEFAULT NULL,
+  `vsch_RecurType`         enum('none','weekly','monthly','yearly')       NOT NULL DEFAULT 'none',
+  `vsch_RecurDOW`          enum('Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday') DEFAULT NULL,
+  `vsch_RecurDOM`          tinyint(3)                                              DEFAULT NULL,
+  `vsch_StartTime`         time                                                    DEFAULT NULL,
+  `vsch_EndTime`           time                                                    DEFAULT NULL,
+  `vsch_WindowStart`       date                                           NOT NULL,
+  `vsch_WindowEnd`         date                                                    DEFAULT NULL,
+  `vsch_GenerateAheadDays` int(11)                                        NOT NULL DEFAULT 56,
+  `vsch_Active`            tinyint(1) unsigned                            NOT NULL DEFAULT 1,
+  PRIMARY KEY (`vsch_ID`),
+  KEY `vsch_ministry_idx`      (`vsch_vmin_ID`),
+  KEY `vsch_team_idx`          (`vsch_vtem_ID`),
+  KEY `vsch_type_idx`          (`vsch_event_type_id`),
+  KEY `vsch_active_window_idx` (`vsch_Active`, `vsch_WindowStart`),
+  CONSTRAINT `fk_vsch_ministry` FOREIGN KEY (`vsch_vmin_ID`)
+      REFERENCES `volunteer_ministry_vmin` (`vmin_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vsch_team` FOREIGN KEY (`vsch_vtem_ID`)
+      REFERENCES `volunteer_team_vtem` (`vtem_ID`) ON DELETE SET NULL,
+  CONSTRAINT `fk_vsch_event_type` FOREIGN KEY (`vsch_event_type_id`)
+      REFERENCES `event_types` (`type_id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `volunteer_occurrence_vocc` (
+  `vocc_ID`             int(11)                          NOT NULL AUTO_INCREMENT,
+  `vocc_vsch_ID`        int(11)                          NOT NULL,
+  `vocc_event_id`       int(11)                                   DEFAULT NULL,
+  `vocc_OccurrenceDate` date                             NOT NULL,
+  `vocc_StartDateTime`  datetime                                  DEFAULT NULL,
+  `vocc_EndDateTime`    datetime                                  DEFAULT NULL,
+  `vocc_Status`         enum('scheduled','cancelled')    NOT NULL DEFAULT 'scheduled',
+  `vocc_Notes`          varchar(255)                              DEFAULT NULL,
+  `vocc_GeneratedDate`  datetime                         NOT NULL,
+  PRIMARY KEY (`vocc_ID`),
+  -- Two unique keys, one per link mode, each idempotent for its own generation
+  -- path. MySQL permits several NULLs in a unique index, so linked rows never
+  -- collide on the standalone key and vice versa. The keys are per SCHEDULE, so
+  -- occurrences of different schedules may share one events_event row — that is
+  -- two ministries staffing the same service, and it is by design.
+  UNIQUE KEY `vocc_schedule_event_uidx` (`vocc_vsch_ID`, `vocc_event_id`),
+  UNIQUE KEY `vocc_schedule_start_uidx` (`vocc_vsch_ID`, `vocc_StartDateTime`),
+  KEY `vocc_date_idx`  (`vocc_OccurrenceDate`),
+  KEY `vocc_event_idx` (`vocc_event_id`),
+  CONSTRAINT `fk_vocc_schedule` FOREIGN KEY (`vocc_vsch_ID`)
+      REFERENCES `volunteer_schedule_vsch` (`vsch_ID`) ON DELETE CASCADE,
+  -- SET NULL, not CASCADE: deleting a church event must not erase the record
+  -- that people served. The occurrence survives on vocc_OccurrenceDate.
+  CONSTRAINT `fk_vocc_event` FOREIGN KEY (`vocc_event_id`)
+      REFERENCES `events_event` (`event_id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `volunteer_requirement_vreq` (
+  `vreq_ID`       int(11)      NOT NULL AUTO_INCREMENT,
+  `vreq_vsch_ID`  int(11)               DEFAULT NULL,
+  `vreq_vocc_ID`  int(11)               DEFAULT NULL,
+  `vreq_vpos_ID`  int(11)      NOT NULL,
+  `vreq_MinCount` int(11)      NOT NULL DEFAULT 1,
+  `vreq_MaxCount` int(11)               DEFAULT NULL,
+  `vreq_Notes`    varchar(255)          DEFAULT NULL,
+  PRIMARY KEY (`vreq_ID`),
+  UNIQUE KEY `vreq_schedule_position_uidx`   (`vreq_vsch_ID`, `vreq_vpos_ID`),
+  UNIQUE KEY `vreq_occurrence_position_uidx` (`vreq_vocc_ID`, `vreq_vpos_ID`),
+  KEY `vreq_position_idx`                    (`vreq_vpos_ID`),
+  CONSTRAINT `fk_vreq_schedule` FOREIGN KEY (`vreq_vsch_ID`)
+      REFERENCES `volunteer_schedule_vsch` (`vsch_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vreq_occurrence` FOREIGN KEY (`vreq_vocc_ID`)
+      REFERENCES `volunteer_occurrence_vocc` (`vocc_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vreq_position` FOREIGN KEY (`vreq_vpos_ID`)
+      REFERENCES `volunteer_position_vpos` (`vpos_ID`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `volunteer_assignment_vasg` (
+  `vasg_ID`                int(11)               NOT NULL AUTO_INCREMENT,
+  `vasg_vocc_ID`           int(11)               NOT NULL,
+  `vasg_vpos_ID`           int(11)               NOT NULL,
+  `vasg_per_ID`            mediumint(9) unsigned NOT NULL,
+  `vasg_vreq_ID`           int(11)                        DEFAULT NULL,
+  `vasg_Status`            enum('pending','accepted','declined','cancelled','substituted','completed')
+                                                 NOT NULL DEFAULT 'pending',
+  `vasg_Source`            enum('coordinator','self_signup','substitute')
+                                                 NOT NULL DEFAULT 'coordinator',
+  `vasg_AssignedDate`      datetime              NOT NULL,
+  `vasg_AssignedBy_per_ID` mediumint(9) unsigned          DEFAULT NULL,
+  `vasg_RespondedDate`     datetime                       DEFAULT NULL,
+  `vasg_Replaces_vasg_ID`  int(11)                        DEFAULT NULL,
+  `vasg_Notes`             varchar(255)                   DEFAULT NULL,
+  PRIMARY KEY (`vasg_ID`),
+  -- One assignment per person per POSITION per occurrence. Note what this
+  -- deliberately does not say: it is not (occurrence, person), so the same
+  -- person may hold rows for two different positions on one occurrence — lead
+  -- singing and serve communion at the same service. Do not tighten this index.
+  UNIQUE KEY `vasg_occ_pos_per_uidx` (`vasg_vocc_ID`, `vasg_vpos_ID`, `vasg_per_ID`),
+  KEY `vasg_occurrence_idx`     (`vasg_vocc_ID`, `vasg_Status`),
+  KEY `vasg_person_status_idx`  (`vasg_per_ID`, `vasg_Status`),
+  KEY `vasg_position_idx`       (`vasg_vpos_ID`),
+  KEY `vasg_requirement_idx`    (`vasg_vreq_ID`),
+  KEY `vasg_assigned_by_idx`    (`vasg_AssignedBy_per_ID`),
+  KEY `vasg_replaces_idx`       (`vasg_Replaces_vasg_ID`),
+  CONSTRAINT `fk_vasg_occurrence` FOREIGN KEY (`vasg_vocc_ID`)
+      REFERENCES `volunteer_occurrence_vocc` (`vocc_ID`) ON DELETE CASCADE,
+  -- RESTRICT: a position with assignments cannot be deleted, only deactivated,
+  -- so deactivation never destroys history.
+  CONSTRAINT `fk_vasg_position` FOREIGN KEY (`vasg_vpos_ID`)
+      REFERENCES `volunteer_position_vpos` (`vpos_ID`) ON DELETE RESTRICT,
+  CONSTRAINT `fk_vasg_person` FOREIGN KEY (`vasg_per_ID`)
+      REFERENCES `person_per` (`per_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vasg_requirement` FOREIGN KEY (`vasg_vreq_ID`)
+      REFERENCES `volunteer_requirement_vreq` (`vreq_ID`) ON DELETE SET NULL,
+  CONSTRAINT `fk_vasg_assigned_by` FOREIGN KEY (`vasg_AssignedBy_per_ID`)
+      REFERENCES `person_per` (`per_ID`) ON DELETE SET NULL,
+  CONSTRAINT `fk_vasg_replaces` FOREIGN KEY (`vasg_Replaces_vasg_ID`)
+      REFERENCES `volunteer_assignment_vasg` (`vasg_ID`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `volunteer_response_vrsp` (
+  `vrsp_ID`           int(11)               NOT NULL AUTO_INCREMENT,
+  `vrsp_vasg_ID`      int(11)               NOT NULL,
+  `vrsp_per_ID`       mediumint(9) unsigned NOT NULL,
+  `vrsp_Response`     enum('accepted','declined','cancelled','substitute_proposed','substitute_approved','substitute_rejected','substitute_withdrawn')
+                                            NOT NULL,
+  `vrsp_ResponseDate` datetime              NOT NULL,
+  `vrsp_Channel`      enum('web','coordinator') NOT NULL DEFAULT 'web',
+  `vrsp_Comment`      varchar(255)                   DEFAULT NULL,
+  PRIMARY KEY (`vrsp_ID`),
+  KEY `vrsp_assignment_idx` (`vrsp_vasg_ID`, `vrsp_ResponseDate`),
+  KEY `vrsp_person_idx`     (`vrsp_per_ID`),
+  CONSTRAINT `fk_vrsp_assignment` FOREIGN KEY (`vrsp_vasg_ID`)
+      REFERENCES `volunteer_assignment_vasg` (`vasg_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vrsp_person` FOREIGN KEY (`vrsp_per_ID`)
+      REFERENCES `person_per` (`per_ID`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `volunteer_swap_vswp` (
+  `vswp_ID`               int(11)               NOT NULL AUTO_INCREMENT,
+  `vswp_vasg_ID`          int(11)               NOT NULL,
+  `vswp_ProposedBy_per_ID` mediumint(9) unsigned NOT NULL,
+  `vswp_Proposed_per_ID`  mediumint(9) unsigned NOT NULL,
+  `vswp_Status`           enum('proposed','approved','rejected','withdrawn') NOT NULL DEFAULT 'proposed',
+  `vswp_ProposedDate`     datetime              NOT NULL,
+  `vswp_DecidedDate`      datetime                       DEFAULT NULL,
+  `vswp_DecidedBy_per_ID` mediumint(9) unsigned          DEFAULT NULL,
+  `vswp_Comment`          varchar(255)                   DEFAULT NULL,
+  PRIMARY KEY (`vswp_ID`),
+  -- "At most one proposed swap per assignment" is service-enforced: MySQL has no
+  -- partial unique index, so it cannot be expressed here.
+  KEY `vswp_assignment_status_idx` (`vswp_vasg_ID`, `vswp_Status`),
+  KEY `vswp_proposed_person_idx`   (`vswp_Proposed_per_ID`),
+  KEY `vswp_proposed_by_idx`       (`vswp_ProposedBy_per_ID`),
+  KEY `vswp_decided_by_idx`        (`vswp_DecidedBy_per_ID`),
+  CONSTRAINT `fk_vswp_assignment` FOREIGN KEY (`vswp_vasg_ID`)
+      REFERENCES `volunteer_assignment_vasg` (`vasg_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vswp_proposed_by` FOREIGN KEY (`vswp_ProposedBy_per_ID`)
+      REFERENCES `person_per` (`per_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vswp_proposed_person` FOREIGN KEY (`vswp_Proposed_per_ID`)
+      REFERENCES `person_per` (`per_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vswp_decided_by` FOREIGN KEY (`vswp_DecidedBy_per_ID`)
+      REFERENCES `person_per` (`per_ID`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `volunteer_notification_vntf` (
+  `vntf_ID`              int(11)               NOT NULL AUTO_INCREMENT,
+  `vntf_Type`            enum('assignment','reminder','decline_alert','gap_alert','signup_confirm','swap_proposed','swap_resolved')
+                                               NOT NULL,
+  `vntf_Channel`         enum('email')         NOT NULL DEFAULT 'email',
+  `vntf_per_ID`          mediumint(9) unsigned NOT NULL,
+  `vntf_vasg_ID`         int(11)                        DEFAULT NULL,
+  `vntf_vocc_ID`         int(11)                        DEFAULT NULL,
+  -- 190, not 255: the InnoDB index prefix limit for a utf8mb4 unique key.
+  `vntf_DedupeKey`       varchar(190)          NOT NULL,
+  `vntf_ScheduledFor`    datetime              NOT NULL,
+  `vntf_Status`          enum('pending','sent','failed','skipped') NOT NULL DEFAULT 'pending',
+  `vntf_Attempts`        int(11)               NOT NULL DEFAULT 0,
+  `vntf_LastAttemptDate` datetime                       DEFAULT NULL,
+  `vntf_SentDate`        datetime                       DEFAULT NULL,
+  `vntf_LastError`       varchar(255)                   DEFAULT NULL,
+  PRIMARY KEY (`vntf_ID`),
+  -- The idempotency guarantee: enqueue is findOneOrCreate() on this key inside
+  -- the same transaction as the state change, so a retried operation produces no
+  -- second message. Same idiom as event_attend's UNIQUE(event_id, person_id).
+  UNIQUE KEY `vntf_dedupe_uidx` (`vntf_DedupeKey`),
+  KEY `vntf_due_idx`            (`vntf_Status`, `vntf_ScheduledFor`),
+  KEY `vntf_assignment_idx`     (`vntf_vasg_ID`),
+  KEY `vntf_person_idx`         (`vntf_per_ID`),
+  KEY `vntf_occurrence_idx`     (`vntf_vocc_ID`),
+  CONSTRAINT `fk_vntf_person` FOREIGN KEY (`vntf_per_ID`)
+      REFERENCES `person_per` (`per_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vntf_assignment` FOREIGN KEY (`vntf_vasg_ID`)
+      REFERENCES `volunteer_assignment_vasg` (`vasg_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vntf_occurrence` FOREIGN KEY (`vntf_vocc_ID`)
+      REFERENCES `volunteer_occurrence_vocc` (`vocc_ID`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `volunteer_scope_vscp` (
+  `vscp_ID`               int(11)                 NOT NULL AUTO_INCREMENT,
+  `vscp_per_ID`           mediumint(9) unsigned   NOT NULL,
+  `vscp_ScopeType`        enum('ministry','team') NOT NULL,
+  `vscp_ScopeId`          int(11)                 NOT NULL,
+  `vscp_GrantedDate`      datetime                NOT NULL,
+  `vscp_GrantedBy_per_ID` mediumint(9) unsigned            DEFAULT NULL,
+  PRIMARY KEY (`vscp_ID`),
+  -- Makes granting a scope idempotent, the same way event_attend's unique key
+  -- makes checking someone in idempotent.
+  UNIQUE KEY `vscp_person_scope_uidx` (`vscp_per_ID`, `vscp_ScopeType`, `vscp_ScopeId`),
+  KEY `vscp_person_idx`               (`vscp_per_ID`),
+  KEY `vscp_scope_idx`                (`vscp_ScopeType`, `vscp_ScopeId`),
+  KEY `vscp_granted_by_idx`           (`vscp_GrantedBy_per_ID`),
+  CONSTRAINT `fk_vscp_person` FOREIGN KEY (`vscp_per_ID`)
+      REFERENCES `person_per` (`per_ID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vscp_granted_by` FOREIGN KEY (`vscp_GrantedBy_per_ID`)
+      REFERENCES `person_per` (`per_ID`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/mysql/upgrade/7.7.0-volunteer-v2-schema.sql
+++ b/src/mysql/upgrade/7.7.0-volunteer-v2-schema.sql
@@ -191,6 +191,12 @@ CREATE TABLE IF NOT EXISTS `volunteer_occurrence_vocc` (
   -- that people served. The occurrence survives on vocc_OccurrenceDate.
   CONSTRAINT `fk_vocc_event` FOREIGN KEY (`vocc_event_id`)
       REFERENCES `events_event` (`event_id`) ON DELETE SET NULL
+  -- No CHECK "standalone rows must have a start time": once fk_vocc_event has
+  -- SET NULL a deleted event, a formerly linked row legitimately has neither an
+  -- event nor a start time (its date lives in vocc_OccurrenceDate), and MariaDB
+  -- refuses a CHECK on a column an FK action can change anyway. The generator
+  -- (VolunteerScheduleService, #9708) always sets vocc_StartDateTime for
+  -- standalone schedules; vocc_schedule_start_uidx deduplicates those rows.
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `volunteer_requirement_vreq` (
@@ -210,7 +216,12 @@ CREATE TABLE IF NOT EXISTS `volunteer_requirement_vreq` (
   CONSTRAINT `fk_vreq_occurrence` FOREIGN KEY (`vreq_vocc_ID`)
       REFERENCES `volunteer_occurrence_vocc` (`vocc_ID`) ON DELETE CASCADE,
   CONSTRAINT `fk_vreq_position` FOREIGN KEY (`vreq_vpos_ID`)
-      REFERENCES `volunteer_position_vpos` (`vpos_ID`) ON DELETE CASCADE
+      REFERENCES `volunteer_position_vpos` (`vpos_ID`) ON DELETE CASCADE,
+  -- Exactly one parent: a template requirement belongs to a schedule, an
+  -- override to an occurrence, never both and never neither. Enforced on
+  -- MariaDB 10.2.1+ / MySQL 8.0.16+; parsed and ignored by MySQL 5.7.
+  CONSTRAINT `vreq_one_parent_chk`
+      CHECK ((`vreq_vsch_ID` IS NULL) <> (`vreq_vocc_ID` IS NULL))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `volunteer_assignment_vasg` (

--- a/src/mysql/upgrade/7.8.0-volunteer-v2-schema.sql
+++ b/src/mysql/upgrade/7.8.0-volunteer-v2-schema.sql
@@ -1,4 +1,4 @@
--- ChurchCRM 7.7.0 — Volunteer Management v2 core domain model
+-- ChurchCRM 7.8.0 — Volunteer Management v2 core domain model
 -- Implements #9705 (epic #9701); design: .agents/skills/churchcrm/volunteer-v2-design.md §2
 --
 -- Why these tables exist at all, in one line each (the long form, with the


### PR DESCRIPTION
Release target: **7.8.0** — deferred from 7.7.0.

## What Changed

Adds the thirteen `volunteer_*` tables that Volunteer Management v2 is built on, the 7.7.0
migration that creates them, the matching `Install.sql` and Cypress seed blocks, the hand-written
Propel model and query subclasses, and an API spec that proves the constraints at the database
level.

This is schema only. There is no service, no endpoint, no route, no UI and no setting in this PR —
those belong to #9706 onward. **No user-visible change, so no docs issue is needed.**

Domain: Ministry → Team → Position, Volunteer Pool (a link to an existing ChurchCRM Group),
Qualification (person ↔ position), Schedule → Occurrence, Staffing Requirement, Assignment,
Assignment Response, Substitution/Swap, Notification outbox, and Scope. Open Gap is derived, not
stored.

Deliberately **not** in this PR, to keep `upgrade.json` conflict-free: `usr_VolunteerManager`
(#9706) and `events_event.event_ministry_id` (#9713). Each ships its own migration script appended
after this one, in that order — #9713's foreign key needs `volunteer_ministry_vmin` to exist first.

Fixes #9705
Part of #9701

## Type
- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Reuse decisions (epic #9701 requires these to be answered)

**Migration conventions — reused wholesale, worked example `7.6.4-pledge-denominations.sql`.**
That is the newest hand-written table in the tree, and the new script copies it line for line:
`CREATE TABLE IF NOT EXISTS`, `ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`,
`_idx` / `_uidx` index names, a leading comment that names the issue and explains *why* the table
exists. Following `db-schema-migration.md`, the script is appended to the **existing `current`
block** in `upgrade.json` and `dbVersion` stays `7.7.0` — this is a script for the release already
in development, not a new release, so no `pre-X.Y.Z` block is created. `Install.sql` is updated as
well, because nothing in the build validates it against `schema.xml` and the two have already
drifted for `events_event`. (Registration in `upgrade.json` was subsequently deferred to the 7.8.0
block at the maintainer's request — see Pre-Merge.)

**Foreign-key column types matched to the parent, which is NOT what the nearest neighbours do.**
`person_per.per_ID` is `mediumint(9) unsigned` and `group_grp.grp_ID` is `mediumint(8) unsigned`,
but `person2group2role_p2g2r.p2g2r_per_ID` declares `mediumint(8) unsigned` against the 9-wide
parent, and `event_audience.event_id` declares `mediumint(8) unsigned` against `events_event`'s
plain `int(11)`. Copying either would silently narrow the V2 key space and make the join types
disagree. Every V2 foreign-key column therefore takes the parent's exact type — and the spec
asserts that by comparing `information_schema.COLUMNS.COLUMN_TYPE` on both sides rather than
trusting the declaration. The `PrimaryContact` foreign-key block in `events_event` was likewise
**not** used as a template: it maps `local="event_type"` to `person_per.per_ID` and is wrong.

**`event_attend`'s `UNIQUE` + `findOneOrCreate()` idiom reused as the idempotency pattern.**
`event_attend` has `UNIQUE (event_id, person_id)` and `Event::checkInPerson()` uses
`findOneOrCreate()` against it, which is exactly why checking somebody in twice is harmless. The
same shape is applied three times here: `vscp_person_scope_uidx` makes granting a scope idempotent,
`vocc_schedule_event_uidx` / `vocc_schedule_start_uidx` make occurrence generation idempotent (one
key per link mode — MySQL permits several NULLs in a unique index, so linked and standalone rows
never collide with each other), and `vntf_dedupe_uidx` makes enqueuing a notification idempotent,
which is what #9710's "duplicate notifications are avoided when operations are retried" needs.

**Group Roles evaluated and rejected as the qualification model — with the primary key as the
evidence.** `person2group2role_p2g2r` has primary key `(p2g2r_per_ID, p2g2r_grp_ID)`: one role per
person per group. A volunteer qualified for Setup, Espresso **and** Expeditor in one team is
therefore not merely awkward to express, it is structurally impossible. Two further facts confirm
it: `GroupService::deleteGroupRole()` renumbers the `lst_OptionID` of every surviving higher role,
so any foreign key kept to a role id would silently re-point at a different role; and
`Group::preSave/preInsert/preUpdate/preDelete` plus the four equivalents on
`Person2group2roleP2g2r` call `AuthService::requireUserGroupMembership('bManageGroups')`, which
reads `$_SESSION` flags an API-key caller never sets. `volunteer_qualification_vqal` with
`UNIQUE (vqal_per_ID, vqal_vpos_ID)` — one row per person per **position** — expresses the
requirement directly.

**Group Properties (both systems) evaluated and rejected as a home for qualification.** The
per-group property tables are created at runtime as `groupprop_<id>` with generated `c1..cN`
columns, no primary key on the master table, raw SQL throughout, and they are dropped when the
feature is disabled for a group. Nothing can foreign-key into that, and a qualification that
disappears when someone toggles a group setting is not a qualification.

**Groups reused as the roster, and membership is not copied.** `volunteer_pool_vpol` stores
`(owner, grp_ID)` and nothing else — no people. `ON DELETE CASCADE` on the group foreign key means
deleting a group unlinks the pool without touching a single assignment or response row. A link
table rather than a nullable `vtem_grp_ID` column, because more than one pool may feed one team.

**Open Gap deliberately has no table.** A gap is
`max(0, requirement.MinCount - count(assignments in ('pending','accepted')))`, computed on demand.
#9705 asks for gaps derivable "without duplicating assignment truth", and a persisted gap is a
cache that disagrees with the assignments the first time a decline is processed outside the happy
path. `declined` and `cancelled` rows simply do not count as live, which is how "a decline creates
a gap" falls out with no extra code.

**The `db:query` Cypress task is test infrastructure, justified rather than convenient.** There is
no PHP test suite in this repository — no PHPUnit, no `tests/`, no composer `test` script — so
100 % of behavioural coverage is Cypress E2E, and #9705 delivers no endpoint for a spec to call.
Its acceptance criteria ("duplicate assignments are prevented", "the migration does not modify V1
volunteer data") live in UNIQUE keys, foreign keys, ON DELETE rules and enum domains, none of which
has an HTTP surface. A node-event task is the only way a spec can reach them. `mysql2` is already a
devDependency, so this adds no dependency; the task is registered in `cypress/configs/_shared.ts`
so every config can use it, and #9707–#9714 reuse it rather than each inventing its own.

## Files Changed

| File | Change |
|---|---|
| `orm/schema.xml` | the 13 tables, with foreign keys, InnoDB vendor blocks and a `description` on every table |
| `src/mysql/upgrade/7.8.0-volunteer-v2-schema.sql` | new — creates the 13 tables, ordered so every FK target exists first |
| `src/mysql/upgrade.json` | the script appended to the existing `current` block; `dbVersion` unchanged |
| `src/mysql/install/Install.sql` | the same 13 `CREATE TABLE` blocks for fresh installs |
| `cypress/data/seed.sql` | the same 13 blocks, dump style, so Cypress runs against the real schema |
| `src/ChurchCRM/model/ChurchCRM/Volunteer*.php` (26 files) | hand-written model and query subclasses with the enum vocabularies as constants |
| `cypress/configs/_shared.ts`, `cypress/configs/docker.config.ts` | the `db:query` node-event task |
| `cypress/support/api-commands.js`, `cypress/support/commands.d.ts` | the `cy.dbQuery` wrapper and its declaration |
| `cypress/e2e/api/private/standard/private.volunteer.setup.spec.js` | new — 37 assertions over the schema guarantees |

`src/ChurchCRM/model/ChurchCRM/Base/` and `Map/` are gitignored, so nothing from the Propel
regeneration is committed.

## Testing

```bash
npm run docker:test:start
rm -f src/logs/$(date +%Y-%m-%d)-*.log

npm run test:api -- --spec "cypress/e2e/api/private/standard/private.volunteer.setup.spec.js"

# regression — the two specs nearest this change
npm run test:api -- --spec "cypress/e2e/api/private/standard/private.calendar.events-checkin.spec.js"
npm run test:api -- --spec "cypress/e2e/api/private/admin/private.admin.volunteer-opportunities.spec.js"

cat src/logs/$(date +%Y-%m-%d)-php.log
```

The spec builds the design's worked example as fixture rows (Coffee Bar and Sunday Worship, with
both occurrences pointing at one `events_event` row so two ministries staff the same service) and
asserts:

- all 13 tables exist, are InnoDB and are `utf8mb4`, with exactly the documented column set;
- every primary key is `<prefix>_ID` and no table carries a redundant `UNIQUE` on it;
- every index ends in `_idx` or `_uidx`;
- all 33 foreign keys exist with the documented `ON DELETE` rule, and the set is exactly the
  expected one — no extras, no omissions;
- the two polymorphic columns have **no** foreign key, and an owner id pointing at nothing is
  accepted, because that is a service concern;
- every UNIQUE key rejects a duplicate with `ER_DUP_ENTRY`, including `vasg_occ_pos_per_uidx`
  refusing the same person twice on one position while **allowing** that person on two different
  positions of the same occurrence;
- the documented MySQL NULL trap on `vpos_ministry_team_name_uidx` is pinned, so nobody "fixes" it
  with a `NOT NULL DEFAULT 0` sentinel that would break the foreign key;
- foreign keys reject orphans, deleting an occurrence cascades its assignments, deleting a position
  that has assignments is refused, deleting the replaced assignment nulls `vasg_Replaces_vasg_ID`,
  and deleting a person cascades their qualifications, assignments and scopes while a grant they
  made survives with a null granter;
- enum columns reject an unknown value — the spec reads `@@sql_mode` first and asserts rejection
  under strict mode, truncation otherwise;
- `volunteeropportunity_vol` and `person2volunteeropp_p2vo` have identical row counts before and
  after the whole run.

**Results:** 37 tests. Before the schema existed: 3 passing, 6 failing, 28 skipped. After: 37/37
passing. Regression: `private.calendar.events-checkin.spec.js` 34/34 and
`private.admin.volunteer-opportunities.spec.js` 14/14. `npm run lint` and `npm run build` clean.
`src/logs/*-php.log` is not created (no PHP errors); the `ERROR` lines in `app.log` are the
expected `400` negative paths asserted by the check-in spec.

Test database observed: MariaDB 10.11.19, `sql_mode =
STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION`.

### Migration paths verified

1. **Fresh install** — `Install.sql` loaded into an empty database creates all 13 tables and all 33
   foreign keys, none of them `utf8mb3`.
2. **Upgrade** — the 13 tables dropped from a seeded database and
   `7.8.0-volunteer-v2-schema.sql` applied by hand produces structures **byte-identical** to the
   fresh install for all 13 tables (`SHOW CREATE TABLE` diff, `AUTO_INCREMENT=` counters
   normalised). Applying the script a second time changes nothing.
3. **Seed** — recreating the Cypress database volume from scratch brings the 13 tables and their
   33 foreign keys up from `seed.sql` with no rows.
4. **Real upgrade from 6.0.0 through the application** — `cypress/fixtures/upgrade/churchcrm-6.0.0.sql`
   (the nightly `test-upgrade` fixture) loaded into an empty database, then one page load. The
   Bootstrapper ran every script from `6.2.0.sql` through `7.8.0-volunteer-v2-schema.sql` and logged
   "Database auto-upgrade completed successfully"; the result is `version_ver` 7.7.0, 13 tables,
   33 foreign keys, and `volunteeropportunity_vol` unchanged. The fixture's parent columns
   (`per_ID mediumint(9) unsigned`, `grp_ID mediumint(8) unsigned`, `event_id`/`type_id int(11)`,
   all InnoDB) are what the foreign keys were typed against.

### Reviewer note: these are the first enforced foreign keys in the schema

`orm/schema.xml` declares `<foreign-key>` elements for existing tables, but `Install.sql`,
`seed.sql` and every upgrade script to date contain no `FOREIGN KEY` clause —
`information_schema.REFERENTIAL_CONSTRAINTS` is empty on a stock install. The V2 tables declare
real constraints, as the design (§2.0) specifies, so `ON DELETE CASCADE` / `SET NULL` / `RESTRICT`
genuinely fire and orphan inserts are rejected. Every constraint points at a V2 table or at
`person_per`, `group_grp`, `events_event` or `event_types`, all InnoDB since at least 6.0.0. If the
project would rather keep foreign keys ORM-only, the constraints can be dropped from the three SQL
files without changing `schema.xml`; the spec's ON DELETE assertions would go with them.

## Pre-Merge
- [x] Tested locally
- [x] No new warnings
- [x] Build passes (`npm run lint`, `npm run build`)
- [x] Backward compatible — **migration documented**

**Migration:** `src/mysql/upgrade/7.8.0-volunteer-v2-schema.sql`. Per the maintainer's release
decision (Volunteer v2 targets 7.8.0), the script is **not registered** in `upgrade.json`: the
maintainer's correction (cherry-picked as `dbb292947`) renamed it to 7.8.0 and removed it from the
active 7.7.0 block; it is registered when the 7.8.0 development boundary opens. Until then a fresh
install gets the tables from `Install.sql` and the Cypress database from `seed.sql`; an upgraded
7.7.0 database does not get them, which is intended — nothing in 7.7.0 reads them. The script itself
only runs `CREATE TABLE IF NOT EXISTS`, adds no column, drops nothing, alters nothing and reads no
existing data, so it is additive and a no-op on re-run; fresh install, hand-applied upgrade and the
6.0.0→current run through the Bootstrapper were verified before the deferral (see Testing) and will
be re-run once the script is registered in the 7.8.0 block.

**Sequencing note for reviewers:** #9706 and #9713 add their own `7.8.0-volunteer-v2-*.sql`
scripts (a permission column and the event ministry column), likewise unregistered until the 7.8.0
block opens. When that block is created the order must be this script → #9706's → #9713's, because
#9713's foreign key targets `volunteer_ministry_vmin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

