### PR TITLE
Escape the event title for attribute context in the event action menu

### DIFF
--- a/.agents/skills/churchcrm/frontend-development.md
+++ b/.agents/skills/churchcrm/frontend-development.md
@@ -1492,13 +1492,20 @@ literal `</script>` before saving.
 3. CSP forbids inline `onclick` outright (the project rule lives in
    MEMORY.md → "no inline `onclick` (CSP)").
 
-**Pattern:** put the user string into an HTML attribute (`escapeHtml()` IS the
-right encoding here — attribute context), then read it from a delegated click
-handler.
+**Pattern:** put the user string into an HTML attribute, then read it from a
+delegated click handler.
+
+Use `window.CRM.escapeAttribute()` for **every** attribute context (`data-*`,
+`title=`, `value=`, …). `escapeHtml()` encodes only `&`, `<` and `>`, so a `"`
+or `'` in the value closes the quoted attribute early and the rest of the
+string is parsed as further attributes on the element; `escapeAttribute()`
+wraps `escapeHtml()` and additionally encodes both quote characters. Reserve
+`escapeHtml()` for HTML *text* context (element bodies, bootbox message
+strings). <!-- learned: 2026-09-12 -->
 
 ```js
 // In the row renderer (DataTables, list, etc.)
-var nameAttr = window.CRM.escapeHtml(row.Name);  // attribute-safe
+var nameAttr = window.CRM.escapeAttribute(row.Name);  // attribute-safe: also encodes " and '
 var html = '<button class="btn btn-outline-secondary"' +
   ' data-row-action="rename"' +
   ' data-row-id="' + row.Id + '"' +

--- a/.agents/skills/churchcrm/table-action-menu.md
+++ b/.agents/skills/churchcrm/table-action-menu.md
@@ -76,6 +76,7 @@ renderers.
 - `familyId` — optional; when provided, adds a "View Family" item after Edit
 - `inCart` — optional; flips cart button to RemoveFromCart state
 - The global `.delete-person` delegated handler is registered in `CRMJSOM.js` — **no per-page copy needed**
+- Any user-supplied string going into a `data-*` (or other) attribute must be encoded with `window.CRM.escapeAttribute()`, which encodes quotes as well; `window.CRM.escapeHtml()` is for HTML text context only <!-- learned: 2026-09-12 -->
 - These functions call `i18next.t()` at render time (safe: DataTables render after locales load)
 
 ```javascript

