### PR TITLE
Fix issue #9824: Make the OpenAPI generator accept its flags anywhere and write its output

### DIFF
--- a/.agents/skills/churchcrm/api-development.md
+++ b/.agents/skills/churchcrm/api-development.md
@@ -400,12 +400,33 @@ Public spec: `Utility`, `Auth`, `Registration`, `Calendar`, `Lookups`
 
 Private spec: `Calendar`, `People`, `Families`, `Groups`, `Properties`, `Finance`, `Users`, `2FA`, `System`, `Admin`, `Cart`, `Search`, `Map`
 
-### Regenerating the spec
+### Regenerating the spec <!-- learned: 2026-09-12 -->
 
-After annotating, run from `CRM/src/`:
+`zircote/swagger-php` is a **dev dependency** (`require-dev` in `src/composer.json`) and
+`npm run build` runs `composer install --no-dev`, which removes it. On a freshly built tree the
+generator fatals on the missing class, so install the dev dependencies first:
+
 ```bash
+cd src
+composer install              # NOT --no-dev; swagger-php is require-dev
 composer run openapi:public   # → CRM/docs/openapi/generated/public-api.yaml
 composer run openapi:private  # → CRM/docs/openapi/generated/private-api.yaml
+```
+
+Each command prints `✓ OpenAPI spec written to: <path> (<bytes>, <n> file(s) scanned)` on
+stderr. **If the whole spec scrolls past on stdout instead, no file was written** — that was
+issue #9824: `generate.php` used `getopt()`, which stops at the first non-option argument, so the
+`--output` / `--format` / `--exclude` flags that came after the scan paths were discarded. The
+script now parses `$argv` itself and accepts flags anywhere (`--output=FILE`, `--output FILE`,
+`-o FILE`), and a missing info file, scan path or `--exclude` path is a hard error instead of a
+warning. Running it by hand:
+
+```bash
+cd src
+php ../docs/openapi/generate.php --output=../docs/openapi/generated/private-api.yaml \
+    --format=yaml --exclude=api/routes/public \
+    ../docs/openapi/openapi-private-info.php api/routes/ admin/routes/api/ \
+    finance/routes/api/ kiosk/routes/api/ plugins/routes/api/
 ```
 
 Commit the updated YAML files to the CRM repo. The rest is automated:

--- a/docs/openapi/generate.php
+++ b/docs/openapi/generate.php
@@ -165,14 +165,17 @@ if (!in_array($format, ['yaml', 'json'], true)) {
 $srcDir = __DIR__ . '/../../src';
 
 $resolvePath = static function (string $path) use ($srcDir): string {
-    // If already absolute, use as-is
+    // Every branch returns a CANONICAL absolute path (realpath) when the path exists, so
+    // that scan paths and --exclude paths compare lexically whatever form the caller used
+    // (absolute, relative to src/, relative to the cwd). Only a nonexistent path comes
+    // back unnormalised, and the callers reject those before comparing anything.
     if ($path === '' || $path[0] === '/') {
-        return $path;
+        return realpath($path) ?: $path;
     }
     // Try relative to src/ first
     $attempt = $srcDir . '/' . $path;
     if (file_exists($attempt)) {
-        return $attempt;
+        return realpath($attempt) ?: $attempt;
     }
     // Try relative to current directory
     return realpath($path) ?: $path;
@@ -209,7 +212,10 @@ foreach ($paths as $path) {
     $finder->files()->name('*.php')->in($rawPath)->followLinks();
 
     foreach ($excludeResolved as $excl) {
-        if (str_starts_with($excl, $rawPath)) {
+        // Both sides are canonical (see $resolvePath). The separator check keeps
+        // "…/routes-old" from matching a scan path of "…/routes".
+        $prefix = rtrim($rawPath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+        if (str_starts_with($excl . DIRECTORY_SEPARATOR, $prefix)) {
             $rel = ltrim(substr($excl, strlen($rawPath)), DIRECTORY_SEPARATOR);
             if ($rel !== '') {
                 $finder->exclude($rel);
@@ -264,7 +270,12 @@ if ($output !== null) {
 
     $openapi->saveAs($output, $format);
     clearstatcache(true, $output);
-    fwrite(STDERR, sprintf("✓ OpenAPI spec written to: %s (%d bytes, %d file(s) scanned)\n", $output, (int) filesize($output), count($filesToScan)));
+    $filesize = filesize($output);
+    if ($filesize === false) {
+        fwrite(STDERR, "Warning: could not stat the output file after writing it: $output\n");
+        $filesize = 0;
+    }
+    fwrite(STDERR, sprintf("✓ OpenAPI spec written to: %s (%d bytes, %d file(s) scanned)\n", $output, $filesize, count($filesToScan)));
 } else {
     echo ($format === 'json' ? $openapi->toJson() : $openapi->toYaml()) . "\n";
 }

--- a/docs/openapi/generate.php
+++ b/docs/openapi/generate.php
@@ -9,11 +9,24 @@ declare(strict_types=1);
  * Generates OpenAPI (Swagger) documentation from route file annotations.
  * This is a build/documentation tool and should not be shipped with production code.
  *
- * Usage: php generate.php [paths...] [--output file] [--format yaml|json] [--exclude path]
+ * Usage: php generate.php <info-file> [paths...] [--output FILE] [--format yaml|json] [--exclude PATH]... [--debug]
+ *
+ * Argument order: flags may appear before, between or after the positional
+ * arguments — the first positional is the *-info.php file, the rest are the
+ * files/directories to scan. This script deliberately does NOT use getopt():
+ * getopt() stops parsing at the first non-option argument, so the flags the
+ * composer scripts pass after the scan paths were silently discarded and the
+ * spec went to stdout instead of --output (issue #9824). Everything after a
+ * bare `--` is treated as a positional path.
+ *
+ * Dependencies: the generator needs `zircote/swagger-php`, which is a
+ * **dev dependency** of src/composer.json. `npm run build` runs
+ * `composer install --no-dev`, so on a freshly built tree run
+ * `composer install` (without --no-dev) in src/ before generating.
  *
  * Examples:
  *   php generate.php openapi-public-info.php ../src/api/routes/public/ --output public-api.yaml
- *   php generate.php openapi-private-info.php ../src/api/routes/ --output private-api.yaml
+ *   php generate.php --output private-api.yaml openapi-private-info.php ../src/api/routes/
  *
  * @license MIT
  */
@@ -36,38 +49,124 @@ use OpenApi\Generator;
 use OpenApi\Loggers\DefaultLogger;
 use Symfony\Component\Finder\Finder;
 
-// Parse command-line arguments
-$options = getopt('o:f:e::d', ['output:', 'format:', 'exclude:', 'debug']);
+$usage = <<<USAGE
+Usage: php generate.php <info-file> [paths...] [options]
+
+Options (may be given before, between or after the positional arguments):
+  -o, --output FILE        Write the spec to FILE instead of stdout
+  -f, --format yaml|json   Output format (default: yaml)
+  -e, --exclude PATH       Exclude PATH from the scan (repeatable)
+  -d, --debug              List the scanned files on stderr
+  --                       Treat every following argument as a path
+
+USAGE;
+
+$fail = static function (string $message) use ($usage): void {
+    fwrite(STDERR, "Error: $message\n\n$usage");
+    exit(1);
+};
+
+// ---------------------------------------------------------------------------
+// Parse command-line arguments (see the header note: no getopt() here).
+// ---------------------------------------------------------------------------
+/** @var string[] $paths */
 $paths = [];
+/** @var string[] $excludes */
+$excludes = [];
+$output = null;
+$format = 'yaml';
+$debug = false;
+$positionalsOnly = false;
+
+$takeValue = static function (string $flag, ?string $inline, int &$index) use ($argv, $argc, $fail): string {
+    if ($inline !== null) {
+        if ($inline === '') {
+            $fail("missing value for $flag");
+        }
+
+        return $inline;
+    }
+    if ($index + 1 >= $argc) {
+        $fail("missing value for $flag");
+    }
+
+    return $argv[++$index];
+};
 
 for ($i = 1; $i < $argc; $i++) {
     $arg = $argv[$i];
 
-    if (in_array($arg, ['-d', '--debug'])) {
-        continue;
-    }
-    if (in_array($arg, ['-o', '--output', '-f', '--format', '-e', '--exclude'])) {
-        $i++; // Skip next arg (the value)
+    if ($positionalsOnly || $arg === '' || $arg === '-' || !str_starts_with($arg, '-')) {
+        $paths[] = $arg;
         continue;
     }
 
-    if (!str_starts_with($arg, '-')) {
-        $paths[] = $arg;
+    if ($arg === '--') {
+        $positionalsOnly = true;
+        continue;
+    }
+
+    // Split "--name=value" (and "-o=value") into flag + inline value.
+    $flag = $arg;
+    $inline = null;
+    if (str_contains($arg, '=')) {
+        [$flag, $inline] = explode('=', $arg, 2);
+    }
+
+    // Short flags may carry their value attached: "-oFILE".
+    if ($inline === null && strlen($flag) > 2 && !str_starts_with($flag, '--')) {
+        $inline = substr($flag, 2);
+        $flag = substr($flag, 0, 2);
+    }
+
+    switch ($flag) {
+        case '-o':
+        case '--output':
+            $output = $takeValue($flag, $inline, $i);
+            break;
+
+        case '-f':
+        case '--format':
+            $format = strtolower($takeValue($flag, $inline, $i));
+            break;
+
+        case '-e':
+        case '--exclude':
+            $excludes[] = $takeValue($flag, $inline, $i);
+            break;
+
+        case '-d':
+        case '--debug':
+            if ($inline !== null) {
+                $fail("$flag does not take a value");
+            }
+            $debug = true;
+            break;
+
+        case '-h':
+        case '--help':
+            fwrite(STDOUT, $usage);
+            exit(0);
+
+        default:
+            $fail("unknown option: $arg");
     }
 }
 
 if (empty($paths)) {
-    fwrite(STDERR, "Usage: php openapi-generate.php [paths...] [--output file] [--format yaml|json] [--exclude path]\n");
-    exit(1);
+    $fail('no info file or scan paths given');
+}
+
+if (!in_array($format, ['yaml', 'json'], true)) {
+    $fail("unsupported --format '$format' (expected yaml or json)");
 }
 
 // Resolve absolute paths (relative to this script's directory or src/)
-$scriptDir = __DIR__;
 $srcDir = __DIR__ . '/../../src';
 
 $resolvePath = static function (string $path) use ($srcDir): string {
     // If already absolute, use as-is
-    if ($path[0] === '/') {
+    if ($path === '' || $path[0] === '/') {
         return $path;
     }
     // Try relative to src/ first
@@ -79,51 +178,62 @@ $resolvePath = static function (string $path) use ($srcDir): string {
     return realpath($path) ?: $path;
 };
 
-/** @var string[] $resolvedPaths */
-$resolvedPaths = array_map($resolvePath, $paths);
-
+// Collect files to scan. A missing info file or scan path is a hard error:
+// silently scanning nothing is what made issue #9824 invisible for so long.
 /** @var string[] $excludeResolved */
 $excludeResolved = [];
-if (!empty($options['e']) || !empty($options['exclude'])) {
-    $excludes = array_filter(array_merge(
-        (array)($options['e'] ?? []),
-        (array)($options['exclude'] ?? [])
-    ));
-    $excludeResolved = array_map($resolvePath, $excludes);
+foreach ($excludes as $exclude) {
+    $resolved = $resolvePath($exclude);
+    if (!file_exists($resolved)) {
+        $fail("--exclude path does not exist: $exclude (resolved to $resolved)");
+    }
+    $excludeResolved[] = $resolved;
 }
 
-// Collect files to scan
+/** @var string[] $filesToScan */
 $filesToScan = [];
 
-foreach ($resolvedPaths as $rawPath) {
+foreach ($paths as $path) {
+    $rawPath = $resolvePath($path);
+
     if (!file_exists($rawPath)) {
-        fwrite(STDERR, "Warning: path does not exist: $rawPath\n");
-        continue;
+        $fail("path does not exist: $path (resolved to $rawPath)");
     }
 
     if (is_file($rawPath)) {
         $filesToScan[] = $rawPath;
-    } else {
-        $finder = new Finder();
-        $finder->files()->name('*.php')->in($rawPath)->followLinks();
+        continue;
+    }
 
-        foreach ($excludeResolved as $excl) {
-            if (str_starts_with($excl, $rawPath)) {
-                $rel = ltrim(substr($excl, strlen($rawPath)), DIRECTORY_SEPARATOR);
-                if ($rel !== '') {
-                    $finder->exclude($rel);
-                }
+    $finder = new Finder();
+    $finder->files()->name('*.php')->in($rawPath)->followLinks();
+
+    foreach ($excludeResolved as $excl) {
+        if (str_starts_with($excl, $rawPath)) {
+            $rel = ltrim(substr($excl, strlen($rawPath)), DIRECTORY_SEPARATOR);
+            if ($rel !== '') {
+                $finder->exclude($rel);
             }
         }
+    }
 
-        foreach ($finder as $file) {
-            $filesToScan[] = $file->getPathname();
-        }
+    foreach ($finder as $file) {
+        $filesToScan[] = $file->getPathname();
+    }
+}
+
+if (empty($filesToScan)) {
+    $fail('no PHP files matched the given paths');
+}
+
+if ($debug) {
+    fwrite(STDERR, sprintf("Scanning %d file(s):\n", count($filesToScan)));
+    foreach ($filesToScan as $file) {
+        fwrite(STDERR, "  $file\n");
     }
 }
 
 // Generate OpenAPI spec
-$debug = !empty($options['d']) || !empty($options['debug']);
 $generator = new Generator(new DefaultLogger());
 $generator->setAnalyser(new ChurchCRMDocBlockAnalyser());
 
@@ -135,24 +245,26 @@ if ($openapi === null) {
 }
 
 // Output
-$format = strtolower($options['f'] ?? $options['format'] ?? 'yaml');
-$output = $options['o'] ?? $options['output'] ?? null;
-
-if ($output) {
+if ($output !== null) {
     // If output is relative, resolve it against src/ (where composer scripts run from)
     if (!str_starts_with($output, '/')) {
         $output = $srcDir . '/' . $output;
     }
 
-    // Normalize the path to remove .. and .
-    $output = realpath(dirname($output)) . '/' . basename($output);
-
     if (is_dir($output)) {
         $output = rtrim($output, '/') . '/openapi.' . $format;
     }
 
+    // Normalize the path to remove .. and .
+    $outputDir = realpath(dirname($output));
+    if ($outputDir === false) {
+        $fail('output directory does not exist: ' . dirname($output));
+    }
+    $output = $outputDir . '/' . basename($output);
+
     $openapi->saveAs($output, $format);
-    fwrite(STDERR, "✓ OpenAPI spec written to: $output\n");
+    clearstatcache(true, $output);
+    fwrite(STDERR, sprintf("✓ OpenAPI spec written to: %s (%d bytes, %d file(s) scanned)\n", $output, (int) filesize($output), count($filesToScan)));
 } else {
     echo ($format === 'json' ? $openapi->toJson() : $openapi->toYaml()) . "\n";
 }

--- a/src/composer.json
+++ b/src/composer.json
@@ -101,7 +101,7 @@
     "graph-viz": "php vendor/bin/propel --config-dir=../orm graphviz:generate",
     "datadictionary": "php vendor/bin/propel --config-dir=../orm datadictionary:generate",
     "post-autoload-dump": ["@orm-gen"],
-    "openapi:public": "php ../docs/openapi/generate.php ../docs/openapi/openapi-public-info.php api/routes/public/ --output ../docs/openapi/generated/public-api.yaml --format yaml",
-    "openapi:private": "php ../docs/openapi/generate.php ../docs/openapi/openapi-private-info.php api/routes/ admin/routes/api/ finance/routes/api/ kiosk/routes/api/ plugins/routes/api/ --exclude api/routes/public --output ../docs/openapi/generated/private-api.yaml --format yaml"
+    "openapi:public": "php ../docs/openapi/generate.php --output=../docs/openapi/generated/public-api.yaml --format=yaml ../docs/openapi/openapi-public-info.php api/routes/public/",
+    "openapi:private": "php ../docs/openapi/generate.php --output=../docs/openapi/generated/private-api.yaml --format=yaml --exclude=api/routes/public ../docs/openapi/openapi-private-info.php api/routes/ admin/routes/api/ finance/routes/api/ kiosk/routes/api/ plugins/routes/api/"
   }
 }


### PR DESCRIPTION
## What Changed
<!-- Short summary - what and why (not how) -->

`composer run openapi:private` and `composer run openapi:public` never wrote their output file.
`docs/openapi/generate.php` parsed its arguments with PHP's `getopt()`, which stops at the first
non-option argument, and both composer scripts in `src/composer.json` passed the info file and the
scan paths *before* `--output`, `--format` and `--exclude`. Every flag was therefore discarded:
the full spec was printed to stdout, `docs/openapi/generated/*.yaml` was never touched, and the
private spec silently included the `/public/*` routes that `--exclude api/routes/public` was meant
to drop. The command exited 0, so nothing looked wrong.

`generate.php` now parses `$argv` itself and accepts every flag **anywhere** among the positional
arguments (`--output=FILE`, `--output FILE`, `-o FILE`, `-oFILE`; `--format`/`-f`;
repeatable `--exclude`/`-e`; `--debug`/`-d`; `--help`; `--` ends flag parsing). A missing info file,
scan path, `--exclude` path or output directory is now a hard error (message on STDERR, exit 1)
instead of a warning that produced an empty spec, an unsupported `--format` is rejected, and a
successful run prints where the file was written, how big it is and how many files were scanned.
The generation logic itself is unchanged.

The two composer scripts were also reordered so the flags precede the paths (belt and braces — they
work either way now), and the script header documents both the argument order and the fact that
`zircote/swagger-php` is a **dev** dependency, so `npm run build` (`composer install --no-dev`)
leaves a tree where the generator fatals until `composer install` is run again.

Fixes #9824

## Type
<!-- Check one -->
- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🏗️ Build/Infrastructure
- [ ] 🔒 Security

## Testing
<!-- How to verify this works -->

All commands run from a clean checkout of this branch. `zircote/swagger-php` is `require-dev`, so
the dev dependencies must be installed first:

```bash
cd src && composer install      # NOT --no-dev
```

### Before (on `master`, a22e68128)

```console
$ cd src && composer run openapi:private
> php ../docs/openapi/generate.php ../docs/openapi/openapi-private-info.php api/routes/ ... --exclude api/routes/public --output ../docs/openapi/generated/private-api.yaml --format yaml
openapi: 3.0.0
info:
  title: 'ChurchCRM Private API'
  ...                                     # 217,775 bytes of spec on stdout

$ git status --porcelain                  # nothing — the target file was never written
$ shasum -a 256 docs/openapi/generated/private-api.yaml
05a908c8c044f781f70dd498f6f37f4640e024226134bf6c014e964e1f3470e8  docs/openapi/generated/private-api.yaml   # unchanged before and after the run

$ cd src && composer run openapi:private 2>/dev/null | grep -cE '^  /public/'
7                                         # --exclude api/routes/public ignored

$ cd src && composer run openapi:public 2>/dev/null | wc -c
15059                                     # same failure; public-api.yaml untouched
```

### After (this branch)

```console
$ cd src && composer run openapi:private
> php ../docs/openapi/generate.php --output=../docs/openapi/generated/private-api.yaml --format=yaml --exclude=api/routes/public ../docs/openapi/openapi-private-info.php api/routes/ admin/routes/api/ finance/routes/api/ kiosk/routes/api/ plugins/routes/api/
✓ OpenAPI spec written to: .../docs/openapi/generated/private-api.yaml (203492 bytes, 45 file(s) scanned)

$ cd src && composer run openapi:public
✓ OpenAPI spec written to: .../docs/openapi/generated/public-api.yaml (15058 bytes, 6 file(s) scanned)

$ git status --porcelain docs/openapi/generated/
 M docs/openapi/generated/private-api.yaml
 M docs/openapi/generated/public-api.yaml

$ grep -cE '^  /public/' docs/openapi/generated/private-api.yaml
0                                         # --exclude honoured
$ grep -c 'operationId: getEcho' docs/openapi/generated/private-api.yaml docs/openapi/generated/public-api.yaml
docs/openapi/generated/private-api.yaml:0
docs/openapi/generated/public-api.yaml:1  # the public route lives only in the public spec
```

The old argument order still works (flags after the paths), and the failure modes are now loud:

```console
$ php ../docs/openapi/generate.php ../docs/openapi/openapi-public-info.php api/routes/public/ --output out.yaml   # flags last → still writes
✓ OpenAPI spec written to: .../out.yaml (15058 bytes, 6 file(s) scanned)

$ php ../docs/openapi/generate.php ../docs/openapi/openapi-public-info.php api/routes/nope/ --output out.yaml
Error: path does not exist: api/routes/nope/ (resolved to api/routes/nope/)      # exit 1
$ php ../docs/openapi/generate.php ... --exclude api/routes/bogus
Error: --exclude path does not exist: api/routes/bogus (...)                     # exit 1
$ php ../docs/openapi/generate.php ... --outpt out.yaml
Error: unknown option: --outpt                                                   # exit 1
$ php ../docs/openapi/generate.php ... --output
Error: missing value for --output                                                # exit 1
$ php ../docs/openapi/generate.php ... --format xml
Error: unsupported --format 'xml' (expected yaml or json)                        # exit 1
$ php ../docs/openapi/generate.php --output /nonexistent-dir/x.yaml ...
Error: output directory does not exist: /nonexistent-dir                         # exit 1
```

Short forms (`-o FILE`, `-oFILE`, `-f json`), `--output=FILE`, repeated `--exclude`, `--debug`
(lists the scanned files on stderr), `--help` and `--` were all exercised by hand; a successful run
exits 0.

### Regenerated specs are intentionally NOT in this PR

Running the now-working generators produces a large, purely mechanical diff:

```
 docs/openapi/generated/private-api.yaml | 6686 +++++++++++++++++--------------
 docs/openapi/generated/public-api.yaml  |  370 +-
 2 files changed, 3814 insertions(+), 3242 deletions(-)
```

That is the accumulated drift from every annotation added since the last manual regeneration (the
generators have been silently doing nothing), and the issue itself says it "probably [deserves] its
own PR". Regenerating it here would bury the 200-line fix under ~7,000 lines of churn and make the
review worthless, so the regenerated YAML was reverted (`git checkout -- docs/openapi/generated/`)
and belongs in a follow-up PR — which reviewers can now produce with two commands. Separately,
`.github/workflows/validate-openapi.yml` / `publish-openapi.yml` have been regenerating specs from
the same broken commands, so their artifacts were equally stale.

### Build / lint

- `php -l docs/openapi/generate.php` → *No syntax errors detected* (the shipped-file syntax
  validator scopes itself to `src/` signature files, so this build tool is checked directly)
- `npm run build:php:validate` → syntax, namespace-case, use-statement-case and ORM base-class
  checks all pass
- `npm run lint` → Biome clean (10 pre-existing CSS specificity warnings, untouched by this PR);
  icon validators pass
- `composer validate` in `src/` → valid (only the pre-existing "version field" advisory)
- pre-commit hooks (locale-check, PHP validation, YAML validation) all passed on the commit

## Screenshots
<!-- Only for UI changes - drag & drop images here -->

n/a — build tooling only.

## Pre-Merge
- [x] Tested locally
- [x] No new warnings
- [x] Build passes
- [x] Backward compatible (or migration documented) — the old flags-after-paths order still works,
      and the only behaviour change is that previously-silent failures (missing path, bad format,
      unknown flag) now exit non-zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)