--- a/cypress/e2e/ui/tables/event-action-menu-title.spec.js
+++ b/cypress/e2e/ui/tables/event-action-menu-title.spec.js
@@ -1,0 +1,200 @@
+/// <reference types="cypress" />
+
+/**
+ * Regression tests: the event action menu must encode the event title for
+ * ATTRIBUTE context when it writes it into `data-event_title="…"`.
+ *
+ * `window.CRM.escapeHtml()` encodes `&`, `<` and `>` but leaves `"` and `'`
+ * untouched, so it is only correct for HTML *text* context. Attribute values
+ * need `window.CRM.escapeAttribute()`, which additionally encodes both quote
+ * characters. `window.CRM.renderPersonActionMenu()` already uses
+ * `escapeAttribute()` for its `data-person_name` attribute; this spec pins the
+ * same behaviour for `window.CRM.renderEventActionMenu()` so an ordinary
+ * apostrophe-and-quote title such as `Choir "Spring" Night & Co's` round-trips
+ * unchanged and does not add stray attributes to the Delete button.
+ *
+ * Scenarios covered:
+ *   1. Renderer  - window.CRM.renderEventActionMenu() output parsed with DOMParser
+ *   2. Events Dashboard (/event/dashboard) - PHP placeholder hydrated by the renderer
+ *   3. V2 Dashboard (/v2/dashboard) - "Today's Events" DataTable column
+ *
+ * Fixtures are created and removed through the API with the cleanup-before
+ * pattern (see .agents/skills/churchcrm/cypress-testing.md): `before` deletes
+ * any leftovers from an earlier (possibly crashed) run, then creates the
+ * fixture; `after` removes it again for tidiness.
+ */
+
+// Plain-English title exercising all three characters that matter here:
+// a double quote, a single quote and an ampersand.
+const EVENT_TITLE = 'Choir "Spring" Night & Co\'s';
+
+// The Delete item must carry exactly these attributes — no more.
+const EXPECTED_DELETE_ATTRS = ["type", "class", "data-event_id", "data-event_title"];
+
+/**
+ * Every event currently stored under the fixture title.
+ * GET /api/events answers 404 when the events table is empty.
+ *
+ * @returns {Cypress.Chainable<number[]>} matching event ids
+ */
+function findFixtureEventIds() {
+    return cy.makePrivateAdminAPICall("GET", "/api/events", null, [200, 404]).then((resp) => {
+        if (resp.status !== 200) {
+            return [];
+        }
+        const payload = resp.body.Events || resp.body;
+        const events = Array.isArray(payload) ? payload : Object.values(payload);
+        return events.filter((e) => e && e.Title === EVENT_TITLE).map((e) => e.Id);
+    });
+}
+
+/**
+ * Delete every event stored under the fixture title.
+ * Accepts 404 so a fresh database is fine too.
+ */
+function deleteFixtureEvents() {
+    findFixtureEventIds().then((ids) => {
+        ids.forEach((id) => {
+            cy.makePrivateAdminAPICall("DELETE", `/api/events/${id}`, {}, [200, 404]);
+        });
+    });
+}
+
+/**
+ * Create the fixture event and yield its id.
+ *
+ * Start/End are sent as local (not UTC) datetime strings because the API
+ * stores them verbatim. Midday-to-end-of-day keeps the row in the dashboard's
+ * "current events" tbody rather than the collapsible "past events" one.
+ *
+ * @returns {Cypress.Chainable<number>} the new event id
+ */
+function createFixtureEvent() {
+    const now = new Date();
+    const day = [
+        now.getFullYear(),
+        String(now.getMonth() + 1).padStart(2, "0"),
+        String(now.getDate()).padStart(2, "0"),
+    ].join("-");
+
+    return cy
+        .makePrivateAdminAPICall(
+            "POST",
+            "/api/events",
+            {
+                Title: EVENT_TITLE,
+                Type: 1,
+                PinnedCalendars: [1],
+                Start: `${day}T12:00:00`,
+                End: `${day}T23:59:00`,
+            },
+            200,
+        )
+        .then(() => findFixtureEventIds())
+        .then((ids) => {
+            expect(ids, "fixture event should exist after creation").to.have.length(1);
+            return ids[0];
+        });
+}
+
+/**
+ * Assert a rendered Delete button round-trips the literal title and carries
+ * exactly the expected attribute set.
+ *
+ * @param {HTMLElement} btn     - the `.delete-event` button
+ * @param {string}      context - label for assertion messages
+ */
+function assertDeleteButtonAttributes(btn, context) {
+    expect(btn.getAttribute("data-event_title"), `[${context}] data-event_title`).to.equal(EVENT_TITLE);
+
+    const names = Array.from(btn.attributes)
+        .map((a) => a.name)
+        .sort();
+    expect(names, `[${context}] attribute set`).to.deep.equal([...EXPECTED_DELETE_ATTRS].sort());
+}
+
+describe("Event action menu — title in data-event_title", () => {
+    let eventId;
+
+    before(() => {
+        // 1. Remove anything an earlier (possibly failed) run left behind.
+        deleteFixtureEvents();
+        // 2. Create the fixture this spec needs.
+        createFixtureEvent().then((id) => {
+            eventId = id;
+        });
+    });
+
+    after(() => {
+        deleteFixtureEvents();
+    });
+
+    // Session setup runs last in each test's setup chain — cy.request() resets
+    // the PHP session cookie, so it must come after all API calls.
+    beforeEach(() => cy.setupAdminSession());
+
+    // ── Scenario 1: the renderer itself ──────────────────────────────────────
+    it("renderEventActionMenu() writes the literal title into data-event_title", () => {
+        cy.visit("/v2/dashboard");
+        cy.window().should("have.nested.property", "CRM.renderEventActionMenu");
+
+        cy.window().then((win) => {
+            const html = win.CRM.renderEventActionMenu(1, EVENT_TITLE);
+            const doc = new DOMParser().parseFromString(html, "text/html");
+            // querySelectorAll (not querySelector + .to.exist): Cypress overrides
+            // the `exist` assertion with jQuery semantics, which a raw Element
+            // does not satisfy.
+            const buttons = doc.querySelectorAll(".delete-event");
+
+            expect(buttons.length, "renderer emits exactly one .delete-event button").to.equal(1);
+            assertDeleteButtonAttributes(buttons[0], "renderEventActionMenu");
+            expect(buttons[0].getAttribute("data-event_id"), "[renderEventActionMenu] data-event_id").to.equal("1");
+        });
+    });
+
+    // ── Scenario 2: Events Dashboard (PHP placeholder + JS hydration) ────────
+    it("[/event/dashboard] the row's Delete item round-trips the title", () => {
+        cy.visit("/event/dashboard");
+
+        // The placeholder is hydrated by list-events.php once locales are ready.
+        // Assert on existence, not visibility: past-event tbodies start collapsed.
+        cy.get(`.event-action-menu-placeholder[data-event-id="${eventId}"] .delete-event`, { timeout: 15000 })
+            .should("exist")
+            .then(($btn) => {
+                assertDeleteButtonAttributes($btn[0], "event dashboard");
+                expect($btn.attr("data-event_title")).to.equal(EVENT_TITLE);
+                expect($btn.attr("data-event_id")).to.equal(String(eventId));
+            });
+    });
+
+    // ── Scenario 3: V2 Dashboard "Today's Events" DataTable ──────────────────
+    // GET /events/today filters on the server's calendar day. When the server
+    // clock has rolled past midnight relative to the browser's, the fixture is
+    // not "today" for the widget; skip rather than assert on an absent row.
+    it("[/v2/dashboard] the Today's Events Delete item round-trips the title", function () {
+        cy.makePrivateAdminAPICall("GET", "/api/events/today", null, [200, 404])
+            .then((resp) => {
+                // GET /events/today answers { "events": [ { id, title, … } ] }.
+                const events = (resp.status === 200 && resp.body.events) || [];
+                return events.some((e) => e && Number(e.id) === Number(eventId));
+            })
+            .then((isToday) => {
+                if (!isToday) {
+                    cy.log("fixture event is not in the server's today window — skipping");
+                    this.skip();
+                    return;
+                }
+
+                // cy.request() above reset the PHP session cookie.
+                cy.setupAdminSession();
+                cy.visit("/v2/dashboard");
+
+                cy.get(`#todayEventsDashboardItem .delete-event[data-event_id="${eventId}"]`, { timeout: 15000 })
+                    .should("exist")
+                    .then(($btn) => {
+                        assertDeleteButtonAttributes($btn[0], "v2 dashboard");
+                        expect($btn.attr("data-event_title")).to.equal(EVENT_TITLE);
+                    });
+            });
+    });
+});

--- a/src/skin/js/CRMJSOM.js
+++ b/src/skin/js/CRMJSOM.js
@@ -747,7 +747,8 @@ window.CRM.renderEventActionMenu = (eventId, eventTitle, options) => {
   options = options || {};
   const inactive = options.inactive || false;
   const root = window.CRM.root;
-  const escapedTitle = window.CRM.escapeHtml(eventTitle || "");
+  // use escapeAttribute (encodes quotes) for data-* attribute context, as renderPersonActionMenu does
+  const escapedTitle = window.CRM.escapeAttribute(eventTitle || "");
 
   const statusButton = inactive
     ? '<button type="button" class="dropdown-item activate-event" data-event_id="' +


### PR DESCRIPTION
## What Changed

`window.CRM.renderEventActionMenu()` writes the event title into the Delete item's
`data-event_title` attribute. It built that value with `window.CRM.escapeHtml()`, which encodes
only `&`, `<` and `>`, so a title containing a quote character did not survive the round trip
through the attribute: the value was truncated at the first double quote and the remainder of the
title was parsed as further attributes on the `<button>`.

This switches the call to `window.CRM.escapeAttribute()`, which wraps `escapeHtml()` and
additionally encodes `"` and `'`. `renderPersonActionMenu()` already uses `escapeAttribute()` for
its `data-person_name` attribute, so after this change the two shared action-menu renderers are
consistent. The delete handler's read-back re-escape stays on `escapeHtml()` — that value goes
into the bootbox message body, which is HTML text context.

The skill guidance was saying the opposite, so it is corrected in the same change:
`.agents/skills/churchcrm/frontend-development.md` now says `escapeAttribute()` is the encoding
for every attribute context, and `table-action-menu.md` carries the same one-line rule next to
the shared renderers.

Fixes: Reported privately through the repository's security advisory process; maintainers can find
the report in the Security tab.

## Type
<!-- Check one -->
- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing

New spec: `cypress/e2e/ui/tables/event-action-menu-title.spec.js`. It creates an event titled
`Choir "Spring" Night & Co's` through `POST /api/events` (cleanup-before pattern: leftovers are
deleted in `before` and again in `after`) and asserts in three places that the Delete item's
`data-event_title` round-trips the literal title and that the button carries exactly `type`,
`class`, `data-event_id` and `data-event_title`:

1. the string returned by `window.CRM.renderEventActionMenu()`, parsed with `DOMParser`;
2. the hydrated row on `/event/dashboard`;
3. the Today's Events DataTable row on `/v2/dashboard`.

```
npm run test:ui -- --spec cypress/e2e/ui/tables/event-action-menu-title.spec.js
```

| Run | Tests | Passing | Failing | Pending |
|-----|-------|---------|---------|---------|
| Before the change (`src/skin/js/CRMJSOM.js` unmodified) | 3 | 0 | **3** | 0 |
| After the change | 3 | **3** | 0 | 0 |

Each of the three "before" failures is the same assertion: `data-event_title` read back as
`'Choir '` instead of `'Choir "Spring" Night & Co\'s'`.

Regression runs (same isolated stack, after the change):

```
npm run test:ui -- --spec "cypress/e2e/ui/tables/action-menu-overflow.spec.js,cypress/e2e/ui/events/*.spec.js"
```

| Spec | Tests | Passing | Failing | Pending |
|------|-------|---------|---------|---------|
| `tables/action-menu-overflow.spec.js` | 8 | 8 | 0 | 0 |
| `events/cart-to-event.spec.js` | 3 | 3 | 0 | 0 |
| `events/external.calendar.spec.js` | 8 | 8 | 0 | 0 |
| `events/fullcalendar-v7.spec.js` | 4 | 3 | 0 | 1 (pre-existing `it.skip`) |
| `events/mobile.calendar.spec.js` | 5 | 5 | 0 | 0 |
| `events/standard.calendar.spec.js` | 14 | 14 | 0 | 0 |
| `events/standard.calendar.timezone-badge.spec.js` | 2 | 2 | 0 | 0 |
| `events/standard.event-detail.spec.js` | 8 | 8 | 0 | 0 |
| `events/standard.events.spec.js` | 8 | 8 | 0 | 0 |
| **Total** | **60** | **59** | **0** | **1** |

Lint and build:

- `npx biome check src/skin/js/CRMJSOM.js` — 7 warnings / 19 infos, byte-for-byte the same counts
  as the `master` version of the file; no new diagnostics.
- `npm run lint` — passes (10 pre-existing stylelint warnings elsewhere in the tree).
- `npm run build` — passes.

## Screenshots

None — no visual change.

## Pre-Merge
- [x] Tested locally
- [x] No new warnings
- [x] Build passes
- [x] Backward compatible (or migration documented)

Backward compatibility note: the attribute is read back through jQuery's `.data()`, which decodes
HTML entities, so consumers receive the same literal string as before for titles that contain no
quote characters — and now the correct one for titles that do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
